### PR TITLE
Add property-based tests for CBOR serialization round-trips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,6 +2268,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2440,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2622,6 +2671,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3453,6 +3514,7 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3470,6 +3532,7 @@ dependencies = [
  "pallas-crypto 1.0.0-alpha.5",
  "pallas-primitives 1.0.0-alpha.5",
  "pallas-traverse 1.0.0-alpha.5",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3636,6 +3699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,6 +3830,15 @@ dependencies = [
  "rand_core 0.5.1",
  "sha2 0.9.9",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ indicatif = "0.17"
 futures-util = "0.3"
 memmap2 = "0.9"
 fs2 = "0.4"
+proptest = "1"
 
 [profile.release]
 opt-level = 3

--- a/crates/torsten-primitives/Cargo.toml
+++ b/crates/torsten-primitives/Cargo.toml
@@ -20,3 +20,4 @@ minicbor = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+proptest = { workspace = true }

--- a/crates/torsten-primitives/tests/proptest_roundtrips.rs
+++ b/crates/torsten-primitives/tests/proptest_roundtrips.rs
@@ -1,0 +1,376 @@
+//! Property-based tests for primitive type round-trips.
+//!
+//! Uses `proptest` to verify that serialization round-trips (to_bytes/from_bytes,
+//! to_hex/from_hex) are identity functions for all core Cardano types.
+
+use proptest::prelude::*;
+use torsten_primitives::address::*;
+use torsten_primitives::credentials::{Credential, Pointer};
+use torsten_primitives::hash::{Hash28, Hash32};
+use torsten_primitives::network::NetworkId;
+use torsten_primitives::value::{AssetName, Lovelace, Value};
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+fn arb_hash32() -> impl Strategy<Value = Hash32> {
+    prop::array::uniform32(any::<u8>()).prop_map(Hash32::from_bytes)
+}
+
+fn arb_hash28() -> impl Strategy<Value = Hash28> {
+    prop::array::uniform28(any::<u8>()).prop_map(Hash28::from_bytes)
+}
+
+fn arb_network_id() -> impl Strategy<Value = NetworkId> {
+    prop_oneof![Just(NetworkId::Testnet), Just(NetworkId::Mainnet),]
+}
+
+fn arb_credential() -> impl Strategy<Value = Credential> {
+    prop_oneof![
+        arb_hash28().prop_map(Credential::VerificationKey),
+        arb_hash28().prop_map(Credential::Script),
+    ]
+}
+
+fn arb_base_address() -> impl Strategy<Value = Address> {
+    (arb_network_id(), arb_credential(), arb_credential()).prop_map(|(network, payment, stake)| {
+        Address::Base(BaseAddress {
+            network,
+            payment,
+            stake,
+        })
+    })
+}
+
+fn arb_enterprise_address() -> impl Strategy<Value = Address> {
+    (arb_network_id(), arb_credential())
+        .prop_map(|(network, payment)| Address::Enterprise(EnterpriseAddress { network, payment }))
+}
+
+fn arb_reward_address() -> impl Strategy<Value = Address> {
+    (arb_network_id(), arb_credential())
+        .prop_map(|(network, stake)| Address::Reward(RewardAddress { network, stake }))
+}
+
+/// Pointer address strategy with bounded pointer values (variable-length
+/// encoding must fit within reasonable bounds).
+fn arb_pointer_address() -> impl Strategy<Value = Address> {
+    (
+        arb_network_id(),
+        arb_credential(),
+        0u64..=1_000_000_000,
+        0u64..=10_000,
+        0u64..=1_000,
+    )
+        .prop_map(|(network, payment, slot, tx_index, cert_index)| {
+            Address::Pointer(PointerAddress {
+                network,
+                payment,
+                pointer: Pointer {
+                    slot,
+                    tx_index,
+                    cert_index,
+                },
+            })
+        })
+}
+
+fn arb_shelley_address() -> impl Strategy<Value = Address> {
+    prop_oneof![
+        arb_base_address(),
+        arb_enterprise_address(),
+        arb_reward_address(),
+        arb_pointer_address(),
+    ]
+}
+
+fn arb_asset_name() -> impl Strategy<Value = AssetName> {
+    prop::collection::vec(any::<u8>(), 0..=32).prop_map(AssetName)
+}
+
+// ===========================================================================
+// Property-based tests
+// ===========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    // -----------------------------------------------------------------------
+    // Hash32: hex round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_hex_roundtrip(hash in arb_hash32()) {
+        let hex_str = hash.to_hex();
+        let recovered = Hash32::from_hex(&hex_str).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash28: hex round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash28_hex_roundtrip(hash in arb_hash28()) {
+        let hex_str = hash.to_hex();
+        let recovered = Hash28::from_hex(&hex_str).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash: from_bytes / as_bytes identity
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_bytes_roundtrip(bytes in prop::array::uniform32(any::<u8>())) {
+        let hash = Hash32::from_bytes(bytes);
+        prop_assert_eq!(*hash.as_bytes(), bytes);
+    }
+
+    #[test]
+    fn prop_hash28_bytes_roundtrip(bytes in prop::array::uniform28(any::<u8>())) {
+        let hash = Hash28::from_bytes(bytes);
+        prop_assert_eq!(*hash.as_bytes(), bytes);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash: TryFrom<&[u8]> round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_try_from_slice(bytes in prop::array::uniform32(any::<u8>())) {
+        let hash = Hash32::from_bytes(bytes);
+        let slice: &[u8] = hash.as_ref();
+        let recovered = Hash32::try_from(slice).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    #[test]
+    fn prop_hash28_try_from_slice(bytes in prop::array::uniform28(any::<u8>())) {
+        let hash = Hash28::from_bytes(bytes);
+        let slice: &[u8] = hash.as_ref();
+        let recovered = Hash28::try_from(slice).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash28 -> Hash32 padding: first 28 bytes preserved, last 4 are zero
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash28_to_hash32_padding(hash in arb_hash28()) {
+        let h32 = hash.to_hash32_padded();
+        prop_assert_eq!(&h32.as_bytes()[..28], hash.as_bytes());
+        prop_assert_eq!(&h32.as_bytes()[28..], &[0u8; 4]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash: Display and from_hex round-trip (Display uses hex)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_display_roundtrip(hash in arb_hash32()) {
+        let display_str = format!("{}", hash);
+        let recovered = Hash32::from_hex(&display_str).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Address: to_bytes / from_bytes round-trip (Shelley address types)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_address_bytes_roundtrip(addr in arb_shelley_address()) {
+        let bytes = addr.to_bytes();
+        let decoded = Address::from_bytes(&bytes).unwrap();
+        prop_assert_eq!(addr, decoded);
+    }
+
+    // -----------------------------------------------------------------------
+    // Address: Base address is always 57 bytes
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_base_address_length(addr in arb_base_address()) {
+        let bytes = addr.to_bytes();
+        prop_assert_eq!(bytes.len(), 57);
+    }
+
+    // -----------------------------------------------------------------------
+    // Address: Enterprise address is always 29 bytes
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_enterprise_address_length(addr in arb_enterprise_address()) {
+        let bytes = addr.to_bytes();
+        prop_assert_eq!(bytes.len(), 29);
+    }
+
+    // -----------------------------------------------------------------------
+    // Address: Reward address is always 29 bytes
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_reward_address_length(addr in arb_reward_address()) {
+        let bytes = addr.to_bytes();
+        prop_assert_eq!(bytes.len(), 29);
+    }
+
+    // -----------------------------------------------------------------------
+    // Address: network_id is preserved
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_address_preserves_network(addr in arb_shelley_address()) {
+        let expected_net = addr.network_id();
+        let bytes = addr.to_bytes();
+        let decoded = Address::from_bytes(&bytes).unwrap();
+        prop_assert_eq!(decoded.network_id(), expected_net);
+    }
+
+    // -----------------------------------------------------------------------
+    // Address: payment_credential is preserved
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_address_preserves_payment_cred(addr in arb_shelley_address()) {
+        let expected_cred = addr.payment_credential().cloned();
+        let bytes = addr.to_bytes();
+        let decoded = Address::from_bytes(&bytes).unwrap();
+        prop_assert_eq!(decoded.payment_credential().cloned(), expected_cred);
+    }
+
+    // -----------------------------------------------------------------------
+    // NetworkId: to_u8 / from_u8 round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_network_id_roundtrip(net in arb_network_id()) {
+        let byte = net.to_u8();
+        let recovered = NetworkId::from_u8(byte).unwrap();
+        prop_assert_eq!(net, recovered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lovelace: checked_add commutativity
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_lovelace_add_commutative(a in 0u64..=u64::MAX / 2, b in 0u64..=u64::MAX / 2) {
+        let la = Lovelace(a);
+        let lb = Lovelace(b);
+        prop_assert_eq!(la.checked_add(lb), lb.checked_add(la));
+    }
+
+    // -----------------------------------------------------------------------
+    // Lovelace: checked_add then checked_sub identity
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_lovelace_add_sub_identity(a in 0u64..=u64::MAX / 2, b in 0u64..=u64::MAX / 2) {
+        let la = Lovelace(a);
+        let lb = Lovelace(b);
+        let sum = la.checked_add(lb).unwrap();
+        let result = sum.checked_sub(lb).unwrap();
+        prop_assert_eq!(result, la);
+    }
+
+    // -----------------------------------------------------------------------
+    // Value: ADA-only geq reflexivity
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_value_geq_reflexive(coin in any::<u64>()) {
+        let v = Value::lovelace(coin);
+        prop_assert!(v.geq(&v));
+    }
+
+    // -----------------------------------------------------------------------
+    // Value: add identity (adding zero)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_value_add_zero_identity(coin in any::<u64>()) {
+        let v = Value::lovelace(coin);
+        let zero = Value::lovelace(0);
+        let result = v.add(&zero);
+        prop_assert_eq!(result.coin, v.coin);
+        prop_assert!(result.multi_asset.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Value: is_pure_ada for ADA-only values
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_value_ada_only_is_pure(coin in any::<u64>()) {
+        let v = Value::lovelace(coin);
+        prop_assert!(v.is_pure_ada());
+    }
+
+    // -----------------------------------------------------------------------
+    // AssetName: length constraint (0..=32 bytes)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_asset_name_valid_length(name in arb_asset_name()) {
+        prop_assert!(name.0.len() <= 32);
+    }
+
+    // -----------------------------------------------------------------------
+    // AssetName: new() rejects names > 32 bytes
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_asset_name_rejects_too_long(len in 33usize..=128) {
+        let bytes = vec![0u8; len];
+        prop_assert!(AssetName::new(bytes).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash: serde JSON round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_serde_roundtrip(hash in arb_hash32()) {
+        let json = serde_json::to_string(&hash).unwrap();
+        let recovered: Hash32 = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    #[test]
+    fn prop_hash28_serde_roundtrip(hash in arb_hash28()) {
+        let json = serde_json::to_string(&hash).unwrap();
+        let recovered: Hash28 = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(hash, recovered);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lovelace: Display always ends with " lovelace"
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_lovelace_display(amount in any::<u64>()) {
+        let l = Lovelace(amount);
+        let display = format!("{}", l);
+        prop_assert!(display.ends_with(" lovelace"));
+        prop_assert!(display.starts_with(&amount.to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash: ordering is consistent with byte ordering
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_ordering_consistent(a in arb_hash32(), b in arb_hash32()) {
+        let ord_hash = a.cmp(&b);
+        let ord_bytes = a.as_bytes().cmp(b.as_bytes());
+        prop_assert_eq!(ord_hash, ord_bytes);
+    }
+
+    #[test]
+    fn prop_hash28_ordering_consistent(a in arb_hash28(), b in arb_hash28()) {
+        let ord_hash = a.cmp(&b);
+        let ord_bytes = a.as_bytes().cmp(b.as_bytes());
+        prop_assert_eq!(ord_hash, ord_bytes);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pointer address: variable-length encoding round-trip through address
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_pointer_address_roundtrip(
+        network in arb_network_id(),
+        cred in arb_credential(),
+        slot in 0u64..=100_000_000,
+        tx_index in 0u64..=10_000,
+        cert_index in 0u64..=1_000,
+    ) {
+        let addr = Address::Pointer(PointerAddress {
+            network,
+            payment: cred,
+            pointer: Pointer { slot, tx_index, cert_index },
+        });
+        let bytes = addr.to_bytes();
+        let decoded = Address::from_bytes(&bytes).unwrap();
+        prop_assert_eq!(addr, decoded);
+    }
+}

--- a/crates/torsten-serialization/Cargo.toml
+++ b/crates/torsten-serialization/Cargo.toml
@@ -20,3 +20,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+proptest = { workspace = true }

--- a/crates/torsten-serialization/tests/cbor_proptest.rs
+++ b/crates/torsten-serialization/tests/cbor_proptest.rs
@@ -1,0 +1,689 @@
+//! Property-based tests for CBOR serialization round-trips.
+//!
+//! Uses `proptest` to generate arbitrary inputs and verify that
+//! encode-then-decode is the identity for all primitive CBOR types
+//! and higher-level Cardano types.
+
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+use torsten_primitives::hash::{Hash28, Hash32};
+use torsten_primitives::time::SlotNo;
+use torsten_primitives::transaction::{PlutusData, TransactionInput, TransactionMetadatum};
+use torsten_primitives::value::{AssetName, Lovelace, Value};
+use torsten_serialization::cbor::*;
+use torsten_serialization::encode::*;
+
+// ---------------------------------------------------------------------------
+// Proptest strategies for Cardano types
+// ---------------------------------------------------------------------------
+
+fn arb_hash32() -> impl Strategy<Value = Hash32> {
+    prop::array::uniform32(any::<u8>()).prop_map(Hash32::from_bytes)
+}
+
+fn arb_hash28() -> impl Strategy<Value = Hash28> {
+    prop::array::uniform28(any::<u8>()).prop_map(Hash28::from_bytes)
+}
+
+fn arb_asset_name() -> impl Strategy<Value = AssetName> {
+    prop::collection::vec(any::<u8>(), 0..=32).prop_map(AssetName)
+}
+
+fn arb_value_ada_only() -> impl Strategy<Value = Value> {
+    any::<u64>().prop_map(Value::lovelace)
+}
+
+fn arb_multi_asset() -> impl Strategy<Value = BTreeMap<Hash28, BTreeMap<AssetName, u64>>> {
+    prop::collection::btree_map(
+        arb_hash28(),
+        prop::collection::btree_map(arb_asset_name(), any::<u64>(), 1..=3),
+        1..=3,
+    )
+}
+
+fn arb_value_multi_asset() -> impl Strategy<Value = Value> {
+    (any::<u64>(), arb_multi_asset()).prop_map(|(coin, multi_asset)| Value {
+        coin: Lovelace(coin),
+        multi_asset,
+    })
+}
+
+fn arb_value() -> impl Strategy<Value = Value> {
+    prop_oneof![arb_value_ada_only(), arb_value_multi_asset(),]
+}
+
+fn arb_tx_input() -> impl Strategy<Value = TransactionInput> {
+    (arb_hash32(), any::<u32>()).prop_map(|(transaction_id, index)| TransactionInput {
+        transaction_id,
+        index,
+    })
+}
+
+/// Strategy for PlutusData with bounded recursion depth.
+fn arb_plutus_data() -> impl Strategy<Value = PlutusData> {
+    let leaf = prop_oneof![
+        // Integer: use a range that fits in CBOR encoding (avoid i128 extremes)
+        (-1_000_000_000i128..1_000_000_000i128).prop_map(PlutusData::Integer),
+        prop::collection::vec(any::<u8>(), 0..=64).prop_map(PlutusData::Bytes),
+    ];
+
+    leaf.prop_recursive(
+        3,  // depth
+        32, // max nodes
+        8,  // items per collection
+        |inner| {
+            prop_oneof![
+                // List
+                prop::collection::vec(inner.clone(), 0..=4).prop_map(PlutusData::List),
+                // Map
+                prop::collection::vec((inner.clone(), inner.clone()), 0..=3)
+                    .prop_map(PlutusData::Map),
+                // Constr (small constructors 0-6)
+                (0..7u64, prop::collection::vec(inner.clone(), 0..=3))
+                    .prop_map(|(tag, fields)| PlutusData::Constr(tag, fields)),
+                // Constr (medium constructors 7-127)
+                (7..128u64, prop::collection::vec(inner.clone(), 0..=2))
+                    .prop_map(|(tag, fields)| PlutusData::Constr(tag, fields)),
+                // Constr (large constructors >= 128 using tag 102)
+                (128..256u64, prop::collection::vec(inner, 0..=2))
+                    .prop_map(|(tag, fields)| PlutusData::Constr(tag, fields)),
+            ]
+        },
+    )
+}
+
+/// Strategy for TransactionMetadatum with bounded recursion.
+fn arb_metadatum() -> impl Strategy<Value = TransactionMetadatum> {
+    let leaf = prop_oneof![
+        (-1_000_000_000i128..1_000_000_000i128).prop_map(TransactionMetadatum::Int),
+        prop::collection::vec(any::<u8>(), 0..=64).prop_map(TransactionMetadatum::Bytes),
+        "[a-zA-Z0-9 ]{0,64}".prop_map(TransactionMetadatum::Text),
+    ];
+
+    leaf.prop_recursive(
+        2,  // depth
+        16, // max nodes
+        4,  // items per collection
+        |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 0..=3).prop_map(TransactionMetadatum::List),
+                prop::collection::vec((inner.clone(), inner), 0..=3)
+                    .prop_map(TransactionMetadatum::Map),
+            ]
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Helper: decode CBOR unsigned integer
+// ---------------------------------------------------------------------------
+
+fn decode_cbor_uint(data: &[u8]) -> Option<(u64, usize)> {
+    if data.is_empty() {
+        return None;
+    }
+    let major = data[0] >> 5;
+    if major != 0 {
+        return None; // Not unsigned int
+    }
+    let additional = data[0] & 0x1f;
+    match additional {
+        0..=23 => Some((additional as u64, 1)),
+        24 => {
+            if data.len() < 2 {
+                return None;
+            }
+            Some((data[1] as u64, 2))
+        }
+        25 => {
+            if data.len() < 3 {
+                return None;
+            }
+            Some((u16::from_be_bytes([data[1], data[2]]) as u64, 3))
+        }
+        26 => {
+            if data.len() < 5 {
+                return None;
+            }
+            Some((
+                u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as u64,
+                5,
+            ))
+        }
+        27 => {
+            if data.len() < 9 {
+                return None;
+            }
+            Some((
+                u64::from_be_bytes([
+                    data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
+                ]),
+                9,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Decode a CBOR signed integer (major type 0 or 1).
+fn decode_cbor_int(data: &[u8]) -> Option<(i128, usize)> {
+    if data.is_empty() {
+        return None;
+    }
+    let major = data[0] >> 5;
+    match major {
+        0 => {
+            let (val, len) = decode_cbor_uint(data)?;
+            Some((val as i128, len))
+        }
+        1 => {
+            // Negative integer: value is -1 - additional
+            let additional = data[0] & 0x1f;
+            match additional {
+                0..=23 => Some((-(additional as i128) - 1, 1)),
+                24 => {
+                    if data.len() < 2 {
+                        return None;
+                    }
+                    Some((-(data[1] as i128) - 1, 2))
+                }
+                25 => {
+                    if data.len() < 3 {
+                        return None;
+                    }
+                    let val = u16::from_be_bytes([data[1], data[2]]) as i128;
+                    Some((-val - 1, 3))
+                }
+                26 => {
+                    if data.len() < 5 {
+                        return None;
+                    }
+                    let val = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as i128;
+                    Some((-val - 1, 5))
+                }
+                27 => {
+                    if data.len() < 9 {
+                        return None;
+                    }
+                    let val = u64::from_be_bytes([
+                        data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
+                    ]) as i128;
+                    Some((-val - 1, 9))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Decode a CBOR byte string and return (bytes, total_consumed).
+fn decode_cbor_bytes(data: &[u8]) -> Option<(Vec<u8>, usize)> {
+    if data.is_empty() {
+        return None;
+    }
+    let major = data[0] >> 5;
+    if major != 2 {
+        return None;
+    }
+    let additional = data[0] & 0x1f;
+    let (len, header_size) = match additional {
+        0..=23 => (additional as usize, 1),
+        24 => {
+            if data.len() < 2 {
+                return None;
+            }
+            (data[1] as usize, 2)
+        }
+        25 => {
+            if data.len() < 3 {
+                return None;
+            }
+            (u16::from_be_bytes([data[1], data[2]]) as usize, 3)
+        }
+        26 => {
+            if data.len() < 5 {
+                return None;
+            }
+            (
+                u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize,
+                5,
+            )
+        }
+        _ => return None,
+    };
+    if data.len() < header_size + len {
+        return None;
+    }
+    Some((
+        data[header_size..header_size + len].to_vec(),
+        header_size + len,
+    ))
+}
+
+/// Decode a CBOR text string and return (string, total_consumed).
+fn decode_cbor_text(data: &[u8]) -> Option<(String, usize)> {
+    if data.is_empty() {
+        return None;
+    }
+    let major = data[0] >> 5;
+    if major != 3 {
+        return None;
+    }
+    let additional = data[0] & 0x1f;
+    let (len, header_size) = match additional {
+        0..=23 => (additional as usize, 1),
+        24 => {
+            if data.len() < 2 {
+                return None;
+            }
+            (data[1] as usize, 2)
+        }
+        25 => {
+            if data.len() < 3 {
+                return None;
+            }
+            (u16::from_be_bytes([data[1], data[2]]) as usize, 3)
+        }
+        _ => return None,
+    };
+    if data.len() < header_size + len {
+        return None;
+    }
+    let s = std::str::from_utf8(&data[header_size..header_size + len]).ok()?;
+    Some((s.to_string(), header_size + len))
+}
+
+// ===========================================================================
+// Property-based tests: CBOR primitive encoding round-trips
+// ===========================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    // -----------------------------------------------------------------------
+    // encode_uint / decode round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_uint_roundtrip(value in any::<u64>()) {
+        let encoded = encode_uint(value);
+        let (decoded, consumed) = decode_cbor_uint(&encoded).unwrap();
+        prop_assert_eq!(decoded, value);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_uint produces minimal CBOR encoding
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_uint_minimal(value in any::<u64>()) {
+        let encoded = encode_uint(value);
+        let expected_len = if value < 24 { 1 }
+            else if value < 256 { 2 }
+            else if value < 65536 { 3 }
+            else if value < 4294967296 { 5 }
+            else { 9 };
+        prop_assert_eq!(encoded.len(), expected_len);
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_int / decode round-trip (positive and negative)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_int_roundtrip(value in -1_000_000_000_000i128..1_000_000_000_000i128) {
+        let encoded = encode_int(value);
+        let (decoded, consumed) = decode_cbor_int(&encoded).unwrap();
+        prop_assert_eq!(decoded, value);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_bytes / decode round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_bytes_roundtrip(data in prop::collection::vec(any::<u8>(), 0..=512)) {
+        let encoded = encode_bytes(&data);
+        let (decoded, consumed) = decode_cbor_bytes(&encoded).unwrap();
+        prop_assert_eq!(decoded, data);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_text / decode round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_text_roundtrip(text in "[a-zA-Z0-9 _\\-\\.]{0,256}") {
+        let encoded = encode_text(&text);
+        let (decoded, consumed) = decode_cbor_text(&encoded).unwrap();
+        prop_assert_eq!(decoded, text);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash32 CBOR encode / decode round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash32_cbor_roundtrip(hash in arb_hash32()) {
+        let encoded = encode_hash32(&hash);
+        let (decoded, consumed) = decode_hash32(&encoded).unwrap();
+        prop_assert_eq!(decoded, hash);
+        prop_assert_eq!(consumed, encoded.len());
+        // Hash32 always encodes to exactly 34 bytes (0x58, 0x20, + 32 bytes)
+        prop_assert_eq!(encoded.len(), 34);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hash28 CBOR encode: correct length and decodable
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_hash28_cbor_encode(hash in arb_hash28()) {
+        let encoded = encode_hash28(&hash);
+        // Hash28 always encodes to exactly 30 bytes (0x58, 0x1c, + 28 bytes)
+        prop_assert_eq!(encoded.len(), 30);
+        // Verify it decodes as valid CBOR byte string
+        let (decoded_bytes, consumed) = decode_cbor_bytes(&encoded).unwrap();
+        prop_assert_eq!(decoded_bytes.len(), 28);
+        prop_assert_eq!(&decoded_bytes[..], hash.as_bytes());
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // Point CBOR encoding: Origin always fixed, Specific encodes correctly
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_point_specific_encoding(slot in any::<u64>(), hash in arb_hash32()) {
+        use torsten_primitives::block::Point;
+        let point = Point::Specific(SlotNo(slot), hash);
+        let encoded = encode_point(&point);
+        // Should start with 0x82 (array of 2)
+        prop_assert_eq!(encoded[0], 0x82);
+        // After the array header, decode the slot
+        let (decoded_slot, slot_len) = decode_cbor_uint(&encoded[1..]).unwrap();
+        prop_assert_eq!(decoded_slot, slot);
+        // After the slot, decode the hash
+        let (decoded_hash, _) = decode_hash32(&encoded[1 + slot_len..]).unwrap();
+        prop_assert_eq!(decoded_hash, hash);
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionInput CBOR encoding round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_tx_input_cbor_roundtrip(input in arb_tx_input()) {
+        let encoded = encode_tx_input(&input);
+        // Should start with 0x82 (array of 2)
+        prop_assert_eq!(encoded[0], 0x82);
+        // Decode hash
+        let (decoded_hash, hash_len) = decode_hash32(&encoded[1..]).unwrap();
+        prop_assert_eq!(decoded_hash, input.transaction_id);
+        // Decode index
+        let (decoded_index, _) = decode_cbor_uint(&encoded[1 + hash_len..]).unwrap();
+        prop_assert_eq!(decoded_index as u32, input.index);
+    }
+
+    // -----------------------------------------------------------------------
+    // Value (ADA-only): encode_value produces valid CBOR uint
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_value_ada_only_roundtrip(coin in any::<u64>()) {
+        let value = Value::lovelace(coin);
+        let encoded = encode_value(&value);
+        // Pure ADA is just a CBOR uint
+        let (decoded_coin, consumed) = decode_cbor_uint(&encoded).unwrap();
+        prop_assert_eq!(decoded_coin, coin);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // Value (multi-asset): produces valid CBOR array(2)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_value_multi_asset_structure(value in arb_value_multi_asset()) {
+        let encoded = encode_value(&value);
+        // Multi-asset value starts with 0x82 (array of 2)
+        prop_assert_eq!(encoded[0], 0x82);
+        // First element is the coin amount
+        let (decoded_coin, _) = decode_cbor_uint(&encoded[1..]).unwrap();
+        prop_assert_eq!(decoded_coin, value.coin.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // PlutusData CBOR encoding: well-formed (non-empty output, no panics)
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_plutus_data_encodes_without_panic(data in arb_plutus_data()) {
+        let encoded = encode_plutus_data(&data);
+        prop_assert!(!encoded.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // PlutusData::Integer CBOR round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_plutus_data_integer_roundtrip(n in -1_000_000_000i128..1_000_000_000i128) {
+        let data = PlutusData::Integer(n);
+        let encoded = encode_plutus_data(&data);
+        let (decoded, consumed) = decode_cbor_int(&encoded).unwrap();
+        prop_assert_eq!(decoded, n);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // PlutusData::Bytes CBOR round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_plutus_data_bytes_roundtrip(bytes in prop::collection::vec(any::<u8>(), 0..=128)) {
+        let data = PlutusData::Bytes(bytes.clone());
+        let encoded = encode_plutus_data(&data);
+        let (decoded, consumed) = decode_cbor_bytes(&encoded).unwrap();
+        prop_assert_eq!(decoded, bytes);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // PlutusData::Constr tag encoding correctness
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_plutus_constr_small_tag(tag in 0u64..7) {
+        let data = PlutusData::Constr(tag, vec![]);
+        let encoded = encode_plutus_data(&data);
+        // Small constructors use 1-byte CBOR tag (0xd8) followed by 121+tag
+        prop_assert_eq!(encoded[0], 0xd8);
+        prop_assert_eq!(encoded[1], (121 + tag) as u8);
+        prop_assert_eq!(encoded[2], 0x80); // empty array
+    }
+
+    #[test]
+    fn prop_plutus_constr_medium_tag(tag in 7u64..128) {
+        let data = PlutusData::Constr(tag, vec![]);
+        let encoded = encode_plutus_data(&data);
+        // Medium constructors use 2-byte CBOR tag (0xd9) followed by 1280+(tag-7)
+        prop_assert_eq!(encoded[0], 0xd9);
+        let expected_tag = 1280 + (tag - 7);
+        let actual_tag = u16::from_be_bytes([encoded[1], encoded[2]]);
+        prop_assert_eq!(actual_tag as u64, expected_tag);
+        prop_assert_eq!(encoded[3], 0x80); // empty array
+    }
+
+    #[test]
+    fn prop_plutus_constr_large_tag(tag in 128u64..512) {
+        let data = PlutusData::Constr(tag, vec![]);
+        let encoded = encode_plutus_data(&data);
+        // Large constructors use tag 102 (0xd8 0x66)
+        prop_assert_eq!(encoded[0], 0xd8);
+        prop_assert_eq!(encoded[1], 0x66);
+        // Followed by array(2): [constructor_index, fields_array]
+        prop_assert_eq!(encoded[2], 0x82);
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionMetadatum: encoding never panics and produces non-empty output
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_metadatum_encodes_without_panic(meta in arb_metadatum()) {
+        let encoded = encode_metadatum(&meta);
+        prop_assert!(!encoded.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionMetadatum::Int round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_metadatum_int_roundtrip(n in -1_000_000_000i128..1_000_000_000i128) {
+        let meta = TransactionMetadatum::Int(n);
+        let encoded = encode_metadatum(&meta);
+        let (decoded, consumed) = decode_cbor_int(&encoded).unwrap();
+        prop_assert_eq!(decoded, n);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionMetadatum::Bytes round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_metadatum_bytes_roundtrip(bytes in prop::collection::vec(any::<u8>(), 0..=64)) {
+        let meta = TransactionMetadatum::Bytes(bytes.clone());
+        let encoded = encode_metadatum(&meta);
+        let (decoded, consumed) = decode_cbor_bytes(&encoded).unwrap();
+        prop_assert_eq!(decoded, bytes);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // TransactionMetadatum::Text round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_metadatum_text_roundtrip(text in "[a-zA-Z0-9 ]{0,64}") {
+        let meta = TransactionMetadatum::Text(text.clone());
+        let encoded = encode_metadatum(&meta);
+        let (decoded, consumed) = decode_cbor_text(&encoded).unwrap();
+        prop_assert_eq!(decoded, text);
+        prop_assert_eq!(consumed, encoded.len());
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_bool round-trip
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_bool_roundtrip(value in any::<bool>()) {
+        let encoded = encode_bool(value);
+        prop_assert_eq!(encoded.len(), 1);
+        let decoded = match encoded[0] {
+            0xf5 => true,
+            0xf4 => false,
+            _ => panic!("unexpected bool encoding"),
+        };
+        prop_assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_array_header: correct CBOR encoding
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_array_header_valid(len in 0usize..=1000) {
+        let encoded = encode_array_header(len);
+        // Verify CBOR major type 4 (array)
+        prop_assert_eq!(encoded[0] >> 5, 4);
+        // Decode the length
+        let additional = encoded[0] & 0x1f;
+        let decoded_len = if additional < 24 {
+            additional as usize
+        } else if additional == 24 {
+            encoded[1] as usize
+        } else if additional == 25 {
+            u16::from_be_bytes([encoded[1], encoded[2]]) as usize
+        } else {
+            panic!("unexpected array header size");
+        };
+        prop_assert_eq!(decoded_len, len);
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_map_header: correct CBOR encoding
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_map_header_valid(len in 0usize..=1000) {
+        let encoded = encode_map_header(len);
+        // Verify CBOR major type 5 (map)
+        prop_assert_eq!(encoded[0] >> 5, 5);
+        // Decode the length
+        let additional = encoded[0] & 0x1f;
+        let decoded_len = if additional < 24 {
+            additional as usize
+        } else if additional == 24 {
+            encoded[1] as usize
+        } else if additional == 25 {
+            u16::from_be_bytes([encoded[1], encoded[2]]) as usize
+        } else {
+            panic!("unexpected map header size");
+        };
+        prop_assert_eq!(decoded_len, len);
+    }
+
+    // -----------------------------------------------------------------------
+    // encode_tag: correct CBOR encoding
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_tag_valid(tag in 0u64..=65535) {
+        let encoded = encode_tag(tag);
+        // Verify CBOR major type 6 (tag)
+        prop_assert_eq!(encoded[0] >> 5, 6);
+        // Decode the tag value
+        let additional = encoded[0] & 0x1f;
+        let decoded_tag = if additional < 24 {
+            additional as u64
+        } else if additional == 24 {
+            encoded[1] as u64
+        } else if additional == 25 {
+            u16::from_be_bytes([encoded[1], encoded[2]]) as u64
+        } else {
+            panic!("unexpected tag encoding for {}", tag);
+        };
+        prop_assert_eq!(decoded_tag, tag);
+    }
+
+    // -----------------------------------------------------------------------
+    // Encode/decode idempotence: encoding the same value twice gives same bytes
+    // -----------------------------------------------------------------------
+    #[test]
+    fn prop_encode_uint_deterministic(value in any::<u64>()) {
+        let a = encode_uint(value);
+        let b = encode_uint(value);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prop_encode_int_deterministic(value in -1_000_000_000_000i128..1_000_000_000_000i128) {
+        let a = encode_int(value);
+        let b = encode_int(value);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prop_encode_hash32_deterministic(hash in arb_hash32()) {
+        let a = encode_hash32(&hash);
+        let b = encode_hash32(&hash);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prop_encode_plutus_data_deterministic(data in arb_plutus_data()) {
+        let a = encode_plutus_data(&data);
+        let b = encode_plutus_data(&data);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prop_encode_value_deterministic(value in arb_value()) {
+        let a = encode_value(&value);
+        let b = encode_value(&value);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn prop_encode_metadatum_deterministic(meta in arb_metadatum()) {
+        let a = encode_metadatum(&meta);
+        let b = encode_metadatum(&meta);
+        prop_assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary
- Add 59 property-based tests using `proptest` across `torsten-serialization` (31 tests) and `torsten-primitives` (28 tests)
- Verify encode-then-decode identity for all CBOR primitive types (uint, int, bytes, text, bool, array/map headers, tags)
- Verify round-trip correctness for Hash32, Hash28, Address (all Shelley types), TransactionInput, Point, Value, PlutusData, and TransactionMetadatum
- Verify encoding determinism, size invariants, and structural properties (e.g., PlutusData Constr tag ranges, Address byte lengths)

## Test plan
- [x] `cargo test -p torsten-serialization --test cbor_proptest` -- 31 tests pass
- [x] `cargo test -p torsten-primitives --test proptest_roundtrips` -- 28 tests pass
- [x] `cargo test --all --exclude torsten-integration-tests` -- all 843 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean

Closes #28