### PR TITLE
fix(n2c): encode GetStakeSnapshots argument set and filter response (#406)

### DIFF
--- a/crates/dugite-network/src/n2c_client.rs
+++ b/crates/dugite-network/src/n2c_client.rs
@@ -425,9 +425,33 @@ impl N2CClient {
 
     /// Query stake snapshots (`GetStakeSnapshots` -- Shelley query tag 20).
     ///
-    /// Returns raw MsgResult CBOR payload.
+    /// Returns raw MsgResult CBOR payload. Requests snapshots for all pools.
+    ///
+    /// Note: `GetStakeSnapshots` takes a mandatory `Set (KeyHash StakePool)` argument.
+    /// An empty set requests all pools. See [`Self::query_stake_snapshots_for_pools`]
+    /// for per-pool filtering.
     pub async fn query_stake_snapshot(&mut self) -> Result<Vec<u8>, NetworkError> {
-        self.send_shelley_query(20).await
+        self.query_stake_snapshots_for_pools(&[]).await
+    }
+
+    /// Query stake snapshots for a specific set of pools
+    /// (`GetStakeSnapshots` -- Shelley query tag 20).
+    ///
+    /// Each entry in `pool_ids` must be a 28-byte pool key hash. Pass an empty
+    /// slice to request snapshots for all pools.
+    ///
+    /// Wire format:
+    /// `[3, [0, [0, [6, [20, tag(258) [<pool_hash>, ...]]]]]]`
+    ///
+    /// Returns raw MsgResult CBOR payload.
+    pub async fn query_stake_snapshots_for_pools(
+        &mut self,
+        pool_ids: &[Vec<u8>],
+    ) -> Result<Vec<u8>, NetworkError> {
+        let inner = encode_get_stake_snapshots_query(pool_ids)?;
+        let buf = encode_conway_block_query(&inner)?;
+        self.send_query(buf).await?;
+        self.recv_query().await
     }
 
     /// Query account state (`GetAccountState` -- Shelley query tag 29).
@@ -768,6 +792,29 @@ fn encode_hard_fork_query(sub_tag: u32) -> Result<Vec<u8>, NetworkError> {
     enc.array(1).map_err(cbor_err)?;
     enc.u32(sub_tag).map_err(cbor_err)?;
     Ok(buf)
+}
+
+/// Encode the inner body of a `GetStakeSnapshots` (Shelley tag 20) query.
+///
+/// Produces `[20, tag(258) [<pool_hash>, ...]]`. The tag(258) wrapper is
+/// always emitted, even for an empty set, because `GetStakeSnapshots` takes
+/// a mandatory `Set (KeyHash StakePool)` argument in Haskell. An empty set
+/// requests all pools.
+///
+/// Each pool ID must be a 28-byte key hash.
+pub(crate) fn encode_get_stake_snapshots_query(
+    pool_ids: &[Vec<u8>],
+) -> Result<Vec<u8>, NetworkError> {
+    let mut inner = Vec::new();
+    let mut enc = minicbor::Encoder::new(&mut inner);
+    enc.array(2).map_err(cbor_err)?;
+    enc.u32(20).map_err(cbor_err)?; // GetStakeSnapshots
+    enc.tag(minicbor::data::Tag::new(258)).map_err(cbor_err)?;
+    enc.array(pool_ids.len() as u64).map_err(cbor_err)?;
+    for pid in pool_ids {
+        enc.bytes(pid).map_err(cbor_err)?;
+    }
+    Ok(inner)
 }
 
 /// Encode a Conway-era BlockQuery (QueryIfCurrent) with full HFC telescope.
@@ -1497,5 +1544,69 @@ mod tests {
     fn test_utctime_to_iso8601() {
         let s = utctime_to_iso8601(2022, 298, 0);
         assert_eq!(s, "2022-10-25T00:00:00Z");
+    }
+
+    // ─── GetStakeSnapshots (tag 20) query encoding (issue #406) ──────────
+
+    /// Single-pool `GetStakeSnapshots` query must encode as
+    /// `[20, tag(258) [<28-byte hash>]]` exactly.
+    ///
+    /// Byte layout for a single-pool set containing 0xAA repeated 28 times:
+    /// - `82`                  — array(2)
+    /// - `14`                  — unsigned 20 (shelley tag)
+    /// - `d9 01 02`            — tag(258)
+    /// - `81`                  — array(1)
+    /// - `58 1c aa..aa` (x28)  — byte string, length 28
+    #[test]
+    fn test_encode_get_stake_snapshots_single_pool() {
+        let pool = vec![0xAAu8; 28];
+        let bytes = encode_get_stake_snapshots_query(&[pool]).unwrap();
+
+        let mut expected: Vec<u8> = Vec::new();
+        expected.push(0x82); // array(2)
+        expected.push(0x14); // 20
+        expected.extend_from_slice(&[0xd9, 0x01, 0x02]); // tag(258)
+        expected.push(0x81); // array(1)
+        expected.extend_from_slice(&[0x58, 0x1c]); // bstr(28)
+        expected.extend_from_slice(&[0xAA; 28]);
+
+        assert_eq!(
+            hex::encode(&bytes),
+            hex::encode(&expected),
+            "single-pool GetStakeSnapshots wire mismatch"
+        );
+    }
+
+    /// Empty-set (all pools) `GetStakeSnapshots` query must still emit the
+    /// tag(258) wrapper: `[20, tag(258) []]`. cardano-node rejects any form
+    /// without the tag.
+    #[test]
+    fn test_encode_get_stake_snapshots_empty_set_has_tag() {
+        let bytes = encode_get_stake_snapshots_query(&[]).unwrap();
+
+        // Expected: 82 14 d9 01 02 80
+        let expected: Vec<u8> = vec![0x82, 0x14, 0xd9, 0x01, 0x02, 0x80];
+        assert_eq!(
+            hex::encode(&bytes),
+            hex::encode(&expected),
+            "empty GetStakeSnapshots must include tag(258) wrapper"
+        );
+    }
+
+    /// Multi-pool `GetStakeSnapshots` must order pools as supplied.
+    #[test]
+    fn test_encode_get_stake_snapshots_two_pools() {
+        let pool_a = vec![0x11u8; 28];
+        let pool_b = vec![0x22u8; 28];
+        let bytes = encode_get_stake_snapshots_query(&[pool_a.clone(), pool_b.clone()]).unwrap();
+
+        // Decode back and verify structure.
+        let mut dec = minicbor::Decoder::new(&bytes);
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u32().unwrap(), 20);
+        assert_eq!(dec.tag().unwrap().as_u64(), 258);
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.bytes().unwrap(), pool_a.as_slice());
+        assert_eq!(dec.bytes().unwrap(), pool_b.as_slice());
     }
 }

--- a/crates/dugite-node/src/node/n2c_query/encoding.rs
+++ b/crates/dugite-node/src/node/n2c_query/encoding.rs
@@ -2741,6 +2741,78 @@ mod tests {
         );
     }
 
+    // ─── Stake snapshots (tag 20) — golden vector (issue #406) ──────────────
+
+    /// Golden vector for `GetStakeSnapshots` response encoding.
+    ///
+    /// Haskell's `StakeSnapshots` record encodes as `encodeListLen 4` followed by
+    /// `ssStakeSnapshots` (a CBOR map from pool key hash to `StakeSnapshot`),
+    /// then `ssMarkTotal`, `ssSetTotal`, `ssGoTotal` (all `NonZero Coin`).
+    /// The inner `StakeSnapshot` encodes as `encodeListLen 3` of `[sMark, sSet, sGo]`.
+    ///
+    /// See `cardano-ledger-api`'s `Cardano.Ledger.Api.State.Query` for the reference.
+    ///
+    /// Layout verified: `array(4) [map(1){hash => array(3)[m,s,g]}, mark_total, set_total, go_total]`.
+    #[test]
+    fn test_stake_snapshots_golden_vector() {
+        let result = QueryResult::StakeSnapshots(StakeSnapshotsResult {
+            pools: vec![PoolStakeSnapshotEntry {
+                pool_id: vec![0xAA; 28],
+                mark_stake: 100,
+                set_stake: 200,
+                go_stake: 300,
+            }],
+            total_mark_stake: 1_000,
+            total_set_stake: 2_000,
+            total_go_stake: 3_000,
+        });
+        let encoded = encode_query_result(&result);
+        let inner = strip_wrappers(&encoded);
+
+        // Hand-built expected bytes.
+        let mut expected: Vec<u8> = Vec::new();
+        expected.push(0x84); // array(4)
+        expected.push(0xa1); // map(1)
+        expected.extend_from_slice(&[0x58, 0x1c]); // bstr(28)
+        expected.extend_from_slice(&[0xAA; 28]);
+        expected.push(0x83); // array(3)
+        expected.extend_from_slice(&[0x18, 100]); // uint 100
+        expected.extend_from_slice(&[0x18, 200]); // uint 200
+        expected.extend_from_slice(&[0x19, 0x01, 0x2c]); // uint 300 (go stake)
+        expected.extend_from_slice(&[0x19, 0x03, 0xe8]); // total mark 1000
+        expected.extend_from_slice(&[0x19, 0x07, 0xd0]); // total set 2000
+        expected.extend_from_slice(&[0x19, 0x0b, 0xb8]); // total go 3000
+
+        assert_eq!(
+            hex::encode(&inner),
+            hex::encode(&expected),
+            "StakeSnapshots golden vector mismatch"
+        );
+    }
+
+    /// Totals in `StakeSnapshots` are `NonZero Coin` — they must serialise as at
+    /// least 1 even if the underlying value was 0. This prevents cardano-cli
+    /// from choking on a zeroed out "total" field while the node is still
+    /// bootstrapping epoch snapshots.
+    #[test]
+    fn test_stake_snapshots_zero_totals_encode_as_one() {
+        let result = QueryResult::StakeSnapshots(StakeSnapshotsResult {
+            pools: vec![],
+            total_mark_stake: 0,
+            total_set_stake: 0,
+            total_go_stake: 0,
+        });
+        let encoded = encode_query_result(&result);
+        let inner = strip_wrappers(&encoded);
+
+        let mut dec = Decoder::new(&inner);
+        assert_eq!(dec.array().unwrap(), Some(4));
+        assert_eq!(dec.map().unwrap(), Some(0));
+        assert_eq!(dec.u64().unwrap(), 1);
+        assert_eq!(dec.u64().unwrap(), 1);
+        assert_eq!(dec.u64().unwrap(), 1);
+    }
+
     // ─── Stake snapshots (tag 20) — pool IDs must be 28 bytes ───────────────
 
     #[test]

--- a/crates/dugite-node/src/node/n2c_query/mod.rs
+++ b/crates/dugite-node/src/node/n2c_query/mod.rs
@@ -477,7 +477,7 @@ impl QueryHandler {
             17 => stake::handle_stake_pool_params(&self.state, decoder),
             18 => stake::handle_reward_info_pools(&self.state),
             19 => stake::handle_pool_state(&self.state, decoder),
-            20 => stake::handle_stake_snapshots(&self.state),
+            20 => stake::handle_stake_snapshots(&self.state, decoder),
             21 => stake::handle_pool_distr(&self.state, decoder),
             22 => stake::handle_stake_deleg_deposits(&self.state, decoder),
             23 => governance::handle_constitution(&self.state),

--- a/crates/dugite-node/src/node/n2c_query/stake.rs
+++ b/crates/dugite-node/src/node/n2c_query/stake.rs
@@ -193,9 +193,40 @@ pub(crate) fn handle_spo_stake_distr(
 }
 
 /// Handle GetStakeSnapshots (tag 20).
-pub(crate) fn handle_stake_snapshots(state: &NodeStateSnapshot) -> QueryResult {
+///
+/// Argument: mandatory `tag(258) Set<KeyHash StakePool>`. An empty set
+/// requests all pools (Haskell's `getStakeSnapshots` semantics).
+///
+/// Before the fix for issue #406 the argument was ignored entirely and the
+/// response always contained every pool. This both violated the wire protocol
+/// (trailing CBOR bytes in the decoder) and broke compatibility with
+/// `cardano-cli query stake-snapshot --stake-pool-id <id>`.
+pub(crate) fn handle_stake_snapshots(
+    state: &NodeStateSnapshot,
+    decoder: &mut minicbor::Decoder<'_>,
+) -> QueryResult {
     debug!("Query: GetStakeSnapshots");
-    QueryResult::StakeSnapshots(state.stake_snapshots.clone())
+    let filter_pools = parse_pool_id_set(decoder);
+    let snapshots = &state.stake_snapshots;
+    if filter_pools.is_empty() {
+        QueryResult::StakeSnapshots(snapshots.clone())
+    } else {
+        let filtered_pools = snapshots
+            .pools
+            .iter()
+            .filter(|p| filter_pools.iter().any(|h| h == &p.pool_id))
+            .cloned()
+            .collect();
+        // Totals are global — matching Haskell's `StakeSnapshots` record, where
+        // `ssMarkTotal` / `ssSetTotal` / `ssGoTotal` are the total active stake
+        // across the whole epoch snapshot regardless of any pool filter.
+        QueryResult::StakeSnapshots(crate::node::n2c_query::types::StakeSnapshotsResult {
+            pools: filtered_pools,
+            total_mark_stake: snapshots.total_mark_stake,
+            total_set_stake: snapshots.total_set_stake,
+            total_go_stake: snapshots.total_go_stake,
+        })
+    }
 }
 
 /// Handle GetPoolDistr (tag 21) -- returns pool stake distribution.
@@ -861,30 +892,113 @@ mod tests {
 
     // ─── GetStakeSnapshots (tag 20) ────────────────────────────────────
 
-    #[test]
-    fn test_stake_snapshots() {
+    fn make_stake_snapshots_state() -> NodeStateSnapshot {
         use crate::node::n2c_query::types::{PoolStakeSnapshotEntry, StakeSnapshotsResult};
-        let state = NodeStateSnapshot {
+        NodeStateSnapshot {
             stake_snapshots: StakeSnapshotsResult {
-                pools: vec![PoolStakeSnapshotEntry {
-                    pool_id: vec![1u8; 28],
-                    mark_stake: 100,
-                    set_stake: 200,
-                    go_stake: 300,
-                }],
-                total_mark_stake: 100,
-                total_set_stake: 200,
-                total_go_stake: 300,
+                pools: vec![
+                    PoolStakeSnapshotEntry {
+                        pool_id: vec![1u8; 28],
+                        mark_stake: 100,
+                        set_stake: 200,
+                        go_stake: 300,
+                    },
+                    PoolStakeSnapshotEntry {
+                        pool_id: vec![2u8; 28],
+                        mark_stake: 1_000,
+                        set_stake: 2_000,
+                        go_stake: 3_000,
+                    },
+                ],
+                total_mark_stake: 10_100,
+                total_set_stake: 20_200,
+                total_go_stake: 30_300,
             },
             ..NodeStateSnapshot::default()
-        };
-        let result = handle_stake_snapshots(&state);
+        }
+    }
+
+    #[test]
+    fn test_stake_snapshots_empty_filter_returns_all_pools() {
+        let state = make_stake_snapshots_state();
+        let cbor = make_empty_filter_cbor();
+        let mut dec = minicbor::Decoder::new(&cbor);
+        let result = handle_stake_snapshots(&state, &mut dec);
+        match result {
+            QueryResult::StakeSnapshots(ss) => {
+                assert_eq!(ss.pools.len(), 2);
+                assert_eq!(ss.total_mark_stake, 10_100);
+                assert_eq!(ss.total_set_stake, 20_200);
+                assert_eq!(ss.total_go_stake, 30_300);
+            }
+            _ => panic!("Expected StakeSnapshots"),
+        }
+    }
+
+    #[test]
+    fn test_stake_snapshots_filter_single_pool() {
+        let state = make_stake_snapshots_state();
+        let cbor = make_pool_filter_cbor(&[2u8; 28]);
+        let mut dec = minicbor::Decoder::new(&cbor);
+        let result = handle_stake_snapshots(&state, &mut dec);
         match result {
             QueryResult::StakeSnapshots(ss) => {
                 assert_eq!(ss.pools.len(), 1);
-                assert_eq!(ss.total_mark_stake, 100);
-                assert_eq!(ss.total_set_stake, 200);
-                assert_eq!(ss.total_go_stake, 300);
+                assert_eq!(ss.pools[0].pool_id, vec![2u8; 28]);
+                assert_eq!(ss.pools[0].mark_stake, 1_000);
+                // Totals are global even when filtered (matches Haskell semantics)
+                assert_eq!(ss.total_mark_stake, 10_100);
+                assert_eq!(ss.total_set_stake, 20_200);
+                assert_eq!(ss.total_go_stake, 30_300);
+            }
+            _ => panic!("Expected StakeSnapshots"),
+        }
+    }
+
+    /// Feed the full Shelley inner query body `[20, tag(258) [hash1, hash2]]`
+    /// through the same parsing the dispatcher would apply — verifies that the
+    /// argument is consumed correctly and filtering hits the expected pool set.
+    #[test]
+    fn test_stake_snapshots_parses_tagged_set_from_query_body() {
+        let state = make_stake_snapshots_state();
+
+        // Build the inner Shelley query body: [20, tag(258) [p1, p2]]
+        let mut buf = Vec::new();
+        let mut enc = minicbor::Encoder::new(&mut buf);
+        enc.array(2).unwrap();
+        enc.u32(20).unwrap();
+        enc.tag(minicbor::data::Tag::new(258)).unwrap();
+        enc.array(2).unwrap();
+        enc.bytes(&[1u8; 28]).unwrap();
+        enc.bytes(&[2u8; 28]).unwrap();
+
+        // Dispatcher would peel the outer array and read the tag u32 first.
+        let mut dec = minicbor::Decoder::new(&buf);
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u32().unwrap(), 20);
+        // Handler receives the decoder positioned at the argument set.
+        let result = handle_stake_snapshots(&state, &mut dec);
+        match result {
+            QueryResult::StakeSnapshots(ss) => {
+                assert_eq!(ss.pools.len(), 2);
+                assert_eq!(ss.pools[0].pool_id, vec![1u8; 28]);
+                assert_eq!(ss.pools[1].pool_id, vec![2u8; 28]);
+            }
+            _ => panic!("Expected StakeSnapshots"),
+        }
+    }
+
+    #[test]
+    fn test_stake_snapshots_filter_unknown_pool_returns_empty_list() {
+        let state = make_stake_snapshots_state();
+        let cbor = make_pool_filter_cbor(&[0xFFu8; 28]);
+        let mut dec = minicbor::Decoder::new(&cbor);
+        let result = handle_stake_snapshots(&state, &mut dec);
+        match result {
+            QueryResult::StakeSnapshots(ss) => {
+                assert!(ss.pools.is_empty());
+                // Totals remain global
+                assert_eq!(ss.total_mark_stake, 10_100);
             }
             _ => panic!("Expected StakeSnapshots"),
         }


### PR DESCRIPTION
## Summary

Fixes #406 — `cardano-cli query stake-snapshot` against `dugite-node` failed with `mux: bearer closed` because dugite sent `GetStakeSnapshots` as a bare `[20]` with no argument, which cardano-node 10.6.2 rejects.

Two bugs, one root cause:

1. **Client bug**: `n2c_client.rs` encoded Shelley tag 20 as `[20]` — a single-element array with no payload. Haskell's `GetStakeSnapshots` takes a **mandatory** `Set (KeyHash StakePool)` argument.
2. **Server bug**: `handle_stake_snapshots` ignored any argument entirely and always returned every pool. This both violated the wire protocol (trailing CBOR bytes in the decoder) and broke per-pool filtering.

## Wire format fix

### Query (client -> server)

**Before** (rejected by cardano-node):
```
[3, [0, [0, [6, [20]]]]]
```

**After**:
```
[3, [0, [0, [6, [20, tag(258) [<28-byte pool hash>, ...]]]]]]
```

Empty set still emits the `tag(258)` wrapper (`82 14 d9 01 02 80`), which is Haskell's "request all pools" semantics.

### Response (server -> client)

Verified against `cardano-ledger-api`'s `Cardano.Ledger.Api.State.Query.StakeSnapshots`:

```
array(4) [ Map<KeyHash StakePool, StakeSnapshot>  -- ssStakeSnapshots
        , NonZero Coin                           -- ssMarkTotal
        , NonZero Coin                           -- ssSetTotal
        , NonZero Coin ]                         -- ssGoTotal

StakeSnapshot = array(3) [ Coin, Coin, Coin ]    -- [sMark, sSet, sGo]
```

Dugite's existing encoder already matched this layout; added a handwritten golden vector to lock it in and protect against regressions.

## API changes

- New public method: `N2cClient::query_stake_snapshots_for_pools(&[Vec<u8>])`
- Existing `query_stake_snapshot()` now delegates to the new method with an empty pool list (same no-arg caller behaviour, correct wire format)
- New free-standing (crate-visible) helper `encode_get_stake_snapshots_query` for testability

## Server behaviour

- `handle_stake_snapshots` now takes `&mut minicbor::Decoder` and parses the mandatory `tag(258) Set<KeyHash StakePool>` argument
- Empty filter -> all snapshots (matches Haskell semantics)
- Non-empty filter -> per-pool map is filtered, but the three global totals remain unfiltered (matches Haskell `ssMarkTotal`/`ssSetTotal`/`ssGoTotal` which are per-epoch globals)
- Dispatcher at `n2c_query/mod.rs` tag 20 updated to pass the decoder

## Test strategy

- **Client encoding** (`dugite-network`): 3 unit tests asserting exact hex bytes for single-pool, empty-set, and two-pool queries. Empty-set test locks in the tag(258) wrapper.
- **Server parse + filter** (`dugite-node` `stake.rs`): 4 tests covering empty filter (all pools), single-pool filter, full query body parse (through the same decoder state the dispatcher produces), and unknown-pool filter (empty result, totals still global).
- **Response encoding** (`dugite-node` `encoding.rs`): golden hex vector for `[pool_map, mark_total, set_total, go_total]` with an inner `StakeSnapshot` 3-element array; plus a `NonZero Coin` test verifying zero totals encode as 1.

## Quality gates

All green:

- `cargo build --all-targets` - clean
- `cargo nextest run -p dugite-network -p dugite-node` - 805 passed, 1 skipped (no new failures)
- `cargo clippy --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean

## Test plan

- [x] Unit tests added for client encoding with exact hex vectors
- [x] Unit tests added for server parse and filter
- [x] Golden vector added for response encoding
- [x] All quality gates pass locally
- [ ] CI green on this branch
- [ ] Manual: `cardano-cli query stake-snapshot --testnet-magic 2 --stake-pool-id <id>` against a live dugite-node returns filtered JSON matching cardano-node format (left for follow-up soak verification, #406 reference output included in the issue)

Closes #406.