### PR TITLE
fix: remove EnableP2P config field, always run P2P governor

### DIFF
--- a/config/mainnet-config.json
+++ b/config/mainnet-config.json
@@ -4,7 +4,6 @@
   "Protocol": {
     "RequiresNetworkMagic": "RequiresMagic"
   },
-  "EnableP2P": true,
   "DiffusionMode": "InitiatorAndResponder",
   "TargetNumberOfRootPeers": 60,
   "TargetNumberOfActivePeers": 15,

--- a/config/preprod-config.json
+++ b/config/preprod-config.json
@@ -1,7 +1,6 @@
 {
   "Network": "Testnet",
   "NetworkMagic": 1,
-  "EnableP2P": true,
   "DiffusionMode": "InitiatorAndResponder",
   "TargetNumberOfRootPeers": 60,
   "TargetNumberOfActivePeers": 15,

--- a/config/preview-config.json
+++ b/config/preview-config.json
@@ -4,7 +4,6 @@
   "ByronGenesisHash": "81cf23542e33d64c541699926c2b5e6e9c286583f0c8a3fb5f22ea7b352dd174",
   "ConwayGenesisFile": "preview-conway-genesis.json",
   "DiffusionMode": "InitiatorAndResponder",
-  "EnableP2P": true,
   "MinSeverity": "Info",
   "Network": "Testnet",
   "NetworkMagic": 2,

--- a/crates/dugite-config/src/app.rs
+++ b/crates/dugite-config/src/app.rs
@@ -615,7 +615,7 @@ mod tests {
     #[test]
     fn test_cursor_down_up() {
         let mut app =
-            make_app(r#"{"EnableP2P": true, "MinSeverity": "Info", "Protocol": "Cardano"}"#);
+            make_app(r#"{"TurnOnLogMetrics": true, "MinSeverity": "Info", "Protocol": "Cardano"}"#);
         // All items land in their known sections; at least one section has items.
         let initial_sec = app.cursor_section;
         let initial_item = app.cursor_item;
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_toggle_section_collapses_and_expands() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         assert!(app.sections[0].expanded);
         app.toggle_section();
         assert!(!app.sections[0].expanded);
@@ -644,8 +644,8 @@ mod tests {
 
     #[test]
     fn test_begin_edit_bool_toggles_immediately() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
-        // Find EnableP2P.
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
+        // Find TurnOnLogMetrics.
         app.begin_edit();
         // The edit should have completed immediately (bool toggle).
         assert_eq!(app.edit_mode, EditMode::None);
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn test_request_quit_with_unsaved_changes() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         // Modify something.
         app.begin_edit(); // bool toggle
         assert!(app.is_modified());
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn test_request_quit_clean_quits_immediately() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         assert!(!app.is_modified());
         app.request_quit();
         assert!(app.should_quit);
@@ -713,9 +713,10 @@ mod tests {
 
     #[test]
     fn test_sections_are_ordered() {
-        let app =
-            make_app(r#"{"EnableP2P": true, "MinSeverity": "Info", "ByronGenesisFile": "b.json"}"#);
-        // EnableP2P -> Network, MinSeverity -> Logging, ByronGenesisFile -> Genesis
+        let app = make_app(
+            r#"{"DiffusionMode": "InitiatorAndResponder", "MinSeverity": "Info", "ByronGenesisFile": "b.json"}"#,
+        );
+        // DiffusionMode -> Network, MinSeverity -> Logging, ByronGenesisFile -> Genesis
         // Expected order: Network, Genesis, Logging
         let names: Vec<&str> = app.sections.iter().map(|s| s.name.as_str()).collect();
         let net_pos = names.iter().position(|n| *n == "Network").unwrap();
@@ -731,7 +732,7 @@ mod tests {
 
     #[test]
     fn test_enter_search_activates_search_mode() {
-        let mut app = make_app(r#"{"EnableP2P": true, "MinSeverity": "Info"}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true, "MinSeverity": "Info"}"#);
         assert!(!app.search_active);
         app.enter_search();
         assert!(app.search_active);
@@ -740,16 +741,17 @@ mod tests {
 
     #[test]
     fn test_search_type_filters_items() {
-        let mut app =
-            make_app(r#"{"EnableP2P": true, "MinSeverity": "Info", "ByronGenesisFile": "b.json"}"#);
+        let mut app = make_app(
+            r#"{"TurnOnLogMetrics": true, "MinSeverity": "Info", "ByronGenesisFile": "b.json"}"#,
+        );
         app.enter_search();
-        app.search_type_char('E');
+        app.search_type_char('T');
+        app.search_type_char('u');
+        app.search_type_char('r');
         app.search_type_char('n');
-        app.search_type_char('a');
-        app.search_type_char('b');
-        app.search_type_char('l');
-        app.search_type_char('e');
-        // "Enable" is a prefix of "EnableP2P" — should appear in filtered items.
+        app.search_type_char('O');
+        app.search_type_char('n');
+        // "TurnOn" is a prefix of "TurnOnLogMetrics" — should appear in filtered items.
         assert!(!app.filtered_items.is_empty());
         // Cursor should have moved to the match.
         let (sec, item) = app.filtered_items[0];
@@ -759,9 +761,9 @@ mod tests {
 
     #[test]
     fn test_clear_search_restores_all() {
-        let mut app = make_app(r#"{"EnableP2P": true, "MinSeverity": "Info"}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true, "MinSeverity": "Info"}"#);
         app.enter_search();
-        app.search_type_char('E');
+        app.search_type_char('T');
         assert!(!app.filtered_items.is_empty());
         app.clear_search();
         assert!(!app.search_active);
@@ -771,14 +773,15 @@ mod tests {
 
     #[test]
     fn test_search_backspace_updates_filter() {
-        let mut app =
-            make_app(r#"{"EnableP2P": true, "MinSeverity": "Info", "ByronGenesisFile": "b.json"}"#);
+        let mut app = make_app(
+            r#"{"TurnOnLogMetrics": true, "MinSeverity": "Info", "ByronGenesisFile": "b.json"}"#,
+        );
         app.enter_search();
-        app.search_type_char('E');
-        let count_after_e = app.filtered_items.len();
-        app.search_type_char('n');
-        app.search_backspace(); // back to "E"
-        assert_eq!(app.filtered_items.len(), count_after_e);
+        app.search_type_char('T');
+        let count_after_t = app.filtered_items.len();
+        app.search_type_char('u');
+        app.search_backspace(); // back to "T"
+        assert_eq!(app.filtered_items.len(), count_after_t);
     }
 
     // -----------------------------------------------------------------------
@@ -787,24 +790,24 @@ mod tests {
 
     #[test]
     fn test_diff_empty_initially() {
-        let app = make_app(r#"{"EnableP2P": true}"#);
+        let app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         assert!(app.diff_entries().is_empty());
     }
 
     #[test]
     fn test_diff_captures_change() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         app.begin_edit(); // toggle bool: true -> false
         let diff = app.diff_entries();
         assert_eq!(diff.len(), 1);
-        assert_eq!(diff[0].key, "EnableP2P");
+        assert_eq!(diff[0].key, "TurnOnLogMetrics");
         assert_eq!(diff[0].original, "true");
         assert_eq!(diff[0].current, "false");
     }
 
     #[test]
     fn test_toggle_diff_overlay() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         assert!(!app.show_diff);
         app.toggle_diff();
         assert!(app.show_diff);
@@ -814,7 +817,7 @@ mod tests {
 
     #[test]
     fn test_close_diff_overlay() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         app.show_diff = true;
         app.close_diff();
         assert!(!app.show_diff);
@@ -822,9 +825,9 @@ mod tests {
 
     #[test]
     fn test_originals_snapshot_is_immutable_after_edits() {
-        let mut app = make_app(r#"{"EnableP2P": true}"#);
+        let mut app = make_app(r#"{"TurnOnLogMetrics": true}"#);
         app.begin_edit(); // toggle: true -> false
                           // The original snapshot must still say "true".
-        assert_eq!(app.originals.get("EnableP2P"), Some("true"));
+        assert_eq!(app.originals.get("TurnOnLogMetrics"), Some("true"));
     }
 }

--- a/crates/dugite-config/src/schema.rs
+++ b/crates/dugite-config/src/schema.rs
@@ -174,17 +174,6 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
         tuning_hint: "Use 'RequiresMagic' for all testnets, 'RequiresNoMagic' for mainnet.",
     },
     ParamDef {
-        key: "EnableP2P",
-        section: "Network",
-        param_type: ParamType::Bool,
-        default: "true",
-        description: "Enable the Ouroboros P2P networking stack. When true, Dugite \
-                      uses the diffusion layer for peer discovery and connection management. \
-                      Set to false only for legacy non-P2P relay configurations.",
-        tuning_hint: "Always enable for production. \
-                      Disable only for isolated testing or legacy topology setups.",
-    },
-    ParamDef {
         key: "DiffusionMode",
         section: "Network",
         param_type: ParamType::Enum {
@@ -626,7 +615,7 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
 pub fn build_lookup() -> HashMap<&'static str, &'static ParamDef> {
     let mut map = HashMap::new();
     for def in KNOWN_PARAMS {
-        // First occurrence wins — avoids duplicates like the EnableP2P one above.
+        // First occurrence wins — avoids duplicates.
         map.entry(def.key).or_insert(def);
     }
     map
@@ -724,7 +713,6 @@ pub fn network_defaults(network: Network) -> serde_json::Map<String, serde_json:
     map.insert("RequiresNetworkMagic".into(), json!(req_magic));
 
     // P2P networking.
-    map.insert("EnableP2P".into(), json!(true));
     map.insert("DiffusionMode".into(), json!("InitiatorAndResponder"));
     map.insert("PeerSharing".into(), json!("PeerSharingPublic"));
     map.insert("TargetNumberOfActivePeers".into(), json!(15));

--- a/crates/dugite-monitor/src/metrics.rs
+++ b/crates/dugite-monitor/src/metrics.rs
@@ -41,11 +41,6 @@ impl MetricsSnapshot {
     pub fn get_u64(&self, name: &str) -> u64 {
         self.get(name) as u64
     }
-
-    /// Check whether a metric with the given name was received.
-    pub fn has(&self, name: &str) -> bool {
-        self.values.contains_key(name)
-    }
 }
 
 /// Parse Prometheus text exposition format into a `MetricsSnapshot`.

--- a/crates/dugite-monitor/src/ui.rs
+++ b/crates/dugite-monitor/src/ui.rs
@@ -706,20 +706,15 @@ fn render_connections_panel(frame: &mut Frame, app: &App, theme: &Theme, area: R
     // matching Haskell's connectionStateToCounters exactly.
     let conn_unidirectional = app.metrics.get_u64("dugite_conn_unidirectional");
 
-    // Read the authoritative P2P status from the node's config-derived metric.
-    // Falls back to the heuristic (any peer activity) when the metric is missing
-    // (e.g. connecting to an older dugite-node version).
-    let p2p_enabled = if app.metrics.has("dugite_p2p_enabled") {
-        app.metrics.get_u64("dugite_p2p_enabled") == 1
+    // P2P governor always runs (matching Haskell cardano-node). Show
+    // diffusion mode instead: InitiatorAndResponder (relay) vs InitiatorOnly (BP).
+    let diffusion_initiator_only = app.metrics.get_u64("dugite_diffusion_mode") == 1;
+    let p2p_color = theme.success;
+    let p2p_label = if diffusion_initiator_only {
+        "InitiatorOnly"
     } else {
-        outbound > 0 || inbound > 0 || cold > 0 || warm > 0 || hot > 0
+        "Enabled"
     };
-    let p2p_color = if p2p_enabled {
-        theme.success
-    } else {
-        theme.error
-    };
-    let p2p_label = if p2p_enabled { "Enabled" } else { "Disabled" };
 
     let col_w = inner.width.saturating_sub(2) as usize;
 

--- a/crates/dugite-node/src/config.rs
+++ b/crates/dugite-node/src/config.rs
@@ -85,16 +85,6 @@ pub struct NodeConfig {
     #[serde(default)]
     pub conway_genesis_hash: Option<String>,
 
-    /// Enable P2P networking (default: true, matching cardano-node).
-    ///
-    /// When false, the peer governor is disabled and the node uses static
-    /// topology connections only (no churn, no ledger-based discovery, no
-    /// peer sharing).  The current Haskell cardano-node always runs P2P
-    /// (this field was removed upstream), but we retain it for operators who
-    /// want minimal networking during testing.
-    #[serde(default = "default_enable_p2p")]
-    pub enable_p2_p: bool,
-
     /// Diffusion mode — controls inbound connection acceptance.
     ///
     /// `"InitiatorAndResponder"` (default): full relay mode, accepts inbound.
@@ -231,10 +221,6 @@ pub struct TraceOptions {
 
 fn default_network() -> NetworkId {
     NetworkId::Mainnet
-}
-
-fn default_enable_p2p() -> bool {
-    true
 }
 
 fn default_root_peers() -> usize {
@@ -446,7 +432,6 @@ impl Default for NodeConfig {
             shelley_genesis_hash: None,
             alonzo_genesis_hash: None,
             conway_genesis_hash: None,
-            enable_p2_p: true,
             diffusion_mode: DiffusionMode::default(),
             peer_sharing: None,
             target_number_of_root_peers: 60,

--- a/crates/dugite-node/src/metrics.rs
+++ b/crates/dugite-node/src/metrics.rs
@@ -448,9 +448,6 @@ pub struct NodeMetrics {
     /// native `dugite_*` metrics.  Allows existing cardano-node Grafana dashboards
     /// to work without modification.  Controlled by `--compat-metrics` CLI flag.
     compat_metrics: std::sync::atomic::AtomicBool,
-    /// 1 when P2P networking (peer governor, churn, discovery) is enabled, 0 for
-    /// static topology mode.  Set once at startup from the `EnableP2P` config field.
-    pub p2p_enabled: AtomicU64,
     /// Diffusion mode: 0 = InitiatorAndResponder, 1 = InitiatorOnly.
     /// Set once at startup from the `DiffusionMode` config field.
     pub diffusion_mode: AtomicU64,
@@ -529,7 +526,6 @@ impl NodeMetrics {
             is_block_producer: AtomicU64::new(0),
             pool_id_hex: std::sync::Mutex::new(String::new()),
             compat_metrics: std::sync::atomic::AtomicBool::new(false),
-            p2p_enabled: AtomicU64::new(1),
             diffusion_mode: AtomicU64::new(0),
             peer_sharing_enabled: AtomicU64::new(1),
         }
@@ -743,16 +739,13 @@ impl NodeMetrics {
     /// node configuration.  These are read by the TUI to display the correct
     /// P2P status and diffusion mode.
     ///
-    /// - `p2p`: whether the peer governor is active (`EnableP2P` config field)
     /// - `diffusion_mode`: the `DiffusionMode` config enum
     /// - `peer_sharing`: whether peer sharing mini-protocol is enabled
     pub fn set_p2p_config(
         &self,
-        p2p: bool,
         diffusion_mode: &crate::config::DiffusionMode,
         peer_sharing: bool,
     ) {
-        self.p2p_enabled.store(u64::from(p2p), Ordering::Relaxed);
         self.diffusion_mode.store(
             match diffusion_mode {
                 crate::config::DiffusionMode::InitiatorAndResponder => 0,
@@ -1080,11 +1073,6 @@ impl NodeMetrics {
                 "dugite_is_block_producer",
                 "1 when running as a block producer (forge credentials loaded), 0 for relay",
                 &self.is_block_producer,
-            ),
-            (
-                "dugite_p2p_enabled",
-                "1 when P2P networking (peer governor) is enabled, 0 for static topology mode",
-                &self.p2p_enabled,
             ),
             (
                 "dugite_diffusion_mode",

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1240,27 +1240,16 @@ impl Node {
             // Advertise P2P configuration so the TUI can display the real state
             // rather than guessing from peer counts.
             let effective_peer_sharing = args.config.effective_peer_sharing(is_bp);
-            m.set_p2p_config(
-                args.config.enable_p2_p,
-                &args.config.diffusion_mode,
-                effective_peer_sharing,
-            );
+            m.set_p2p_config(&args.config.diffusion_mode, effective_peer_sharing);
             Arc::new(m)
         };
 
         // Log P2P configuration at startup for diagnostics.
         info!(
-            p2p_enabled = args.config.enable_p2_p,
             diffusion_mode = %args.config.diffusion_mode,
             peer_sharing = args.config.effective_peer_sharing(block_producer.is_some()),
             "P2P networking configuration"
         );
-        if !args.config.enable_p2_p {
-            warn!(
-                "P2P is disabled — running in static topology mode \
-                 (no peer governor, no churn, no ledger-based discovery)"
-            );
-        }
 
         // ── Phase 1: Initialize ChainFragment from ImmutableDB tip ──────────
         //
@@ -2025,8 +2014,9 @@ impl Node {
             info!("N2N server skipped (DiffusionMode=InitiatorOnly, outbound connections only)");
         }
 
-        // Start ledger-based peer discovery task (only when P2P is enabled)
-        if self.config.enable_p2_p {
+        // Ledger-based peer discovery — gated by useLedgerAfterSlot in the
+        // topology, matching Haskell's ledgerPeersThread which always runs.
+        {
             let ledger = self.ledger_state.clone();
             let pm = peer_manager.clone();
             let topology = self.topology.clone();
@@ -2546,12 +2536,6 @@ impl Node {
 
                 // ── Governor evaluation (periodic, every 2s) ────────────
                 _ = governor_ticker.tick() => {
-                    // When P2P is disabled, skip governor evaluation entirely —
-                    // static topology connections are maintained without churn.
-                    if !self.config.enable_p2_p {
-                        continue;
-                    }
-
                     // Compute governor actions based on current peer state.
                     let actions = {
                         let pm = peer_manager.read().await;


### PR DESCRIPTION
## Summary

Fixes #365 — static topology mode (`EnableP2P: false`) did not connect to peers.

- **Root cause:** The governor loop at `mod.rs:2551` did `if !enable_p2_p { continue }`, skipping all governor actions. `PromoteToWarm` never fired, so `spawn_connect` was never called and topology peers stayed Cold forever.
- **Haskell reference:** Current cardano-node (10.x) removed the non-P2P diffusion path entirely (ouroboros-network 0.19.0.0). The P2P governor always runs. `DiffusionMode` controls inbound connections (`InitiatorOnly` vs `InitiatorAndResponder`).
- **Fix:** Remove `enable_p2_p` field and all gating logic. The governor now always runs, matching Haskell. `EnableP2P` in existing config JSON files is silently ignored (serde skips unknown fields), so this is backwards-compatible.

### Changes (10 files, -114/+49 lines)
- Remove `enable_p2_p` from `NodeConfig`, defaults, and all 8 reference sites
- Remove governor bypass (`if !enable_p2_p { continue }`)
- Remove ledger peer discovery gate (already gated by `useLedgerAfterSlot`)
- Remove `dugite_p2p_enabled` Prometheus metric and unused `has()` method
- Update monitor to show DiffusionMode instead of P2P toggle
- Remove EnableP2P from config editor schema, defaults, and JSON configs

## Test plan
- [x] `cargo build --all-targets` — zero warnings
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo nextest run -p dugite-config -p dugite-monitor` — 155/155 pass
- [x] Pre-existing failures on main confirmed unrelated (n2c_client CBOR, disk_monitor disk space)
- [ ] Verify node connects to topology peers with `EnableP2P: false` in config
- [ ] Verify node connects to topology peers with `EnableP2P` absent from config