### PR TITLE
fix(crypto,network,cli,node): complete rand 0.8→0.9 migration + bump rand_chacha to 0.10

### DIFF
--- a/crates/dugite-cli/src/commands/node.rs
+++ b/crates/dugite-cli/src/commands/node.rs
@@ -144,7 +144,7 @@ impl NodeCmd {
                 // Generate proper Sum6Kes key pair (depth-6 binary sum composition)
                 use rand::RngCore;
                 let mut seed = [0u8; 32];
-                rand::thread_rng().fill_bytes(&mut seed);
+                rand::rng().fill_bytes(&mut seed);
 
                 let (sk_bytes, pk_bytes) = dugite_crypto::kes::kes_keygen(&seed)
                     .map_err(|e| anyhow::anyhow!("KES key generation failed: {e}"))?;

--- a/crates/dugite-cli/src/commands/stake_pool.rs
+++ b/crates/dugite-cli/src/commands/stake_pool.rs
@@ -226,7 +226,7 @@ impl StakePoolCmd {
                 // Generate proper Sum6Kes key pair (depth-6 binary sum composition)
                 use rand::RngCore;
                 let mut seed = [0u8; 32];
-                rand::thread_rng().fill_bytes(&mut seed);
+                rand::rng().fill_bytes(&mut seed);
 
                 let (sk_bytes, pk_bytes) = dugite_crypto::kes::kes_keygen(&seed)
                     .map_err(|e| anyhow::anyhow!("KES key generation failed: {e}"))?;

--- a/crates/dugite-crypto/src/keys.rs
+++ b/crates/dugite-crypto/src/keys.rs
@@ -1,6 +1,6 @@
 use dugite_primitives::hash::{blake2b_224, Hash28};
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use rand::rngs::OsRng;
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -30,8 +30,11 @@ pub struct PaymentVerificationKey {
 
 impl PaymentSigningKey {
     pub fn generate() -> Self {
-        let signing_key = SigningKey::generate(&mut OsRng);
-        PaymentSigningKey { inner: signing_key }
+        let mut seed = [0u8; 32];
+        rand::rng().fill_bytes(&mut seed);
+        PaymentSigningKey {
+            inner: SigningKey::from_bytes(&seed),
+        }
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, KeyError> {

--- a/crates/dugite-crypto/src/vrf.rs
+++ b/crates/dugite-crypto/src/vrf.rs
@@ -1690,7 +1690,7 @@ pub fn generate_vrf_keypair_from_secret(secret: &[u8; 32]) -> VrfKeyPair {
 /// Generate a new VRF key pair using a cryptographically secure RNG.
 pub fn generate_vrf_keypair() -> VrfKeyPair {
     let mut seed = [0u8; 32];
-    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut seed);
+    rand::RngCore::fill_bytes(&mut rand::rng(), &mut seed);
     let sk = SecretKey03::from_bytes(&seed);
     let secret_bytes = sk.to_bytes();
 

--- a/crates/dugite-network/src/peer/governor.rs
+++ b/crates/dugite-network/src/peer/governor.rs
@@ -167,7 +167,7 @@ impl Governor {
         peer_manager: &PeerManager,
         local_root_groups: &[LocalRootGroupTarget],
     ) -> Vec<GovernorAction> {
-        use rand::seq::SliceRandom;
+        use rand::seq::IndexedRandom;
 
         let mut actions = Vec::new();
 
@@ -459,7 +459,7 @@ impl Governor {
             // routable responses to the cold set.
             let sharing_peers = peer_manager.peers_with_peer_sharing(PeerState::Warm);
             if !sharing_peers.is_empty() {
-                if let Some(&peer) = sharing_peers.choose(&mut rand::thread_rng()) {
+                if let Some(&peer) = sharing_peers.choose(&mut rand::rng()) {
                     actions.push(GovernorAction::PeerShareRequest(peer));
                 }
             }

--- a/crates/dugite-network/src/peer/manager.rs
+++ b/crates/dugite-network/src/peer/manager.rs
@@ -124,7 +124,7 @@ impl PeerInfo {
         // Exponential backoff: 5s, 10s, 20s, 40s, 80s, 160s (cap), ±2s fuzz.
         let exp = (self.failure_count - 1).min(COLD_RETRY_MAX_EXP);
         let base = COLD_RETRY_BASE_SECS * 2f64.powi(exp as i32);
-        let fuzz: f64 = rand::thread_rng().gen_range(-2.0..2.0);
+        let fuzz: f64 = rand::rng().random_range(-2.0..2.0);
         let delay_secs = (base + fuzz).max(1.0);
         self.next_connect_after = Some(Instant::now() + Duration::from_secs_f64(delay_secs));
     }

--- a/crates/dugite-node/src/mithril.rs
+++ b/crates/dugite-node/src/mithril.rs
@@ -2420,7 +2420,11 @@ mod tests {
         data.insert("b.txt".to_string(), hash_b);
 
         // Generate a real Ed25519 signature over the manifest hash.
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let signing_key = {
+            let mut seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rng(), &mut seed);
+            ed25519_dalek::SigningKey::from_bytes(&seed)
+        };
         let vkey_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
 
         let manifest_hash = {
@@ -2478,11 +2482,19 @@ mod tests {
 
         // Use a valid key but wrong signature (all zeros is not a valid sig
         // for this message with overwhelming probability).
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let signing_key = {
+            let mut seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rng(), &mut seed);
+            ed25519_dalek::SigningKey::from_bytes(&seed)
+        };
         let vkey_bytes = signing_key.verifying_key().to_bytes();
 
         // Create a valid-format but wrong signature.
-        let wrong_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let wrong_key = {
+            let mut seed = [0u8; 32];
+            rand::RngCore::fill_bytes(&mut rand::rng(), &mut seed);
+            ed25519_dalek::SigningKey::from_bytes(&seed)
+        };
         let manifest_hash = compute_manifest_hash(&AncillaryManifest {
             data: data.clone(),
             signature: None,


### PR DESCRIPTION
## Summary
- PR #402 bumped \`rand = \"0.8\"\` to \`rand = \"0.9\"\` in \`Cargo.toml\` without updating the API call sites, leaving \`main\` broken (\`dugite-crypto\` fails to compile due to \`OsRng: RngCore\` and \`OsRng: CryptoRngCore\` trait bounds).
- This PR updates the remaining seven call sites so the workspace compiles again:
  - \`rand::thread_rng()\` → \`rand::rng()\`
  - \`Rng::gen_range\` → \`Rng::random_range\`
  - \`rand::seq::SliceRandom\` → \`rand::seq::IndexedRandom\`
  - \`SigningKey::generate(&mut OsRng)\` → generate seed via \`rand::rng().fill_bytes\` and use \`SigningKey::from_bytes\`, sidestepping the rand_core 0.6 vs 0.9 incompatibility between \`ed25519-dalek 2.2\` and \`rand 0.9\`.

## Test plan
- [x] \`cargo check --workspace --all-targets\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo nextest run -p dugite-crypto -p dugite-network -p dugite-cli -p dugite-node\` (1021 passed)