### PR TITLE
build(nix): add Nix flake with packages, dev shell, and NixOS module

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,14 @@ checkpoints.json
 .monitoring-data/
 .claude/worktrees/
 .DS_Store
+
+# Nix
+result
+result-*
+
+# Direnv
+.direnv*
+
+# Claude
+
+.claude/settings.local.json

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,158 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1773646590,
+        "narHash": "sha256-qwnecNC3DB0hSu6MvU27xh/Mg9uPbmmg7d1wBOtO7ds=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "350a4df2afc34c1ae115173e0509cec7067a06c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773610124,
+        "narHash": "sha256-EpC7ELOKmb+xXaqpK5ZRpJ5g9fxxg6tWny7/rUBfrwk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fe1300f4360e13f39d6d1d006e54fd5093e9ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773543526,
+        "narHash": "sha256-CKmkYqUi2pI1uDGDfpK0mkZbRLyjUKCpYDU3eMHtmks=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "90c8906e6443e7cee18cece9c2621a8b1c10794c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773630837,
+        "narHash": "sha256-zJhgAGnbVKeBMJOb9ctZm4BGS/Rnrz+5lfSXTVah4HQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f600ea449c7b5bb596fa1cf21c871cc5b9e31316",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Torsten - A Rust implementation of the Cardano node";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    crane.url = "github:ipetkov/crane";
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    flake-parts,
+    nixpkgs,
+    ...
+  } @ inputs: let
+    inherit ((import ./flake/lib.nix {inherit inputs;}).flake.lib) recursiveImports;
+  in
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      imports =
+        recursiveImports [
+          ./flake
+          ./perSystem
+        ]
+        ++ [
+          inputs.treefmt-nix.flakeModule
+        ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = {system, ...}: {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [inputs.rust-overlay.overlays.default];
+        };
+      };
+    }
+    // {
+      inherit inputs;
+    };
+}

--- a/flake/lib.nix
+++ b/flake/lib.nix
@@ -1,0 +1,38 @@
+{inputs, ...}: {
+  flake.lib = inputs.nixpkgs.lib.extend (_self: lib: {
+    recursiveImports = let
+      # Recursively constructs an attrset of a given folder, recursing on
+      # directories, value of attrs is the filetype
+      getDir = dir:
+        lib.mapAttrs
+        (
+          file: type:
+            if type == "directory"
+            then getDir "${dir}/${file}"
+            else type
+        )
+        (builtins.readDir dir);
+
+      # Collects all files of a directory as a list of strings of paths
+      files = path:
+        if lib.pathType path == "directory"
+        then
+          lib.collect lib.isString (lib.mapAttrsRecursive
+            (path: _type: lib.concatStringsSep "/" path)
+            (getDir path))
+        else [path];
+
+      # Filters out files that don't end with .nix and also make the strings absolute path based
+      validFiles = path:
+        map
+        (file:
+          if lib.hasPrefix "/nix/store" file
+          then file
+          else path + "/${file}")
+        (lib.filter
+          (lib.hasSuffix ".nix")
+          (files path));
+    in
+      lib.concatMap validFiles;
+  });
+}

--- a/flake/nixosModules/service-torsten.nix
+++ b/flake/nixosModules/service-torsten.nix
@@ -1,0 +1,158 @@
+{
+  flake.nixosModules.service-torsten = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    cfg = config.services.torsten;
+  in
+    with lib; {
+      options.services.torsten = {
+        enable = mkEnableOption "torsten Cardano node";
+
+        package = mkOption {
+          type = types.package;
+          default = pkgs.torsten-node;
+          description = "The torsten package to use";
+        };
+
+        network = mkOption {
+          type = types.enum ["mainnet" "preprod" "preview"];
+          default = "mainnet";
+          description = "Cardano network to connect to";
+        };
+
+        configFile = mkOption {
+          type = types.path;
+          description = "Path to node configuration JSON file";
+        };
+
+        topologyFile = mkOption {
+          type = types.path;
+          description = "Path to topology JSON file";
+        };
+
+        databasePath = mkOption {
+          type = types.str;
+          default = "/var/lib/torsten";
+          description = "Path to blockchain database directory";
+        };
+
+        socketPath = mkOption {
+          type = types.str;
+          default = "/run/torsten/node.sock";
+          description = "Path to node socket";
+        };
+
+        hostAddr = mkOption {
+          type = types.str;
+          default = "0.0.0.0";
+          description = "Address to bind the node";
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 3001;
+          description = "Port for P2P connections";
+        };
+
+        mithrilImport = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Import Mithril snapshot on first run";
+        };
+
+        extraArgs = mkOption {
+          type = types.listOf types.str;
+          default = [];
+          description = "Extra command-line arguments to pass to torsten-node";
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "torsten";
+          description = "User to run torsten service as";
+        };
+
+        group = mkOption {
+          type = types.str;
+          default = "torsten";
+          description = "Group for torsten service";
+        };
+      };
+
+      config = mkIf cfg.enable {
+        users.users.${cfg.user} = {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.databasePath;
+          createHome = true;
+        };
+
+        users.groups.${cfg.group} = {};
+
+        systemd.services.torsten = {
+          description = "Torsten Cardano Node";
+          wantedBy = ["multi-user.target"];
+          after = ["network-online.target"];
+          wants = ["network-online.target"];
+
+          environment = {
+            RUST_LOG = "torsten=info,torsten_network=debug";
+          };
+
+          preStart = mkIf cfg.mithrilImport ''
+            if [ ! -d "${cfg.databasePath}/immutable" ]; then
+              echo "Importing Mithril snapshot..."
+              ${cfg.package}/bin/torsten-node mithril-import \
+                --network-magic ${
+                if cfg.network == "mainnet"
+                then "764824073"
+                else if cfg.network == "preprod"
+                then "1"
+                else "2"
+              } \
+                --database-path ${cfg.databasePath}
+            fi
+          '';
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+            Restart = "always";
+            RestartSec = "30s";
+            TimeoutStartSec = "600";
+
+            StateDirectory = "torsten";
+            RuntimeDirectory = "torsten";
+
+            ExecStart = ''
+              ${cfg.package}/bin/torsten-node run \
+                --config ${cfg.configFile} \
+                --topology ${cfg.topologyFile} \
+                --database-path ${cfg.databasePath} \
+                --socket-path ${cfg.socketPath} \
+                --host-addr ${cfg.hostAddr} \
+                --port ${toString cfg.port} \
+                ${concatStringsSep " " cfg.extraArgs}
+            '';
+
+            # Resource limits
+            MemoryMax = "8G";
+
+            # Hardening
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            ReadWritePaths = [cfg.databasePath "/run/torsten"];
+          };
+        };
+
+        # Firewall
+        networking.firewall.allowedTCPPorts = [cfg.port];
+      };
+    };
+}

--- a/perSystem/devShells.nix
+++ b/perSystem/devShells.nix
@@ -1,0 +1,64 @@
+{
+  perSystem = {
+    config,
+    pkgs,
+    inputs',
+    ...
+  }: let
+    # Use stable toolchain - same as packages.nix
+    toolchain = with inputs'.fenix.packages;
+      combine [
+        stable.rustc
+        stable.cargo
+        stable.clippy
+        stable.rustfmt
+        stable.rust-analyzer
+      ];
+  in {
+    devShells.default = with pkgs;
+      mkShell {
+        packages =
+          [
+            # Rust toolchain (stable from fenix)
+            toolchain
+            cmake
+            pkg-config
+            openssl
+            zlib
+
+            # Task runner
+            just
+
+            # Utilities
+            jq
+            fd
+            ripgrep
+
+            # Tree formatter
+            config.treefmt.build.wrapper
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isDarwin [
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
+          ];
+
+        shellHook = ''
+          echo "🦀 Torsten - Cardano Node in Rust"
+          echo ""
+          echo "Rust: $(rustc --version)"
+          echo "Cargo: $(cargo --version)"
+          echo ""
+          echo "Commands:"
+          echo "  cargo build --all-targets          # Build everything"
+          echo "  cargo test --all                   # Run all tests"
+          echo "  cargo clippy --all-targets -- -D warnings  # Lint"
+          echo "  cargo fmt --all -- --check         # Check formatting"
+          echo ""
+          echo "  cargo build --release              # Build release binary"
+          echo "  cargo run -p torsten-node -- --help"
+          echo "  cargo run -p torsten-cli -- --help"
+          echo "  cargo run -p torsten-tui"
+        '';
+      };
+  };
+}

--- a/perSystem/formatter.nix
+++ b/perSystem/formatter.nix
@@ -1,0 +1,9 @@
+{
+  perSystem = {pkgs, ...}: {
+    treefmt = {
+      projectRootFile = "flake.nix";
+      programs.rustfmt.enable = true;
+      programs.alejandra.enable = true;
+    };
+  };
+}

--- a/perSystem/packages.nix
+++ b/perSystem/packages.nix
@@ -1,0 +1,113 @@
+{inputs, ...}: {
+  perSystem = {
+    inputs',
+    system,
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    # Use stable toolchain for Torsten
+    toolchain = with inputs'.fenix.packages;
+      combine [
+        stable.rustc
+        stable.cargo
+        stable.clippy
+        stable.rustfmt
+      ];
+
+    craneLib = (inputs.crane.mkLib pkgs).overrideToolchain toolchain;
+
+    src = lib.fileset.toSource {
+      root = ./..;
+      fileset = lib.fileset.unions [
+        ../Cargo.lock
+        ../Cargo.toml
+        ../crates
+        ../tests
+      ];
+    };
+
+    # Extract pname and version from workspace Cargo.toml
+    cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+    version = cargoToml.workspace.package.version;
+
+    commonArgs = {
+      inherit src;
+      strictDeps = true;
+
+      nativeBuildInputs = with pkgs; [
+        pkg-config
+        installShellFiles
+      ];
+
+      buildInputs = with pkgs; lib.optionals stdenv.hostPlatform.isDarwin [
+        darwin.apple_sdk.frameworks.Security
+        darwin.apple_sdk.frameworks.SystemConfiguration
+      ];
+
+      meta = {
+        description = "Torsten - A Rust implementation of the Cardano node";
+        license = lib.licenses.asl20;
+      };
+    };
+
+    # Build dependencies separately for caching
+    cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  in {
+    packages = {
+      default = config.packages.torsten-node;
+
+      # Torsten node
+      torsten-node = craneLib.buildPackage (commonArgs
+        // {
+          inherit cargoArtifacts;
+          pname = "torsten-node";
+          inherit version;
+          cargoExtraArgs = "-p torsten-node";
+          doCheck = true;
+
+          meta = commonArgs.meta // {
+            mainProgram = "torsten-node";
+          };
+        });
+
+      # Torsten CLI
+      torsten-cli = craneLib.buildPackage (commonArgs
+        // {
+          inherit cargoArtifacts;
+          pname = "torsten-cli";
+          inherit version;
+          cargoExtraArgs = "-p torsten-cli";
+          doCheck = true;
+
+          meta = commonArgs.meta // {
+            mainProgram = "torsten-cli";
+          };
+        });
+
+      # Torsten TUI
+      torsten-tui = craneLib.buildPackage (commonArgs
+        // {
+          inherit cargoArtifacts;
+          pname = "torsten-tui";
+          inherit version;
+          cargoExtraArgs = "-p torsten-tui";
+          doCheck = true;
+
+          meta = commonArgs.meta // {
+            mainProgram = "torsten-tui";
+          };
+        });
+
+      # All binaries in one package
+      torsten-all = craneLib.buildPackage (commonArgs
+        // {
+          inherit cargoArtifacts;
+          pname = "torsten";
+          inherit version;
+          doCheck = true;
+        });
+    };
+  };
+}


### PR DESCRIPTION

## Summary

<!-- Brief description of what this PR does -->

Add complete Nix flake infrastructure for building and deploying Torsten:

- Main flake with inputs (nixpkgs, crane, fenix, rust-overlay, treefmt)
- Modular structure using flake-parts and recursive imports
- Package definitions for torsten-node, torsten-cli, torsten-tui, and combined
- Development shell with Rust stable toolchain and build dependencies
- NixOS module for running Torsten node as a systemd service
- Formatter configuration (rustfmt + alejandra)
- Multi-platform support (x86_64/aarch64 linux/darwin)

Packages use crane for efficient Rust builds with separate dependency caching. NixOS module supports Mithril import, network configuration, and hardened systemd service.


## Testing

- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] New tests added for new functionality
- [ ] Tested on preview testnet (if applicable)

## Related Issues

<!-- Link any related issues: Fixes #123, Related to #456 -->
