### PR TITLE
Fix #126: GetRatifyState (tag 32) standalone encoding — add EnactState

### DIFF
--- a/crates/torsten-network/src/n2c/query/encoding.rs
+++ b/crates/torsten-network/src/n2c/query/encoding.rs
@@ -338,11 +338,12 @@ pub(crate) fn encode_query_result_value(
             }
         }
         QueryResult::RatifyState {
+            gov,
             enacted,
             expired,
             delayed,
         } => {
-            encode_ratify_state(enc, enacted, expired, *delayed);
+            encode_ratify_state(enc, gov, enacted, expired, *delayed);
         }
         QueryResult::NoFuturePParams => {
             // GetFuturePParams result: Maybe PParams = Nothing
@@ -1314,13 +1315,79 @@ fn encode_gov_action_tag(enc: &mut minicbor::Encoder<&mut Vec<u8>>, action_type:
 
 fn encode_ratify_state(
     enc: &mut minicbor::Encoder<&mut Vec<u8>>,
+    gov: &crate::query_handler::GovStateSnapshot,
     enacted: &[(ProposalSnapshot, GovActionId)],
     expired: &[GovActionId],
     delayed: bool,
 ) {
-    // RatifyState = array(4) [enacted_seq, expired_seq, delayed_bool, future_pparam_update]
+    // Haskell RatifyState = array(4):
+    //   [0] EnactState(array(7))
+    //   [1] rsEnacted: Seq GovActionState (plain array)
+    //   [2] rsExpired: Set GovActionId (tag(258) + array)
+    //   [3] rsDelayed: Bool
     enc.array(4).ok();
-    // enacted: Seq of (GovActionState, GovActionId)
+
+    // [0] EnactState = array(7) — reuses the same encoding as the embedded
+    // version in encode_gov_state. See lines 991-1059 for the canonical
+    // EnactState field order.
+    enc.array(7).ok();
+    // ensCommittee: StrictMaybe Committee
+    if gov.committee.members.is_empty() && gov.committee.threshold.is_none() {
+        enc.array(0).ok(); // SNothing
+    } else {
+        enc.array(1).ok(); // SJust
+        enc.array(2).ok();
+        enc.map(gov.committee.members.len() as u64).ok();
+        for m in &gov.committee.members {
+            enc.array(2).ok();
+            enc.u8(m.cold_credential_type).ok();
+            enc.bytes(&m.cold_credential).ok();
+            enc.u64(m.expiry_epoch.unwrap_or(0)).ok();
+        }
+        if let Some((num, den)) = gov.committee.threshold {
+            encode_tagged_rational(enc, num, den);
+        } else {
+            encode_tagged_rational(enc, 2, 3);
+        }
+    }
+    // ensConstitution: array(2) [Anchor, StrictMaybe ScriptHash]
+    enc.array(2).ok();
+    enc.array(2).ok();
+    enc.str(&gov.constitution_url).ok();
+    enc.bytes(&gov.constitution_hash).ok();
+    if let Some(ref script) = gov.constitution_script {
+        enc.bytes(script).ok();
+    } else {
+        enc.null().ok();
+    }
+    // ensCurPParams
+    encode_protocol_params_cbor(enc, &gov.cur_pparams);
+    // ensPrevPParams
+    encode_protocol_params_cbor(enc, &gov.prev_pparams);
+    // ensTreasury
+    enc.u64(gov.treasury).ok();
+    // ensWithdrawals: empty map
+    enc.map(0).ok();
+    // ensPrevGovActionIds: GovRelation StrictMaybe = array(4)
+    enc.array(4).ok();
+    let roots = [
+        &gov.enacted_pparam_update,
+        &gov.enacted_hard_fork,
+        &gov.enacted_committee,
+        &gov.enacted_constitution,
+    ];
+    for root in &roots {
+        if let Some((tx_id, action_index)) = root {
+            enc.array(1).ok(); // SJust
+            enc.array(2).ok();
+            enc.bytes(tx_id).ok();
+            enc.u32(*action_index).ok();
+        } else {
+            enc.array(0).ok(); // SNothing
+        }
+    }
+
+    // [1] rsEnacted: Seq of GovActionState (plain array, no tag 258)
     enc.array(enacted.len() as u64).ok();
     for (proposal, action_id) in enacted {
         enc.array(2).ok();
@@ -1329,18 +1396,16 @@ fn encode_ratify_state(
         enc.bytes(&action_id.tx_id).ok();
         enc.u32(action_id.action_index).ok();
     }
-    // expired: Seq of GovActionId
+    // [2] rsExpired: Set of GovActionId (tag(258) + array per Haskell Set encoding)
+    enc.tag(minicbor::data::Tag::new(258)).ok();
     enc.array(expired.len() as u64).ok();
     for action_id in expired {
         enc.array(2).ok();
         enc.bytes(&action_id.tx_id).ok();
         enc.u32(action_id.action_index).ok();
     }
-    // delayed
+    // [3] rsDelayed
     enc.bool(delayed).ok();
-    // future pparams: NoPParamsUpdate [0]
-    enc.array(1).ok();
-    enc.u32(0).ok();
 }
 
 // ─── Relay encoding ───────────────────────────────────────────────────────────

--- a/crates/torsten-network/src/n2c/query/mod.rs
+++ b/crates/torsten-network/src/n2c/query/mod.rs
@@ -543,6 +543,7 @@ mod tests {
     #[test]
     fn test_encode_ratify_state() {
         let buf = encode(&QueryResult::RatifyState {
+            gov: Box::new(crate::query_handler::GovStateSnapshot::default()),
             enacted: Vec::new(),
             expired: Vec::new(),
             delayed: false,
@@ -550,14 +551,23 @@ mod tests {
         let mut dec = decode_msg_result(&buf);
         strip_hfc(&mut dec);
         let arr = dec.array().unwrap().unwrap();
-        assert_eq!(arr, 4);
-        // enacted: Seq (array)
+        assert_eq!(arr, 4, "RatifyState must be array(4)");
+        // [0] EnactState = array(7) (from default GovStateSnapshot)
+        let enact = dec.array().unwrap().unwrap();
+        assert_eq!(enact, 7, "EnactState must be array(7)");
+        // Skip all 7 EnactState fields
+        for _ in 0..7 {
+            dec.skip().unwrap();
+        }
+        // [1] enacted: Seq (plain array)
         let enacted_len = dec.array().unwrap().unwrap();
         assert_eq!(enacted_len, 0);
-        // expired: Seq (array)
+        // [2] expired: Set (tag(258) + array)
+        let tag = dec.tag().unwrap();
+        assert_eq!(tag.as_u64(), 258);
         let expired_len = dec.array().unwrap().unwrap();
         assert_eq!(expired_len, 0);
-        // delayed
+        // [3] delayed
         assert!(!dec.bool().unwrap());
     }
 
@@ -589,6 +599,7 @@ mod tests {
             action_index: 3,
         };
         let buf = encode(&QueryResult::RatifyState {
+            gov: Box::new(crate::query_handler::GovStateSnapshot::default()),
             enacted: vec![(enacted_proposal, enacted_id)],
             expired: vec![expired_id],
             delayed: true,
@@ -597,7 +608,13 @@ mod tests {
         strip_hfc(&mut dec);
         let arr = dec.array().unwrap().unwrap();
         assert_eq!(arr, 4, "RatifyState must be array(4)");
-        // enacted: array(1) of (GovActionState, GovActionId)
+        // [0] EnactState = array(7)
+        let enact = dec.array().unwrap().unwrap();
+        assert_eq!(enact, 7, "EnactState must be array(7)");
+        for _ in 0..7 {
+            dec.skip().unwrap();
+        }
+        // [1] enacted: array(1) of (GovActionState, GovActionId)
         let enacted_len = dec.array().unwrap().unwrap();
         assert_eq!(enacted_len, 1);
         // Each entry is array(2) [GovActionState, GovActionId]
@@ -610,19 +627,17 @@ mod tests {
         assert_eq!(gaid, 2);
         assert_eq!(dec.bytes().unwrap(), &[0x11; 32]);
         assert_eq!(dec.u32().unwrap(), 0);
-        // expired: array(1) of GovActionId
+        // [2] expired: tag(258) + array(1) of GovActionId
+        let tag = dec.tag().unwrap();
+        assert_eq!(tag.as_u64(), 258);
         let expired_len = dec.array().unwrap().unwrap();
         assert_eq!(expired_len, 1);
         let gaid2 = dec.array().unwrap().unwrap();
         assert_eq!(gaid2, 2);
         assert_eq!(dec.bytes().unwrap(), &[0x22; 32]);
         assert_eq!(dec.u32().unwrap(), 3);
-        // delayed = true
+        // [3] delayed = true
         assert!(dec.bool().unwrap());
-        // future_pparams: NoPParamsUpdate [0]
-        let fp = dec.array().unwrap().unwrap();
-        assert_eq!(fp, 1);
-        assert_eq!(dec.u32().unwrap(), 0);
     }
 
     #[test]

--- a/crates/torsten-network/src/query_handler/governance.rs
+++ b/crates/torsten-network/src/query_handler/governance.rs
@@ -85,7 +85,23 @@ fn parse_gov_action_id_set(decoder: &mut minicbor::Decoder<'_>) -> Vec<(Vec<u8>,
 /// results from the most recent epoch transition's ratification pass.
 pub(crate) fn handle_ratify_state(state: &NodeStateSnapshot) -> QueryResult {
     debug!("Query: GetRatifyState");
+    // Build a GovStateSnapshot from NodeStateSnapshot fields for EnactState encoding.
+    let gov = crate::query_handler::GovStateSnapshot {
+        proposals: state.governance_proposals.clone(),
+        committee: state.committee.clone(),
+        constitution_url: state.constitution_url.clone(),
+        constitution_hash: state.constitution_hash.clone(),
+        constitution_script: state.constitution_script.clone(),
+        cur_pparams: Box::new(state.protocol_params.clone()),
+        prev_pparams: Box::new(state.protocol_params.clone()), // best available
+        enacted_pparam_update: state.enacted_pparam_update.clone(),
+        enacted_hard_fork: state.enacted_hard_fork.clone(),
+        enacted_committee: state.enacted_committee.clone(),
+        enacted_constitution: state.enacted_constitution.clone(),
+        treasury: state.treasury,
+    };
     QueryResult::RatifyState {
+        gov: Box::new(gov),
         enacted: state.ratify_enacted.clone(),
         expired: state.ratify_expired.clone(),
         delayed: state.ratify_delayed,
@@ -252,6 +268,7 @@ mod tests {
         let result = handle_ratify_state(&state);
         match result {
             QueryResult::RatifyState {
+                gov: _,
                 enacted,
                 expired,
                 delayed,
@@ -300,6 +317,7 @@ mod tests {
         let result = handle_ratify_state(&state);
         match result {
             QueryResult::RatifyState {
+                gov: _,
                 enacted,
                 expired,
                 delayed,

--- a/crates/torsten-network/src/query_handler/types.rs
+++ b/crates/torsten-network/src/query_handler/types.rs
@@ -145,8 +145,12 @@ pub enum QueryResult {
     /// GetProposals (tag 31): returns Seq of GovActionState
     Proposals(Vec<ProposalSnapshot>),
     /// GetRatifyState (tag 32): ratification state
-    /// array(4) [enacted_seq, expired_seq, delayed_bool, future_pparam_update]
+    /// Haskell: array(4) [EnactState(array(7)), enacted_seq, expired_set, delayed_bool]
+    /// Carries the full GovStateSnapshot so the encoder can build the EnactState
+    /// field (committee, constitution, pparams, treasury, prev gov action IDs).
     RatifyState {
+        /// Full governance state for EnactState encoding
+        gov: Box<GovStateSnapshot>,
         /// Enacted GovActionStates (recently ratified)
         enacted: Vec<(ProposalSnapshot, GovActionId)>,
         /// Expired GovActionIds


### PR DESCRIPTION
## Summary

The standalone `GetRatifyState` (tag 32) response was missing the `EnactState(array(7))` as its first field.

**Before (wrong):** `array(4) [enacted_seq, expired_seq, delayed_bool, future_pparams]`
**After (correct):** `array(4) [EnactState(array(7)), enacted_seq, expired_set(tag 258), delayed_bool]`

EnactState includes: committee, constitution, cur/prev pparams, treasury, withdrawals, and prev gov action IDs — matching the embedded encoding used in GovState (tag 24).

Closes #126

## Test plan
- [x] `cargo test --all` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Golden tests for embedded RatifyState (in GovState) still pass
- [x] Updated standalone RatifyState tests verify EnactState is first field