### PR TITLE
Fix #117: N2C spo-stake-distribution, stake-pool-default-vote, future-pparams encoding

### DIFF
--- a/crates/torsten-network/src/n2c/query/encoding.rs
+++ b/crates/torsten-network/src/n2c/query/encoding.rs
@@ -346,9 +346,8 @@ pub(crate) fn encode_query_result_value(
         }
         QueryResult::NoFuturePParams => {
             // GetFuturePParams result: Maybe PParams = Nothing
-            // Generic Serialise: Nothing = [0] (constructor 0)
-            enc.array(1).ok();
-            enc.u8(0).ok();
+            // Haskell encodeMaybe: Nothing = encodeListLen 0 = empty array (0x80)
+            enc.array(0).ok();
         }
         QueryResult::PoolDistr2 {
             pools,
@@ -363,14 +362,16 @@ pub(crate) fn encode_query_result_value(
         QueryResult::LedgerPeerSnapshot(peers) => {
             encode_ledger_peer_snapshot(enc, peers);
         }
-        QueryResult::StakePoolDefaultVote(entries) => {
-            // Map<PoolId, DefaultVote>
-            // DefaultVote: [0]=NoConfidence, [1]=Abstain, [2]=DRepVote
+        QueryResult::StakePoolDefaultVote(vote) => {
+            // Bare word8: 0=DefaultNo, 1=DefaultAbstain, 2=DefaultNoConfidence
+            enc.u8(*vote).ok();
+        }
+        QueryResult::SPOStakeDistr(entries) => {
+            // Map<pool_hash(28), Coin> — plain map from pool key hash to lovelace
             enc.map(entries.len() as u64).ok();
-            for entry in entries {
-                enc.bytes(&entry.pool_id).ok();
-                enc.array(1).ok();
-                enc.u32(entry.default_vote as u32).ok();
+            for (pool_id, stake) in entries {
+                enc.bytes(pool_id).ok();
+                enc.u64(*stake).ok();
             }
         }
         QueryResult::Error(msg) => {
@@ -1929,8 +1930,8 @@ mod tests {
     use super::*;
     use crate::query_handler::{
         CommitteeMemberSnapshot, CommitteeSnapshot, DRepSnapshot, DRepStakeEntry,
-        PoolDefaultVoteEntry, PoolParamsSnapshot, PoolStakeSnapshotEntry, StakeAddressSnapshot,
-        StakeDelegDepositEntry, StakePoolSnapshot, StakeSnapshotsResult, VoteDelegateeEntry,
+        PoolParamsSnapshot, PoolStakeSnapshotEntry, StakeAddressSnapshot, StakeDelegDepositEntry,
+        StakePoolSnapshot, StakeSnapshotsResult, VoteDelegateeEntry,
     };
     use minicbor::Decoder;
 
@@ -2419,26 +2420,38 @@ mod tests {
         );
     }
 
-    // ─── Default vote (tag 35) — pool IDs must be 28 bytes ─────────────────
+    // ─── Default vote (tag 35) — bare word8 encoding ───────────────────────
 
     #[test]
-    fn test_stake_pool_default_vote_pool_id_is_28_bytes() {
-        let result = QueryResult::StakePoolDefaultVote(vec![PoolDefaultVoteEntry {
-            pool_id: vec![0xBC; 28],
-            default_vote: 1, // Abstain
-        }]);
+    fn test_stake_pool_default_vote_bare_word8() {
+        let result = QueryResult::StakePoolDefaultVote(1); // DefaultAbstain
         let encoded = encode_query_result(&result);
         let inner = strip_wrappers(&encoded);
 
-        // Inner: map(1) { pool_id_bytes => default_vote }
+        // Inner: bare word8 (0=DefaultNo, 1=DefaultAbstain, 2=DefaultNoConfidence)
         let mut dec = Decoder::new(&inner);
-        dec.map().unwrap();
-        let pool_id = dec.bytes().unwrap();
-        assert_eq!(
-            pool_id.len(),
-            28,
-            "StakePoolDefaultVote pool_id must be 28 bytes, got {}",
-            pool_id.len()
-        );
+        assert_eq!(dec.u8().unwrap(), 1);
+    }
+
+    // ─── SPO stake distribution (tag 30) — Map<pool_hash, Coin> ─────────
+
+    #[test]
+    fn test_spo_stake_distr_map_encoding() {
+        let result = QueryResult::SPOStakeDistr(vec![
+            (vec![0x33; 28], 1_000_000),
+            (vec![0x44; 28], 2_000_000),
+        ]);
+        let encoded = encode_query_result(&result);
+        let inner = strip_wrappers(&encoded);
+
+        let mut dec = Decoder::new(&inner);
+        let map_len = dec.map().unwrap().unwrap();
+        assert_eq!(map_len, 2);
+        // First entry
+        assert_eq!(dec.bytes().unwrap(), &[0x33; 28]);
+        assert_eq!(dec.u64().unwrap(), 1_000_000);
+        // Second entry
+        assert_eq!(dec.bytes().unwrap(), &[0x44; 28]);
+        assert_eq!(dec.u64().unwrap(), 2_000_000);
     }
 }

--- a/crates/torsten-network/src/n2c/query/mod.rs
+++ b/crates/torsten-network/src/n2c/query/mod.rs
@@ -831,28 +831,33 @@ mod tests {
         let buf = encode(&QueryResult::NoFuturePParams);
         let mut dec = decode_msg_result(&buf);
         strip_hfc(&mut dec);
-        // Maybe PParams = Nothing = [0]
+        // Maybe PParams = Nothing = empty array (0x80)
         let arr = dec.array().unwrap().unwrap();
-        assert_eq!(arr, 1);
-        assert_eq!(dec.u8().unwrap(), 0);
+        assert_eq!(arr, 0);
     }
 
     #[test]
     fn test_encode_pool_default_vote() {
-        let buf = encode(&QueryResult::StakePoolDefaultVote(vec![
-            PoolDefaultVoteEntry {
-                pool_id: vec![0xEE; 28],
-                default_vote: 1, // Abstain
-            },
-        ]));
+        // QueryStakePoolDefaultVote returns a bare word8
+        let buf = encode(&QueryResult::StakePoolDefaultVote(1)); // DefaultAbstain
         let mut dec = decode_msg_result(&buf);
         strip_hfc(&mut dec);
+        assert_eq!(dec.u8().unwrap(), 1); // DefaultAbstain
+    }
+
+    #[test]
+    fn test_encode_spo_stake_distr() {
+        let buf = encode(&QueryResult::SPOStakeDistr(vec![(
+            vec![0x33; 28],
+            1_000_000,
+        )]));
+        let mut dec = decode_msg_result(&buf);
+        strip_hfc(&mut dec);
+        // Map<pool_hash, Coin>
         let map_len = dec.map().unwrap().unwrap();
         assert_eq!(map_len, 1);
-        assert_eq!(dec.bytes().unwrap(), &[0xEE; 28]);
-        let arr = dec.array().unwrap().unwrap();
-        assert_eq!(arr, 1);
-        assert_eq!(dec.u32().unwrap(), 1); // Abstain
+        assert_eq!(dec.bytes().unwrap(), &[0x33; 28]);
+        assert_eq!(dec.u64().unwrap(), 1_000_000);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/torsten-network/src/query_handler/mod.rs
+++ b/crates/torsten-network/src/query_handler/mod.rs
@@ -12,11 +12,10 @@ use tracing::{debug, warn};
 pub use types::{
     CommitteeMemberSnapshot, CommitteeSnapshot, DRepSnapshot, DRepStakeEntry, EraBound, EraSummary,
     GenesisConfigSnapshot, GovActionId, GovStateSnapshot, LedgerPeerEntry, MultiAssetSnapshot,
-    NodeStateSnapshot, NonMyopicRewardEntry, PoolDefaultVoteEntry, PoolParamsSnapshot,
-    PoolRewardInfo, PoolStakeSnapshotEntry, ProposalSnapshot, ProtocolParamsSnapshot, QueryResult,
-    RelaySnapshot, ShelleyPParamsSnapshot, SnapshotStakeData, StakeAddressSnapshot,
-    StakeDelegDepositEntry, StakePoolSnapshot, StakeSnapshotsResult, UtxoQueryProvider,
-    UtxoSnapshot, VoteDelegateeEntry,
+    NodeStateSnapshot, NonMyopicRewardEntry, PoolParamsSnapshot, PoolRewardInfo,
+    PoolStakeSnapshotEntry, ProposalSnapshot, ProtocolParamsSnapshot, QueryResult, RelaySnapshot,
+    ShelleyPParamsSnapshot, SnapshotStakeData, StakeAddressSnapshot, StakeDelegDepositEntry,
+    StakePoolSnapshot, StakeSnapshotsResult, UtxoQueryProvider, UtxoSnapshot, VoteDelegateeEntry,
 };
 
 /// Handler for local state queries.

--- a/crates/torsten-network/src/query_handler/stake.rs
+++ b/crates/torsten-network/src/query_handler/stake.rs
@@ -3,9 +3,7 @@
 use tracing::debug;
 
 use super::parse_credential_set;
-use super::types::{
-    LedgerPeerEntry, NodeStateSnapshot, PoolDefaultVoteEntry, PoolRewardInfo, QueryResult,
-};
+use super::types::{LedgerPeerEntry, NodeStateSnapshot, PoolRewardInfo, QueryResult};
 
 /// Handle GetFilteredDelegationsAndRewardAccounts (tag 10).
 ///
@@ -153,24 +151,33 @@ pub(crate) fn handle_pool_distr2(
 /// Handle GetSPOStakeDistr (tag 30) — filtered SPO stake distribution.
 ///
 /// Argument: tag(258) Set<KeyHash StakePool>
-/// Returns: Map<pool_hash, IndividualPoolStake> — same format as GetStakeDistribution (tag 5)
+/// Returns: Map<pool_hash(28), Coin> — SPO voting power per pool (lovelace).
+///
+/// NOTE: This is NOT the same as GetStakeDistribution (tag 5) which uses
+/// IndividualPoolStake (rational + VRF hash). GetSPOStakeDistr returns a plain
+/// map from pool key hash to absolute stake in lovelace, used for governance
+/// vote tallying.
 pub(crate) fn handle_spo_stake_distr(
     state: &NodeStateSnapshot,
     decoder: &mut minicbor::Decoder<'_>,
 ) -> QueryResult {
     debug!("Query: GetSPOStakeDistr");
     let filter_pools = parse_pool_id_set(decoder);
-    if filter_pools.is_empty() {
-        QueryResult::StakeDistribution(state.stake_pools.clone())
+    let entries: Vec<(Vec<u8>, u64)> = if filter_pools.is_empty() {
+        state
+            .stake_pools
+            .iter()
+            .map(|p| (p.pool_id.clone(), p.stake))
+            .collect()
     } else {
-        let filtered = state
+        state
             .stake_pools
             .iter()
             .filter(|p| filter_pools.iter().any(|h| h == &p.pool_id))
-            .cloned()
-            .collect();
-        QueryResult::StakeDistribution(filtered)
-    }
+            .map(|p| (p.pool_id.clone(), p.stake))
+            .collect()
+    };
+    QueryResult::SPOStakeDistr(entries)
 }
 
 /// Handle GetStakeSnapshots (tag 20).
@@ -298,22 +305,24 @@ pub(crate) fn handle_reward_info_pools(state: &NodeStateSnapshot) -> QueryResult
     QueryResult::RewardInfoPools(entries)
 }
 
-/// Handle QueryStakePoolDefaultVote (tag 35) — per-pool default vote.
+/// Handle QueryStakePoolDefaultVote (tag 35) — single pool default vote.
 ///
 /// Per CIP-1694, the default vote depends on the pool operator's DRep delegation:
-/// - AlwaysAbstain (drep_type=2) → DefaultVote::Abstain (1)
-/// - AlwaysNoConfidence (drep_type=3) → DefaultVote::NoConfidence (0)
-/// - Specific DRep (drep_type=0|1) → DefaultVote::DRepVote (2) — follows the DRep
-/// - No delegation → DefaultVote::Abstain (1)
+/// - AlwaysAbstain (drep_type=2) → DefaultAbstain = 1
+/// - AlwaysNoConfidence (drep_type=3) → DefaultNoConfidence = 2
+/// - Specific DRep (drep_type=0|1) → DefaultNo = 0
+/// - No delegation → DefaultNo = 0
 ///
-/// Argument: tag(258) Set<KeyHash StakePool>
-/// Returns: Map<PoolId, DefaultVote>
+/// Argument: single KeyHash StakePool (28 bytes) — NOT a Set
+/// Returns: bare word8 (DefaultVote)
 pub(crate) fn handle_pool_default_vote(
     state: &NodeStateSnapshot,
     decoder: &mut minicbor::Decoder<'_>,
 ) -> QueryResult {
     debug!("Query: QueryStakePoolDefaultVote");
-    let filter_pools = parse_pool_id_set(decoder);
+
+    // Parse single pool hash (28 bytes), NOT a Set
+    let pool_hash = decoder.bytes().map(|b| b.to_vec()).unwrap_or_default();
 
     // Build lookup: owner credential hash → DRep delegation type
     let vote_deleg_map: std::collections::HashMap<&[u8], u8> = state
@@ -322,32 +331,28 @@ pub(crate) fn handle_pool_default_vote(
         .map(|v| (v.credential_hash.as_slice(), v.drep_type))
         .collect();
 
-    let pool_iter = state
+    // Find the pool params for the requested pool
+    let default_vote = state
         .pool_params_entries
         .iter()
-        .filter(|pp| filter_pools.is_empty() || filter_pools.iter().any(|h| h == &pp.pool_id));
-
-    let entries: Vec<PoolDefaultVoteEntry> = pool_iter
+        .find(|pp| pp.pool_id == pool_hash)
         .map(|pp| {
             // Check if any pool owner has a vote delegation
-            let default_vote = pp
-                .owners
+            pp.owners
                 .iter()
                 .find_map(|owner| vote_deleg_map.get(owner.as_slice()))
                 .map(|drep_type| match drep_type {
-                    2 => 1, // AlwaysAbstain → Abstain
-                    3 => 0, // AlwaysNoConfidence → NoConfidence
-                    _ => 2, // Specific DRep → DRepVote (follow the DRep)
+                    // Haskell DefaultVote encoding:
+                    // 0 = DefaultNo, 1 = DefaultAbstain, 2 = DefaultNoConfidence
+                    2 => 1, // AlwaysAbstain → DefaultAbstain
+                    3 => 2, // AlwaysNoConfidence → DefaultNoConfidence
+                    _ => 0, // Specific DRep or other → DefaultNo
                 })
-                .unwrap_or(1); // No delegation → Abstain
-            PoolDefaultVoteEntry {
-                pool_id: pp.pool_id.clone(),
-                default_vote,
-            }
+                .unwrap_or(0) // No delegation → DefaultNo
         })
-        .collect();
+        .unwrap_or(0); // Pool not found → DefaultNo
 
-    QueryResult::StakePoolDefaultVote(entries)
+    QueryResult::StakePoolDefaultVote(default_vote)
 }
 
 /// Handle GetLedgerPeerSnapshot (tag 34) — relay peers from pool registrations.
@@ -539,10 +544,15 @@ mod tests {
         let mut dec = minicbor::Decoder::new(&cbor);
         let result = handle_spo_stake_distr(&state, &mut dec);
         match result {
-            QueryResult::StakeDistribution(pools) => {
-                assert_eq!(pools.len(), 2);
+            QueryResult::SPOStakeDistr(entries) => {
+                assert_eq!(entries.len(), 2);
+                // Should be (pool_hash, stake_lovelace) pairs
+                assert_eq!(entries[0].0, vec![1u8; 28]);
+                assert_eq!(entries[0].1, 600_000_000);
+                assert_eq!(entries[1].0, vec![2u8; 28]);
+                assert_eq!(entries[1].1, 400_000_000);
             }
-            _ => panic!("Expected StakeDistribution"),
+            _ => panic!("Expected SPOStakeDistr"),
         }
     }
 
@@ -560,11 +570,12 @@ mod tests {
         let mut dec = minicbor::Decoder::new(&cbor);
         let result = handle_spo_stake_distr(&state, &mut dec);
         match result {
-            QueryResult::StakeDistribution(pools) => {
-                assert_eq!(pools.len(), 1);
-                assert_eq!(pools[0].pool_id, vec![1u8; 28]);
+            QueryResult::SPOStakeDistr(entries) => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].0, vec![1u8; 28]);
+                assert_eq!(entries[0].1, 600_000_000);
             }
-            _ => panic!("Expected StakeDistribution"),
+            _ => panic!("Expected SPOStakeDistr"),
         }
     }
 
@@ -603,28 +614,23 @@ mod tests {
     }
 
     #[test]
-    fn test_pool_default_vote_no_delegation() {
+    fn test_pool_default_vote_no_delegation_with_owners() {
         let mut state = make_state_with_pools();
-        // Give pools owners
+        // Give pools owners but no vote delegatees
         state.pool_params_entries[0].owners = vec![vec![10u8; 28]];
         state.pool_params_entries[1].owners = vec![vec![20u8; 28]];
-        // No vote delegatees
+        // Query pool 1: no delegation → DefaultNo (0)
         let cbor = {
             let mut buf = Vec::new();
             let mut enc = minicbor::Encoder::new(&mut buf);
-            enc.tag(minicbor::data::Tag::new(258)).ok();
-            enc.array(0).ok();
+            enc.bytes(&[1u8; 28]).ok();
             buf
         };
         let mut dec = minicbor::Decoder::new(&cbor);
         let result = handle_pool_default_vote(&state, &mut dec);
         match result {
-            QueryResult::StakePoolDefaultVote(entries) => {
-                assert_eq!(entries.len(), 2);
-                // No delegation → Abstain (1)
-                for e in &entries {
-                    assert_eq!(e.default_vote, 1, "Expected Abstain for undelegated pool");
-                }
+            QueryResult::StakePoolDefaultVote(vote) => {
+                assert_eq!(vote, 0, "No delegation → DefaultNo (0)");
             }
             _ => panic!("Expected StakePoolDefaultVote"),
         }
@@ -1041,25 +1047,78 @@ mod tests {
                 drep_hash: Some(vec![30u8; 28]),
             },
         ];
+
+        // Query pool 1 (owner delegates to AlwaysNoConfidence → DefaultNoConfidence = 2)
+        let cbor1 = {
+            let mut buf = Vec::new();
+            let mut enc = minicbor::Encoder::new(&mut buf);
+            enc.bytes(&[1u8; 28]).ok();
+            buf
+        };
+        let mut dec = minicbor::Decoder::new(&cbor1);
+        let result = handle_pool_default_vote(&state, &mut dec);
+        match result {
+            QueryResult::StakePoolDefaultVote(vote) => {
+                assert_eq!(
+                    vote, 2,
+                    "AlwaysNoConfidence delegation → DefaultNoConfidence (2)"
+                );
+            }
+            _ => panic!("Expected StakePoolDefaultVote"),
+        }
+
+        // Query pool 2 (owner delegates to specific DRep → DefaultNo = 0)
+        let cbor2 = {
+            let mut buf = Vec::new();
+            let mut enc = minicbor::Encoder::new(&mut buf);
+            enc.bytes(&[2u8; 28]).ok();
+            buf
+        };
+        let mut dec = minicbor::Decoder::new(&cbor2);
+        let result = handle_pool_default_vote(&state, &mut dec);
+        match result {
+            QueryResult::StakePoolDefaultVote(vote) => {
+                assert_eq!(vote, 0, "Specific DRep delegation → DefaultNo (0)");
+            }
+            _ => panic!("Expected StakePoolDefaultVote"),
+        }
+    }
+
+    #[test]
+    fn test_pool_default_vote_no_delegation() {
+        let state = make_state_with_pools();
+        // Pool 1 has no owners with vote delegation → DefaultNo = 0
         let cbor = {
             let mut buf = Vec::new();
             let mut enc = minicbor::Encoder::new(&mut buf);
-            enc.tag(minicbor::data::Tag::new(258)).ok();
-            enc.array(0).ok();
+            enc.bytes(&[1u8; 28]).ok();
             buf
         };
         let mut dec = minicbor::Decoder::new(&cbor);
         let result = handle_pool_default_vote(&state, &mut dec);
         match result {
-            QueryResult::StakePoolDefaultVote(entries) => {
-                assert_eq!(entries.len(), 2);
-                let pool1 = entries.iter().find(|e| e.pool_id == vec![1u8; 28]).unwrap();
-                let pool2 = entries.iter().find(|e| e.pool_id == vec![2u8; 28]).unwrap();
-                assert_eq!(
-                    pool1.default_vote, 0,
-                    "NoConfidence delegation → NoConfidence vote"
-                );
-                assert_eq!(pool2.default_vote, 2, "DRep delegation → DRepVote");
+            QueryResult::StakePoolDefaultVote(vote) => {
+                assert_eq!(vote, 0, "No delegation → DefaultNo (0)");
+            }
+            _ => panic!("Expected StakePoolDefaultVote"),
+        }
+    }
+
+    #[test]
+    fn test_pool_default_vote_unknown_pool() {
+        let state = make_state_with_pools();
+        // Unknown pool → DefaultNo = 0
+        let cbor = {
+            let mut buf = Vec::new();
+            let mut enc = minicbor::Encoder::new(&mut buf);
+            enc.bytes(&[0xFFu8; 28]).ok();
+            buf
+        };
+        let mut dec = minicbor::Decoder::new(&cbor);
+        let result = handle_pool_default_vote(&state, &mut dec);
+        match result {
+            QueryResult::StakePoolDefaultVote(vote) => {
+                assert_eq!(vote, 0, "Unknown pool → DefaultNo (0)");
             }
             _ => panic!("Expected StakePoolDefaultVote"),
         }

--- a/crates/torsten-network/src/query_handler/types.rs
+++ b/crates/torsten-network/src/query_handler/types.rs
@@ -136,9 +136,12 @@ pub enum QueryResult {
     /// GetLedgerPeerSnapshot (tag 34): ledger peer snapshot
     /// Versioned snapshot: array(2) [version, peers]
     LedgerPeerSnapshot(Vec<LedgerPeerEntry>),
-    /// QueryStakePoolDefaultVote (tag 35): per-pool default vote
-    /// Map<PoolId, DefaultVote> where DefaultVote = NoConfidence(0) | Abstain(1) | DRepVote(2)
-    StakePoolDefaultVote(Vec<PoolDefaultVoteEntry>),
+    /// QueryStakePoolDefaultVote (tag 35): single pool default vote
+    /// Haskell returns a bare word8: 0=DefaultNo, 1=DefaultAbstain, 2=DefaultNoConfidence
+    StakePoolDefaultVote(u8),
+    /// GetSPOStakeDistr (tag 30): Map<pool_hash, Coin>
+    /// SPO voting power per pool (lovelace), NOT IndividualPoolStake format
+    SPOStakeDistr(Vec<(Vec<u8>, u64)>),
     /// GetProposals (tag 31): returns Seq of GovActionState
     Proposals(Vec<ProposalSnapshot>),
     /// GetRatifyState (tag 32): ratification state
@@ -618,15 +621,6 @@ pub struct ProposalSnapshot {
     pub drep_votes: Vec<VoteEntry>,
     /// SPO votes: (pool_keyhash_28bytes, vote) — SPO uses bare KeyHash, no credential wrapper
     pub spo_votes: Vec<(Vec<u8>, u8)>,
-}
-
-/// Default vote entry for QueryStakePoolDefaultVote (tag 35)
-#[derive(Debug, Clone)]
-pub struct PoolDefaultVoteEntry {
-    /// Pool ID (28 bytes)
-    pub pool_id: Vec<u8>,
-    /// Default vote: 0=NoConfidence, 1=Abstain, 2=DRepVote
-    pub default_vote: u8,
 }
 
 /// Ledger peer entry for GetLedgerPeerSnapshot (tag 34)


### PR DESCRIPTION
## Summary

Fixes three N2C LocalStateQuery CBOR encoding bugs that caused cardano-cli 10.15 deserialization failures. These were the last 3 failing queries out of 22 tested.

- **GetSPOStakeDistr (tag 30)**: Was returning `IndividualPoolStake` format (rational + VRF hash). Haskell returns `Map<pool_hash, Coin>` — plain map from pool key hash to lovelace. New `SPOStakeDistr` variant encodes correctly.
- **QueryStakePoolDefaultVote (tag 35)**: Three sub-bugs — was parsing a Set instead of single pool hash, returning a Map instead of bare word8, and had wrong value semantics (AlwaysNoConfidence→2, DRep→0).
- **GetFuturePParams (tag 33)**: Encoded `Nothing` as `array(1)[0]` (Sum encoding) but query returns `Maybe PParams` which uses `encodeMaybe`: `Nothing` = empty array `0x80`.

## Test plan

- [x] All 409 torsten-network tests pass
- [x] Full workspace `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Verify against live cardano-cli 10.15: `query spo-stake-distribution`, `query stake-pool-default-vote`, `query future-pparams`

Closes #117