### PR TITLE
fix: repair CI pipeline failures across all workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,6 +6,11 @@ on:
     # Nightly at 2 AM UTC
     - cron: '0 2 * * *'
 
+env:
+  CARGO_HOME: /home/runner/.cargo
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
@@ -23,9 +28,20 @@ jobs:
           - governance
           - ledger_snapshot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            fuzz/target
+          key: ${{ runner.os }}-fuzz-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-fuzz-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -40,7 +56,7 @@ jobs:
 
       - name: Upload corpus
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: corpus-${{ matrix.target }}
           path: fuzz/corpus/fuzz_${{ matrix.target }}/
@@ -48,7 +64,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: crashes-${{ matrix.target }}
           path: fuzz/artifacts/fuzz_${{ matrix.target }}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build stage ----
-FROM rust:1.88-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libclang-dev clang pkg-config && \

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1088,7 +1088,9 @@ impl Node {
             // misconfiguration of issuing an opcert with --kes-period 0 instead
             // of the current KES period.
             let tip_slot = {
-                let ls = ledger_state.try_read().expect("ledger_state lock uncontested during init");
+                let ls = ledger_state
+                    .try_read()
+                    .expect("ledger_state lock uncontested during init");
                 ls.tip.point.slot().map(|s| s.0).unwrap_or(0)
             };
             if tip_slot > 0 {


### PR DESCRIPTION
## Summary

- **CI**: Fix `cargo fmt` violation in `crates/dugite-node/src/node/mod.rs:1091` (long line wrapping)
- **Release/Docker**: Update Dockerfile from `rust:1.88-bookworm` to `rust:1.93-bookworm` — `fixed@1.31.0` requires `rustc 1.93` (MSRV)
- **Fuzz Testing**: Upgrade `actions/checkout` and `actions/upload-artifact` from v4 to v5 (Node.js 20 deprecation), add cargo caching and env vars for consistent builds
- **Dependabot**: Configure for `cargo` and `github-actions` ecosystems (was unconfigured placeholder)

## Workflow Status Before This PR

| Workflow | Status | Root Cause |
|----------|--------|------------|
| CI | Failing | `cargo fmt --check` rejects long line in mod.rs |
| Release | Failing | Docker build uses rustc 1.88, `fixed` crate needs 1.93 |
| Fuzz Testing | Failing | Stale targets removed in prior commit; actions still on v4 |
| Nightly Benchmarks | Failing | Old workflow had wrong output path (`benches/results/` vs `benches/`); already fixed on main |
| Code Scanning | Passing | No changes needed |
| Deploy Docs | Passing | No changes needed |
| Dependabot | Inactive | Empty `package-ecosystem` field |

## Test plan
- [ ] CI workflow passes (fmt, build, clippy, nextest)
- [ ] Release workflow Docker build compiles with rust:1.93
- [ ] Fuzz workflow runs with v5 actions and correct 9 targets
- [ ] Dependabot begins creating PRs for cargo and github-actions updates