### PR TITLE
Extract Hash28-to-Hash32 padding into utility method

### DIFF
--- a/crates/torsten-cli/src/commands/transaction.rs
+++ b/crates/torsten-cli/src/commands/transaction.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
-use torsten_primitives::hash::Hash32;
+use torsten_primitives::hash::{Hash28, Hash32};
 
 #[derive(Args, Debug)]
 pub struct TransactionCmd {
@@ -470,7 +470,6 @@ fn parse_mint_args(mint_args: &[String]) -> Result<Vec<MintEntry>> {
 fn parse_json_native_script(
     json: &serde_json::Value,
 ) -> Result<torsten_primitives::transaction::NativeScript> {
-    use torsten_primitives::hash::Hash32;
     use torsten_primitives::transaction::NativeScript;
 
     let script_type = json["type"]
@@ -488,9 +487,9 @@ fn parse_json_native_script(
                 bail!("keyHash must be 28 bytes, got {}", key_hash_bytes.len());
             }
             // Pad 28-byte key hash to Hash32 (our internal representation)
-            let mut bytes = [0u8; 32];
-            bytes[..28].copy_from_slice(&key_hash_bytes);
-            Ok(NativeScript::ScriptPubkey(Hash32::from_bytes(bytes)))
+            let h28 = Hash28::try_from(key_hash_bytes.as_slice())
+                .map_err(|_| anyhow::anyhow!("Failed to convert key hash to Hash28"))?;
+            Ok(NativeScript::ScriptPubkey(h28.to_hash32_padded()))
         }
         "all" | "ScriptAll" => {
             let scripts = parse_json_script_list(json)?;

--- a/crates/torsten-ledger/src/state.rs
+++ b/crates/torsten-ledger/src/state.rs
@@ -1681,9 +1681,7 @@ impl LedgerState {
         for (pool_id, pool_reg) in go_snapshot.pool_params.iter() {
             let mut owner_stake = 0u64;
             for owner in &pool_reg.owners {
-                let mut key_bytes = [0u8; 32];
-                key_bytes[..28].copy_from_slice(owner.as_bytes());
-                let owner_key = Hash32::from_bytes(key_bytes);
+                let owner_key = owner.to_hash32_padded();
                 if go_snapshot.delegations.get(&owner_key) == Some(pool_id) {
                     owner_stake += go_snapshot
                         .stake_distribution
@@ -1789,11 +1787,7 @@ impl LedgerState {
             let owner_set: std::collections::HashSet<Hash32> = pool_reg
                 .owners
                 .iter()
-                .map(|o| {
-                    let mut kb = [0u8; 32];
-                    kb[..28].copy_from_slice(o.as_bytes());
-                    Hash32::from_bytes(kb)
-                })
+                .map(|o| o.to_hash32_padded())
                 .collect();
 
             if let Some(delegators) = delegators_by_pool.get(pool_id) {
@@ -2510,9 +2504,7 @@ impl LedgerState {
                     }
                 }
                 DRep::ScriptHash(h) => {
-                    let mut padded = [0u8; 32];
-                    padded[..28].copy_from_slice(h.as_bytes());
-                    let hash32 = Hash32::from_bytes(padded);
+                    let hash32 = h.to_hash32_padded();
                     if self.governance.dreps.get(&hash32).is_some_and(|d| d.active) {
                         *cache.entry(hash32).or_default() += stake;
                     }
@@ -2551,9 +2543,7 @@ impl LedgerState {
                     }
                 }
                 DRep::ScriptHash(h) => {
-                    let mut padded = [0u8; 32];
-                    padded[..28].copy_from_slice(h.as_bytes());
-                    let hash32 = Hash32::from_bytes(padded);
+                    let hash32 = h.to_hash32_padded();
                     if self.governance.dreps.get(&hash32).is_some_and(|d| d.active) {
                         total += stake;
                     }
@@ -2821,10 +2811,7 @@ impl LedgerState {
 
 /// Extract a Hash32 from a Credential for use as a map key
 fn credential_to_hash(credential: &Credential) -> Hash32 {
-    let h28 = credential.to_hash();
-    let mut bytes = [0u8; 32];
-    bytes[..28].copy_from_slice(h28.as_bytes());
-    Hash32::from_bytes(bytes)
+    credential.to_hash().to_hash32_padded()
 }
 
 /// Extract the staking credential hash from an address (Base and Reward addresses only).
@@ -4012,9 +3999,7 @@ mod tests {
         );
 
         // Pool_id padded to 32 bytes should NOT have rewards (old bug)
-        let mut pool_key_bytes = [0u8; 32];
-        pool_key_bytes[..28].copy_from_slice(pool_id.as_bytes());
-        let pool_key = Hash32::from_bytes(pool_key_bytes);
+        let pool_key = pool_id.to_hash32_padded();
         let pool_id_reward = state
             .reward_accounts
             .get(&pool_key)
@@ -4338,9 +4323,7 @@ mod tests {
         let mut return_addr = vec![0xE1u8]; // header byte
         return_addr.extend_from_slice(&[42u8; 28]); // 28-byte key hash
 
-        let mut key_bytes = [0u8; 32];
-        key_bytes[..28].copy_from_slice(&[42u8; 28]);
-        let reward_key = Hash32::from_bytes(key_bytes);
+        let reward_key = Hash28::from_bytes([42u8; 28]).to_hash32_padded();
 
         // Submit a proposal with deposit
         let proposal = ProposalProcedure {
@@ -4380,9 +4363,7 @@ mod tests {
         let mut reward_addr = vec![0xE1u8];
         reward_addr.extend_from_slice(&[55u8; 28]);
 
-        let mut key_bytes = [0u8; 32];
-        key_bytes[..28].copy_from_slice(&[55u8; 28]);
-        let reward_key = Hash32::from_bytes(key_bytes);
+        let reward_key = Hash28::from_bytes([55u8; 28]).to_hash32_padded();
 
         let mut withdrawals = std::collections::BTreeMap::new();
         withdrawals.insert(reward_addr, Lovelace(50_000_000_000));
@@ -4793,12 +4774,10 @@ mod tests {
             );
             // Set up vote delegation and stake for each DRep
             let stake_key = Hash32::from_bytes([100 + i as u8; 32]);
-            let mut drep_bytes = [0u8; 32];
-            drep_bytes[..28].copy_from_slice(&[i as u8; 28]);
-            state
-                .governance
-                .vote_delegations
-                .insert(stake_key, DRep::KeyHash(Hash32::from_bytes(drep_bytes)));
+            state.governance.vote_delegations.insert(
+                stake_key,
+                DRep::KeyHash(Hash28::from_bytes([i as u8; 28]).to_hash32_padded()),
+            );
             state
                 .stake_distribution
                 .stake_map
@@ -5012,11 +4991,7 @@ mod tests {
 
         // 6/10 SPOs vote yes (60% > 51%)
         for i in 0..6 {
-            let pool_hash = Hash32::from_bytes({
-                let mut b = [0u8; 32];
-                b[..28].copy_from_slice(Hash28::from_bytes([100 + i as u8; 28]).as_bytes());
-                b
-            });
+            let pool_hash = Hash28::from_bytes([100 + i as u8; 28]).to_hash32_padded();
             let voter = Voter::StakePool(pool_hash);
             state.process_vote(
                 &voter,
@@ -5145,9 +5120,7 @@ mod tests {
     /// Matches the format produced by credential_to_hash (padded with zeros).
     fn make_cc_hot_key(byte_val: u8) -> (Hash28, Hash32) {
         let h28 = Hash28::from_bytes([byte_val; 28]);
-        let mut h32_bytes = [0u8; 32];
-        h32_bytes[..28].copy_from_slice(&[byte_val; 28]);
-        (h28, Hash32::from_bytes(h32_bytes))
+        (h28, h28.to_hash32_padded())
     }
 
     #[test]

--- a/crates/torsten-ledger/src/validation.rs
+++ b/crates/torsten-ledger/src/validation.rs
@@ -722,10 +722,7 @@ pub fn validate_transaction_with_pools(
             .iter()
             .map(|w| {
                 // Hash the vkey to get the 28-byte key hash, then pad to Hash32
-                let kh = torsten_primitives::hash::blake2b_224(&w.vkey);
-                let mut bytes = [0u8; 32];
-                bytes[..28].copy_from_slice(kh.as_bytes());
-                Hash32::from_bytes(bytes)
+                torsten_primitives::hash::blake2b_224(&w.vkey).to_hash32_padded()
             })
             .collect();
         let slot = SlotNo(current_slot);

--- a/crates/torsten-node/src/node.rs
+++ b/crates/torsten-node/src/node.rs
@@ -2516,9 +2516,7 @@ impl Node {
                     .filter(|(_, d)| match d {
                         torsten_primitives::transaction::DRep::KeyHash(h) => h == hash,
                         torsten_primitives::transaction::DRep::ScriptHash(h) => {
-                            let mut padded = [0u8; 32];
-                            padded[..28].copy_from_slice(h.as_bytes());
-                            torsten_primitives::hash::Hash32::from_bytes(padded) == *hash
+                            h.to_hash32_padded() == *hash
                         }
                         _ => false,
                     })

--- a/crates/torsten-primitives/src/hash.rs
+++ b/crates/torsten-primitives/src/hash.rs
@@ -23,6 +23,19 @@ impl<'de, const N: usize> serde::Deserialize<'de> for Hash<N> {
 pub type Hash28 = Hash<28>;
 pub type Hash32 = Hash<32>;
 
+impl Hash28 {
+    /// Convert a 28-byte hash to a 32-byte hash by zero-padding the last 4 bytes.
+    ///
+    /// This is used throughout the codebase when 28-byte credential/key hashes
+    /// (e.g., pool IDs, DRep key hashes, stake key hashes) need to be used as
+    /// Hash32 map keys or compared with Hash32 values.
+    pub fn to_hash32_padded(&self) -> Hash32 {
+        let mut bytes = [0u8; 32];
+        bytes[..28].copy_from_slice(self.as_bytes());
+        Hash32::from_bytes(bytes)
+    }
+}
+
 pub type BlockHeaderHash = Hash32;
 pub type TransactionHash = Hash32;
 pub type ScriptHash = Hash28;
@@ -142,5 +155,38 @@ mod tests {
             hash.to_string(),
             "0000000000000000000000000000000000000000000000000000000000000000"
         );
+    }
+
+    #[test]
+    fn test_hash28_to_hash32_padded_zeros() {
+        let h28 = Hash28::ZERO;
+        let h32 = h28.to_hash32_padded();
+        assert_eq!(h32, Hash32::ZERO);
+    }
+
+    #[test]
+    fn test_hash28_to_hash32_padded_nonzero() {
+        let h28 = Hash28::from_bytes([0xAB; 28]);
+        let h32 = h28.to_hash32_padded();
+        // First 28 bytes should match the original
+        assert_eq!(&h32.as_bytes()[..28], h28.as_bytes());
+        // Last 4 bytes should be zero-padded
+        assert_eq!(&h32.as_bytes()[28..], &[0u8; 4]);
+    }
+
+    #[test]
+    fn test_hash28_to_hash32_padded_preserves_content() {
+        let h28 = blake2b_224(b"cardano pool key");
+        let h32 = h28.to_hash32_padded();
+        // Round-trip: the first 28 bytes of h32 should reconstruct h28
+        let recovered = Hash28::try_from(&h32.as_bytes()[..28]).unwrap();
+        assert_eq!(recovered, h28);
+    }
+
+    #[test]
+    fn test_hash28_to_hash32_padded_distinct_inputs() {
+        let h28_a = Hash28::from_bytes([1u8; 28]);
+        let h28_b = Hash28::from_bytes([2u8; 28]);
+        assert_ne!(h28_a.to_hash32_padded(), h28_b.to_hash32_padded());
     }
 }

--- a/crates/torsten-serialization/src/multi_era.rs
+++ b/crates/torsten-serialization/src/multi_era.rs
@@ -578,9 +578,7 @@ fn convert_native_script_inner(script: &pallas_primitives::alonzo::NativeScript)
     match script {
         PNS::ScriptPubkey(h) => {
             // ScriptPubkey contains AddrKeyhash (28 bytes); pad to Hash32
-            let mut bytes = [0u8; 32];
-            bytes[..28].copy_from_slice(h.as_ref());
-            NativeScript::ScriptPubkey(Hash32::from_bytes(bytes))
+            NativeScript::ScriptPubkey(pallas_hash_to_torsten28(h).to_hash32_padded())
         }
         PNS::ScriptAll(scripts) => {
             NativeScript::ScriptAll(scripts.iter().map(convert_native_script_inner).collect())
@@ -922,9 +920,7 @@ fn convert_pallas_drep(drep: &pallas_primitives::conway::DRep) -> DRep {
     match drep {
         PD::Key(h) => {
             // DRep key hash is 28 bytes; pad to Hash32
-            let mut bytes = [0u8; 32];
-            bytes[..28].copy_from_slice(h.as_ref());
-            DRep::KeyHash(Hash32::from_bytes(bytes))
+            DRep::KeyHash(pallas_hash_to_torsten28(h).to_hash32_padded())
         }
         PD::Script(h) => DRep::ScriptHash(pallas_hash_to_torsten28(h)),
         PD::Abstain => DRep::Abstain,
@@ -1175,9 +1171,7 @@ fn convert_pallas_voter(voter: &pallas_primitives::conway::Voter) -> Voter {
         PV::DRepScript(h) => Voter::DRep(Credential::Script(pallas_hash_to_torsten28(h))),
         PV::StakePoolKey(h) => {
             // Pool key hash is 28 bytes; pad to Hash32
-            let mut bytes = [0u8; 32];
-            bytes[..28].copy_from_slice(h.as_ref());
-            Voter::StakePool(Hash32::from_bytes(bytes))
+            Voter::StakePool(pallas_hash_to_torsten28(h).to_hash32_padded())
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #35

Added `Hash28::to_hash32_padded()` utility method and replaced 15 manual padding instances across 6 files to eliminate code duplication and prevent inconsistent padding.

## Changes

**New method** in `crates/torsten-primitives/src/hash.rs`:
```rust
impl Hash28 {
    pub fn to_hash32_padded(&self) -> Hash32 {
        let mut bytes = [0u8; 32];
        bytes[..28].copy_from_slice(self.as_bytes());
        Hash32::from_bytes(bytes)
    }
}
```

**15 replacements across 6 files:**
- `torsten-ledger/src/state.rs` — 10 occurrences (pool owners, DRep keys, credential_to_hash)
- `torsten-serialization/src/multi_era.rs` — 3 occurrences (NativeScript, DRep, StakePoolKey)
- `torsten-ledger/src/validation.rs` — 1 occurrence (native script vkey hash)
- `torsten-node/src/node.rs` — 1 occurrence (DRep ScriptHash comparison)
- `torsten-cli/src/commands/transaction.rs` — 1 occurrence (native script keyHash)

## Test plan

- [x] 4 unit tests for `to_hash32_padded()` (round-trip, zero-padding, different inputs, all-zeros)
- [x] All workspace tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean