### PR TITLE
Replace anonymous tuple in BlockProvider::get_tip with typed TipInfo struct

### DIFF
--- a/crates/torsten-network/src/lib.rs
+++ b/crates/torsten-network/src/lib.rs
@@ -17,7 +17,7 @@ pub use miniprotocols::peersharing::{
 pub use miniprotocols::txsubmission::{TxSubmissionClient, TxSubmissionError, TxSubmissionStats};
 pub use n2c_client::N2CClient;
 pub use n2c_server::{N2CServer, TxValidator};
-pub use n2n_server::{BlockAnnouncement, BlockProvider, N2NServer, RollbackAnnouncement};
+pub use n2n_server::{BlockAnnouncement, BlockProvider, N2NServer, RollbackAnnouncement, TipInfo};
 pub use peer::PeerConnection;
 pub use peer_manager::{DiffusionMode, PeerManager, PeerManagerConfig, PeerPerformance};
 pub use pipelined::PipelinedPeerClient;

--- a/crates/torsten-network/src/n2c_server.rs
+++ b/crates/torsten-network/src/n2c_server.rs
@@ -704,13 +704,14 @@ async fn handle_local_chainsync(
                 if cursor.has_intersection {
                     // Check for rollback: if client cursor is ahead of the chain tip,
                     // a rollback has occurred and we need to notify the client
-                    let (tip_slot, tip_hash, tip_block_no) = provider.get_tip();
-                    if cursor.cursor_slot > tip_slot {
+                    let tip = provider.get_tip();
+                    if cursor.cursor_slot > tip.slot {
                         debug!(
                             cursor_slot = cursor.cursor_slot,
-                            tip_slot, "LocalChainSync: MsgRollBackward (chain rolled back)"
+                            tip_slot = tip.slot,
+                            "LocalChainSync: MsgRollBackward (chain rolled back)"
                         );
-                        cursor.cursor_slot = tip_slot;
+                        cursor.cursor_slot = tip.slot;
 
                         let mut buf = Vec::new();
                         let mut enc = minicbor::Encoder::new(&mut buf);
@@ -719,9 +720,9 @@ async fn handle_local_chainsync(
                             .map_err(|e| N2CServerError::Protocol(e.to_string()))?;
                         enc.u32(3)
                             .map_err(|e| N2CServerError::Protocol(e.to_string()))?;
-                        let tip_h = Hash32::from_bytes(tip_hash);
-                        encode_point(&mut enc, tip_slot, &tip_h)?;
-                        encode_tip(&mut enc, tip_slot, &tip_h, tip_block_no)?;
+                        let tip_h = Hash32::from_bytes(tip.hash);
+                        encode_point(&mut enc, tip.slot, &tip_h)?;
+                        encode_tip(&mut enc, tip.slot, &tip_h, tip.block_number)?;
 
                         return Ok(Some(Segment {
                             transmission_time: 0,
@@ -738,7 +739,7 @@ async fn handle_local_chainsync(
                         debug!(slot, "LocalChainSync: MsgRollForward");
                         cursor.cursor_slot = slot;
 
-                        let (tip_slot, tip_hash, tip_block_no) = provider.get_tip();
+                        let tip = provider.get_tip();
 
                         // Extract era tag from block CBOR: [era_tag, ...]
                         let era_id = {
@@ -764,8 +765,8 @@ async fn handle_local_chainsync(
                         enc.bytes(&cbor)
                             .map_err(|e| N2CServerError::Protocol(e.to_string()))?;
                         // tip
-                        let tip_h = Hash32::from_bytes(tip_hash);
-                        encode_tip(&mut enc, tip_slot, &tip_h, tip_block_no)?;
+                        let tip_h = Hash32::from_bytes(tip.hash);
+                        encode_tip(&mut enc, tip.slot, &tip_h, tip.block_number)?;
 
                         return Ok(Some(Segment {
                             transmission_time: 0,
@@ -2909,7 +2910,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_local_chainsync_block_delivery() {
-        use crate::n2n_server::BlockProvider;
+        use crate::n2n_server::{BlockProvider, TipInfo};
 
         struct MockBlockProvider;
 
@@ -2921,8 +2922,12 @@ mod tests {
                 // Only recognize our test hash
                 *hash == [0xbb; 32]
             }
-            fn get_tip(&self) -> (u64, [u8; 32], u64) {
-                (200, [0xcc; 32], 10)
+            fn get_tip(&self) -> TipInfo {
+                TipInfo {
+                    slot: 200,
+                    hash: [0xcc; 32],
+                    block_number: 10,
+                }
             }
             fn get_next_block_after_slot(
                 &self,
@@ -3013,7 +3018,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_local_chainsync_rollback() {
-        use crate::n2n_server::BlockProvider;
+        use crate::n2n_server::{BlockProvider, TipInfo};
         use std::sync::atomic::{AtomicU64, Ordering};
 
         struct RollbackProvider {
@@ -3027,9 +3032,13 @@ mod tests {
             fn has_block(&self, hash: &[u8; 32]) -> bool {
                 *hash == [0xbb; 32]
             }
-            fn get_tip(&self) -> (u64, [u8; 32], u64) {
+            fn get_tip(&self) -> TipInfo {
                 let slot = self.tip_slot.load(Ordering::Relaxed);
-                (slot, [0xcc; 32], slot / 10)
+                TipInfo {
+                    slot,
+                    hash: [0xcc; 32],
+                    block_number: slot / 10,
+                }
             }
             fn get_next_block_after_slot(
                 &self,

--- a/crates/torsten-network/src/n2n_server.rs
+++ b/crates/torsten-network/src/n2n_server.rs
@@ -41,14 +41,25 @@ pub struct RollbackAnnouncement {
     pub tip_block_number: u64,
 }
 
+/// Typed representation of the current chain tip
+#[derive(Debug, Clone, Copy)]
+pub struct TipInfo {
+    /// Slot number of the tip block
+    pub slot: u64,
+    /// Header hash of the tip block
+    pub hash: [u8; 32],
+    /// Block number of the tip block
+    pub block_number: u64,
+}
+
 /// Callback trait for retrieving block data from storage
 pub trait BlockProvider: Send + Sync + 'static {
     /// Get raw CBOR block bytes by header hash
     fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>>;
     /// Check if a block exists
     fn has_block(&self, hash: &[u8; 32]) -> bool;
-    /// Get the current chain tip (slot, hash, block_number)
-    fn get_tip(&self) -> (u64, [u8; 32], u64);
+    /// Get the current chain tip
+    fn get_tip(&self) -> TipInfo;
     /// Get the next block after a given slot.
     /// Returns (slot, hash, cbor) of the first block with slot > after_slot.
     fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)>;
@@ -767,11 +778,11 @@ async fn handle_n2n_chainsync(
     match msg_tag {
         // MsgRequestNext → check if there's a block beyond the peer's cursor
         0 => {
-            let (tip_slot, tip_hash, tip_block) = block_provider.get_tip();
+            let tip = block_provider.get_tip();
 
             // If no cursor set or cursor is at tip, await
             let cursor_slot = peer_state.chainsync_cursor_slot.unwrap_or(0);
-            if cursor_slot >= tip_slot {
+            if cursor_slot >= tip.slot {
                 // At tip — send MsgAwaitReply
                 let mut buf = Vec::new();
                 let mut enc = minicbor::Encoder::new(&mut buf);
@@ -797,8 +808,12 @@ async fn handle_n2n_chainsync(
                 peer_state.chainsync_cursor_hash = Some(next_hash);
 
                 // MsgRollForward: [2, [era_tag, tag(24) header_cbor], tip]
-                let buf =
-                    build_chainsync_roll_forward(&block_cbor, tip_slot, &tip_hash, tip_block)?;
+                let buf = build_chainsync_roll_forward(
+                    &block_cbor,
+                    tip.slot,
+                    &tip.hash,
+                    tip.block_number,
+                )?;
 
                 Ok(Some(Segment {
                     transmission_time: 0,
@@ -844,7 +859,7 @@ async fn handle_n2n_chainsync(
                 }
             }
 
-            let (tip_slot, tip_hash, tip_block) = block_provider.get_tip();
+            let tip = block_provider.get_tip();
             let mut buf = Vec::new();
             let mut enc = minicbor::Encoder::new(&mut buf);
 
@@ -862,14 +877,14 @@ async fn handle_n2n_chainsync(
                 // Intersection point
                 encode_point(&mut enc, int_slot, &int_hash)?;
                 // Tip
-                encode_tip(&mut enc, tip_slot, &tip_hash, tip_block)?;
+                encode_tip(&mut enc, tip.slot, &tip.hash, tip.block_number)?;
             } else {
                 // MsgIntersectNotFound: [6, tip]
                 enc.array(2)
                     .map_err(|e| N2NServerError::Protocol(e.to_string()))?;
                 enc.u32(6)
                     .map_err(|e| N2NServerError::Protocol(e.to_string()))?;
-                encode_tip(&mut enc, tip_slot, &tip_hash, tip_block)?;
+                encode_tip(&mut enc, tip.slot, &tip.hash, tip.block_number)?;
             }
 
             Ok(Some(Segment {
@@ -1580,8 +1595,12 @@ mod tests {
         fn has_block(&self, _hash: &[u8; 32]) -> bool {
             true
         }
-        fn get_tip(&self) -> (u64, [u8; 32], u64) {
-            (100, [0xAA; 32], 50)
+        fn get_tip(&self) -> TipInfo {
+            TipInfo {
+                slot: 100,
+                hash: [0xAA; 32],
+                block_number: 50,
+            }
         }
         fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
             if after_slot < 100 {

--- a/crates/torsten-node/src/node.rs
+++ b/crates/torsten-node/src/node.rs
@@ -14,7 +14,7 @@ use torsten_network::server::NodeServerConfig;
 use torsten_network::{
     BlockFetchPool, BlockProvider, ChainSyncEvent, DiffusionMode, HeaderBatchResult, N2CServer,
     NodeServer, NodeStateSnapshot, NodeToNodeClient, PeerManager, PeerManagerConfig,
-    PipelinedPeerClient, QueryHandler, TxValidator,
+    PipelinedPeerClient, QueryHandler, TipInfo, TxValidator,
 };
 use torsten_primitives::block::Point;
 use torsten_primitives::protocol_params::ProtocolParameters;
@@ -64,7 +64,7 @@ impl BlockProvider for ChainDBBlockProvider {
         db.has_block(&block_hash)
     }
 
-    fn get_tip(&self) -> (u64, [u8; 32], u64) {
+    fn get_tip(&self) -> TipInfo {
         let db = self.chain_db.blocking_read();
         let tip = db.get_tip();
         let slot = tip.point.slot().map(|s| s.0).unwrap_or(0);
@@ -79,7 +79,11 @@ impl BlockProvider for ChainDBBlockProvider {
             })
             .unwrap_or([0u8; 32]);
         let block_no = tip.block_number.0;
-        (slot, hash, block_no)
+        TipInfo {
+            slot,
+            hash,
+            block_number: block_no,
+        }
     }
 
     fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {


### PR DESCRIPTION
## Summary
- Replaces `(u64, Hash32)` return type in `BlockProvider::get_tip()` with a named `TipInfo` struct
- Improves code readability and type safety across storage and network layers

Closes #22

## Test plan
- [x] All existing tests pass with the new type
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean