### PR TITLE
Replace unwrap panics with graceful error handling in storage layer

### DIFF
--- a/crates/torsten-storage/src/chain_db.rs
+++ b/crates/torsten-storage/src/chain_db.rs
@@ -162,10 +162,18 @@ impl TipMetadata {
         if data.len() < TIP_METADATA_SIZE {
             return Err(ChainDBError::CorruptTipMetadata(data.len()));
         }
-        let slot = SlotNo(u64::from_be_bytes(data[..8].try_into().unwrap()));
+        let slot = SlotNo(u64::from_be_bytes(
+            data[..8]
+                .try_into()
+                .map_err(|_| ChainDBError::CorruptTipMetadata(data.len()))?,
+        ));
         let mut hash_bytes = [0u8; 32];
         hash_bytes.copy_from_slice(&data[8..40]);
-        let block_no = BlockNo(u64::from_be_bytes(data[40..48].try_into().unwrap()));
+        let block_no = BlockNo(u64::from_be_bytes(
+            data[40..48]
+                .try_into()
+                .map_err(|_| ChainDBError::CorruptTipMetadata(data.len()))?,
+        ));
         Ok(TipMetadata {
             slot,
             hash: Hash32::from_bytes(hash_bytes),
@@ -524,10 +532,11 @@ impl ChainDB {
             None => return Ok(None),
         };
         let slot_bytes: &[u8] = slot_value.as_ref();
-        if slot_bytes.len() != 8 {
-            return Ok(None);
-        }
-        let slot = SlotNo(u64::from_be_bytes(slot_bytes.try_into().unwrap()));
+        let slot_arr: [u8; 8] = match slot_bytes.try_into() {
+            Ok(arr) => arr,
+            Err(_) => return Ok(None),
+        };
+        let slot = SlotNo(u64::from_be_bytes(slot_arr));
 
         // slot -> hash
         let hash = self
@@ -609,7 +618,11 @@ impl ChainDB {
                 if kb.len() != 18 || !kb.starts_with(b"slot_hash:") {
                     continue;
                 }
-                let slot = SlotNo(u64::from_be_bytes(kb[10..18].try_into().unwrap()));
+                let slot_arr: [u8; 8] = match kb[10..18].try_into() {
+                    Ok(arr) => arr,
+                    Err(_) => continue,
+                };
+                let slot = SlotNo(u64::from_be_bytes(slot_arr));
                 let hb = value.as_ref();
                 if hb.len() != 32 {
                     continue;
@@ -702,8 +715,8 @@ impl ChainDB {
                 // Check if this block's slot is at or before the target
                 if let Ok(Some(slot_val)) = self.tree.get(&make_hash_key(&current_hash)) {
                     let slot_bytes: &[u8] = slot_val.as_ref();
-                    if slot_bytes.len() == 8 {
-                        let block_slot = u64::from_be_bytes(slot_bytes.try_into().unwrap());
+                    if let Ok(arr) = <[u8; 8]>::try_from(slot_bytes) {
+                        let block_slot = u64::from_be_bytes(arr);
                         if block_slot <= target_slot && target_hash.is_none() {
                             break;
                         }
@@ -746,8 +759,8 @@ impl ChainDB {
             for hash in &removed {
                 if let Ok(Some(slot_val)) = self.tree.get(&make_hash_key(hash)) {
                     let slot_bytes: &[u8] = slot_val.as_ref();
-                    if slot_bytes.len() == 8 {
-                        let slot = SlotNo(u64::from_be_bytes(slot_bytes.try_into().unwrap()));
+                    if let Ok(arr) = <[u8; 8]>::try_from(slot_bytes) {
+                        let slot = SlotNo(u64::from_be_bytes(arr));
                         let _ = self.tree.delete(&make_slot_hash_key(slot));
                     }
                 }
@@ -760,8 +773,8 @@ impl ChainDB {
             if let Some(th) = target_hash {
                 if let Ok(Some(slot_val)) = self.tree.get(&make_hash_key(&th)) {
                     let slot_bytes: &[u8] = slot_val.as_ref();
-                    if slot_bytes.len() == 8 {
-                        let slot = SlotNo(u64::from_be_bytes(slot_bytes.try_into().unwrap()));
+                    if let Ok(arr) = <[u8; 8]>::try_from(slot_bytes) {
+                        let slot = SlotNo(u64::from_be_bytes(arr));
                         // Derive block_no: old tip block_no minus removed count
                         let new_block_no = current_tip
                             .map(|t| BlockNo(t.block_no.0.saturating_sub(removed.len() as u64)))

--- a/crates/torsten-storage/src/immutable_db.rs
+++ b/crates/torsten-storage/src/immutable_db.rs
@@ -24,6 +24,17 @@ const SECONDARY_ENTRY_SIZE: usize = 56;
 pub enum ImmutableDBError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Malformed secondary index entry in chunk {chunk}: {reason}")]
+    MalformedSecondaryEntry { chunk: u64, reason: String },
+}
+
+/// Read a big-endian u64 from an 8-byte slice without panicking.
+///
+/// Returns `None` if the slice is not exactly 8 bytes.
+#[inline]
+fn read_be_u64(data: &[u8]) -> Option<u64> {
+    let bytes: [u8; 8] = data.try_into().ok()?;
+    Some(u64::from_be_bytes(bytes))
 }
 
 /// Location of a block within a chunk file.
@@ -108,7 +119,25 @@ impl ImmutableDB {
             let secondary_data = fs::read(&secondary_path)?;
             let entry_count = secondary_data.len() / SECONDARY_ENTRY_SIZE;
             if entry_count == 0 {
+                if !secondary_data.is_empty() {
+                    warn!(
+                        chunk = chunk_num,
+                        bytes = secondary_data.len(),
+                        "Secondary index too small for a single entry ({SECONDARY_ENTRY_SIZE} bytes required), skipping"
+                    );
+                }
                 continue;
+            }
+
+            // Warn about trailing bytes that don't form a complete entry
+            let remainder = secondary_data.len() % SECONDARY_ENTRY_SIZE;
+            if remainder != 0 {
+                warn!(
+                    chunk = chunk_num,
+                    total_bytes = secondary_data.len(),
+                    trailing_bytes = remainder,
+                    "Secondary index has trailing bytes (possibly truncated)"
+                );
             }
 
             // Parse secondary index entries: (block_offset, header_hash, slot)
@@ -116,10 +145,30 @@ impl ImmutableDB {
             let mut pos = 0;
             while pos + SECONDARY_ENTRY_SIZE <= secondary_data.len() {
                 let data = &secondary_data[pos..];
-                let block_offset = u64::from_be_bytes(data[0..8].try_into().unwrap());
+                let block_offset = match read_be_u64(&data[0..8]) {
+                    Some(v) => v,
+                    None => {
+                        warn!(
+                            chunk = chunk_num,
+                            pos, "Malformed block_offset in secondary index, skipping entry"
+                        );
+                        pos += SECONDARY_ENTRY_SIZE;
+                        continue;
+                    }
+                };
                 let mut header_hash = [0u8; 32];
                 header_hash.copy_from_slice(&data[16..48]);
-                let block_or_ebb = u64::from_be_bytes(data[48..56].try_into().unwrap());
+                let block_or_ebb = match read_be_u64(&data[48..56]) {
+                    Some(v) => v,
+                    None => {
+                        warn!(
+                            chunk = chunk_num,
+                            pos, "Malformed slot/ebb in secondary index, skipping entry"
+                        );
+                        pos += SECONDARY_ENTRY_SIZE;
+                        continue;
+                    }
+                };
                 entries.push((block_offset, header_hash, block_or_ebb));
                 pos += SECONDARY_ENTRY_SIZE;
             }
@@ -240,18 +289,30 @@ impl ImmutableDB {
             let mut pos = 0;
             while pos + SECONDARY_ENTRY_SIZE <= secondary_data.len() {
                 let data = &secondary_data[pos..];
-                let block_offset = u64::from_be_bytes(data[0..8].try_into().unwrap());
+                let block_offset = match read_be_u64(&data[0..8]) {
+                    Some(v) => v,
+                    None => {
+                        pos += SECONDARY_ENTRY_SIZE;
+                        continue;
+                    }
+                };
                 let mut header_hash = [0u8; 32];
                 header_hash.copy_from_slice(&data[16..48]);
-                let slot = u64::from_be_bytes(data[48..56].try_into().unwrap());
+                let slot = match read_be_u64(&data[48..56]) {
+                    Some(v) => v,
+                    None => {
+                        pos += SECONDARY_ENTRY_SIZE;
+                        continue;
+                    }
+                };
 
                 if slot > after_slot {
-                    // Compute block end from next entry or chunk length
+                    // Compute block end from next entry or chunk length.
+                    // Only read the next entry's offset if a full entry exists
+                    // (not just trailing garbage bytes).
                     let next_pos = pos + SECONDARY_ENTRY_SIZE;
-                    let block_end = if next_pos + 8 <= secondary_data.len() {
-                        u64::from_be_bytes(
-                            secondary_data[next_pos..next_pos + 8].try_into().unwrap(),
-                        )
+                    let block_end = if next_pos + SECONDARY_ENTRY_SIZE <= secondary_data.len() {
+                        read_be_u64(&secondary_data[next_pos..next_pos + 8]).unwrap_or(chunk_len)
                     } else {
                         chunk_len
                     };
@@ -308,8 +369,20 @@ impl ImmutableDB {
             let mut pos = 0;
             while pos + SECONDARY_ENTRY_SIZE <= secondary_data.len() {
                 let data = &secondary_data[pos..];
-                let block_offset = u64::from_be_bytes(data[0..8].try_into().unwrap());
-                let slot = u64::from_be_bytes(data[48..56].try_into().unwrap());
+                let block_offset = match read_be_u64(&data[0..8]) {
+                    Some(v) => v,
+                    None => {
+                        pos += SECONDARY_ENTRY_SIZE;
+                        continue;
+                    }
+                };
+                let slot = match read_be_u64(&data[48..56]) {
+                    Some(v) => v,
+                    None => {
+                        pos += SECONDARY_ENTRY_SIZE;
+                        continue;
+                    }
+                };
                 entries.push((block_offset, slot));
                 pos += SECONDARY_ENTRY_SIZE;
             }
@@ -525,5 +598,236 @@ mod tests {
         let db = ImmutableDB::open(dir.path()).unwrap();
         assert_eq!(db.tip_slot(), 300);
         assert_eq!(db.tip_hash(), Hash32::from_bytes([3u8; 32]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Malformed / truncated secondary index handling
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_secondary_index() {
+        // Empty secondary file should be gracefully skipped
+        let dir = tempfile::tempdir().unwrap();
+        let chunk_path = dir.path().join("00000.chunk");
+        let secondary_path = dir.path().join("00000.secondary");
+
+        // Create a non-empty chunk but an empty secondary index
+        fs::File::create(&chunk_path)
+            .unwrap()
+            .write_all(b"some block data")
+            .unwrap();
+        fs::File::create(&secondary_path).unwrap();
+
+        let db = ImmutableDB::open(dir.path()).unwrap();
+        assert_eq!(db.total_blocks(), 0);
+        assert_eq!(db.tip_slot(), 0);
+    }
+
+    #[test]
+    fn test_truncated_secondary_index_less_than_entry_size() {
+        // Secondary file with fewer than 56 bytes should be skipped
+        let dir = tempfile::tempdir().unwrap();
+        let chunk_path = dir.path().join("00000.chunk");
+        let secondary_path = dir.path().join("00000.secondary");
+
+        fs::File::create(&chunk_path)
+            .unwrap()
+            .write_all(b"block data")
+            .unwrap();
+        // Write only 30 bytes — not enough for a single 56-byte entry
+        fs::File::create(&secondary_path)
+            .unwrap()
+            .write_all(&[0u8; 30])
+            .unwrap();
+
+        let db = ImmutableDB::open(dir.path()).unwrap();
+        assert_eq!(db.total_blocks(), 0);
+    }
+
+    #[test]
+    fn test_truncated_secondary_index_trailing_bytes() {
+        // Secondary file with one valid entry + trailing bytes that
+        // don't form a complete entry. The valid entry should be parsed;
+        // the trailing bytes should be ignored.
+        let dir = tempfile::tempdir().unwrap();
+        let chunk_path = dir.path().join("00000.chunk");
+        let secondary_path = dir.path().join("00000.secondary");
+
+        let block_data = b"hello_block";
+        fs::File::create(&chunk_path)
+            .unwrap()
+            .write_all(block_data)
+            .unwrap();
+
+        // Build one valid 56-byte secondary entry
+        let mut entry = [0u8; 56];
+        entry[0..8].copy_from_slice(&0u64.to_be_bytes()); // block_offset = 0
+        entry[16..48].copy_from_slice(&[7u8; 32]); // header_hash
+        entry[48..56].copy_from_slice(&42u64.to_be_bytes()); // slot = 42
+
+        let mut secondary_file = fs::File::create(&secondary_path).unwrap();
+        secondary_file.write_all(&entry).unwrap();
+        // Append 20 trailing garbage bytes (less than a full entry)
+        secondary_file.write_all(&[0xFFu8; 20]).unwrap();
+
+        let db = ImmutableDB::open(dir.path()).unwrap();
+        assert_eq!(db.total_blocks(), 1);
+        assert_eq!(db.tip_slot(), 42);
+        assert!(db.has_block(&Hash32::from_bytes([7u8; 32])));
+
+        // Block data should be readable
+        let cbor = db.get_block(&Hash32::from_bytes([7u8; 32])).unwrap();
+        assert_eq!(cbor, block_data);
+    }
+
+    #[test]
+    fn test_corrupted_secondary_data_graceful() {
+        // Even with corrupted data in the secondary index, the parser
+        // should not panic. It may produce wrong block locations, but
+        // read_block_at will catch invalid offsets.
+        let dir = tempfile::tempdir().unwrap();
+        let chunk_path = dir.path().join("00000.chunk");
+        let secondary_path = dir.path().join("00000.secondary");
+
+        fs::File::create(&chunk_path)
+            .unwrap()
+            .write_all(b"data")
+            .unwrap();
+
+        // Write 56 bytes of garbage — valid entry size but nonsensical values
+        let garbage = [0xABu8; 56];
+        fs::File::create(&secondary_path)
+            .unwrap()
+            .write_all(&garbage)
+            .unwrap();
+
+        // Should not panic
+        let db = ImmutableDB::open(dir.path()).unwrap();
+        assert_eq!(db.total_blocks(), 1);
+
+        // The block offset decoded from garbage will likely be out of range,
+        // so get_block should return None without panicking
+        let hash = {
+            let mut h = [0u8; 32];
+            h.copy_from_slice(&garbage[16..48]);
+            Hash32::from_bytes(h)
+        };
+        // get_block won't panic even with wild offsets
+        let _ = db.get_block(&hash);
+    }
+
+    #[test]
+    fn test_missing_chunk_file_skipped() {
+        // Secondary exists but chunk file is missing — should skip gracefully
+        let dir = tempfile::tempdir().unwrap();
+        // Only create a secondary file, no .chunk file
+        let secondary_path = dir.path().join("00000.secondary");
+        let mut entry = [0u8; 56];
+        entry[48..56].copy_from_slice(&100u64.to_be_bytes());
+        fs::File::create(&secondary_path)
+            .unwrap()
+            .write_all(&entry)
+            .unwrap();
+
+        // Also need the chunk file to exist for it to be discovered
+        // (chunks are discovered by scanning for .chunk files)
+        // So this should result in 0 blocks since there's no .chunk
+        let db = ImmutableDB::open(dir.path()).unwrap();
+        assert_eq!(db.total_blocks(), 0);
+    }
+
+    #[test]
+    fn test_read_be_u64_helper() {
+        // Verify the helper function
+        assert_eq!(read_be_u64(&[0, 0, 0, 0, 0, 0, 0, 1]), Some(1));
+        assert_eq!(
+            read_be_u64(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+            Some(u64::MAX)
+        );
+        assert_eq!(read_be_u64(&[0, 0, 0, 0, 0, 0, 0]), None); // 7 bytes
+        assert_eq!(read_be_u64(&[0, 0, 0, 0, 0, 0, 0, 0, 0]), None); // 9 bytes
+        assert_eq!(read_be_u64(&[]), None); // empty
+    }
+
+    #[test]
+    fn test_get_next_block_after_slot_with_truncated_secondary() {
+        // Create a valid chunk + secondary, then verify queries work with
+        // trailing bytes in the secondary index.
+        let dir = tempfile::tempdir().unwrap();
+        let chunk_path = dir.path().join("00000.chunk");
+        let secondary_path = dir.path().join("00000.secondary");
+
+        fs::File::create(&chunk_path)
+            .unwrap()
+            .write_all(b"b1b2")
+            .unwrap();
+
+        let mut secondary_file = fs::File::create(&secondary_path).unwrap();
+
+        // Entry 1: offset=0, hash=[1;32], slot=10
+        let mut e1 = [0u8; 56];
+        e1[0..8].copy_from_slice(&0u64.to_be_bytes());
+        e1[16..48].copy_from_slice(&[1u8; 32]);
+        e1[48..56].copy_from_slice(&10u64.to_be_bytes());
+        secondary_file.write_all(&e1).unwrap();
+
+        // Entry 2: offset=2, hash=[2;32], slot=20
+        let mut e2 = [0u8; 56];
+        e2[0..8].copy_from_slice(&2u64.to_be_bytes());
+        e2[16..48].copy_from_slice(&[2u8; 32]);
+        e2[48..56].copy_from_slice(&20u64.to_be_bytes());
+        secondary_file.write_all(&e2).unwrap();
+
+        // Trailing garbage (less than a full entry)
+        secondary_file.write_all(&[0xCC; 10]).unwrap();
+
+        let db = ImmutableDB::open(dir.path()).unwrap();
+        assert_eq!(db.total_blocks(), 2);
+
+        // get_next_block_after_slot should work correctly
+        let result = db.get_next_block_after_slot(0);
+        assert!(result.is_some());
+        let (slot, _, _) = result.unwrap();
+        assert_eq!(slot, 10);
+
+        let result = db.get_next_block_after_slot(10);
+        assert!(result.is_some());
+        let (slot, _, _) = result.unwrap();
+        assert_eq!(slot, 20);
+    }
+
+    #[test]
+    fn test_get_blocks_in_slot_range_with_truncated_secondary() {
+        // Verify slot range queries gracefully handle trailing bytes
+        let dir = tempfile::tempdir().unwrap();
+        let chunk_path = dir.path().join("00000.chunk");
+        let secondary_path = dir.path().join("00000.secondary");
+
+        fs::File::create(&chunk_path)
+            .unwrap()
+            .write_all(b"aabb")
+            .unwrap();
+
+        let mut secondary_file = fs::File::create(&secondary_path).unwrap();
+
+        let mut e1 = [0u8; 56];
+        e1[0..8].copy_from_slice(&0u64.to_be_bytes());
+        e1[16..48].copy_from_slice(&[1u8; 32]);
+        e1[48..56].copy_from_slice(&10u64.to_be_bytes());
+        secondary_file.write_all(&e1).unwrap();
+
+        let mut e2 = [0u8; 56];
+        e2[0..8].copy_from_slice(&2u64.to_be_bytes());
+        e2[16..48].copy_from_slice(&[2u8; 32]);
+        e2[48..56].copy_from_slice(&20u64.to_be_bytes());
+        secondary_file.write_all(&e2).unwrap();
+
+        // 40 trailing garbage bytes
+        secondary_file.write_all(&[0xDD; 40]).unwrap();
+
+        let db = ImmutableDB::open(dir.path()).unwrap();
+
+        let blocks = db.get_blocks_in_slot_range(5, 25);
+        assert_eq!(blocks.len(), 2);
     }
 }

--- a/crates/torsten-storage/src/lsm.rs
+++ b/crates/torsten-storage/src/lsm.rs
@@ -145,10 +145,16 @@ impl TipMetadata {
         if data.len() < TIP_METADATA_SIZE {
             return Err(LsmImmutableDBError::CorruptTipMetadata(data.len()));
         }
-        let slot = SlotNo(u64::from_be_bytes(data[..8].try_into().unwrap()));
+        let slot =
+            SlotNo(u64::from_be_bytes(data[..8].try_into().map_err(|_| {
+                LsmImmutableDBError::CorruptTipMetadata(data.len())
+            })?));
         let mut hash_bytes = [0u8; 32];
         hash_bytes.copy_from_slice(&data[8..40]);
-        let block_no = BlockNo(u64::from_be_bytes(data[40..48].try_into().unwrap()));
+        let block_no =
+            BlockNo(u64::from_be_bytes(data[40..48].try_into().map_err(
+                |_| LsmImmutableDBError::CorruptTipMetadata(data.len()),
+            )?));
         Ok(TipMetadata {
             slot,
             hash: Hash32::from_bytes(hash_bytes),
@@ -338,10 +344,11 @@ impl LsmImmutableDB {
             None => return Ok(None),
         };
         let slot_bytes: &[u8] = slot_value.as_ref();
-        if slot_bytes.len() != 8 {
-            return Ok(None);
-        }
-        let slot = SlotNo(u64::from_be_bytes(slot_bytes.try_into().unwrap()));
+        let slot_arr: [u8; 8] = match slot_bytes.try_into() {
+            Ok(arr) => arr,
+            Err(_) => return Ok(None),
+        };
+        let slot = SlotNo(u64::from_be_bytes(slot_arr));
         self.get_block_by_slot(slot)
     }
 
@@ -384,7 +391,11 @@ impl LsmImmutableDB {
             if kb.len() != 13 || !kb.starts_with(b"slot:") {
                 continue;
             }
-            let slot = SlotNo(u64::from_be_bytes(kb[5..13].try_into().unwrap()));
+            let slot_arr: [u8; 8] = match kb[5..13].try_into() {
+                Ok(arr) => arr,
+                Err(_) => continue,
+            };
+            let slot = SlotNo(u64::from_be_bytes(slot_arr));
             let hash = self
                 .tree
                 .get(&make_slot_hash_key(slot))


### PR DESCRIPTION
## Summary

Fixes #9

Replaced all `try_into().unwrap()` calls in the storage layer (immutable_db, chain_db, lsm) with proper error handling to prevent panics on corrupted or malformed data.

## Changes

**immutable_db.rs** (7 unwraps replaced):
- Added `read_be_u64()` helper returning `Option<u64>` instead of panicking
- Added `MalformedSecondaryEntry` error variant
- Malformed secondary index entries are skipped with warning logs
- Fixed `get_next_block_after_slot()` to validate entry size before reading

**chain_db.rs** (5 unwraps replaced):
- `TipMetadata::decode()`: returns `CorruptTipMetadata` error
- `get_block_by_number()`: returns `Ok(None)` on malformed data
- `rollback_to_point()`: graceful handling of corrupt backward-walk data

**lsm.rs** (4 unwraps replaced):
- `TipMetadata::decode()`: returns error instead of panic
- `get_block_by_hash()` / `get_next_block_after_slot()`: skip malformed entries

## Test plan

- [x] 8 new tests: empty secondary, truncated secondary, trailing bytes, corrupted data, missing chunk file, read_be_u64 helper, truncated next-block and slot-range queries
- [x] All 42 storage tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean