### PR TITLE
Fix TUI sync progress stuck at 0% during replay + remove duplicate bar

### DIFF
--- a/crates/torsten-node/src/node/sync.rs
+++ b/crates/torsten-node/src/node/sync.rs
@@ -1938,6 +1938,7 @@ impl Node {
         let snapshot_path = self.database_path.join("ledger-snapshot.bin");
         let replay_dir = replay_dir.to_path_buf();
         let bel = self.byron_epoch_length;
+        let metrics = self.metrics.clone();
 
         let security_param = self
             .shelley_genesis
@@ -2025,6 +2026,11 @@ impl Node {
                             } else {
                                 0.0
                             };
+                            // Update Prometheus metric so TUI/monitoring can track replay progress
+                            metrics.set_sync_progress(pct);
+                            metrics.set_slot(slot);
+                            metrics.set_block_number(ls_guard.tip.block_number.0);
+                            metrics.set_epoch(ls_guard.epoch.0);
                             info!(
                                 progress = format_args!("{pct:>6.2}%"),
                                 blocks = replayed,
@@ -2196,6 +2202,11 @@ impl Node {
                                 } else {
                                     0.0
                                 };
+                                // Update Prometheus metric so TUI/monitoring can track replay progress
+                                self.metrics.set_sync_progress(pct);
+                                self.metrics.set_slot(slot.0);
+                                self.metrics.set_block_number(block_no);
+                                self.metrics.set_epoch(ls.epoch.0);
                                 info!(
                                     progress = format_args!("{pct:>6.2}%"),
                                     block = block_no,

--- a/crates/torsten-tui/src/ui.rs
+++ b/crates/torsten-tui/src/ui.rs
@@ -40,7 +40,6 @@ use crate::widgets::epoch_progress::EpochProgress;
 use crate::widgets::header_bar::HeaderBar;
 use crate::widgets::mempool_gauge::MempoolGauge;
 use crate::widgets::sparkline_history::SparklineHistory;
-use crate::widgets::sync_progress::SyncProgressBar;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -276,9 +275,8 @@ fn render_node_panel(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
 
     let col_w = inner.width.saturating_sub(2) as usize; // subtract 1-char side padding each side
 
-    // Reserve the last row for the sync progress bar (SyncProgressBar widget).
-    // The text rows occupy everything above it.
-    let text_row_count = (inner.height as usize).saturating_sub(1);
+    // All rows available for text content (sync progress shown in header).
+    let text_row_count = inner.height as usize;
 
     let mut lines = vec![
         kv_aligned("Role", role, role_color, theme, col_w),
@@ -324,26 +322,6 @@ fn render_node_panel(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         height: text_row_count as u16,
     };
     frame.render_widget(Paragraph::new(lines), text_area);
-
-    // Sync progress bar — rendered on the last row inside the Node panel.
-    // Provides a visual glance at sync state; color matches the header pill.
-    let (_, is_synced, is_stalled) = app.sync_status();
-    let sync_pct = app.sync_progress_pct();
-    let bar_y = inner.y + text_row_count as u16;
-    if bar_y < inner.y + inner.height && inner.width >= 6 {
-        let bar_area = Rect {
-            x: inner.x + 1,
-            y: bar_y,
-            width: inner.width.saturating_sub(2),
-            height: 1,
-        };
-        SyncProgressBar::new(sync_pct, is_synced, is_stalled)
-            .fill_color_synced(theme.success)
-            .fill_color_syncing(theme.warning)
-            .fill_color_stalled(theme.error)
-            .empty_color(theme.gauge_empty)
-            .render(bar_area, frame.buffer_mut());
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/torsten-tui/src/widgets/sync_progress.rs
+++ b/crates/torsten-tui/src/widgets/sync_progress.rs
@@ -19,6 +19,7 @@ use ratatui::{
 };
 
 /// A sync progress bar widget that renders a filled gauge with color-coded status.
+#[allow(dead_code)]
 pub struct SyncProgressBar {
     /// Progress ratio from 0.0 to 100.0 (percentage).
     progress: f64,
@@ -36,6 +37,7 @@ pub struct SyncProgressBar {
     color_empty: Color,
 }
 
+#[allow(dead_code)]
 impl SyncProgressBar {
     /// Create a new progress bar.
     ///


### PR DESCRIPTION
## Summary

- **Sync progress during replay**: Both chunk-file and LSM replay paths computed progress for logging but never called `metrics.set_sync_progress()`. The TUI/Prometheus always showed 0%. Now both paths update `sync_progress_pct`, `slot`, `block_number`, and `epoch` metrics every 5 seconds during replay.
- **Remove duplicate progress bar**: The `SyncProgressBar` at the bottom of the Node panel duplicated the sync status in the header. Removed to free a row for content.

## Test plan

- [x] All workspace tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Run node with Mithril replay and verify TUI shows increasing progress