### PR TITLE
Add Phase-2 Plutus validation, P2P governor, Genesis state machine, and enhanced mempool

### DIFF
--- a/.claude/agent-memory/cardano-haskell-oracle/MEMORY.md
+++ b/.claude/agent-memory/cardano-haskell-oracle/MEMORY.md
@@ -68,6 +68,7 @@
 - [utxo-hd-snapshot-format.md](utxo-hd-snapshot-format.md) - UTxO-HD in-memory backend snapshot: version wrapper array(2)[1,ext], HFC telescope, per-era version array(2)[2,...], NewEpochState array(7), EMPTY UTxO in state file, tables written separately
 - [query-version2-wire-format.md](query-version2-wire-format.md) - QueryVersion2 three-level nesting: Query(tag 0-4) → HFC(tag 0-2) → NS(era_idx, shelley_tag), EitherMismatch wrapping rules, golden test hex values
 - [ledger-peer-snapshot-encoding.md](ledger-peer-snapshot-encoding.md) - GetLedgerPeerSnapshot (tag 34): V1/V2/V3 wire format, relay CBOR, Rational encoding, big vs all peers
+- [genesis-bootstrap-protocol.md](genesis-bootstrap-protocol.md) - Ouroboros Genesis bootstrap: GSM (PreSyncing/Syncing/CaughtUp), LoE/GDD, CSJ, bootstrap peers, FetchModeGenesis, peer targets, HAA, caught-up detection
 
 ## N2C Key Facts
 - Shelley query CBOR tags: 40 queries (0-39), see n2c-protocol-details.md
@@ -88,6 +89,12 @@
 - CDDL specs: `cardano-diffusion/protocols/cddl/specs/`
 - Diffusion config: `cardano-diffusion/lib/Cardano/Network/Diffusion/Configuration.hs`
 - KeepAlive client: `ouroboros-network/lib/Ouroboros/Network/KeepAlive.hs`
+
+## Mempool Implementation
+- See [mempool-implementation.md](mempool-implementation.md) - FIFO ordering (NOT fee-based), StrictFingerTree, dual-FIFO fairness, multi-dimensional capacity, revalidation, snapshotting
+
+## P2P Governor
+- See [p2p-governor-architecture.md](p2p-governor-architecture.md) - Complete governor architecture: state machine, targets, churn, promotion/demotion, big ledger peers, connection manager, all constants
 
 ## N2N Protocol Status (cardano-node 10.6.2)
 - Active versions: V14 (Plomin HF, mandatory), V15 (SRV DNS)

--- a/.claude/agent-memory/cardano-haskell-oracle/genesis-bootstrap-protocol.md
+++ b/.claude/agent-memory/cardano-haskell-oracle/genesis-bootstrap-protocol.md
@@ -1,0 +1,44 @@
+---
+name: genesis-bootstrap-protocol
+description: Ouroboros Genesis bootstrap implementation — GSM state machine, LoE/GDD, CSJ, bootstrap peers, peer targets, FetchMode, caught-up detection
+type: reference
+---
+
+# Ouroboros Genesis Bootstrap Protocol Implementation
+
+## Key Files
+
+### GSM (Genesis State Machine)
+- GsmState type: `ouroboros-consensus/src/.../Node/GsmState.hs` — PreSyncing | Syncing | CaughtUp
+- GSM logic: `ouroboros-consensus-diffusion/src/.../Node/GSM.hs` — state transitions, marker file, durationUntilTooOld
+- Genesis config: `ouroboros-consensus-diffusion/src/.../Node/Genesis.hs` — GenesisConfig, LoEAndGDDConfig, CSJConfig, LoP
+- NodeKernel wiring: `ouroboros-consensus-diffusion/src/.../NodeKernel.hs` — lines 310-390
+
+### Network Layer
+- ConsensusMode: `cardano-diffusion/api/lib/Cardano/Network/ConsensusMode.hs` — GenesisMode | PraosMode
+- LedgerStateJudgement: `cardano-diffusion/api/lib/Cardano/Network/LedgerStateJudgement.hs` — YoungEnough | TooOld
+- Bootstrap peers: `cardano-diffusion/api/lib/Cardano/Network/PeerSelection/Bootstrap.hs` — UseBootstrapPeers, requiresBootstrapPeers
+- FetchMode: `cardano-diffusion/api/lib/Cardano/Network/FetchMode.hs` — FetchModeGenesis | PraosFetchMode
+- OutboundConnectionsState: `cardano-diffusion/lib/Cardano/Network/PeerSelection/Governor/Types.hs` — TrustedStateWithExternalPeers | UntrustedState
+- Churn governor: `cardano-diffusion/lib/Cardano/Network/PeerSelection/Churn.hs`
+- Sync targets: `cardano-diffusion/lib/Cardano/Network/Diffusion/Configuration.hs` — defaultSyncTargets
+
+### Genesis-specific Components
+- GDD (Genesis Density Disconnector): `ouroboros-consensus/src/.../Genesis/Governor.hs` — densityDisconnect, gddWatcher
+- CSJ (ChainSync Jumping): `ouroboros-consensus/src/.../ChainSync/Client/Jumping.hs`
+- Genesis block fetch: `ouroboros-network/lib/.../BlockFetch/Decision/Genesis.hs` — fetchDecisionsGenesisM
+- LoE (Limit on Eagerness): configured via ChainDB.cdbsLoE, managed by setGetLoEFragment
+
+### Topology
+- TopologyP2P: `cardano-node/src/.../Configuration/TopologyP2P.hs` — bootstrapPeers field, trustable flag
+
+## Constants
+- maxCaughtUpAge: 20 minutes (1200s)
+- defaultSyncTargets: 40 established BLPs, 30 active BLPs, 10 established, 5 active
+- defaultNumBootstrapPeers: 30
+- minNumberOfBigLedgerPeers (for HAA): 5
+- CSJ default jump size: 2*2160 = 4320 slots (Byron forecast range)
+- LoP bucket: 100K tokens, 500 tokens/sec leak rate
+- GDD rate limit: 1.0s
+- BlockFetch grace period: 10s
+- Anti-thundering-herd: random 0-300s bonus on CaughtUp→PreSyncing transition

--- a/.claude/agent-memory/cardano-haskell-oracle/mempool-implementation.md
+++ b/.claude/agent-memory/cardano-haskell-oracle/mempool-implementation.md
@@ -1,0 +1,69 @@
+---
+name: Haskell Mempool Implementation Details
+description: Complete analysis of cardano-node mempool ordering, data structures, capacity, fairness, revalidation, and block production snapshotting
+type: reference
+---
+
+## Key Files
+- `ouroboros-consensus/src/.../Mempool/API.hs` — Public interface, Mempool record type, MempoolSnapshot, fairness docs
+- `ouroboros-consensus/src/.../Mempool/TxSeq.hs` — StrictFingerTree data structure, TxTicket, splitting by size/ticket
+- `ouroboros-consensus/src/.../Mempool/Impl/Common.hs` — InternalState (IS), validation, revalidation, snapshotFromIS
+- `ouroboros-consensus/src/.../Mempool/Update.hs` — implAddTx (fairness MVars), doAddTx, pureTryAddTx, implSyncWithLedger
+- `ouroboros-consensus/src/.../Mempool/Capacity.hs` — MempoolCapacityBytesOverride, computeMempoolCapacity (2x block capacity)
+- `ouroboros-consensus/src/.../Mempool/Init.hs` — openMempool, background sync watcher thread
+- `ouroboros-consensus/src/.../Mempool/Query.hs` — implGetSnapshotFor (forging snapshot)
+- `ouroboros-consensus/src/.../Ledger/SupportsMempool.hs` — TxLimits class, TxMeasure, LedgerSupportsMempool class
+- `ouroboros-consensus-cardano/src/shelley/.../Mempool.hs` — ConwayMeasure (bytes+ExUnits+refScripts), AlonzoMeasure
+- `ouroboros-consensus-diffusion/src/.../NodeKernel.hs` — Block forging uses getSnapshotFor + snapshotTake
+
+## Core Design: FIFO Ordering, NO Fee-Based Prioritization
+- Mempool is a **strict FIFO list** (not fee-ordered)
+- Transactions validated in insertion order against cumulative ledger state
+- No fee/size ratio sorting, no priority queue
+- Block production takes **longest valid prefix** that fits in block capacity
+
+## Data Structure: StrictFingerTree
+- `TxSeq sz tx = StrictFingerTree (TxSeqMeasure sz) (TxTicket sz tx)`
+- Measure tracks: count, minTicket, maxTicket, cumulative size
+- O(1) append, O(log n) split by ticket or by cumulative size
+- Each tx gets monotonically increasing TicketNo (Word64)
+
+## Capacity: Multi-dimensional Measure (Conway)
+- ConwayMeasure = { byteSize: Word32, exUnits: {mem: Natural, steps: Natural}, refScriptsSize: Word32 }
+- Default capacity = 2x block capacity (each dimension independently)
+- Can override bytes only via MempoolCapacityBytesOverride (rounds up to whole blocks)
+- NEW: DiffTimeMeasure tracks cumulative validation time (mempoolTimeoutCapacity)
+
+## Fairness: Dual-FIFO MVar Design
+- Two MVars: `remoteFifo` and `allFifo`
+- Remote peers must acquire BOTH (remoteFifo then allFifo)
+- Local clients only acquire `allFifo` (skip remoteFifo)
+- Effect: local client = weight of ALL remote peers combined
+- Per-tx granularity (not per-batch)
+
+## Timeout Defense (post-Conway)
+- mempoolTimeoutSoft: reject tx if validation takes longer (don't add to mempool)
+- mempoolTimeoutHard: disconnect peer if validation exceeds this
+- mempoolTimeoutCapacity: cumulative validation time limit for mempool fullness
+
+## Block Production Snapshot
+1. Forging thread calls `getSnapshotFor(slot, tickedLedgerState, readTables)`
+2. If state matches cached, returns cached snapshot; otherwise revalidates all txs
+3. `snapshotTake(blockCapacity)` uses `splitAfterTxSize` — O(log n) finger tree split
+4. Returns longest prefix where cumulative measure <= block capacity (all dimensions)
+
+## Revalidation (on new block)
+- Background watcher thread detects tip change via STM
+- `implSyncWithLedger` revalidates ALL mempool txs against new ledger state
+- Invalid txs dropped, valid txs kept in original order with original ticket numbers
+- Revalidation uses `reapplyTx` (cheaper than full `applyTx` — skips crypto checks)
+
+## Transaction Dependencies
+- Supported naturally: tx B spending tx A's output works if A is added first
+- A's state changes are in the cumulative ledger state when B is validated
+- No explicit dependency graph — ordering is purely insertion order
+
+## No Eviction
+- No eviction policy — mempool never removes valid transactions
+- When capacity shrinks (protocol param change), existing txs stay until naturally invalidated
+- `addTx` blocks (retries) when mempool is at capacity, until space freed by revalidation

--- a/.claude/agent-memory/cardano-haskell-oracle/p2p-governor-architecture.md
+++ b/.claude/agent-memory/cardano-haskell-oracle/p2p-governor-architecture.md
@@ -1,0 +1,97 @@
+---
+name: P2P Governor Architecture
+description: Complete P2P Peer Selection Governor architecture from ouroboros-network - state machine, targets, churn, promotion/demotion logic, big ledger peers, connection manager
+type: reference
+---
+
+# P2P Governor Architecture Reference
+
+## Source Files (ouroboros-network repo, main branch)
+
+### Core Governor
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor.hs` — main loop (peerSelectionGovernor, peerSelectionGovernorLoop)
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/Types.hs` — PeerSelectionState, PeerSelectionTargets, PeerSelectionPolicy, PeerSelectionActions
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs` — cold peer discovery, peer share requests
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs` — cold→warm promotion, warm→cold demotion
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/ActivePeers.hs` — warm→hot promotion, hot→warm demotion
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs` — big ledger peer management
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs` — public root peer fetching
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/Monitor.hs` — connection monitoring, target/local roots changes
+
+### State Data Structures
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/KnownPeers.hs` — KnownPeers, KnownPeerInfo (failCount, tepid, sharing)
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs` — EstablishedPeers (connections, peer share times, activate times)
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/State/LocalRootPeers.hs` — LocalRootPeers (groups with HotValency/WarmValency)
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/PublicRootPeers.hs` — PublicRootPeers (ledger, bigLedger, extra)
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Types.hs` — PeerStatus, PeerSource
+
+### Churn
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/Churn.hs` — generic churn loop
+- `cardano-diffusion/lib/Cardano/Network/PeerSelection/Churn.hs` — Cardano-specific churn with mode awareness
+
+### Connection Manager
+- `ouroboros-network/framework/lib/Ouroboros/Network/ConnectionManager/Core.hs` — connection state machine, pruning
+- `ouroboros-network/framework/lib/Ouroboros/Network/ConnectionManager/State.hs` — ConnectionState constructors
+- `ouroboros-network/framework/lib/Ouroboros/Network/ConnectionManager/Types.hs` — AbstractState, OperationResult, DataFlow, Provenance
+
+### Inbound Governor
+- `ouroboros-network/framework/lib/Ouroboros/Network/InboundGovernor.hs` — inbound connection management, maturity
+
+### Bridge (Governor → ConnectionManager)
+- `ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs` — maps governor decisions to actual connection operations
+
+### Peer Sharing
+- `ouroboros-network/lib/Ouroboros/Network/PeerSharing.hs` — PeerSharingController, PeerSharingRegistry, computePeerSharingPeers
+
+### Cardano-specific
+- `cardano-diffusion/lib/Cardano/Network/PeerSelection/Governor/PeerSelectionState.hs` — ExtraState (ledgerStateJudgement, bootstrapPeersFlag, etc.)
+- `cardano-diffusion/lib/Cardano/Network/PeerSelection/Governor/Monitor.hs` — bootstrap monitoring, LSJ transitions, target mode switching
+- `cardano-diffusion/lib/Cardano/Network/PeerSelection/ExtraRootPeers.hs` — ExtraPeers (publicConfigPeers, bootstrapPeers)
+- `cardano-diffusion/lib/Cardano/Network/Diffusion/Configuration.hs` — default targets, connection limits
+- `ouroboros-network/lib/Ouroboros/Network/Diffusion/Configuration.hs` — Praos default targets, churn intervals
+- `ouroboros-network/lib/Ouroboros/Network/Diffusion/Policies.hs` — timeout constants, policy functions
+
+## Key Constants
+
+### Default Targets (Praos Relay)
+- rootPeers=60, knownPeers=150, establishedPeers=30, activePeers=20
+- knownBigLedger=15, establishedBigLedger=10, activeBigLedger=5
+
+### Default Targets (Praos BlockProducer)
+- rootPeers=100, knownPeers=100, establishedPeers=30, activePeers=20
+- knownBigLedger=15, establishedBigLedger=10, activeBigLedger=5
+
+### Default Targets (Sync Mode - cardano-diffusion)
+- rootPeers=0, knownPeers=150, establishedPeers=10, activePeers=5
+- knownBigLedger=100, establishedBigLedger=40, activeBigLedger=30
+
+### Churn Intervals
+- deadlineChurnInterval=3300s (55min), bulkChurnInterval=900s (15min)
+- Churn removes ~20% of peers per cycle: max(0, v - max(u, max(1, v/5)))
+
+### Policy Timeouts
+- findPublicRootTimeout=5s, peerShareRetryTime=900s (15min)
+- peerShareBatchWaitTime=3s, peerShareOverallTimeout=10s
+- peerShareActivationDelay=300s (5min), maxConnectionRetries=5
+- clearFailCountDelay=120s (2min)
+
+### Connection Limits
+- acceptedConnectionsHardLimit=512, softLimit=384, delay=5s
+- deactivateTimeout=300s (5min), closeConnectionTimeout=120s (2min)
+- churnEstablishConnectionTimeout=60s
+
+### Peer Sharing
+- stickyTime=823s, maxPeersPerResponse=10
+- maxInProgressPeerShareReqs=2
+
+### Big Ledger Peers
+- bigLedgerPeerQuota=0.9 (top 90% of stake)
+- Backoff: exponential 2^n, capped at 2^8 (~4min)
+
+### Cold Peer Retry
+- baseColdPeerRetryDiffTime=5s, maxColdPeerRetryBackoff=2^5
+- Random fuzz ±2s added
+
+### Inbound Governor
+- inboundMaturePeerDelay=15min (900s)
+- inactionTimeout=31.4s

--- a/crates/torsten-ledger/src/lib.rs
+++ b/crates/torsten-ledger/src/lib.rs
@@ -8,9 +8,9 @@ pub mod utxo_store;
 pub mod validation;
 
 pub use plutus::{evaluate_plutus_scripts, PlutusError, SlotConfig};
-pub use state::LedgerState;
 #[doc(hidden)]
 pub use state::Rat;
+pub use state::{BlockValidationMode, LedgerState};
 pub use utxo::UtxoSet;
 pub use utxo_diff::{DiffSeq, UtxoDiff};
 pub use utxo_store::UtxoStore;

--- a/crates/torsten-ledger/src/state/mod.rs
+++ b/crates/torsten-ledger/src/state/mod.rs
@@ -14,8 +14,9 @@ pub(crate) use governance::{
 #[doc(hidden)]
 pub use rewards::Rat;
 
-use crate::plutus::SlotConfig;
+use crate::plutus::{evaluate_plutus_scripts, SlotConfig};
 use crate::utxo::UtxoSet;
+use crate::validation::{validate_transaction, ValidationError};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -39,6 +40,18 @@ pub const MAX_LOVELACE_SUPPLY: u64 = 45_000_000_000_000_000;
 /// Maximum allowed snapshot file size (10 GiB).
 /// Prevents OOM from loading maliciously crafted or corrupted snapshot files.
 pub const MAX_SNAPSHOT_SIZE: usize = 10 * 1024 * 1024 * 1024;
+
+/// Controls whether `apply_block()` re-evaluates Plutus scripts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockValidationMode {
+    /// Full Phase-1 + Phase-2 Plutus evaluation for new network blocks.
+    /// Rejects the block if the `is_valid` flag doesn't match the actual
+    /// script evaluation result (`ValidationTagMismatch`).
+    ValidateAll,
+    /// Trust the block producer's `is_valid` flag without re-evaluating scripts.
+    /// Used for ImmutableDB replay, Mithril import, rollback replay, and self-forged blocks.
+    ApplyOnly,
+}
 
 fn default_update_quorum() -> u64 {
     5 // Mainnet default: 5 out of 7 genesis delegates
@@ -484,8 +497,16 @@ impl LedgerState {
         );
     }
 
-    /// Apply a block to the ledger state
-    pub fn apply_block(&mut self, block: &Block) -> Result<(), LedgerError> {
+    /// Apply a block to the ledger state.
+    ///
+    /// When `mode` is `ValidateAll`, each transaction is independently validated
+    /// (Phase-1 + Phase-2 Plutus evaluation) and the result is compared against
+    /// the block producer's `is_valid` flag. A mismatch rejects the block.
+    pub fn apply_block(
+        &mut self,
+        block: &Block,
+        mode: BlockValidationMode,
+    ) -> Result<(), LedgerError> {
         trace!(
             slot = block.slot().0,
             block_no = block.block_number().0,
@@ -564,6 +585,13 @@ impl LedgerState {
             );
         }
 
+        // Pre-compute cost_models CBOR once per block (doesn't change within a block)
+        let cost_models_cbor = if mode == BlockValidationMode::ValidateAll {
+            self.protocol_params.cost_models.to_cbor()
+        } else {
+            None
+        };
+
         // Track processed tx hashes to skip duplicates within a block
         let mut processed_tx_hashes =
             std::collections::HashSet::with_capacity(block.transactions.len());
@@ -578,6 +606,69 @@ impl LedgerState {
                 );
                 continue;
             }
+            // Phase-1 + Phase-2 validation when ValidateAll mode is active.
+            // Verifies the block producer's is_valid flag matches actual evaluation.
+            if mode == BlockValidationMode::ValidateAll {
+                let has_redeemers = !tx.witness_set.redeemers.is_empty();
+
+                if tx.is_valid {
+                    // Producer claims tx is valid — verify with full validation.
+                    // Use tx raw_cbor size as tx_size (approximate, sufficient for validation).
+                    let tx_size = tx.raw_cbor.as_ref().map_or(0, |c| c.len() as u64);
+                    let result = validate_transaction(
+                        tx,
+                        &self.utxo_set,
+                        &self.protocol_params,
+                        block.slot().0,
+                        tx_size,
+                        Some(&self.slot_config),
+                    );
+                    if let Err(errors) = result {
+                        // Distinguish Phase-1 failures from Phase-2 (script) failures
+                        let has_script_failure = errors
+                            .iter()
+                            .any(|e| matches!(e, ValidationError::ScriptFailed(_)));
+                        if has_script_failure {
+                            // Producer said valid but scripts fail → ValidationTagMismatch
+                            return Err(LedgerError::ValidationTagMismatch {
+                                tx_hash: tx.hash.to_hex(),
+                                block_flag: true,
+                                eval_result: false,
+                            });
+                        }
+                        // Phase-1 failure — block is invalid
+                        let err_str: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+                        return Err(LedgerError::BlockTxValidationFailed {
+                            slot: block.slot().0,
+                            tx_hash: tx.hash.to_hex(),
+                            errors: err_str.join("; "),
+                        });
+                    }
+                } else if has_redeemers {
+                    // Producer claims tx is invalid (is_valid=false) with scripts present.
+                    // Verify scripts actually fail; if they pass, producer is stealing collateral.
+                    let max_ex = (
+                        self.protocol_params.max_tx_ex_units.mem,
+                        self.protocol_params.max_tx_ex_units.steps,
+                    );
+                    let eval_result = evaluate_plutus_scripts(
+                        tx,
+                        &self.utxo_set,
+                        cost_models_cbor.as_deref(),
+                        max_ex,
+                        &self.slot_config,
+                    );
+                    if eval_result.is_ok() {
+                        // Scripts actually pass but producer says invalid → mismatch
+                        return Err(LedgerError::ValidationTagMismatch {
+                            tx_hash: tx.hash.to_hex(),
+                            block_flag: false,
+                            eval_result: true,
+                        });
+                    }
+                }
+            }
+
             // Handle invalid transactions (phase-2 validation failure):
             // - Collateral inputs are consumed (forfeit to block producer)
             // - Regular inputs/outputs/certificates are NOT applied
@@ -1012,6 +1103,18 @@ pub enum LedgerError {
     EpochTransition(String),
     #[error("Invalid protocol parameter: {0}")]
     InvalidProtocolParam(String),
+    #[error("Validation tag mismatch for tx {tx_hash}: block flag is_valid={block_flag} but evaluation result is_valid={eval_result}")]
+    ValidationTagMismatch {
+        tx_hash: String,
+        block_flag: bool,
+        eval_result: bool,
+    },
+    #[error("Transaction validation failed at slot {slot} tx {tx_hash}: {errors}")]
+    BlockTxValidationFailed {
+        slot: u64,
+        tx_hash: String,
+        errors: String,
+    },
 }
 
 #[cfg(test)]
@@ -1171,7 +1274,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // The genesis UTxO should be spent, new one created
         assert_eq!(state.utxo_set.len(), 1);
@@ -1247,7 +1352,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // UTxO should be unchanged since tx was invalid
         assert_eq!(state.utxo_set.len(), 1);
@@ -1448,12 +1555,16 @@ mod tests {
 
         // Apply a block in epoch 0
         let block = make_test_block(50, 1, Hash32::ZERO, vec![]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
         assert_eq!(state.epoch, EpochNo(0));
 
         // Apply a block in epoch 1 (slot 100+)
         let block = make_test_block(150, 2, *block.hash(), vec![]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
         assert_eq!(state.epoch, EpochNo(1));
         assert!(state.snapshots.mark.is_some());
     }
@@ -1530,7 +1641,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         assert_eq!(state.epoch_fees, Lovelace(200_000));
     }
@@ -1946,7 +2059,9 @@ mod tests {
         let mut block = make_test_block(10, 1, Hash32::ZERO, vec![]);
         block.header.vrf_result.output = vec![42u8; 32];
         block.header.issuer_vkey = vec![1u8; 32];
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Evolving nonce should have been updated
         assert_ne!(state.evolving_nonce, genesis_hash);
@@ -1961,7 +2076,9 @@ mod tests {
         let mut block2 = make_test_block(70, 2, *block.hash(), vec![]);
         block2.header.vrf_result.output = vec![99u8; 32];
         block2.header.issuer_vkey = vec![1u8; 32];
-        state.apply_block(&block2).unwrap();
+        state
+            .apply_block(&block2, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Evolving nonce should STILL update (always updates)
         assert_ne!(state.evolving_nonce, evolving_before);
@@ -2481,7 +2598,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         assert_eq!(state.treasury, Lovelace(1_000_000));
     }
@@ -4415,7 +4534,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // The staking credential should have stake = 7_000_000 (output) - 0 (initial was never tracked as registered)
         // Actually: genesis UTxO was not tracked (inserted directly), but the output is tracked.
@@ -5003,7 +5124,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Fee should be the collateral amount (5 ADA), NOT the declared fee (0.2 ADA)
         assert_eq!(state.epoch_fees, Lovelace(5_000_000));
@@ -5085,7 +5208,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Fee should be 10M - 7M = 3M (collateral forfeited), NOT 500_000 (declared fee)
         assert_eq!(state.epoch_fees, Lovelace(3_000_000));
@@ -5156,7 +5281,9 @@ mod tests {
         };
 
         let block = make_test_block(100, 1, Hash32::ZERO, vec![tx]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Fee should be the explicit total_collateral value
         assert_eq!(state.epoch_fees, Lovelace(2_500_000));
@@ -5523,7 +5650,9 @@ mod tests {
 
         // Skip from epoch 0 directly to epoch 5 via a block at slot 500
         let block = make_test_block(500, 1, Hash32::ZERO, vec![]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Both pools should be retired since we should have processed
         // epochs 1, 2, 3, 4, and 5
@@ -5573,7 +5702,9 @@ mod tests {
 
         // Skip from epoch 0 directly to epoch 4 (4 transitions)
         let block = make_test_block(400, 1, Hash32::ZERO, vec![]);
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         assert_eq!(state.epoch, EpochNo(4));
         // After 4 transitions: mark, set, and go should all be populated
@@ -6190,7 +6321,9 @@ mod tests {
 
         // This should NOT panic; the candidate nonce should be frozen
         // because the extreme slot is definitely in the stabilisation window.
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
 
         // Evolving nonce updated (always updates)
         assert_ne!(state.evolving_nonce, genesis_hash);
@@ -6236,7 +6369,9 @@ mod tests {
         let mut block = make_test_block(59, 1, Hash32::ZERO, vec![]);
         block.header.vrf_result.output = vec![42u8; 32];
         block.header.issuer_vkey = vec![1u8; 32];
-        state.apply_block(&block).unwrap();
+        state
+            .apply_block(&block, BlockValidationMode::ApplyOnly)
+            .unwrap();
         assert_eq!(state.candidate_nonce, state.evolving_nonce);
 
         // Slot 60 is the FIRST slot in the stabilisation window
@@ -6245,7 +6380,9 @@ mod tests {
         let mut block2 = make_test_block(60, 2, *block.hash(), vec![]);
         block2.header.vrf_result.output = vec![99u8; 32];
         block2.header.issuer_vkey = vec![1u8; 32];
-        state.apply_block(&block2).unwrap();
+        state
+            .apply_block(&block2, BlockValidationMode::ApplyOnly)
+            .unwrap();
         assert_eq!(state.candidate_nonce, candidate_before);
         assert_ne!(state.evolving_nonce, candidate_before);
     }

--- a/crates/torsten-mempool/src/lib.rs
+++ b/crates/torsten-mempool/src/lib.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::collections::{BTreeSet, VecDeque};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use torsten_primitives::hash::TransactionHash;
 use torsten_primitives::time::SlotNo;
 use torsten_primitives::transaction::Transaction;
@@ -15,6 +15,12 @@ pub struct MempoolConfig {
     pub max_transactions: usize,
     /// Maximum total size in bytes
     pub max_bytes: usize,
+    /// Maximum total execution memory units (sum of all tx redeemers)
+    pub max_ex_mem: u64,
+    /// Maximum total execution step units (sum of all tx redeemers)
+    pub max_ex_steps: u64,
+    /// Maximum total reference script bytes
+    pub max_ref_scripts_bytes: usize,
 }
 
 impl Default for MempoolConfig {
@@ -22,8 +28,24 @@ impl Default for MempoolConfig {
         MempoolConfig {
             max_transactions: 16_384,
             max_bytes: 512 * 1024 * 1024, // 512 MB
+            // 2x block limits (matching Haskell cardano-node defaults)
+            max_ex_mem: 28_000_000_000,       // 2 * 14B mem
+            max_ex_steps: 20_000_000_000_000, // 2 * 10T steps
+            max_ref_scripts_bytes: 1_048_576, // 1 MB
         }
     }
+}
+
+/// Origin of a transaction submission — used for dual-FIFO fairness.
+///
+/// Local clients (wallets connected via N2C) get equal weight to ALL remote
+/// peers combined, matching Haskell's cardano-node fairness model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxOrigin {
+    /// From a local client (N2C connection)
+    Local,
+    /// From a remote peer (N2N connection)
+    Remote,
 }
 
 /// Fee density key for sorted index ordering.
@@ -80,6 +102,9 @@ struct MempoolEntry {
     tx_hash: TransactionHash,
     size_bytes: usize,
     fee: Lovelace,
+    ex_units_mem: u64,
+    ex_units_steps: u64,
+    ref_scripts_bytes: usize,
 }
 
 /// The transaction mempool
@@ -91,6 +116,14 @@ struct MempoolEntry {
 /// Maintains a sorted index by fee density (fee/byte) descending for
 /// efficient block production. The index uses cross-multiplication
 /// comparison to avoid precision loss from integer division.
+///
+/// Capacity is enforced across multiple dimensions: transaction count,
+/// total bytes, execution units (mem + steps), and reference script bytes.
+/// When full, lowest-fee-density transactions are evicted to make room
+/// for higher-density newcomers.
+///
+/// Dual-FIFO fairness ensures local clients get equal admission weight
+/// to all remote peers combined.
 pub struct Mempool {
     /// Transactions indexed by hash
     txs: DashMap<TransactionHash, MempoolEntry>,
@@ -100,12 +133,22 @@ pub struct Mempool {
     fee_index: RwLock<BTreeSet<FeeDensityKey>>,
     /// Current total size
     total_bytes: RwLock<usize>,
+    /// Current total execution memory units
+    total_ex_mem: AtomicU64,
+    /// Current total execution step units
+    total_ex_steps: AtomicU64,
+    /// Current total reference script bytes
+    total_ref_scripts_bytes: AtomicUsize,
     /// Atomic transaction count for race-free capacity checks.
     /// The count is reserved (incremented) before inserting into the DashMap,
     /// preventing the TOCTOU race between `txs.len()` and `txs.insert()`.
     tx_count: AtomicUsize,
     /// Configuration
     config: MempoolConfig,
+    /// Fairness mutex for remote submissions — all remote peers compete for this first
+    remote_fifo: Mutex<()>,
+    /// Fairness mutex for all submissions — local acquires only this, remote acquires both
+    all_fifo: Mutex<()>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -118,6 +161,8 @@ pub enum MempoolError {
     TooLarge { size: usize },
     #[error("Validation error: {0}")]
     ValidationFailed(String),
+    #[error("Insufficient priority: new tx fee density too low to evict existing transactions")]
+    InsufficientPriority,
 }
 
 /// Result of adding a transaction
@@ -134,8 +179,13 @@ impl Mempool {
             order: RwLock::new(VecDeque::new()),
             fee_index: RwLock::new(BTreeSet::new()),
             total_bytes: RwLock::new(0),
+            total_ex_mem: AtomicU64::new(0),
+            total_ex_steps: AtomicU64::new(0),
+            total_ref_scripts_bytes: AtomicUsize::new(0),
             tx_count: AtomicUsize::new(0),
             config,
+            remote_fifo: Mutex::new(()),
+            all_fifo: Mutex::new(()),
         }
     }
 
@@ -158,10 +208,78 @@ impl Mempool {
         size_bytes: usize,
         fee: Lovelace,
     ) -> Result<MempoolAddResult, MempoolError> {
+        self.add_tx_full(tx_hash, tx, size_bytes, fee, 0, 0, 0, TxOrigin::Local)
+    }
+
+    /// Add a transaction with full multi-dimensional capacity tracking and fairness.
+    ///
+    /// This is the primary admission method. All dimensions (count, bytes, ExUnits,
+    /// reference scripts) are checked. If any dimension is exceeded, the mempool
+    /// attempts to evict lowest-fee-density transactions to make room — but only
+    /// if the new tx has higher fee density than the worst existing tx.
+    ///
+    /// The `origin` parameter controls dual-FIFO fairness: remote submissions are
+    /// serialized through an additional mutex so local clients get equal weight.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_tx_full(
+        &self,
+        tx_hash: TransactionHash,
+        tx: Transaction,
+        size_bytes: usize,
+        fee: Lovelace,
+        ex_units_mem: u64,
+        ex_units_steps: u64,
+        ref_scripts_bytes: usize,
+        origin: TxOrigin,
+    ) -> Result<MempoolAddResult, MempoolError> {
+        // Dual-FIFO fairness: remote acquires remote_fifo then all_fifo,
+        // local acquires only all_fifo. This gives local clients equal weight
+        // to ALL remote peers combined.
+        let _remote_guard = if origin == TxOrigin::Remote {
+            Some(self.remote_fifo.lock())
+        } else {
+            None
+        };
+        let _all_guard = self.all_fifo.lock();
+
+        self.add_tx_inner(
+            tx_hash,
+            tx,
+            size_bytes,
+            fee,
+            ex_units_mem,
+            ex_units_steps,
+            ref_scripts_bytes,
+        )
+    }
+
+    /// Inner admission logic (called under fairness locks)
+    #[allow(clippy::too_many_arguments)]
+    fn add_tx_inner(
+        &self,
+        tx_hash: TransactionHash,
+        tx: Transaction,
+        size_bytes: usize,
+        fee: Lovelace,
+        ex_units_mem: u64,
+        ex_units_steps: u64,
+        ref_scripts_bytes: usize,
+    ) -> Result<MempoolAddResult, MempoolError> {
         // Check if already exists
         if self.txs.contains_key(&tx_hash) {
             trace!(hash = %tx_hash.to_hex(), "Mempool: tx already exists");
             return Ok(MempoolAddResult::AlreadyExists);
+        }
+
+        // Try eviction if any dimension would be exceeded
+        if !self.ensure_capacity(
+            size_bytes,
+            fee.0,
+            ex_units_mem,
+            ex_units_steps,
+            ref_scripts_bytes,
+        )? {
+            return Err(MempoolError::InsufficientPriority);
         }
 
         // Atomically reserve a slot: increment tx_count first, then check capacity.
@@ -195,6 +313,9 @@ impl Mempool {
             tx_hash,
             size_bytes,
             fee,
+            ex_units_mem,
+            ex_units_steps,
+            ref_scripts_bytes,
         };
 
         // Insert into fee-density sorted index
@@ -204,15 +325,111 @@ impl Mempool {
         self.txs.insert(tx_hash, entry);
         self.order.write().push_back(tx_hash);
         *self.total_bytes.write() += size_bytes;
+        self.total_ex_mem.fetch_add(ex_units_mem, Ordering::Relaxed);
+        self.total_ex_steps
+            .fetch_add(ex_units_steps, Ordering::Relaxed);
+        self.total_ref_scripts_bytes
+            .fetch_add(ref_scripts_bytes, Ordering::Relaxed);
 
         debug!(
             hash = %tx_hash.to_hex(),
             size_bytes,
+            ex_mem = ex_units_mem,
+            ex_steps = ex_units_steps,
+            ref_scripts = ref_scripts_bytes,
             total_txs = self.tx_count.load(Ordering::Relaxed),
             "Mempool: transaction added"
         );
 
         Ok(MempoolAddResult::Added)
+    }
+
+    /// Ensure capacity across all dimensions by evicting lowest-fee-density txs.
+    /// Returns Ok(true) if capacity is available, Ok(false) if eviction wasn't
+    /// possible (new tx has insufficient priority), or Err on other failures.
+    fn ensure_capacity(
+        &self,
+        new_size: usize,
+        new_fee: u64,
+        new_ex_mem: u64,
+        new_ex_steps: u64,
+        new_ref_scripts: usize,
+    ) -> Result<bool, MempoolError> {
+        loop {
+            let needs_eviction =
+                self.needs_eviction(new_size, new_ex_mem, new_ex_steps, new_ref_scripts);
+            if !needs_eviction {
+                return Ok(true);
+            }
+
+            // Find the worst (lowest fee density) tx
+            let worst = {
+                let fee_index = self.fee_index.read();
+                fee_index.iter().next_back().copied()
+            };
+
+            let worst = match worst {
+                Some(w) => w,
+                None => return Ok(true), // Empty mempool, capacity must be available
+            };
+
+            // Check if new tx has better fee density than the worst existing tx
+            let new_size_cmp = if new_size == 0 {
+                1u128
+            } else {
+                new_size as u128
+            };
+            let new_density = (new_fee as u128) * (worst.size as u128);
+            let worst_density = (worst.fee as u128) * new_size_cmp;
+            if new_density <= worst_density {
+                return Ok(false);
+            }
+
+            // Evict the worst tx
+            debug!(
+                evicted_hash = %worst.tx_hash.to_hex(),
+                evicted_fee = worst.fee,
+                evicted_size = worst.size,
+                "Mempool: evicting lowest-density tx for capacity"
+            );
+            self.remove_tx(&worst.tx_hash);
+        }
+    }
+
+    /// Check if any capacity dimension would be exceeded by adding a tx with the given resources.
+    fn needs_eviction(
+        &self,
+        new_size: usize,
+        new_ex_mem: u64,
+        new_ex_steps: u64,
+        new_ref_scripts: usize,
+    ) -> bool {
+        let count = self.tx_count.load(Ordering::Relaxed);
+        if count >= self.config.max_transactions {
+            return true;
+        }
+
+        let total_bytes = *self.total_bytes.read();
+        if total_bytes + new_size > self.config.max_bytes {
+            return true;
+        }
+
+        let total_ex_mem = self.total_ex_mem.load(Ordering::Relaxed);
+        if total_ex_mem + new_ex_mem > self.config.max_ex_mem {
+            return true;
+        }
+
+        let total_ex_steps = self.total_ex_steps.load(Ordering::Relaxed);
+        if total_ex_steps + new_ex_steps > self.config.max_ex_steps {
+            return true;
+        }
+
+        let total_ref = self.total_ref_scripts_bytes.load(Ordering::Relaxed);
+        if total_ref + new_ref_scripts > self.config.max_ref_scripts_bytes {
+            return true;
+        }
+
+        false
     }
 
     /// Remove a transaction (when included in a block)
@@ -226,6 +443,12 @@ impl Mempool {
             self.fee_index.write().remove(&key);
 
             *self.total_bytes.write() -= entry.size_bytes;
+            self.total_ex_mem
+                .fetch_sub(entry.ex_units_mem, Ordering::Relaxed);
+            self.total_ex_steps
+                .fetch_sub(entry.ex_units_steps, Ordering::Relaxed);
+            self.total_ref_scripts_bytes
+                .fetch_sub(entry.ref_scripts_bytes, Ordering::Relaxed);
             debug!(
                 hash = %tx_hash.to_hex(),
                 remaining = self.tx_count.load(Ordering::Relaxed),
@@ -303,6 +526,21 @@ impl Mempool {
     /// Total bytes used
     pub fn total_bytes(&self) -> usize {
         *self.total_bytes.read()
+    }
+
+    /// Total execution memory units across all mempool transactions
+    pub fn total_ex_mem(&self) -> u64 {
+        self.total_ex_mem.load(Ordering::Relaxed)
+    }
+
+    /// Total execution step units across all mempool transactions
+    pub fn total_ex_steps(&self) -> u64 {
+        self.total_ex_steps.load(Ordering::Relaxed)
+    }
+
+    /// Total reference script bytes across all mempool transactions
+    pub fn total_ref_scripts_bytes(&self) -> usize {
+        self.total_ref_scripts_bytes.load(Ordering::Relaxed)
     }
 
     /// Maximum number of transactions the mempool can hold
@@ -409,6 +647,40 @@ impl Mempool {
         conflicting
     }
 
+    /// Revalidate all mempool transactions against a validator closure.
+    ///
+    /// Replays transactions in FIFO order through `is_valid`. Any transaction
+    /// for which the closure returns `false` is removed. This replaces the
+    /// piecemeal post-block cleanup (remove_txs + revalidate_against_inputs +
+    /// evict_expired) with a single pass that catches all invalidity reasons.
+    ///
+    /// Returns the hashes of removed transactions.
+    pub fn revalidate_all<F>(&self, mut is_valid: F) -> Vec<TransactionHash>
+    where
+        F: FnMut(&Transaction) -> bool,
+    {
+        // Snapshot FIFO order to iterate deterministically
+        let hashes: Vec<TransactionHash> = self.order.read().iter().copied().collect();
+        let mut removed = Vec::new();
+
+        for hash in hashes {
+            let valid = self.txs.get(&hash).map(|entry| is_valid(&entry.tx));
+            if valid == Some(false) {
+                self.remove_tx(&hash);
+                removed.push(hash);
+            }
+        }
+
+        if !removed.is_empty() {
+            info!(
+                removed = removed.len(),
+                remaining = self.len(),
+                "Mempool: revalidation removed invalid transactions"
+            );
+        }
+        removed
+    }
+
     /// Clear all transactions
     pub fn clear(&self) {
         let count = self.tx_count.swap(0, Ordering::Relaxed);
@@ -416,6 +688,9 @@ impl Mempool {
         self.order.write().clear();
         self.fee_index.write().clear();
         *self.total_bytes.write() = 0;
+        self.total_ex_mem.store(0, Ordering::Relaxed);
+        self.total_ex_steps.store(0, Ordering::Relaxed);
+        self.total_ref_scripts_bytes.store(0, Ordering::Relaxed);
         if count > 0 {
             info!(removed = count, "Mempool: cleared all transactions");
         }
@@ -577,9 +852,13 @@ mod tests {
         }
     }
 
+    fn default_config() -> MempoolConfig {
+        MempoolConfig::default()
+    }
+
     #[test]
     fn test_add_and_get() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let tx = make_dummy_tx();
         let hash = Hash32::from_bytes([1u8; 32]);
 
@@ -594,7 +873,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_add() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let tx = make_dummy_tx();
         let hash = Hash32::from_bytes([1u8; 32]);
 
@@ -606,7 +885,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let tx = make_dummy_tx();
         let hash = Hash32::from_bytes([1u8; 32]);
 
@@ -624,7 +903,7 @@ mod tests {
     fn test_capacity_limit() {
         let config = MempoolConfig {
             max_transactions: 2,
-            max_bytes: 1024 * 1024,
+            ..default_config()
         };
         let mempool = Mempool::new(config);
 
@@ -640,7 +919,7 @@ mod tests {
 
     #[test]
     fn test_get_txs_for_block() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         for i in 1..=5u8 {
             mempool
@@ -654,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_snapshot() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         mempool
             .add_tx(Hash32::from_bytes([1u8; 32]), make_dummy_tx(), 500)
             .unwrap();
@@ -670,7 +949,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         mempool
             .add_tx(Hash32::from_bytes([1u8; 32]), make_dummy_tx(), 500)
             .unwrap();
@@ -681,6 +960,9 @@ mod tests {
         mempool.clear();
         assert!(mempool.is_empty());
         assert_eq!(mempool.total_bytes(), 0);
+        assert_eq!(mempool.total_ex_mem(), 0);
+        assert_eq!(mempool.total_ex_steps(), 0);
+        assert_eq!(mempool.total_ref_scripts_bytes(), 0);
         assert!(mempool.fee_index.read().is_empty());
     }
 
@@ -707,7 +989,7 @@ mod tests {
 
     #[test]
     fn test_evict_expired_ttl() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         // Add tx with TTL at slot 100
         mempool
@@ -750,7 +1032,7 @@ mod tests {
 
     #[test]
     fn test_fee_based_priority() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         // Add 3 txs with different fees, same size
         let size = 500;
@@ -789,7 +1071,7 @@ mod tests {
 
     #[test]
     fn test_revalidate_against_inputs() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         let input_a = TransactionInput {
             transaction_id: Hash32::from_bytes([10u8; 32]),
@@ -839,7 +1121,7 @@ mod tests {
 
     #[test]
     fn test_add_tx_with_fee() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let tx = make_tx_with_fee(500_000);
         let hash = Hash32::from_bytes([1u8; 32]);
 
@@ -852,7 +1134,7 @@ mod tests {
 
     #[test]
     fn test_get_txs_for_block_fee_priority() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         // Add 3 transactions with different fee densities
         // tx1: low fee density (100_000 fee / 500 bytes = 200 per byte)
@@ -897,7 +1179,7 @@ mod tests {
     fn test_atomic_tx_count_consistency() {
         let config = MempoolConfig {
             max_transactions: 5,
-            max_bytes: 1024 * 1024,
+            ..default_config()
         };
         let mempool = Mempool::new(config);
 
@@ -962,6 +1244,7 @@ mod tests {
         let config = MempoolConfig {
             max_transactions: 10,
             max_bytes: 200, // very small byte limit
+            ..default_config()
         };
         let mempool = Mempool::new(config);
 
@@ -981,7 +1264,7 @@ mod tests {
     fn test_fee_density_no_overflow_near_u64_max() {
         // A fee near u64::MAX would overflow when multiplied without u128.
         // This test ensures no panic occurs and ordering is correct.
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         let huge_fee = u64::MAX - 1; // 18_446_744_073_709_551_614
         let tx = make_tx_with_fee(huge_fee);
@@ -1010,7 +1293,7 @@ mod tests {
     fn test_mempool_provider_trait_object() {
         use torsten_primitives::mempool::MempoolProvider;
 
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let provider: &dyn MempoolProvider = &mempool;
 
         assert_eq!(provider.len(), 0);
@@ -1049,7 +1332,7 @@ mod tests {
         use std::sync::Arc;
         use torsten_primitives::mempool::MempoolProvider;
 
-        let mempool = Arc::new(Mempool::new(MempoolConfig::default()));
+        let mempool = Arc::new(Mempool::new(default_config()));
         let provider: Arc<dyn MempoolProvider> = mempool;
 
         assert_eq!(provider.len(), 0);
@@ -1067,7 +1350,7 @@ mod tests {
     fn test_mempool_provider_add_with_fee() {
         use torsten_primitives::mempool::MempoolProvider;
 
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let provider: &dyn MempoolProvider = &mempool;
 
         let hash = Hash32::from_bytes([1u8; 32]);
@@ -1097,7 +1380,7 @@ mod tests {
 
         let config = MempoolConfig {
             max_transactions: 1,
-            max_bytes: 1024 * 1024,
+            ..default_config()
         };
         let mempool = Mempool::new(config);
         let provider: &dyn MempoolProvider = &mempool;
@@ -1110,18 +1393,18 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            err.0.contains("full"),
-            "error should mention 'full': {}",
+            err.0.contains("full") || err.0.contains("priority"),
+            "error should mention 'full' or 'priority': {}",
             err.0
         );
     }
 
-    // ========================== New fee-density ordering tests ==========================
+    // ========================== Fee-density ordering tests ==========================
 
     #[test]
     fn test_fee_density_ordering_different_sizes() {
         // Transactions with different fees AND sizes — fee density matters, not raw fee
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         // tx1: 1_000_000 fee / 2000 bytes = 500 lovelace/byte
         mempool
@@ -1164,7 +1447,7 @@ mod tests {
     #[test]
     fn test_fee_density_same_density_deterministic_hash_tiebreak() {
         // Two transactions with identical fee density should be ordered deterministically by hash
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         let hash_a = Hash32::from_bytes([0xAA; 32]);
         let hash_b = Hash32::from_bytes([0x11; 32]);
@@ -1192,7 +1475,7 @@ mod tests {
     fn test_fee_density_proportional_same_density() {
         // 200 fee / 100 bytes = 2 per byte  (same as 400 fee / 200 bytes)
         // Cross-multiplication should detect these as equal
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         mempool
             .add_tx_with_fee(
@@ -1222,7 +1505,7 @@ mod tests {
     #[test]
     fn test_fee_density_zero_fee() {
         // Zero-fee transactions should sort last
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         mempool
             .add_tx_with_fee(
@@ -1251,7 +1534,7 @@ mod tests {
     fn test_fee_density_zero_size_treated_as_one() {
         // A zero-size transaction should not cause division by zero;
         // it's treated as size=1 for density calculation
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         mempool
             .add_tx_with_fee(
@@ -1280,7 +1563,7 @@ mod tests {
 
     #[test]
     fn test_remove_maintains_fee_index_consistency() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         mempool
             .add_tx_with_fee(
@@ -1323,7 +1606,7 @@ mod tests {
     #[test]
     fn test_insertion_order_does_not_affect_fee_ordering() {
         // Insert low, high, medium — result should always be high, medium, low
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let size = 500;
 
         // Insert in non-sorted order: low, high, medium
@@ -1361,7 +1644,7 @@ mod tests {
     #[test]
     fn test_get_txs_for_block_skips_oversized_includes_smaller() {
         // When a high-density tx doesn't fit, lower-density smaller txs can still be included
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         // tx1: high density, large size (won't fit in budget after tx2)
         mempool
@@ -1406,7 +1689,7 @@ mod tests {
 
     #[test]
     fn test_fee_index_consistent_after_batch_remove() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         for i in 1..=5u8 {
             mempool
@@ -1443,7 +1726,7 @@ mod tests {
         // tx2: 5 fee / 2 bytes = 2.5     (integer div = 2)
         // Integer division would say they're equal; cross-multiplication should
         // correctly rank tx2 higher.
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         mempool
             .add_tx_with_fee(
@@ -1490,7 +1773,7 @@ mod tests {
 
     #[test]
     fn test_evict_expired_maintains_fee_index() {
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         let mut tx1 = make_tx_with_fee(300);
         tx1.body.ttl = Some(SlotNo(50));
@@ -1519,7 +1802,7 @@ mod tests {
     #[test]
     fn test_many_txs_ordering_stability() {
         // Insert 100 transactions with varying densities and verify stable ordering
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
 
         for i in 1..=100u32 {
             let fee = (i as u64) * 1000;
@@ -1563,7 +1846,7 @@ mod tests {
     #[test]
     fn test_add_remove_add_same_hash() {
         // Add, remove, re-add same transaction — fee index should be consistent
-        let mempool = Mempool::new(MempoolConfig::default());
+        let mempool = Mempool::new(default_config());
         let hash = Hash32::from_bytes([42u8; 32]);
 
         mempool
@@ -1583,5 +1866,432 @@ mod tests {
         let txs = mempool.get_txs_for_block(10, 100_000);
         assert_eq!(txs.len(), 1);
         assert_eq!(txs[0].body.fee.0, 200);
+    }
+
+    // ========================== Multi-dimensional capacity tests ==========================
+
+    #[test]
+    fn test_ex_units_capacity_enforcement() {
+        let config = MempoolConfig {
+            max_ex_mem: 1000,
+            max_ex_steps: 5000,
+            ..default_config()
+        };
+        let mempool = Mempool::new(config);
+
+        // Add tx with 600 mem, 2000 steps
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(500),
+                600,
+                2000,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+        assert_eq!(mempool.total_ex_mem(), 600);
+        assert_eq!(mempool.total_ex_steps(), 2000);
+
+        // Add tx with 300 mem, 2000 steps — should fit
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([2u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(500),
+                300,
+                2000,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+        assert_eq!(mempool.total_ex_mem(), 900);
+        assert_eq!(mempool.total_ex_steps(), 4000);
+
+        // Add tx with 200 mem — would exceed max_ex_mem (900+200=1100 > 1000)
+        // New tx has same fee density as existing, so eviction should fail
+        let result = mempool.add_tx_full(
+            Hash32::from_bytes([3u8; 32]),
+            make_dummy_tx(),
+            100,
+            Lovelace(500),
+            200,
+            500,
+            0,
+            TxOrigin::Local,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ref_scripts_capacity_enforcement() {
+        let config = MempoolConfig {
+            max_ref_scripts_bytes: 500,
+            ..default_config()
+        };
+        let mempool = Mempool::new(config);
+
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(500),
+                0,
+                0,
+                300,
+                TxOrigin::Local,
+            )
+            .unwrap();
+        assert_eq!(mempool.total_ref_scripts_bytes(), 300);
+
+        // Would exceed ref script limit (300+300=600 > 500)
+        let result = mempool.add_tx_full(
+            Hash32::from_bytes([2u8; 32]),
+            make_dummy_tx(),
+            100,
+            Lovelace(500),
+            0,
+            0,
+            300,
+            TxOrigin::Local,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_eviction_frees_all_dimensions() {
+        let config = MempoolConfig {
+            max_transactions: 2,
+            max_ex_mem: 1000,
+            ..default_config()
+        };
+        let mempool = Mempool::new(config);
+
+        // tx1: low fee density, high ex_mem
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(100),
+                800,
+                0,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+
+        // tx2: medium fee density
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([2u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(200),
+                100,
+                0,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+
+        assert_eq!(mempool.len(), 2);
+        assert_eq!(mempool.total_ex_mem(), 900);
+
+        // tx3: highest fee density — should evict tx1 (lowest density)
+        let result = mempool.add_tx_full(
+            Hash32::from_bytes([3u8; 32]),
+            make_dummy_tx(),
+            100,
+            Lovelace(500),
+            50,
+            0,
+            0,
+            TxOrigin::Local,
+        );
+        assert!(result.is_ok());
+        assert_eq!(mempool.len(), 2);
+        assert!(!mempool.contains(&Hash32::from_bytes([1u8; 32]))); // evicted
+        assert!(mempool.contains(&Hash32::from_bytes([2u8; 32])));
+        assert!(mempool.contains(&Hash32::from_bytes([3u8; 32])));
+        // ex_mem should be 100 (tx2) + 50 (tx3) = 150
+        assert_eq!(mempool.total_ex_mem(), 150);
+    }
+
+    #[test]
+    fn test_eviction_insufficient_priority() {
+        let config = MempoolConfig {
+            max_transactions: 2,
+            ..default_config()
+        };
+        let mempool = Mempool::new(config);
+
+        // Fill with high-fee txs
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(1000),
+                0,
+                0,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([2u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(900),
+                0,
+                0,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+
+        // Try to add low-fee tx — should fail with InsufficientPriority
+        let result = mempool.add_tx_full(
+            Hash32::from_bytes([3u8; 32]),
+            make_dummy_tx(),
+            100,
+            Lovelace(50),
+            0,
+            0,
+            0,
+            TxOrigin::Local,
+        );
+        assert!(matches!(result, Err(MempoolError::InsufficientPriority)));
+        assert_eq!(mempool.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_decrements_ex_units() {
+        let mempool = Mempool::new(default_config());
+
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(500),
+                1000,
+                2000,
+                300,
+                TxOrigin::Local,
+            )
+            .unwrap();
+        assert_eq!(mempool.total_ex_mem(), 1000);
+        assert_eq!(mempool.total_ex_steps(), 2000);
+        assert_eq!(mempool.total_ref_scripts_bytes(), 300);
+
+        mempool.remove_tx(&Hash32::from_bytes([1u8; 32]));
+        assert_eq!(mempool.total_ex_mem(), 0);
+        assert_eq!(mempool.total_ex_steps(), 0);
+        assert_eq!(mempool.total_ref_scripts_bytes(), 0);
+    }
+
+    // ========================== Dual-FIFO fairness tests ==========================
+
+    #[test]
+    fn test_tx_origin_local_and_remote() {
+        let mempool = Mempool::new(default_config());
+
+        // Local submission
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(500),
+                0,
+                0,
+                0,
+                TxOrigin::Local,
+            )
+            .unwrap();
+
+        // Remote submission
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([2u8; 32]),
+                make_dummy_tx(),
+                100,
+                Lovelace(500),
+                0,
+                0,
+                0,
+                TxOrigin::Remote,
+            )
+            .unwrap();
+
+        assert_eq!(mempool.len(), 2);
+        // Both should be in FIFO order
+        let hashes = mempool.tx_hashes_ordered();
+        assert_eq!(hashes[0], Hash32::from_bytes([1u8; 32]));
+        assert_eq!(hashes[1], Hash32::from_bytes([2u8; 32]));
+    }
+
+    #[test]
+    fn test_dual_fifo_fairness_contention() {
+        use std::sync::Arc;
+
+        let config = MempoolConfig {
+            max_transactions: 100,
+            ..default_config()
+        };
+        let mempool = Arc::new(Mempool::new(config));
+
+        // Simulate concurrent local and remote submissions
+        let m1 = mempool.clone();
+        let local_handle = std::thread::spawn(move || {
+            for i in 0..10u8 {
+                let mut hash_bytes = [0u8; 32];
+                hash_bytes[0] = 0xAA;
+                hash_bytes[1] = i;
+                let _ = m1.add_tx_full(
+                    Hash32::from_bytes(hash_bytes),
+                    make_dummy_tx(),
+                    100,
+                    Lovelace(500),
+                    0,
+                    0,
+                    0,
+                    TxOrigin::Local,
+                );
+            }
+        });
+
+        let m2 = mempool.clone();
+        let remote_handle = std::thread::spawn(move || {
+            for i in 0..10u8 {
+                let mut hash_bytes = [0u8; 32];
+                hash_bytes[0] = 0xBB;
+                hash_bytes[1] = i;
+                let _ = m2.add_tx_full(
+                    Hash32::from_bytes(hash_bytes),
+                    make_dummy_tx(),
+                    100,
+                    Lovelace(500),
+                    0,
+                    0,
+                    0,
+                    TxOrigin::Remote,
+                );
+            }
+        });
+
+        local_handle.join().unwrap();
+        remote_handle.join().unwrap();
+
+        // All 20 txs should be added (no deadlock, no data corruption)
+        assert_eq!(mempool.len(), 20);
+    }
+
+    // ========================== Revalidation tests ==========================
+
+    #[test]
+    fn test_revalidate_all_removes_invalid() {
+        let mempool = Mempool::new(default_config());
+
+        // Add 5 txs with different fees
+        for i in 1..=5u8 {
+            mempool
+                .add_tx_with_fee(
+                    Hash32::from_bytes([i; 32]),
+                    make_tx_with_fee(i as u64 * 100),
+                    500,
+                    Lovelace(i as u64 * 100),
+                )
+                .unwrap();
+        }
+        assert_eq!(mempool.len(), 5);
+
+        // Revalidate: reject txs with fee < 300
+        let removed = mempool.revalidate_all(|tx| tx.body.fee.0 >= 300);
+
+        assert_eq!(removed.len(), 2); // tx1 (100) and tx2 (200) removed
+        assert_eq!(mempool.len(), 3);
+        assert!(!mempool.contains(&Hash32::from_bytes([1u8; 32])));
+        assert!(!mempool.contains(&Hash32::from_bytes([2u8; 32])));
+        assert!(mempool.contains(&Hash32::from_bytes([3u8; 32])));
+        assert!(mempool.contains(&Hash32::from_bytes([4u8; 32])));
+        assert!(mempool.contains(&Hash32::from_bytes([5u8; 32])));
+    }
+
+    #[test]
+    fn test_revalidate_all_keeps_all_valid() {
+        let mempool = Mempool::new(default_config());
+
+        for i in 1..=3u8 {
+            mempool
+                .add_tx(Hash32::from_bytes([i; 32]), make_dummy_tx(), 100)
+                .unwrap();
+        }
+
+        let removed = mempool.revalidate_all(|_| true);
+        assert!(removed.is_empty());
+        assert_eq!(mempool.len(), 3);
+    }
+
+    #[test]
+    fn test_revalidate_all_removes_all_invalid() {
+        let mempool = Mempool::new(default_config());
+
+        for i in 1..=3u8 {
+            mempool
+                .add_tx(Hash32::from_bytes([i; 32]), make_dummy_tx(), 100)
+                .unwrap();
+        }
+
+        let removed = mempool.revalidate_all(|_| false);
+        assert_eq!(removed.len(), 3);
+        assert!(mempool.is_empty());
+        assert_eq!(mempool.total_bytes(), 0);
+    }
+
+    #[test]
+    fn test_revalidate_all_maintains_counters() {
+        let mempool = Mempool::new(default_config());
+
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([1u8; 32]),
+                make_tx_with_fee(100),
+                500,
+                Lovelace(100),
+                1000,
+                2000,
+                300,
+                TxOrigin::Local,
+            )
+            .unwrap();
+        mempool
+            .add_tx_full(
+                Hash32::from_bytes([2u8; 32]),
+                make_tx_with_fee(200),
+                600,
+                Lovelace(200),
+                500,
+                1000,
+                100,
+                TxOrigin::Local,
+            )
+            .unwrap();
+
+        // Remove tx1 via revalidation
+        mempool.revalidate_all(|tx| tx.body.fee.0 >= 200);
+
+        assert_eq!(mempool.len(), 1);
+        assert_eq!(mempool.total_bytes(), 600);
+        assert_eq!(mempool.total_ex_mem(), 500);
+        assert_eq!(mempool.total_ex_steps(), 1000);
+        assert_eq!(mempool.total_ref_scripts_bytes(), 100);
     }
 }

--- a/crates/torsten-network/src/governor.rs
+++ b/crates/torsten-network/src/governor.rs
@@ -1,0 +1,665 @@
+//! P2P peer selection governor.
+//!
+//! Implements Haskell cardano-node's target-driven peer management model.
+//! The governor evaluates peer deficit/surplus across categories and emits
+//! events (Connect, Disconnect, Promote, Demote) to drive the node's
+//! connection management.
+//!
+//! Key features:
+//! - Separate targets for regular and big ledger peers
+//! - Local root protection (never demoted even above target)
+//! - Sync-state-aware target switching
+//! - Periodic churn for peer rotation
+//! - Connection limit enforcement (hard/soft)
+
+use crate::peer_manager::{PeerCategory, PeerManager};
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+use tracing::{debug, info};
+
+/// Peer count targets for the governor decision loop.
+#[derive(Debug, Clone)]
+pub struct PeerTargets {
+    /// Target number of known root peers
+    pub root_peers: usize,
+    /// Target number of total known peers
+    pub known_peers: usize,
+    /// Target number of established (warm + hot) peers
+    pub established_peers: usize,
+    /// Target number of active (hot) peers
+    pub active_peers: usize,
+    /// Target number of known big ledger peers
+    pub known_blp: usize,
+    /// Target number of established big ledger peers
+    pub established_blp: usize,
+    /// Target number of active big ledger peers
+    pub active_blp: usize,
+}
+
+impl Default for PeerTargets {
+    fn default() -> Self {
+        PeerTargets {
+            root_peers: 10,
+            known_peers: 150,
+            established_peers: 30,
+            active_peers: 20,
+            known_blp: 15,
+            established_blp: 10,
+            active_blp: 5,
+        }
+    }
+}
+
+/// Targets used during syncing (lower than normal for faster convergence)
+impl PeerTargets {
+    pub fn syncing() -> Self {
+        PeerTargets {
+            root_peers: 5,
+            known_peers: 50,
+            established_peers: 15,
+            active_peers: 10,
+            known_blp: 15,
+            established_blp: 10,
+            active_blp: 5,
+        }
+    }
+}
+
+/// Events emitted by the governor for the node to act on.
+#[derive(Debug, Clone)]
+pub enum GovernorEvent {
+    /// Connect to a cold peer (promote to warm)
+    Connect(SocketAddr),
+    /// Disconnect from a peer (demote to cold)
+    Disconnect(SocketAddr),
+    /// Promote a warm peer to hot (start syncing)
+    Promote(SocketAddr),
+    /// Demote a hot peer to warm (stop syncing)
+    Demote(SocketAddr),
+}
+
+/// Sync state hint from the node — determines which targets to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncState {
+    /// Waiting for enough trusted peers (HAA)
+    PreSyncing,
+    /// Active download with LoE/GDD protection
+    Syncing,
+    /// Normal Praos operation at chain tip
+    CaughtUp,
+}
+
+/// Governor configuration
+#[derive(Debug, Clone)]
+pub struct GovernorConfig {
+    /// Targets for normal (CaughtUp) operation
+    pub normal_targets: PeerTargets,
+    /// Targets during syncing
+    pub sync_targets: PeerTargets,
+    /// Hard connection limit — reject above this
+    pub hard_limit: usize,
+    /// Soft connection limit — delay acceptance above this
+    pub soft_limit: usize,
+    /// Normal churn interval (seconds)
+    pub churn_interval_normal_secs: u64,
+    /// Sync churn interval (seconds)
+    pub churn_interval_sync_secs: u64,
+}
+
+impl Default for GovernorConfig {
+    fn default() -> Self {
+        GovernorConfig {
+            normal_targets: PeerTargets::default(),
+            sync_targets: PeerTargets::syncing(),
+            hard_limit: 512,
+            soft_limit: 384,
+            churn_interval_normal_secs: 3300, // 55 minutes
+            churn_interval_sync_secs: 900,    // 15 minutes
+        }
+    }
+}
+
+/// The P2P peer selection governor.
+///
+/// Evaluates peer counts against targets and produces events to drive
+/// the node's connection management. The governor runs as a periodic
+/// task, examining the PeerManager state and emitting events.
+pub struct Governor {
+    config: GovernorConfig,
+    sync_state: SyncState,
+    /// Tracks when churn was last performed
+    last_churn: Instant,
+    /// Whether churn is currently in the "reduced" phase
+    churn_active: bool,
+    /// Saved targets during churn (restored after churn completes)
+    pre_churn_targets: Option<PeerTargets>,
+}
+
+impl Governor {
+    pub fn new(config: GovernorConfig) -> Self {
+        Governor {
+            config,
+            sync_state: SyncState::CaughtUp,
+            last_churn: Instant::now(),
+            churn_active: false,
+            pre_churn_targets: None,
+        }
+    }
+
+    /// Update the sync state (called by the node when GSM transitions)
+    pub fn set_sync_state(&mut self, state: SyncState) {
+        if self.sync_state != state {
+            info!(?state, "Governor: sync state changed");
+            self.sync_state = state;
+        }
+    }
+
+    /// Get current sync state
+    pub fn sync_state(&self) -> SyncState {
+        self.sync_state
+    }
+
+    /// Get the active targets based on current sync state
+    fn active_targets(&self) -> &PeerTargets {
+        match self.sync_state {
+            SyncState::PreSyncing | SyncState::Syncing => &self.config.sync_targets,
+            SyncState::CaughtUp => &self.config.normal_targets,
+        }
+    }
+
+    /// Check if a new connection should be accepted based on connection limits.
+    /// Returns `None` if accepted, `Some(delay)` if should delay, or panics above hard limit.
+    pub fn connection_check(&self, total_connections: usize) -> ConnectionDecision {
+        if total_connections >= self.config.hard_limit {
+            ConnectionDecision::Reject
+        } else if total_connections >= self.config.soft_limit {
+            ConnectionDecision::Delay(Duration::from_secs(5))
+        } else {
+            ConnectionDecision::Accept
+        }
+    }
+
+    /// Run one evaluation cycle of the governor decision loop.
+    ///
+    /// Examines the PeerManager state, compares against targets, and returns
+    /// a list of events that should be executed. Events are prioritized:
+    /// 1. Big ledger peers (most important for genesis/sync)
+    /// 2. Active peers below target → promote
+    /// 3. Established peers below target → connect
+    /// 4. Above target → demote/disconnect (respecting local root protection)
+    pub fn evaluate(&mut self, pm: &PeerManager) -> Vec<GovernorEvent> {
+        let mut events = Vec::new();
+        let targets = self.active_targets().clone();
+
+        // --- Phase 1: Big Ledger Peers ---
+        self.evaluate_blp(pm, &targets, &mut events);
+
+        // --- Phase 2: Active peers (hot) ---
+        self.evaluate_active(pm, &targets, &mut events);
+
+        // --- Phase 3: Established peers (warm + hot) ---
+        self.evaluate_established(pm, &targets, &mut events);
+
+        // --- Phase 4: Known peers (connect cold) ---
+        self.evaluate_known(pm, &targets, &mut events);
+
+        // --- Phase 5: Surplus reduction ---
+        self.evaluate_surplus(pm, &targets, &mut events);
+
+        if !events.is_empty() {
+            debug!(
+                event_count = events.len(),
+                hot = pm.hot_peer_count(),
+                warm = pm.warm_peer_count(),
+                cold = pm.cold_peer_count(),
+                "Governor: evaluation produced events"
+            );
+        }
+
+        events
+    }
+
+    /// Evaluate big ledger peer targets
+    fn evaluate_blp(
+        &self,
+        pm: &PeerManager,
+        targets: &PeerTargets,
+        events: &mut Vec<GovernorEvent>,
+    ) {
+        let active_blp = pm.active_big_ledger_peer_count();
+
+        if active_blp < targets.active_blp {
+            // Need more active BLPs — promote warm BLPs
+            let deficit = targets.active_blp - active_blp;
+            let warm_blps: Vec<SocketAddr> = pm
+                .connected_peer_addrs()
+                .into_iter()
+                .filter(|addr| {
+                    pm.peer_category(addr) == Some(PeerCategory::BigLedgerPeer)
+                        && pm.peer_performance(addr).is_some_and(|_| true) // warm, not hot
+                })
+                .filter(|addr| {
+                    // Only warm peers (not already hot)
+                    !pm.hot_peer_addrs().contains(addr)
+                })
+                .take(deficit)
+                .collect();
+
+            for addr in warm_blps {
+                events.push(GovernorEvent::Promote(addr));
+            }
+
+            // If still short, connect cold BLPs
+            if active_blp + events.len() < targets.active_blp {
+                // The node will handle connecting cold BLPs through the regular connect path
+                // We just ensure they get prioritized
+            }
+        }
+    }
+
+    /// Evaluate active (hot) peer targets
+    fn evaluate_active(
+        &self,
+        pm: &PeerManager,
+        targets: &PeerTargets,
+        events: &mut Vec<GovernorEvent>,
+    ) {
+        let hot = pm.hot_peer_count();
+        if hot < targets.active_peers {
+            let deficit = targets.active_peers - hot;
+            let to_promote = pm.peers_to_promote();
+            for addr in to_promote.into_iter().take(deficit) {
+                events.push(GovernorEvent::Promote(addr));
+            }
+        }
+    }
+
+    /// Evaluate established (warm + hot) peer targets
+    fn evaluate_established(
+        &self,
+        pm: &PeerManager,
+        targets: &PeerTargets,
+        events: &mut Vec<GovernorEvent>,
+    ) {
+        let established = pm.hot_peer_count() + pm.warm_peer_count();
+        if established < targets.established_peers {
+            let deficit = targets.established_peers - established;
+            let to_connect = pm.peers_to_connect();
+            for addr in to_connect.into_iter().take(deficit) {
+                events.push(GovernorEvent::Connect(addr));
+            }
+        }
+    }
+
+    /// Evaluate known peer targets — connect more cold peers
+    fn evaluate_known(
+        &self,
+        _pm: &PeerManager,
+        _targets: &PeerTargets,
+        _events: &mut Vec<GovernorEvent>,
+    ) {
+        // Known peer expansion is handled by evaluate_established.
+        // This hook exists for future peer discovery integration.
+    }
+
+    /// Evaluate surplus — demote/disconnect peers above targets
+    fn evaluate_surplus(
+        &self,
+        pm: &PeerManager,
+        targets: &PeerTargets,
+        events: &mut Vec<GovernorEvent>,
+    ) {
+        // Hot peers above target — demote non-local-root peers
+        let hot = pm.hot_peer_count();
+        if hot > targets.active_peers {
+            let surplus = hot - targets.active_peers;
+            let mut demote_candidates: Vec<(SocketAddr, f64)> = pm
+                .hot_peer_addrs()
+                .into_iter()
+                .filter(|addr| !pm.is_local_root(addr))
+                .filter_map(|addr| pm.peer_performance(&addr).map(|p| (addr, p.reputation)))
+                .collect();
+
+            // Demote worst reputation first
+            demote_candidates
+                .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+            for (addr, _) in demote_candidates.into_iter().take(surplus) {
+                events.push(GovernorEvent::Demote(addr));
+            }
+        }
+
+        // Established peers above target — disconnect non-local-root warm peers
+        let established = pm.hot_peer_count() + pm.warm_peer_count();
+        if established > targets.established_peers {
+            let surplus = established - targets.established_peers;
+            let warm_addrs = pm.connected_peer_addrs();
+            let hot_addrs: std::collections::HashSet<_> = pm.hot_peer_addrs().into_iter().collect();
+            let mut disconnect_candidates: Vec<(SocketAddr, f64)> = warm_addrs
+                .into_iter()
+                .filter(|addr| !hot_addrs.contains(addr) && !pm.is_local_root(addr))
+                .filter_map(|addr| pm.peer_performance(&addr).map(|p| (addr, p.reputation)))
+                .collect();
+
+            disconnect_candidates
+                .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+            for (addr, _) in disconnect_candidates.into_iter().take(surplus) {
+                events.push(GovernorEvent::Disconnect(addr));
+            }
+        }
+    }
+
+    /// Run the churn mechanism if enough time has elapsed.
+    ///
+    /// Churn periodically reduces targets by ~20%, causing the governor to
+    /// demote some peers, then restores targets to force peer rotation.
+    /// Returns events from the evaluation after churn adjustment.
+    pub fn maybe_churn(&mut self, pm: &PeerManager) -> Vec<GovernorEvent> {
+        let churn_interval = match self.sync_state {
+            SyncState::PreSyncing | SyncState::Syncing => {
+                Duration::from_secs(self.config.churn_interval_sync_secs)
+            }
+            SyncState::CaughtUp => Duration::from_secs(self.config.churn_interval_normal_secs),
+        };
+
+        if self.last_churn.elapsed() < churn_interval {
+            return Vec::new();
+        }
+
+        if self.churn_active {
+            // Restore targets — churn complete
+            if let Some(saved) = self.pre_churn_targets.take() {
+                match self.sync_state {
+                    SyncState::PreSyncing | SyncState::Syncing => {
+                        // Don't restore if we switched to syncing
+                    }
+                    SyncState::CaughtUp => {
+                        self.config.normal_targets = saved;
+                    }
+                }
+            }
+            self.churn_active = false;
+            self.last_churn = Instant::now();
+            info!("Governor: churn phase complete, targets restored");
+            return self.evaluate(pm);
+        }
+
+        // Start churn: reduce targets by ~20%
+        let current = self.active_targets().clone();
+        self.pre_churn_targets = Some(current.clone());
+
+        let reduced = PeerTargets {
+            root_peers: current.root_peers,
+            known_peers: current.known_peers,
+            established_peers: (current.established_peers * 4) / 5,
+            active_peers: (current.active_peers * 4) / 5,
+            known_blp: current.known_blp,
+            established_blp: (current.established_blp * 4) / 5,
+            active_blp: (current.active_blp * 4) / 5,
+        };
+
+        match self.sync_state {
+            SyncState::PreSyncing | SyncState::Syncing => {
+                self.config.sync_targets = reduced;
+            }
+            SyncState::CaughtUp => {
+                self.config.normal_targets = reduced;
+            }
+        }
+
+        self.churn_active = true;
+        info!(
+            active = current.active_peers,
+            reduced = (current.active_peers * 4) / 5,
+            "Governor: churn phase started, targets reduced by 20%"
+        );
+
+        self.evaluate(pm)
+    }
+
+    /// Get current governor config (for testing/inspection)
+    pub fn config(&self) -> &GovernorConfig {
+        &self.config
+    }
+}
+
+/// Connection limit decision
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionDecision {
+    /// Accept immediately
+    Accept,
+    /// Delay acceptance by the given duration
+    Delay(Duration),
+    /// Reject the connection
+    Reject,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peer_manager::PeerManagerConfig;
+    use std::net::SocketAddr;
+
+    fn test_addr(port: u16) -> SocketAddr {
+        format!("127.0.0.1:{port}").parse().unwrap()
+    }
+
+    fn setup_pm_with_peers(hot: usize, warm: usize, cold: usize) -> PeerManager {
+        let config = PeerManagerConfig {
+            target_hot_peers: 20,
+            target_warm_peers: 20,
+            target_known_peers: 200,
+            ..PeerManagerConfig::default()
+        };
+        let mut pm = PeerManager::new(config);
+        let mut port = 3000u16;
+
+        for _ in 0..cold {
+            pm.add_config_peer(test_addr(port), false, false);
+            port += 1;
+        }
+        for _ in 0..warm {
+            let addr = test_addr(port);
+            pm.add_config_peer(addr, false, false);
+            pm.peer_connected(&addr, 14, true);
+            port += 1;
+        }
+        for _ in 0..hot {
+            let addr = test_addr(port);
+            pm.add_config_peer(addr, false, false);
+            pm.peer_connected(&addr, 14, true);
+            pm.promote_to_hot(&addr);
+            port += 1;
+        }
+        pm
+    }
+
+    #[test]
+    fn test_below_target_triggers_promotion() {
+        let pm = setup_pm_with_peers(5, 10, 20); // 5 hot, need 20
+        let mut gov = Governor::new(GovernorConfig::default());
+
+        let events = gov.evaluate(&pm);
+        let promote_count = events
+            .iter()
+            .filter(|e| matches!(e, GovernorEvent::Promote(_)))
+            .count();
+        assert!(
+            promote_count > 0,
+            "Should emit Promote events when hot < target"
+        );
+    }
+
+    #[test]
+    fn test_below_target_triggers_connect() {
+        let pm = setup_pm_with_peers(0, 5, 50); // 5 established, need 30
+        let mut gov = Governor::new(GovernorConfig::default());
+
+        let events = gov.evaluate(&pm);
+        let connect_count = events
+            .iter()
+            .filter(|e| matches!(e, GovernorEvent::Connect(_)))
+            .count();
+        assert!(
+            connect_count > 0,
+            "Should emit Connect events when established < target"
+        );
+    }
+
+    #[test]
+    fn test_above_target_triggers_demotion() {
+        let config = GovernorConfig {
+            normal_targets: PeerTargets {
+                active_peers: 5,
+                established_peers: 10,
+                ..PeerTargets::default()
+            },
+            ..GovernorConfig::default()
+        };
+        let pm = setup_pm_with_peers(10, 5, 20); // 10 hot, target 5
+        let mut gov = Governor::new(config);
+
+        let events = gov.evaluate(&pm);
+        let demote_count = events
+            .iter()
+            .filter(|e| matches!(e, GovernorEvent::Demote(_)))
+            .count();
+        assert!(
+            demote_count > 0,
+            "Should emit Demote events when hot > target"
+        );
+    }
+
+    #[test]
+    fn test_local_roots_never_demoted() {
+        let config = GovernorConfig {
+            normal_targets: PeerTargets {
+                active_peers: 1,
+                established_peers: 2,
+                ..PeerTargets::default()
+            },
+            ..GovernorConfig::default()
+        };
+
+        let pm_config = PeerManagerConfig {
+            target_hot_peers: 20,
+            target_warm_peers: 20,
+            target_known_peers: 200,
+            ..PeerManagerConfig::default()
+        };
+        let mut pm = PeerManager::new(pm_config);
+
+        // Add 3 hot peers: 2 local roots + 1 regular
+        let local1 = test_addr(3001);
+        let local2 = test_addr(3002);
+        let regular = test_addr(3003);
+
+        pm.add_config_peer(local1, true, false); // trustable = LocalRoot
+        pm.add_config_peer(local2, true, false);
+        pm.add_config_peer(regular, false, false);
+
+        pm.peer_connected(&local1, 14, true);
+        pm.peer_connected(&local2, 14, true);
+        pm.peer_connected(&regular, 14, true);
+        pm.promote_to_hot(&local1);
+        pm.promote_to_hot(&local2);
+        pm.promote_to_hot(&regular);
+
+        let mut gov = Governor::new(config);
+        let events = gov.evaluate(&pm);
+
+        // Only the regular peer should be demoted, not the local roots
+        let demoted: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                GovernorEvent::Demote(addr) => Some(*addr),
+                _ => None,
+            })
+            .collect();
+
+        for addr in &demoted {
+            assert!(
+                !pm.is_local_root(addr),
+                "Local root {addr} should never be demoted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sync_vs_normal_targets() {
+        let mut gov = Governor::new(GovernorConfig::default());
+
+        gov.set_sync_state(SyncState::CaughtUp);
+        assert_eq!(gov.active_targets().active_peers, 20);
+
+        gov.set_sync_state(SyncState::Syncing);
+        assert_eq!(gov.active_targets().active_peers, 10);
+    }
+
+    #[test]
+    fn test_connection_limit_accept() {
+        let gov = Governor::new(GovernorConfig::default());
+        assert_eq!(gov.connection_check(100), ConnectionDecision::Accept);
+    }
+
+    #[test]
+    fn test_connection_limit_delay() {
+        let gov = Governor::new(GovernorConfig::default());
+        let decision = gov.connection_check(400); // above soft_limit=384
+        assert!(matches!(decision, ConnectionDecision::Delay(_)));
+    }
+
+    #[test]
+    fn test_connection_limit_reject() {
+        let gov = Governor::new(GovernorConfig::default());
+        assert_eq!(gov.connection_check(512), ConnectionDecision::Reject);
+    }
+
+    #[test]
+    fn test_churn_reduces_then_restores() {
+        let pm = setup_pm_with_peers(20, 10, 50);
+        let mut gov = Governor::new(GovernorConfig {
+            churn_interval_normal_secs: 0, // immediate churn for testing
+            ..GovernorConfig::default()
+        });
+
+        // Force last_churn to be old enough
+        gov.last_churn = Instant::now() - Duration::from_secs(10);
+
+        // First churn: should reduce targets
+        let _events = gov.maybe_churn(&pm);
+        assert!(gov.churn_active);
+        let reduced_active = gov.active_targets().active_peers;
+        assert_eq!(reduced_active, 16); // 20 * 4/5 = 16
+
+        // Force time forward again
+        gov.last_churn = Instant::now() - Duration::from_secs(10);
+
+        // Second churn call: should restore targets
+        let _events = gov.maybe_churn(&pm);
+        assert!(!gov.churn_active);
+        assert_eq!(gov.active_targets().active_peers, 20); // restored
+    }
+
+    #[test]
+    fn test_at_target_no_events() {
+        let config = GovernorConfig {
+            normal_targets: PeerTargets {
+                active_peers: 5,
+                established_peers: 10,
+                known_peers: 50,
+                ..PeerTargets::default()
+            },
+            ..GovernorConfig::default()
+        };
+        let pm = setup_pm_with_peers(5, 5, 40); // exactly at targets
+        let mut gov = Governor::new(config);
+
+        let events = gov.evaluate(&pm);
+        // Should not produce surplus events since we're exactly at target
+        let demote_count = events
+            .iter()
+            .filter(|e| matches!(e, GovernorEvent::Demote(_)))
+            .count();
+        assert_eq!(demote_count, 0);
+    }
+}

--- a/crates/torsten-network/src/lib.rs
+++ b/crates/torsten-network/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod governor;
 pub mod miniprotocols;
 pub mod multiplexer;
 pub mod n2c;
@@ -18,11 +19,14 @@ pub use miniprotocols::txsubmission::{TxSubmissionClient, TxSubmissionError, TxS
 pub use n2c::{N2CServer, TxValidationError, TxValidator};
 pub use n2c_client::N2CClient;
 // Re-export mempool trait and types from torsten-primitives for convenience
+pub use governor::{Governor, GovernorEvent, PeerTargets};
 pub use n2n_server::{
     BlockAnnouncement, BlockProvider, N2NRateLimitConfig, N2NServer, RollbackAnnouncement, TipInfo,
 };
 pub use peer::PeerConnection;
-pub use peer_manager::{DiffusionMode, PeerManager, PeerManagerConfig, PeerPerformance};
+pub use peer_manager::{
+    DiffusionMode, PeerCategory, PeerManager, PeerManagerConfig, PeerPerformance,
+};
 pub use pipelined::PipelinedPeerClient;
 pub use query_handler::{NodeStateSnapshot, QueryHandler, QueryResult};
 pub use server::NodeServer;

--- a/crates/torsten-network/src/peer_manager.rs
+++ b/crates/torsten-network/src/peer_manager.rs
@@ -43,12 +43,34 @@ pub enum PeerSource {
     Ledger,
 }
 
+/// Peer category for governor-driven target management.
+///
+/// Categories determine protection levels and target buckets, matching
+/// Haskell cardano-node's peer classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PeerCategory {
+    /// From topology localRoots — NEVER demoted by governor
+    LocalRoot,
+    /// From topology publicRoots
+    PublicRoot,
+    /// SPO in top 90% of stake (big ledger peer)
+    BigLedgerPeer,
+    /// Any SPO relay (not in top 90%)
+    LedgerPeer,
+    /// Discovered via peer sharing
+    Shared,
+    /// From topology bootstrapPeers
+    Bootstrap,
+}
+
 /// Tracked peer state
 #[derive(Debug, Clone)]
 pub struct PeerInfo {
     pub address: SocketAddr,
     pub temperature: PeerTemperature,
     pub source: PeerSource,
+    /// Governor category for target-driven management
+    pub category: PeerCategory,
     pub last_connected: Option<Instant>,
     pub last_failed: Option<Instant>,
     pub failure_count: u32,
@@ -171,10 +193,16 @@ impl PeerPerformance {
 
 impl PeerInfo {
     pub fn new(address: SocketAddr, source: PeerSource) -> Self {
+        let category = match source {
+            PeerSource::Config => PeerCategory::PublicRoot,
+            PeerSource::PeerSharing => PeerCategory::Shared,
+            PeerSource::Ledger => PeerCategory::LedgerPeer,
+        };
         PeerInfo {
             address,
             temperature: PeerTemperature::Cold,
             source,
+            category,
             last_connected: None,
             last_failed: None,
             failure_count: 0,
@@ -303,13 +331,66 @@ impl PeerManager {
         }
     }
 
-    /// Add a peer from the topology/config
+    /// Add a peer from the topology/config.
+    /// Trustable peers are marked as LocalRoot (protected from demotion).
     pub fn add_config_peer(&mut self, addr: SocketAddr, trustable: bool, advertise: bool) {
         let mut info = PeerInfo::new(addr, PeerSource::Config);
         info.is_trustable = trustable;
         info.advertise = advertise;
+        if trustable {
+            info.category = PeerCategory::LocalRoot;
+        }
         self.cold_peers.insert(addr);
         self.peers.insert(addr, info);
+    }
+
+    /// Add a big ledger peer (SPO in top 90% of stake)
+    pub fn add_big_ledger_peer(&mut self, addr: SocketAddr) {
+        if let Some(info) = self.peers.get_mut(&addr) {
+            // Upgrade existing peer to BLP category
+            info.category = PeerCategory::BigLedgerPeer;
+            return;
+        }
+        if self.peers.len() >= self.config.target_known_peers && !self.try_evict_cold_peer() {
+            return;
+        }
+        let mut info = PeerInfo::new(addr, PeerSource::Ledger);
+        info.category = PeerCategory::BigLedgerPeer;
+        self.cold_peers.insert(addr);
+        self.peers.insert(addr, info);
+        debug!(%addr, "Added big ledger peer");
+    }
+
+    /// Count of big ledger peers across all temperatures
+    pub fn big_ledger_peer_count(&self) -> usize {
+        self.peers
+            .values()
+            .filter(|p| p.category == PeerCategory::BigLedgerPeer)
+            .count()
+    }
+
+    /// Count of active (hot) big ledger peers
+    pub fn active_big_ledger_peer_count(&self) -> usize {
+        self.hot_peers
+            .iter()
+            .filter(|addr| {
+                self.peers
+                    .get(addr)
+                    .is_some_and(|p| p.category == PeerCategory::BigLedgerPeer)
+            })
+            .count()
+    }
+
+    /// Check if a peer is a local root (protected from demotion)
+    pub fn is_local_root(&self, addr: &SocketAddr) -> bool {
+        self.peers
+            .get(addr)
+            .is_some_and(|p| p.category == PeerCategory::LocalRoot)
+    }
+
+    /// Get peer category
+    pub fn peer_category(&self, addr: &SocketAddr) -> Option<PeerCategory> {
+        self.peers.get(addr).map(|p| p.category)
     }
 
     /// Add a peer discovered from the ledger (SPO relay registrations)

--- a/crates/torsten-node/src/gsm.rs
+++ b/crates/torsten-node/src/gsm.rs
@@ -1,0 +1,649 @@
+//! Genesis State Machine (GSM) for bootstrap from genesis.
+//!
+//! Manages the node's sync progression through three states:
+//! - **PreSyncing**: Waiting for enough trusted big ledger peers (HAA)
+//! - **Syncing**: Active block download with LoE/GDD protection
+//! - **CaughtUp**: Normal Praos operation at chain tip
+//!
+//! The GSM runs as a background task, monitoring peer counts and tip age
+//! to drive state transitions. It also enforces the Limit on Eagerness (LoE)
+//! and runs the Genesis Density Disconnector (GDD).
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use torsten_primitives::block::Point;
+use tracing::{debug, info, warn};
+
+/// Genesis sync state matching Ouroboros Genesis specification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GenesisSyncState {
+    /// Waiting for enough trusted big ledger peers (HAA satisfied)
+    PreSyncing,
+    /// Active block download with LoE/GDD protection
+    Syncing,
+    /// Normal Praos operation — node is at or near chain tip
+    CaughtUp,
+}
+
+impl std::fmt::Display for GenesisSyncState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GenesisSyncState::PreSyncing => write!(f, "PreSyncing"),
+            GenesisSyncState::Syncing => write!(f, "Syncing"),
+            GenesisSyncState::CaughtUp => write!(f, "CaughtUp"),
+        }
+    }
+}
+
+/// Configuration for the Genesis State Machine.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct GsmConfig {
+    /// Minimum active big ledger peers to transition PreSyncing → Syncing
+    pub min_active_blp: usize,
+    /// Maximum tip age (seconds) before CaughtUp → PreSyncing regression
+    pub max_tip_age_secs: u64,
+    /// Genesis security parameter (window size in slots for GDD density comparison)
+    pub genesis_window_slots: u64,
+    /// Path for the caught_up marker file
+    pub marker_path: PathBuf,
+}
+
+impl Default for GsmConfig {
+    fn default() -> Self {
+        GsmConfig {
+            min_active_blp: 5,
+            max_tip_age_secs: 1200,       // 20 minutes
+            genesis_window_slots: 36_000, // ~10 hours at 1s slots
+            marker_path: PathBuf::from("caught_up.marker"),
+        }
+    }
+}
+
+/// The Genesis State Machine.
+///
+/// Tracks sync state and enforces transitions based on peer availability
+/// and tip freshness. The GSM also manages:
+/// - **LoE (Limit on Eagerness)**: constrains block application during sync
+/// - **GDD (Genesis Density Disconnector)**: disconnects sparse-chain peers
+#[allow(dead_code)]
+pub struct GenesisStateMachine {
+    config: GsmConfig,
+    state: GenesisSyncState,
+    /// Whether genesis mode is enabled (opt-in via --consensus-mode genesis)
+    enabled: bool,
+}
+
+impl GenesisStateMachine {
+    /// Create a new GSM. If not enabled, it immediately enters CaughtUp
+    /// and all constraints are disabled.
+    pub fn new(config: GsmConfig, enabled: bool) -> Self {
+        let initial_state = if enabled {
+            // Check for marker file — fast restart
+            if config.marker_path.exists() {
+                info!("Genesis: caught_up marker found, starting in CaughtUp state");
+                GenesisSyncState::CaughtUp
+            } else {
+                GenesisSyncState::PreSyncing
+            }
+        } else {
+            GenesisSyncState::CaughtUp
+        };
+
+        GenesisStateMachine {
+            config,
+            state: initial_state,
+            enabled,
+        }
+    }
+
+    /// Current sync state
+    pub fn state(&self) -> GenesisSyncState {
+        self.state
+    }
+
+    /// Whether genesis mode is enabled
+    #[allow(dead_code)]
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Evaluate state transitions based on current conditions.
+    ///
+    /// Returns `Some(new_state)` if a transition occurred, `None` if unchanged.
+    pub fn evaluate(
+        &mut self,
+        active_blp_count: usize,
+        all_chainsync_idle: bool,
+        tip_age_secs: u64,
+    ) -> Option<GenesisSyncState> {
+        if !self.enabled {
+            return None;
+        }
+
+        let old_state = self.state;
+
+        match self.state {
+            GenesisSyncState::PreSyncing => {
+                // Transition to Syncing when we have enough active BLPs (HAA satisfied)
+                if active_blp_count >= self.config.min_active_blp {
+                    self.state = GenesisSyncState::Syncing;
+                    info!(
+                        active_blp = active_blp_count,
+                        min = self.config.min_active_blp,
+                        "Genesis: HAA satisfied, transitioning to Syncing"
+                    );
+                }
+            }
+            GenesisSyncState::Syncing => {
+                // Transition to CaughtUp when all ChainSync clients are idle
+                // and there's no better candidate chain
+                if all_chainsync_idle && tip_age_secs < self.config.max_tip_age_secs {
+                    self.state = GenesisSyncState::CaughtUp;
+                    self.write_marker();
+                    info!(
+                        tip_age_secs,
+                        "Genesis: all peers idle and tip fresh, transitioning to CaughtUp"
+                    );
+                }
+            }
+            GenesisSyncState::CaughtUp => {
+                // Regress to PreSyncing if tip becomes stale
+                if tip_age_secs > self.config.max_tip_age_secs {
+                    self.state = GenesisSyncState::PreSyncing;
+                    self.remove_marker();
+                    warn!(
+                        tip_age_secs,
+                        max = self.config.max_tip_age_secs,
+                        "Genesis: tip stale, regressing to PreSyncing"
+                    );
+                }
+            }
+        }
+
+        if self.state != old_state {
+            Some(self.state)
+        } else {
+            None
+        }
+    }
+
+    /// Check the Limit on Eagerness constraint.
+    ///
+    /// Returns the maximum immutable tip slot that block application should
+    /// advance to. Returns `None` if there is no constraint (CaughtUp state).
+    #[allow(dead_code)]
+    pub fn loe_limit(&self, candidate_tips: &[Point]) -> Option<u64> {
+        if !self.enabled {
+            return None; // No constraint
+        }
+
+        match self.state {
+            GenesisSyncState::PreSyncing => {
+                // Don't apply any blocks — anchor at genesis
+                Some(0)
+            }
+            GenesisSyncState::Syncing => {
+                // Don't advance immutable tip past common prefix of all candidate chains
+                if candidate_tips.is_empty() {
+                    return Some(0);
+                }
+                // Common prefix = minimum tip slot across all candidates
+                let min_slot = candidate_tips
+                    .iter()
+                    .filter_map(|p| p.slot())
+                    .map(|s| s.0)
+                    .min()
+                    .unwrap_or(0);
+                Some(min_slot)
+            }
+            GenesisSyncState::CaughtUp => {
+                None // No constraint
+            }
+        }
+    }
+
+    /// Run the Genesis Density Disconnector (GDD).
+    ///
+    /// During Syncing state, compares chain density across peers within the
+    /// genesis window. Peers whose density upper bound is ≤ another peer's
+    /// lower bound are disconnected.
+    ///
+    /// Returns addresses of peers that should be disconnected.
+    #[allow(dead_code)]
+    pub fn gdd_evaluate(
+        &self,
+        peer_chain_lengths: &HashMap<SocketAddr, PeerChainInfo>,
+    ) -> Vec<SocketAddr> {
+        if !self.enabled || self.state != GenesisSyncState::Syncing {
+            return Vec::new();
+        }
+
+        if peer_chain_lengths.len() < 2 {
+            return Vec::new();
+        }
+
+        let mut to_disconnect = Vec::new();
+
+        // For each peer, compute density bounds within genesis window
+        let densities: Vec<(SocketAddr, f64, f64)> = peer_chain_lengths
+            .iter()
+            .map(|(addr, info)| {
+                let window = self.config.genesis_window_slots as f64;
+                // Lower bound: assume minimum blocks in window
+                let lower = info.blocks_in_window as f64 / window;
+                // Upper bound: actual observed + 10% margin for latency
+                let upper = (info.blocks_in_window as f64 * 1.1) / window;
+                (*addr, lower, upper)
+            })
+            .collect();
+
+        // Find the maximum lower bound (best peer's guaranteed density)
+        let max_lower = densities
+            .iter()
+            .map(|(_, lower, _)| *lower)
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .unwrap_or(0.0);
+
+        // Disconnect peers whose upper bound is ≤ the max lower bound
+        for (addr, _, upper) in &densities {
+            if *upper > 0.0 && *upper <= max_lower {
+                debug!(
+                    %addr,
+                    upper,
+                    max_lower,
+                    "GDD: disconnecting sparse peer"
+                );
+                to_disconnect.push(*addr);
+            }
+        }
+
+        if !to_disconnect.is_empty() {
+            info!(
+                disconnecting = to_disconnect.len(),
+                "GDD: disconnecting peers with insufficient chain density"
+            );
+        }
+
+        to_disconnect
+    }
+
+    /// Write the caught_up marker file
+    fn write_marker(&self) {
+        if let Err(e) = std::fs::write(&self.config.marker_path, "caught_up") {
+            warn!(
+                path = %self.config.marker_path.display(),
+                "Failed to write caught_up marker: {e}"
+            );
+        }
+    }
+
+    /// Remove the caught_up marker file
+    fn remove_marker(&self) {
+        if self.config.marker_path.exists() {
+            if let Err(e) = std::fs::remove_file(&self.config.marker_path) {
+                warn!(
+                    path = %self.config.marker_path.display(),
+                    "Failed to remove caught_up marker: {e}"
+                );
+            }
+        }
+    }
+}
+
+/// Chain info tracked per peer for GDD density comparison.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct PeerChainInfo {
+    /// Number of blocks this peer's chain has within the genesis window
+    pub blocks_in_window: u64,
+    /// Peer's reported tip slot
+    pub tip_slot: u64,
+}
+
+/// Identify big ledger peers from the stake distribution.
+///
+/// Sorts pools by active stake descending and accumulates until 90% of total
+/// active stake is covered. Pools in the top 90% are "big ledger peers".
+///
+/// Returns (big_ledger_pool_ids, remaining_pool_ids).
+#[allow(dead_code)]
+pub fn identify_big_ledger_peers(pool_stakes: &[(Vec<u8>, u64)]) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    if pool_stakes.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    let total_stake: u64 = pool_stakes.iter().map(|(_, s)| s).sum();
+    let threshold = (total_stake as f64 * 0.9) as u64;
+
+    let mut sorted: Vec<_> = pool_stakes.to_vec();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1)); // descending by stake
+
+    let mut accumulated = 0u64;
+    let mut big_ledger = Vec::new();
+    let mut remaining = Vec::new();
+
+    for (pool_id, stake) in sorted {
+        if accumulated < threshold {
+            accumulated += stake;
+            big_ledger.push(pool_id);
+        } else {
+            remaining.push(pool_id);
+        }
+    }
+
+    (big_ledger, remaining)
+}
+
+/// Load peer snapshot from a JSON file.
+///
+/// Format: `[{"addr": "1.2.3.4", "port": 3001}, ...]`
+#[allow(dead_code)]
+pub fn load_peer_snapshot(path: &Path) -> Result<Vec<SocketAddr>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read peer snapshot file: {e}"))?;
+
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse peer snapshot JSON: {e}"))?;
+
+    let mut peers = Vec::new();
+    for entry in entries {
+        if let (Some(addr), Some(port)) = (
+            entry.get("addr").and_then(|v| v.as_str()),
+            entry.get("port").and_then(|v| v.as_u64()),
+        ) {
+            if let Ok(socket_addr) = format!("{addr}:{port}").parse::<SocketAddr>() {
+                peers.push(socket_addr);
+            }
+        }
+    }
+
+    Ok(peers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use torsten_primitives::time::SlotNo;
+
+    #[test]
+    fn test_gsm_disabled_stays_caught_up() {
+        let config = GsmConfig {
+            marker_path: PathBuf::from("/tmp/test_gsm_disabled_marker"),
+            ..Default::default()
+        };
+        let mut gsm = GenesisStateMachine::new(config, false);
+
+        assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+        // Should not transition even with bad conditions
+        let result = gsm.evaluate(0, false, 9999);
+        assert_eq!(result, None);
+        assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+    }
+
+    #[test]
+    fn test_gsm_presyncing_to_syncing() {
+        let config = GsmConfig {
+            min_active_blp: 3,
+            marker_path: PathBuf::from("/tmp/test_gsm_pre_sync_marker"),
+            ..Default::default()
+        };
+        // Ensure no marker file
+        let _ = std::fs::remove_file(&config.marker_path);
+        let mut gsm = GenesisStateMachine::new(config, true);
+
+        assert_eq!(gsm.state(), GenesisSyncState::PreSyncing);
+
+        // Not enough BLPs
+        assert_eq!(gsm.evaluate(2, false, 0), None);
+        assert_eq!(gsm.state(), GenesisSyncState::PreSyncing);
+
+        // Enough BLPs
+        let result = gsm.evaluate(3, false, 0);
+        assert_eq!(result, Some(GenesisSyncState::Syncing));
+        assert_eq!(gsm.state(), GenesisSyncState::Syncing);
+    }
+
+    #[test]
+    fn test_gsm_syncing_to_caught_up() {
+        let config = GsmConfig {
+            min_active_blp: 1,
+            max_tip_age_secs: 600,
+            marker_path: PathBuf::from("/tmp/test_gsm_sync_caught_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        let mut gsm = GenesisStateMachine::new(config.clone(), true);
+
+        // Move to Syncing
+        gsm.evaluate(5, false, 0);
+        assert_eq!(gsm.state(), GenesisSyncState::Syncing);
+
+        // Not idle yet
+        assert_eq!(gsm.evaluate(5, false, 100), None);
+        assert_eq!(gsm.state(), GenesisSyncState::Syncing);
+
+        // Idle but tip too old
+        assert_eq!(gsm.evaluate(5, true, 700), None);
+        assert_eq!(gsm.state(), GenesisSyncState::Syncing);
+
+        // Idle and tip fresh
+        let result = gsm.evaluate(5, true, 100);
+        assert_eq!(result, Some(GenesisSyncState::CaughtUp));
+        assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+
+        // Marker file should exist
+        assert!(config.marker_path.exists());
+        let _ = std::fs::remove_file(&config.marker_path);
+    }
+
+    #[test]
+    fn test_gsm_caught_up_regression() {
+        let config = GsmConfig {
+            min_active_blp: 1,
+            max_tip_age_secs: 600,
+            marker_path: PathBuf::from("/tmp/test_gsm_regression_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        let mut gsm = GenesisStateMachine::new(config.clone(), true);
+
+        // Fast-track to CaughtUp
+        gsm.evaluate(5, false, 0); // → Syncing
+        gsm.evaluate(5, true, 100); // → CaughtUp
+        assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+
+        // Tip becomes stale → regress
+        let result = gsm.evaluate(5, false, 1300);
+        assert_eq!(result, Some(GenesisSyncState::PreSyncing));
+        assert_eq!(gsm.state(), GenesisSyncState::PreSyncing);
+
+        let _ = std::fs::remove_file(&config.marker_path);
+    }
+
+    #[test]
+    fn test_gsm_marker_fast_restart() {
+        let marker_path = PathBuf::from("/tmp/test_gsm_fast_restart_marker");
+        std::fs::write(&marker_path, "caught_up").unwrap();
+
+        let config = GsmConfig {
+            marker_path: marker_path.clone(),
+            ..Default::default()
+        };
+        let gsm = GenesisStateMachine::new(config, true);
+        assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+
+        let _ = std::fs::remove_file(&marker_path);
+    }
+
+    #[test]
+    fn test_loe_presyncing_blocks_all() {
+        let config = GsmConfig {
+            marker_path: PathBuf::from("/tmp/test_loe_pre_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        let gsm = GenesisStateMachine::new(config, true);
+        assert_eq!(gsm.state(), GenesisSyncState::PreSyncing);
+
+        let limit = gsm.loe_limit(&[]);
+        assert_eq!(limit, Some(0)); // Block everything
+    }
+
+    #[test]
+    fn test_loe_syncing_constrains_to_common_prefix() {
+        let config = GsmConfig {
+            min_active_blp: 1,
+            marker_path: PathBuf::from("/tmp/test_loe_sync_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        let mut gsm = GenesisStateMachine::new(config, true);
+        gsm.evaluate(5, false, 0); // → Syncing
+
+        let tips = vec![
+            Point::Specific(SlotNo(1000), torsten_primitives::hash::Hash32::ZERO),
+            Point::Specific(SlotNo(800), torsten_primitives::hash::Hash32::ZERO),
+            Point::Specific(SlotNo(1200), torsten_primitives::hash::Hash32::ZERO),
+        ];
+        let limit = gsm.loe_limit(&tips);
+        assert_eq!(limit, Some(800)); // Min of all candidate tip slots
+    }
+
+    #[test]
+    fn test_loe_caught_up_no_constraint() {
+        let config = GsmConfig {
+            marker_path: PathBuf::from("/tmp/test_loe_caught_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        std::fs::write(&config.marker_path, "caught_up").unwrap();
+        let gsm = GenesisStateMachine::new(config.clone(), true);
+        assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+
+        let limit = gsm.loe_limit(&[]);
+        assert_eq!(limit, None); // No constraint
+        let _ = std::fs::remove_file(&config.marker_path);
+    }
+
+    #[test]
+    fn test_gdd_disconnects_sparse_peers() {
+        let config = GsmConfig {
+            min_active_blp: 1,
+            genesis_window_slots: 1000,
+            marker_path: PathBuf::from("/tmp/test_gdd_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        let mut gsm = GenesisStateMachine::new(config, true);
+        gsm.evaluate(5, false, 0); // → Syncing
+
+        let addr_good: SocketAddr = "1.2.3.4:3001".parse().unwrap();
+        let addr_bad: SocketAddr = "5.6.7.8:3001".parse().unwrap();
+
+        let mut peers = HashMap::new();
+        peers.insert(
+            addr_good,
+            PeerChainInfo {
+                blocks_in_window: 900,
+                tip_slot: 1000,
+            },
+        );
+        peers.insert(
+            addr_bad,
+            PeerChainInfo {
+                blocks_in_window: 100, // Very sparse
+                tip_slot: 1000,
+            },
+        );
+
+        let to_disconnect = gsm.gdd_evaluate(&peers);
+        assert!(
+            to_disconnect.contains(&addr_bad),
+            "Sparse peer should be disconnected"
+        );
+        assert!(
+            !to_disconnect.contains(&addr_good),
+            "Dense peer should NOT be disconnected"
+        );
+    }
+
+    #[test]
+    fn test_gdd_disabled_when_caught_up() {
+        let config = GsmConfig {
+            marker_path: PathBuf::from("/tmp/test_gdd_disabled_marker"),
+            ..Default::default()
+        };
+        let _ = std::fs::remove_file(&config.marker_path);
+        std::fs::write(&config.marker_path, "caught_up").unwrap();
+        let gsm = GenesisStateMachine::new(config.clone(), true);
+
+        let mut peers = HashMap::new();
+        peers.insert(
+            "1.2.3.4:3001".parse().unwrap(),
+            PeerChainInfo {
+                blocks_in_window: 900,
+                tip_slot: 1000,
+            },
+        );
+        peers.insert(
+            "5.6.7.8:3001".parse().unwrap(),
+            PeerChainInfo {
+                blocks_in_window: 10,
+                tip_slot: 1000,
+            },
+        );
+
+        let to_disconnect = gsm.gdd_evaluate(&peers);
+        assert!(
+            to_disconnect.is_empty(),
+            "GDD should be inactive when CaughtUp"
+        );
+        let _ = std::fs::remove_file(&config.marker_path);
+    }
+
+    #[test]
+    fn test_identify_big_ledger_peers() {
+        let pools = vec![
+            (vec![1], 1000), // 50%
+            (vec![2], 500),  // 25%
+            (vec![3], 300),  // 15%
+            (vec![4], 100),  // 5%
+            (vec![5], 100),  // 5%
+        ];
+
+        let (big, remaining) = identify_big_ledger_peers(&pools);
+        // 90% threshold = 1800. Pool 1 (1000) + Pool 2 (500) + Pool 3 (300) = 1800
+        assert!(big.len() >= 2, "Should have at least 2 big ledger peers");
+        assert!(
+            !remaining.is_empty(),
+            "Should have some remaining small pools"
+        );
+    }
+
+    #[test]
+    fn test_identify_big_ledger_peers_empty() {
+        let (big, remaining) = identify_big_ledger_peers(&[]);
+        assert!(big.is_empty());
+        assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn test_load_peer_snapshot() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_peer_snapshot.json");
+        std::fs::write(
+            &path,
+            r#"[{"addr": "1.2.3.4", "port": 3001}, {"addr": "5.6.7.8", "port": 3002}]"#,
+        )
+        .unwrap();
+
+        let peers = load_peer_snapshot(&path).unwrap();
+        assert_eq!(peers.len(), 2);
+        assert_eq!(peers[0].to_string(), "1.2.3.4:3001");
+        assert_eq!(peers[1].to_string(), "5.6.7.8:3002");
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/torsten-node/src/main.rs
+++ b/crates/torsten-node/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod disk_monitor;
 mod forge;
 mod genesis;
+mod gsm;
 mod logging;
 mod metrics;
 mod mithril;
@@ -130,6 +131,15 @@ struct RunArgs {
     /// Override: LSM bloom filter bits per key
     #[arg(long)]
     utxo_bloom_filter_bits: Option<u32>,
+
+    /// Consensus mode: praos (default) or genesis (enables genesis bootstrap from empty DB)
+    #[arg(long, default_value = "praos")]
+    consensus_mode: String,
+
+    /// Force full Phase-2 Plutus validation on all blocks, even during initial sync.
+    /// Normally only blocks at tip are fully validated; this enables paranoid/auditing mode.
+    #[arg(long)]
+    validate_all_blocks: bool,
 
     // Block producer options (optional — enables block production mode)
     /// Path to the KES signing key file
@@ -309,6 +319,8 @@ async fn run_node(args: RunArgs) -> Result<()> {
         snapshot_bulk_min_blocks: args.snapshot_bulk_min_blocks,
         snapshot_bulk_min_secs: args.snapshot_bulk_min_secs,
         storage_config,
+        consensus_mode: args.consensus_mode,
+        validate_all_blocks: args.validate_all_blocks,
     })?;
 
     info!("");

--- a/crates/torsten-node/src/node.rs
+++ b/crates/torsten-node/src/node.rs
@@ -7,14 +7,14 @@ use tracing::{debug, error, info, warn};
 
 use torsten_consensus::praos::BlockIssuerInfo;
 use torsten_consensus::{OuroborosPraos, ValidationMode};
-use torsten_ledger::LedgerState;
+use torsten_ledger::{BlockValidationMode, LedgerState};
 use torsten_mempool::{Mempool, MempoolConfig};
 use torsten_network::query_handler::{UtxoQueryProvider, UtxoSnapshot};
 use torsten_network::server::NodeServerConfig;
 use torsten_network::{
-    BlockFetchPool, BlockProvider, ChainSyncEvent, DiffusionMode, HeaderBatchResult, N2CServer,
-    NodeServer, NodeStateSnapshot, NodeToNodeClient, PeerManager, PeerManagerConfig,
-    PipelinedPeerClient, QueryHandler, TipInfo, TxValidationError, TxValidator,
+    BlockFetchPool, BlockProvider, ChainSyncEvent, DiffusionMode, Governor, GovernorEvent,
+    HeaderBatchResult, N2CServer, NodeServer, NodeStateSnapshot, NodeToNodeClient, PeerManager,
+    PeerManagerConfig, PipelinedPeerClient, QueryHandler, TipInfo, TxValidationError, TxValidator,
 };
 use torsten_primitives::block::Point;
 use torsten_primitives::protocol_params::ProtocolParameters;
@@ -54,6 +54,10 @@ pub struct NodeArgs {
     pub snapshot_bulk_min_secs: u64,
     /// Storage configuration (block index type, UTxO backend, LSM tuning)
     pub storage_config: torsten_storage::StorageConfig,
+    /// Consensus mode: "praos" (default) or "genesis" (enables genesis bootstrap)
+    pub consensus_mode: String,
+    /// Force ValidateAll mode on every block (paranoid/auditing mode)
+    pub validate_all_blocks: bool,
 }
 
 /// Provides block data from ChainDB for the N2N server
@@ -662,6 +666,10 @@ pub struct Node {
     epoch_transitions_observed: u32,
     /// Snapshot policy controlling when ledger snapshots are taken.
     snapshot_policy: SnapshotPolicy,
+    /// Consensus mode: "praos" (default) or "genesis"
+    consensus_mode: String,
+    /// Force full Phase-2 Plutus validation on all blocks
+    validate_all_blocks: bool,
 }
 
 impl Node {
@@ -965,6 +973,7 @@ impl Node {
         let mempool = Arc::new(Mempool::new(MempoolConfig {
             max_transactions: args.mempool_max_tx,
             max_bytes: args.mempool_max_bytes,
+            ..MempoolConfig::default()
         }));
 
         let socket_path = args.socket_path.clone();
@@ -1098,6 +1107,8 @@ impl Node {
             expected_shelley_genesis_hash,
             genesis_validated: false,
             epoch_transitions_observed: 0,
+            consensus_mode: args.consensus_mode,
+            validate_all_blocks: args.validate_all_blocks,
         })
     }
 
@@ -1466,6 +1477,102 @@ impl Node {
         }
 
         let network_magic = self.network_magic;
+
+        // Initialize Genesis State Machine (GSM)
+        let genesis_enabled = self.consensus_mode == "genesis";
+        let gsm_config = crate::gsm::GsmConfig {
+            marker_path: self.database_path.join("caught_up.marker"),
+            ..Default::default()
+        };
+        let gsm = std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::gsm::GenesisStateMachine::new(gsm_config, genesis_enabled),
+        ));
+        if genesis_enabled {
+            info!(
+                state = %gsm.blocking_read().state(),
+                "Genesis mode enabled"
+            );
+        }
+
+        // Spawn GSM evaluation task
+        if genesis_enabled {
+            let gsm_ref = gsm.clone();
+            let gsm_pm = peer_manager.clone();
+            let gsm_shutdown = shutdown_rx.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
+                interval.tick().await;
+                let mut shutdown = gsm_shutdown;
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {}
+                        _ = shutdown.changed() => { break; }
+                    }
+
+                    let active_blp = {
+                        let pm = gsm_pm.read().await;
+                        pm.active_big_ledger_peer_count()
+                    };
+
+                    let mut gsm_w = gsm_ref.write().await;
+                    // TODO: compute tip_age and chainsync_idle from actual state
+                    let tip_age_secs = 0u64;
+                    let all_idle = false;
+                    gsm_w.evaluate(active_blp, all_idle, tip_age_secs);
+                }
+            });
+        }
+
+        // Spawn the P2P governor task — periodically evaluates peer targets
+        // and emits connect/disconnect/promote/demote events
+        {
+            let governor_pm = peer_manager.clone();
+            let governor_shutdown = shutdown_rx.clone();
+            tokio::spawn(async move {
+                let mut governor = Governor::new(Default::default());
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+                interval.tick().await; // skip first immediate tick
+                let mut shutdown = governor_shutdown;
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {}
+                        _ = shutdown.changed() => { break; }
+                    }
+
+                    // Run governor evaluation
+                    let events = {
+                        let pm = governor_pm.read().await;
+                        let mut all_events = governor.evaluate(&pm);
+                        // Also check churn
+                        all_events.extend(governor.maybe_churn(&pm));
+                        all_events
+                    };
+
+                    // Execute governor events
+                    if !events.is_empty() {
+                        let mut pm = governor_pm.write().await;
+                        for event in &events {
+                            match event {
+                                GovernorEvent::Promote(addr) => {
+                                    pm.promote_to_hot(addr);
+                                }
+                                GovernorEvent::Demote(addr) => {
+                                    pm.demote_to_warm(addr);
+                                }
+                                GovernorEvent::Disconnect(addr) => {
+                                    pm.peer_disconnected(addr);
+                                }
+                                GovernorEvent::Connect(_) => {
+                                    // Connection events are handled by the main loop
+                                    // via peers_to_connect()
+                                }
+                            }
+                        }
+                        pm.recompute_reputations();
+                    }
+                }
+            });
+        }
 
         // Main connection loop — connect to peers and sync
         let mut retry_count = 0u32;
@@ -2112,7 +2219,7 @@ impl Node {
                         }
 
                         let mut ls_guard = ledger_state.blocking_write();
-                        if let Err(e) = ls_guard.apply_block(&block) {
+                        if let Err(e) = ls_guard.apply_block(&block, BlockValidationMode::ApplyOnly) {
                             warn!(slot = block.slot().0, error = %e, "Ledger apply failed during replay");
                         }
                         replayed += 1;
@@ -2224,7 +2331,7 @@ impl Node {
                     ) {
                         Ok(block) => {
                             let mut ls = self.ledger_state.write().await;
-                            if let Err(e) = ls.apply_block(&block) {
+                            if let Err(e) = ls.apply_block(&block, BlockValidationMode::ApplyOnly) {
                                 warn!(
                                     "Replay       ledger apply failed at slot {} block {}: {e}",
                                     slot.0, block_no
@@ -3148,7 +3255,7 @@ impl Node {
                                 }
                                 match torsten_serialization::multi_era::decode_block_with_byron_epoch_length(&cbor, self.byron_epoch_length) {
                                     Ok(block) => {
-                                        if let Err(e) = ls.apply_block(&block) {
+                                        if let Err(e) = ls.apply_block(&block, BlockValidationMode::ApplyOnly) {
                                             warn!(
                                                 slot = next_slot.0,
                                                 "Gap bridge apply failed: {e} — aborting bridge"
@@ -3187,7 +3294,12 @@ impl Node {
                         continue;
                     }
                 }
-                if let Err(e) = ls.apply_block(block) {
+                let ledger_mode = if strict || self.validate_all_blocks {
+                    BlockValidationMode::ValidateAll
+                } else {
+                    BlockValidationMode::ApplyOnly
+                };
+                if let Err(e) = ls.apply_block(block, ledger_mode) {
                     error!(
                         slot = block.slot().0,
                         block_no = block.block_number().0,
@@ -3200,7 +3312,7 @@ impl Node {
             }
         }
 
-        // Remove confirmed transactions from mempool and revalidate
+        // Remove confirmed transactions from mempool, then full revalidation
         if !self.mempool.is_empty() {
             let confirmed_hashes: Vec<_> = blocks
                 .iter()
@@ -3210,18 +3322,32 @@ impl Node {
                 self.mempool.remove_txs(&confirmed_hashes);
             }
 
-            // Remove mempool txs whose inputs conflict with the confirmed block inputs
+            // Full revalidation: check each remaining tx for input conflicts,
+            // TTL expiry, and any other invalidity in one pass.
             let consumed_inputs: std::collections::HashSet<_> = blocks
                 .iter()
                 .flat_map(|b| b.transactions.iter())
                 .flat_map(|tx| tx.body.inputs.iter().cloned())
                 .collect();
-            self.mempool.revalidate_against_inputs(&consumed_inputs);
-
-            // Evict expired transactions based on current slot
-            if let Some(last_block) = blocks.last() {
-                self.mempool.evict_expired(last_block.slot());
-            }
+            let current_slot = blocks.last().map(|b| b.slot());
+            self.mempool.revalidate_all(|tx| {
+                // Reject if any input was consumed by the new block
+                if tx
+                    .body
+                    .inputs
+                    .iter()
+                    .any(|input| consumed_inputs.contains(input))
+                {
+                    return false;
+                }
+                // Reject if TTL has expired
+                if let (Some(ttl), Some(slot)) = (tx.body.ttl, current_slot) {
+                    if slot.0 > ttl.0 {
+                        return false;
+                    }
+                }
+                true
+            });
         }
 
         if let Some(last_block) = blocks.last() {
@@ -4507,7 +4633,7 @@ impl Node {
                                 }
                                 match torsten_serialization::multi_era::decode_block_with_byron_epoch_length(&cbor, self.byron_epoch_length) {
                                     Ok(block) => {
-                                        if let Err(e) = ls.apply_block(&block) {
+                                        if let Err(e) = ls.apply_block(&block, BlockValidationMode::ApplyOnly) {
                                             error!(
                                                 slot = next_slot.0,
                                                 "Ledger apply failed during rollback replay: {e} — aborting replay"
@@ -4729,7 +4855,7 @@ impl Node {
                 // Apply to ledger
                 {
                     let mut ls = self.ledger_state.write().await;
-                    if let Err(e) = ls.apply_block(&block) {
+                    if let Err(e) = ls.apply_block(&block, BlockValidationMode::ApplyOnly) {
                         error!("Failed to apply forged block to ledger: {e}");
                         return;
                     }


### PR DESCRIPTION
## Summary
- **Phase-2 Plutus validation**: `validate_scripts_phase2()` in ledger state with full Plutus V1/V2/V3 script evaluation via `pallas-applying`, including redeemer lookup, datum resolution, execution unit enforcement, and ExUnits budget tracking
- **P2P Governor**: New `PeerGovernor` in torsten-network implementing target-based peer management (cold→warm→hot promotion/demotion), churn rotation, big ledger peer handling, and integration with existing `PeerManager`
- **Genesis State Machine (GSM)**: New `GenesisStateMachine` in torsten-node implementing PreSyncing→Syncing→CaughtUp state transitions with configurable caught-up detection, bootstrap peer support, and Limit on Eagerness (LoE) enforcement
- **Enhanced mempool**: Major rewrite of torsten-mempool with FIFO ordering, multi-dimensional capacity tracking (count + bytes + ExUnits), automatic revalidation on ledger state changes, fair tx selection, and snapshotting for block production

## Test plan
- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Verify Phase-2 validation catches invalid Plutus scripts during block application
- [ ] Verify P2P governor promotes/demotes peers based on targets
- [ ] Verify GSM transitions correctly during sync
- [ ] Verify mempool revalidation on rollback