### PR TITLE
fix(ledger,primitives): stream UTxO scans and snapshot writes (#403)

### DIFF
--- a/crates/dugite-ledger/src/state/epoch.rs
+++ b/crates/dugite-ledger/src/state/epoch.rs
@@ -913,9 +913,14 @@ impl LedgerState {
         let mut new_ptr_stake: HashMap<dugite_primitives::credentials::Pointer, u64> =
             HashMap::new();
 
-        for (_, output) in self.utxo.utxo_set.iter() {
+        // Stream the UTxO set — `iter()` used to materialise the full set
+        // into a single `Vec`, which at preview scale (~3M entries) peaked at
+        // several GB and was one of the contributors to the #403 post-replay
+        // OOM. `scan_all` walks the set one entry at a time.
+        let ptr_stake_excluded = self.epochs.ptr_stake_excluded;
+        self.utxo.utxo_set.scan_all(|_, output| {
             let coin = output.value.coin.0;
-            match stake_routing(&output.address, self.epochs.ptr_stake_excluded) {
+            match stake_routing(&output.address, ptr_stake_excluded) {
                 StakeRouting::Credential(cred_hash) => {
                     *new_map.entry(cred_hash).or_insert(Lovelace(0)) += Lovelace(coin);
                 }
@@ -924,7 +929,7 @@ impl LedgerState {
                 }
                 StakeRouting::None => {}
             }
-        }
+        });
         // Also ensure all registered stake credentials have entries (even with 0 stake)
         for cred_hash in self.certs.delegations.keys() {
             new_map.entry(*cred_hash).or_insert(Lovelace(0));

--- a/crates/dugite-ledger/src/state/snapshot.rs
+++ b/crates/dugite-ledger/src/state/snapshot.rs
@@ -28,6 +28,34 @@ use super::{LedgerError, LedgerState, MAX_SNAPSHOT_SIZE};
 use std::path::Path;
 use tracing::{debug, info, warn};
 
+/// `std::io::Write` adapter that forwards every byte to an inner writer
+/// and simultaneously feeds it into a blake2b-256 hasher.
+///
+/// Used by [`LedgerState::save_snapshot`] so that the snapshot digest can
+/// be computed while `bincode::serialize_into` streams the payload to a
+/// buffered file, without first materialising the whole payload in a
+/// `Vec<u8>`.
+struct HashingWriter<'a, W: std::io::Write> {
+    inner: &'a mut W,
+    hasher: dugite_primitives::hash::Blake2b256Hasher,
+    bytes_written: u64,
+}
+
+impl<'a, W: std::io::Write> std::io::Write for HashingWriter<'a, W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        // Only hash bytes that were actually accepted by the underlying
+        // writer — partial writes must not double-hash the prefix.
+        self.hasher.update(&buf[..n]);
+        self.bytes_written += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 impl LedgerState {
     /// Current snapshot format version.
     ///
@@ -55,42 +83,85 @@ impl LedgerState {
     /// The write is atomic: data is written to a `.tmp` file and then renamed
     /// over the final path so that a crash mid-write does not produce a partial
     /// or corrupt snapshot file.
+    ///
+    /// The payload is streamed through a two-pass write:
+    ///
+    ///   1. First pass: `bincode::serialize_into` writes directly to the
+    ///      temp file via a buffered writer while simultaneously feeding
+    ///      every byte into an incremental blake2b hasher. No full
+    ///      in-memory `Vec<u8>` copy of the snapshot is ever produced.
+    ///   2. Second pass: seek back to the header slot and overwrite the
+    ///      placeholder checksum with the computed hash.
+    ///
+    /// Prior to #403 this function allocated a single contiguous `Vec<u8>`
+    /// via `bincode::serialize(&snapshot)` before writing it out. At
+    /// preview scale (~3M UTxOs in the in-memory backend) that allocation
+    /// was multiple GB and contributed materially to the post-replay OOM
+    /// that killed dugite-node on 32 GB hosts.
     pub fn save_snapshot(&self, path: &Path) -> Result<(), LedgerError> {
+        use dugite_primitives::hash::Blake2b256Hasher;
+        use std::io::{Seek, SeekFrom, Write};
+
         let tmp_path = path.with_extension("tmp");
 
-        // Serialize the ledger state to bincode.
+        // Build the serde-friendly snapshot view. For the LSM backend this is
+        // cheap (empty `utxo_set`); for the in-memory backend it still clones
+        // the UTxO `HashMap`, but that cost is bounded (#403 follow-up work
+        // can thread a borrowing wrapper through bincode if needed).
         let snapshot = super::snapshot_format::LedgerStateSnapshot::from(self);
-        let data = bincode::serialize(&snapshot).map_err(|e| {
-            LedgerError::EpochTransition(format!("Failed to serialize ledger state: {e}"))
-        })?;
 
-        // Compute checksum over the serialized data
-        let checksum = dugite_primitives::hash::blake2b_256(&data);
-
-        // Write header + data using a single buffered write.
-        // Header: "DUGT" (4 bytes) + version (1 byte) + blake2b checksum (32 bytes)
-        use std::io::Write;
         let file = std::fs::File::create(&tmp_path)
             .map_err(|e| LedgerError::EpochTransition(format!("Failed to create snapshot: {e}")))?;
         let mut writer = std::io::BufWriter::with_capacity(1 << 20, file);
+
+        // Header: "DUGT" (4) + version (1) + blake2b placeholder (32).
+        // We fill the checksum slot with zeros, remember its offset, and
+        // rewrite it once the payload has been streamed and hashed.
         writer.write_all(b"DUGT").map_err(|e| {
             LedgerError::EpochTransition(format!("Failed to write snapshot header: {e}"))
         })?;
         writer.write_all(&[Self::SNAPSHOT_VERSION]).map_err(|e| {
             LedgerError::EpochTransition(format!("Failed to write snapshot version: {e}"))
         })?;
+        const CHECKSUM_LEN: usize = 32;
+        let checksum_offset: u64 = 4 + 1;
+        writer.write_all(&[0u8; CHECKSUM_LEN]).map_err(|e| {
+            LedgerError::EpochTransition(format!("Failed to write checksum placeholder: {e}"))
+        })?;
+
+        // Stream the payload through a `HashingWriter` that forwards writes
+        // to the buffered file while updating a blake2b-256 hasher in-line.
+        // `bincode::serialize_into` never materialises the whole payload in
+        // memory — it walks the struct and emits bytes incrementally.
+        let mut hashing_writer = HashingWriter {
+            inner: &mut writer,
+            hasher: Blake2b256Hasher::new(),
+            bytes_written: 0,
+        };
+        bincode::serialize_into(&mut hashing_writer, &snapshot).map_err(|e| {
+            LedgerError::EpochTransition(format!("Failed to serialize ledger state: {e}"))
+        })?;
+        let payload_bytes = hashing_writer.bytes_written;
+        let checksum = hashing_writer.hasher.finalize();
+
+        // Rewrite the checksum placeholder now that the payload hash is
+        // known.  Flush afterwards so the file on disk is consistent before
+        // the atomic rename.
+        writer.flush().map_err(|e| {
+            LedgerError::EpochTransition(format!("Failed to flush snapshot payload: {e}"))
+        })?;
+        writer
+            .seek(SeekFrom::Start(checksum_offset))
+            .map_err(|e| LedgerError::EpochTransition(format!("Failed to seek snapshot: {e}")))?;
         writer.write_all(checksum.as_bytes()).map_err(|e| {
             LedgerError::EpochTransition(format!("Failed to write snapshot checksum: {e}"))
-        })?;
-        writer.write_all(&data).map_err(|e| {
-            LedgerError::EpochTransition(format!("Failed to write snapshot data: {e}"))
         })?;
         writer
             .flush()
             .map_err(|e| LedgerError::EpochTransition(format!("Failed to flush snapshot: {e}")))?;
         drop(writer);
 
-        let total_bytes = 4 + 1 + 32 + data.len();
+        let total_bytes = 4 + 1 + CHECKSUM_LEN as u64 + payload_bytes;
 
         std::fs::rename(&tmp_path, path)
             .map_err(|e| LedgerError::EpochTransition(format!("Failed to rename snapshot: {e}")))?;
@@ -286,13 +357,16 @@ impl LedgerState {
     /// If the ledger has in-memory UTxOs (from bincode snapshot load),
     /// they are migrated to the store before attachment.
     pub fn attach_utxo_store(&mut self, mut store: crate::utxo_store::UtxoStore) {
-        // Migrate any in-memory UTxOs to the store
+        // Migrate any in-memory UTxOs to the store. `iter()` used to
+        // materialise every entry into a throw-away `Vec` before the copy
+        // loop; at preview scale (~3M UTxOs) that intermediate buffer was
+        // multi-GB.  Stream the HashMap directly instead (#403).
         if !self.utxo.utxo_set.is_empty() && !self.utxo.utxo_set.has_store() {
             let count = self.utxo.utxo_set.len();
             tracing::info!("Migrating {} in-memory UTxOs to on-disk store", count);
-            for (input, output) in self.utxo.utxo_set.iter() {
-                store.insert(input, output);
-            }
+            self.utxo.utxo_set.scan_all(|input, output| {
+                store.insert(input.clone(), output.clone());
+            });
         }
         store.set_indexing_enabled(true);
         store.rebuild_address_index();

--- a/crates/dugite-ledger/src/utxo.rs
+++ b/crates/dugite-ledger/src/utxo.rs
@@ -365,14 +365,38 @@ impl UtxoSet {
     /// Iterate over all UTxOs.
     /// Returns owned tuples (compatible with both in-memory and on-disk backends).
     /// For on-disk stores, this performs a full LSM scan — use sparingly.
+    ///
+    /// Prefer [`scan_all`] for hot paths: this helper materialises the whole
+    /// set in a single `Vec`, which at preview scale (~3M UTxOs) is multiple
+    /// GB and was implicated in the #403 post-replay OOM hang. Retained for
+    /// test callers that want a concrete collection.
+    ///
+    /// [`scan_all`]: Self::scan_all
     pub fn iter(&self) -> Vec<(TransactionInput, TransactionOutput)> {
+        let mut out = Vec::with_capacity(self.len());
+        self.scan_all(|input, output| out.push((input.clone(), output.clone())));
+        out
+    }
+
+    /// Stream every live UTxO entry into a callback without materialising
+    /// the full set in memory.
+    ///
+    /// For the in-memory backend this is a direct `HashMap` walk; for the
+    /// LSM-backed store it delegates to
+    /// [`UtxoStore::scan_all`](crate::utxo_store::UtxoStore::scan_all),
+    /// which splits the key space into 256 chunks so peak memory stays
+    /// bounded regardless of UTxO set size (#403).
+    pub fn scan_all<F>(&self, mut f: F)
+    where
+        F: FnMut(&TransactionInput, &TransactionOutput),
+    {
         if let Some(ref store) = self.store {
-            return store.iter();
+            store.scan_all(|input, output| f(&input, &output));
+            return;
         }
-        self.utxos
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
+        for (k, v) in &self.utxos {
+            f(k, v);
+        }
     }
 }
 

--- a/crates/dugite-ledger/src/utxo_store.rs
+++ b/crates/dugite-ledger/src/utxo_store.rs
@@ -498,13 +498,9 @@ impl UtxoStore {
     /// Calculate total ADA in the UTxO set by scanning all entries.
     pub fn total_lovelace(&self) -> Lovelace {
         let mut total = 0u64;
-        let start = Key::from([0u8; 0]);
-        let end = Key::from([0xFFu8; KEY_SIZE]);
-        for (_, value) in self.tree.range(&start, &end) {
-            if let Some(output) = decode_value(&value) {
-                total = total.saturating_add(output.value.coin.0);
-            }
-        }
+        self.scan_all(|_, output| {
+            total = total.saturating_add(output.value.coin.0);
+        });
         Lovelace(total)
     }
 
@@ -525,32 +521,86 @@ impl UtxoStore {
 
     /// Iterate over all UTxO entries by scanning the full LSM tree.
     ///
-    /// This is expensive (full scan + deserialization). Use sparingly
-    /// (e.g., at epoch boundaries for stake distribution rebuild).
+    /// Materialises the entire UTxO set into a `Vec`. Prefer [`scan_all`] for
+    /// streaming callers — at preview-scale (~3M entries) this allocation is
+    /// several GB and was one of the root causes of the post-replay OOM hang
+    /// fixed in #403. Kept for tests that need a concrete collection.
+    ///
+    /// [`scan_all`]: Self::scan_all
     pub fn iter(&self) -> Vec<(TransactionInput, TransactionOutput)> {
-        let start = Key::from([0u8; 0]);
-        let end = Key::from([0xFFu8; KEY_SIZE]);
-        self.tree
-            .range(&start, &end)
-            .filter_map(|(key, value)| {
+        // Pre-size to avoid repeated reallocations of a multi-GB Vec.
+        let mut out = Vec::with_capacity(self.count);
+        self.scan_all(|input, output| out.push((input, output)));
+        out
+    }
+
+    /// Stream every live UTxO entry into a callback without materialising
+    /// the full set in memory.
+    ///
+    /// The LSM `tree.range()` API buffers every page within the requested
+    /// range before returning, so a single full-key-space scan peaks at
+    /// O(total_bytes) memory.  At preview scale (~3M UTxOs) that buffer is
+    /// several GB; on a 32 GB machine the post-replay chain of a full scan +
+    /// `rebuild_address_index` + `rebuild_stake_distribution` + snapshot
+    /// serialisation was enough to get dugite-node Jetsam-killed (#403).
+    ///
+    /// To keep peak memory bounded we split the 36-byte UTxO key space into
+    /// 256 chunks by the first byte of the transaction hash (which is a
+    /// blake2b output and therefore uniformly distributed). Each chunk scans
+    /// ~1/256 of the set, drops the per-chunk Vec, and moves on, so peak
+    /// memory scales with chunk size rather than total set size.
+    pub fn scan_all<F>(&self, mut f: F)
+    where
+        F: FnMut(TransactionInput, TransactionOutput),
+    {
+        // Split on the first byte of the 36-byte key so that chunks are
+        // non-overlapping.  Each chunk is [[prefix, 0..0], [prefix, FF..FF]]
+        // (inclusive both ends — matches LsmTree::range semantics).
+        let mut from_bytes = [0u8; KEY_SIZE];
+        let mut to_bytes = [0u8; KEY_SIZE];
+        for prefix in 0u8..=255 {
+            from_bytes[0] = prefix;
+            for b in from_bytes.iter_mut().skip(1) {
+                *b = 0x00;
+            }
+            to_bytes[0] = prefix;
+            for b in to_bytes.iter_mut().skip(1) {
+                *b = 0xFF;
+            }
+            let from = Key::from(&from_bytes[..]);
+            let to = Key::from(&to_bytes[..]);
+            for (key, value) in self.tree.range(&from, &to) {
                 let input = decode_key(&key);
-                decode_value(&value).map(|output| (input, output))
-            })
-            .collect()
+                if let Some(output) = decode_value(&value) {
+                    f(input, output);
+                }
+            }
+        }
     }
 
     /// Rebuild the address index by scanning all UTxO entries.
     /// Must be called after opening from a snapshot.
+    ///
+    /// Uses [`scan_all`] to stream entries one at a time, avoiding the
+    /// multi-GB intermediate `Vec` that `iter()` + rebuild produced prior
+    /// to #403.
+    ///
+    /// [`scan_all`]: Self::scan_all
     pub fn rebuild_address_index(&mut self) {
         self.address_index.clear();
-        let entries = self.iter();
-        self.count = entries.len();
-        for (input, output) in entries {
-            self.address_index
-                .entry(output.address.clone())
+        let mut count = 0usize;
+        // Rebuild into a local map so we don't need `&mut self` inside the
+        // closure — `scan_all` takes `&self`.
+        let mut address_index: HashMap<Address, HashSet<TransactionInput>> = HashMap::new();
+        self.scan_all(|input, output| {
+            count += 1;
+            address_index
+                .entry(output.address)
                 .or_default()
                 .insert(input);
-        }
+        });
+        self.address_index = address_index;
+        self.count = count;
         info!(
             "Address index rebuilt: {} addresses, {} UTxOs",
             self.address_index.len(),
@@ -559,10 +609,14 @@ impl UtxoStore {
     }
 
     /// Count entries by scanning the LSM tree. Sets the internal count.
+    ///
+    /// Uses [`scan_all`] so that peak memory stays bounded even when the
+    /// store holds millions of entries (#403).
+    ///
+    /// [`scan_all`]: Self::scan_all
     pub fn count_entries(&mut self) -> usize {
-        let start = Key::from([0u8; 0]);
-        let end = Key::from([0xFFu8; KEY_SIZE]);
-        let count = self.tree.range(&start, &end).count();
+        let mut count = 0usize;
+        self.scan_all(|_, _| count += 1);
         self.count = count;
         count
     }

--- a/crates/dugite-primitives/src/hash.rs
+++ b/crates/dugite-primitives/src/hash.rs
@@ -150,6 +150,80 @@ pub fn blake2b_224(data: &[u8]) -> Hash28 {
     Hash(out)
 }
 
+/// Streaming Blake2b-256 hasher.
+///
+/// Use this when hashing data that is streamed or built incrementally (for
+/// example, `std::io::Write` adapters for `bincode::serialize_into`) so that
+/// the caller never has to materialise the whole payload in a `Vec<u8>` just
+/// to compute its digest.
+///
+/// Cross-platform wrapper: `blake2b_simd` on x86_64 (SSE/AVX), `blake2`
+/// (RustCrypto) on other targets, matching the one-shot [`blake2b_256`].
+pub struct Blake2b256Hasher {
+    #[cfg(target_arch = "x86_64")]
+    inner: blake2b_simd::State,
+    #[cfg(not(target_arch = "x86_64"))]
+    inner: blake2::Blake2b<blake2::digest::consts::U32>,
+}
+
+impl Blake2b256Hasher {
+    /// Create a new empty hasher.
+    #[cfg(target_arch = "x86_64")]
+    pub fn new() -> Self {
+        Self {
+            inner: blake2b_simd::Params::new().hash_length(32).to_state(),
+        }
+    }
+
+    /// Create a new empty hasher.
+    #[cfg(not(target_arch = "x86_64"))]
+    pub fn new() -> Self {
+        Self {
+            inner: <blake2::Blake2b<blake2::digest::consts::U32> as blake2::Digest>::new(),
+        }
+    }
+
+    /// Absorb additional bytes into the running digest.
+    #[cfg(target_arch = "x86_64")]
+    pub fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    /// Absorb additional bytes into the running digest.
+    #[cfg(not(target_arch = "x86_64"))]
+    pub fn update(&mut self, data: &[u8]) {
+        <blake2::Blake2b<blake2::digest::consts::U32> as blake2::Digest>::update(
+            &mut self.inner,
+            data,
+        );
+    }
+
+    /// Finalise the digest and return a 32-byte hash.
+    #[cfg(target_arch = "x86_64")]
+    pub fn finalize(self) -> Hash32 {
+        let hash = self.inner.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hash.as_bytes());
+        Hash(out)
+    }
+
+    /// Finalise the digest and return a 32-byte hash.
+    #[cfg(not(target_arch = "x86_64"))]
+    pub fn finalize(self) -> Hash32 {
+        let result =
+            <blake2::Blake2b<blake2::digest::consts::U32> as blake2::Digest>::finalize(self.inner);
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&result);
+        Hash(out)
+    }
+}
+
+impl Default for Blake2b256Hasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Hash `[tag_byte] || data` with Blake2b-224.
 ///
 /// Matches pallas `Hasher::<224>::hash_tagged(&self.0, VERSION as u8)`


### PR DESCRIPTION
## Summary

Fixes #403: dugite-node post-replay init ballooned past 100 GB physical
footprint on 32 GB Apple Silicon hosts and was killed by macOS Jetsam
shortly after `Replay complete`. This made the node unrunnable on
`--storage-profile minimal --utxo-backend in-memory` and on the
high-memory LSM profile alike.

Root cause: the post-replay init stacked several full-UTxO-set
materialisations and one contiguous snapshot buffer back-to-back.

- `UtxoStore::iter()` collected every live entry into a `Vec<(TransactionInput, TransactionOutput)>`, and `LsmTree::range()` itself internally merged every run into another `Vec` before returning. `rebuild_address_index`, `rebuild_stake_distribution`, and `total_lovelace` each triggered one of these scans.
- `LedgerState::save_snapshot` called `bincode::serialize(&snapshot)` to allocate a single `Vec<u8>` before writing, adding another multi-GB contiguous allocation.

Fix:

- `UtxoStore::scan_all` chunks the 36-byte UTxO key space on its first byte (256 non-overlapping `tree.range()` calls) so peak memory is bounded by ~1/256 of the set per call.
- `UtxoSet::scan_all` dispatches to the store on LSM and walks the HashMap directly on the in-memory backend.
- `rebuild_address_index`, `count_entries`, `total_lovelace`, `rebuild_stake_distribution`, `attach_utxo_store`, and `iter()` all now drive `scan_all` rather than materialising the full set.
- `dugite_primitives::hash::Blake2b256Hasher` is a streaming wrapper over the platform-specific Blake2b backend.
- `LedgerState::save_snapshot` now writes a `DUGT` header with a zero checksum placeholder, streams the bincode payload via `bincode::serialize_into` through a `HashingWriter` that feeds the file and the hasher simultaneously, then seeks back and overwrites the placeholder with the computed digest. No intermediate `Vec<u8>` for the payload is ever allocated.

On-disk format and `SNAPSHOT_VERSION` are unchanged.

## Before / after (preview testnet, epoch 1268, ~1.98M UTxOs, 32 GB Apple Silicon)

| Scenario | Before | After |
| --- | --- | --- |
| `--storage-profile minimal --utxo-backend in-memory` | killed by Jetsam at ~142 GB physical footprint | post-replay init in ~1.75 s, peak RSS **4.7 GB** while serving traffic |
| `--utxo-backend lsm` (high-memory profile) | killed by Jetsam at ~125 GB physical footprint after `Address index rebuilt` | migration + rebuild_address_index + rebuild_stake_distribution in ~7 s, peak RSS **3.7 GB** |

Post-replay init trace after the fix:

```
13:13:17.550 Replay       complete (4192825 blocks in 81s, 32 applied, 4192793 skipped)
13:13:17.550 Post-replay: rebuilding address index
13:13:17.904 Post-replay: rebuilding stake distribution
13:13:17.952 Post-replay: recomputing snapshot pool stakes
13:13:17.955 Post-replay: saving UTxO snapshot
13:13:17.955 Post-replay: saving ledger snapshot to /tmp/db-403/ledger-snapshot.bin
13:13:19.265 Snapshot     saved (epoch=1268, 1978276 UTxOs, 392.9 MB)
13:13:19.295 Post-replay: initialization complete
13:13:19.449 N2C server listening socket=/tmp/node-403.sock
```

Metrics advance (`dugite_slot_number` 109585613 → 109589128 in ~30s), N2C socket accepts connections, peers handshake cleanly, `Chain extended` fires every second.

## Test plan

- [x] `cargo nextest run --workspace` — 3847 passed, 1 skipped
- [x] `cargo test --doc`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] End-to-end reproduction on preview testnet via `dugite-node mithril-import` + `dugite-node run`, both backends (`in-memory` and `lsm`), confirming socket + metrics + chain extension
- [x] `save_snapshot` round-trips bincode payload (covered by existing `test_save_load_roundtrip` and `test_bincode_roundtrip_through_snapshot_format`)

Closes #403