### PR TITLE
Fix #120: Infer network name from magic number in CLI

### DIFF
--- a/crates/torsten-cli/src/commands/query.rs
+++ b/crates/torsten-cli/src/commands/query.rs
@@ -405,13 +405,17 @@ impl QueryCmd {
                     100.0
                 };
 
+                let network_name = torsten_primitives::network::NetworkId::name_from_magic(
+                    testnet_magic.unwrap_or(764824073),
+                );
                 println!("{{");
                 println!("    \"slot\": {},", tip.slot);
                 println!("    \"hash\": \"{hash_hex}\",");
                 println!("    \"block\": {block_no},");
                 println!("    \"epoch\": {epoch},");
                 println!("    \"era\": \"{era_str}\",");
-                println!("    \"syncProgress\": \"{sync_progress:.2}\"");
+                println!("    \"syncProgress\": \"{sync_progress:.2}\",");
+                println!("    \"network\": \"{network_name}\"");
                 println!("}}");
                 Ok(())
             }

--- a/crates/torsten-primitives/src/network.rs
+++ b/crates/torsten-primitives/src/network.rs
@@ -45,6 +45,18 @@ impl NetworkId {
         }
     }
 
+    /// Infer a human-readable network name from a network magic number.
+    ///
+    /// Returns "Mainnet", "Preview", "Pre-Production", or "Unknown (<magic>)".
+    pub fn name_from_magic(magic: u64) -> String {
+        match magic {
+            764824073 => "Mainnet".to_string(),
+            2 => "Preview".to_string(),
+            1 => "Pre-Production".to_string(),
+            other => format!("Unknown ({other})"),
+        }
+    }
+
     /// Default system start time for the network.
     /// For testnets, this returns the preprod start; use Shelley genesis for exact value.
     pub fn system_start(self) -> &'static str {
@@ -72,6 +84,14 @@ mod tests {
     fn test_network_magic() {
         assert_eq!(NetworkId::Mainnet.magic(), 764824073);
         assert_eq!(NetworkId::Testnet.magic(), 1);
+    }
+
+    #[test]
+    fn test_name_from_magic() {
+        assert_eq!(NetworkId::name_from_magic(764824073), "Mainnet");
+        assert_eq!(NetworkId::name_from_magic(2), "Preview");
+        assert_eq!(NetworkId::name_from_magic(1), "Pre-Production");
+        assert_eq!(NetworkId::name_from_magic(42), "Unknown (42)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `NetworkId::name_from_magic(magic: u64) -> String` to torsten-primitives
- Maps: 764824073→Mainnet, 2→Preview, 1→Pre-Production, other→Unknown(N)
- `query tip` JSON output now includes `"network": "<name>"`

Closes #120

## Test plan
- [x] `cargo test --all` — all tests pass
- [x] New `test_name_from_magic` unit test covers all known networks + unknown
- [x] `cargo clippy --all-targets -- -D warnings` — clean