### PR TITLE
fix(n2c): dispatch tip-result parser by query opcode; verify server bare-form encoding (#407)

### DIFF
--- a/crates/dugite-cli/src/commands/query.rs
+++ b/crates/dugite-cli/src/commands/query.rs
@@ -866,7 +866,15 @@ impl QueryCmd {
 
                 let epoch = client.query_epoch().await.unwrap_or(0);
                 let era = client.query_era().await.unwrap_or(6);
-                let block_no = client.query_block_no().await.unwrap_or(tip.block_no);
+                // `GetLedgerTip` does not carry a block number, so `tip.block_no`
+                // is always `None` here (see TipResult docs, issue #407). Fall
+                // back to 0 if `GetChainBlockNo` also fails.
+                let block_no = client
+                    .query_block_no()
+                    .await
+                    .ok()
+                    .or(tip.block_no)
+                    .unwrap_or(0);
 
                 // Query system start time from the node for accurate sync progress
                 let system_start_str = client.query_system_start().await.ok();

--- a/crates/dugite-network/src/n2c_client.rs
+++ b/crates/dugite-network/src/n2c_client.rs
@@ -16,14 +16,26 @@ use crate::mux::channel::MuxChannel;
 use crate::mux::{Direction, Mux};
 
 /// Result of a tip query.
+///
+/// `GetLedgerTip` (Shelley BlockQuery tag 0) returns a bare `Point`
+/// `[slot, hash]` — it does **not** carry a block number. Callers that need
+/// the block number must issue `GetChainBlockNo` (top-level outer tag 2, via
+/// [`N2CClient::query_block_no`]) separately.
+///
+/// Accordingly, [`TipResult::block_no`] is `Option<u64>`:
+/// - `None` when populated from a raw `GetLedgerTip` response.
+/// - `Some(_)` when a caller has back-filled it from `GetChainBlockNo`.
+///
+/// See issue #407.
 #[derive(Debug, Clone)]
 pub struct TipResult {
     /// Slot number at the tip.
     pub slot: u64,
     /// Block header hash (32 bytes).
     pub hash: Vec<u8>,
-    /// Block number at the tip.
-    pub block_no: u64,
+    /// Block number at the tip, if known. `GetLedgerTip` never populates this
+    /// — use `GetChainBlockNo` if the value is required.
+    pub block_no: Option<u64>,
     /// Epoch number (filled in by caller if needed).
     pub epoch: u64,
     /// Era index (filled in by caller if needed).
@@ -183,12 +195,17 @@ impl N2CClient {
 
     /// Query the chain tip (`GetLedgerTip` -- Shelley query tag 0).
     ///
-    /// Returns a [`TipResult`] with slot, hash, and block_no populated.
-    /// The `epoch` and `era` fields default to 0; callers fill them via
+    /// Returns a [`TipResult`] populated from the wire `Point` — `slot` and
+    /// `hash` are set; `block_no` is `None` because `GetLedgerTip` does not
+    /// carry a block number (see issue #407 and the [`TipResult`] docs).
+    ///
+    /// `epoch` and `era` default to 0; callers fill them via
     /// [`query_epoch`](Self::query_epoch) / [`query_era`](Self::query_era).
+    /// Callers that need the block number should call
+    /// [`query_block_no`](Self::query_block_no).
     pub async fn query_tip(&mut self) -> Result<TipResult, NetworkError> {
         let result = self.send_shelley_query(0).await?;
-        parse_tip_result(&result)
+        parse_ledger_tip_result(&result)
     }
 
     /// Query the current epoch number (`GetEpochNo` -- Shelley query tag 1).
@@ -830,33 +847,81 @@ fn strip_hfc_wrapper(decoder: &mut minicbor::Decoder) -> Result<(), NetworkError
     }
 }
 
-/// Parse a `GetLedgerTip` MsgResult into a [`TipResult`].
-fn parse_tip_result(payload: &[u8]) -> Result<TipResult, NetworkError> {
+/// Parse a `GetLedgerTip` (Shelley BlockQuery tag 0) MsgResult into a [`TipResult`].
+///
+/// Wire shape (captured from cardano-node 10.6.2, see issue #407):
+/// ```text
+/// 82 04 81 82 1a 06884258 5820 <32-byte hash>
+/// ```
+/// i.e. `MsgResult [4, [[slot, hash]]]`:
+/// - `[4, ...]`   — MsgResult envelope
+/// - `array(1)`   — HFC EitherMismatch success wrapper (BlockQuery > QueryIfCurrent)
+/// - `[slot, hash]` — bare `Point`
+///
+/// `GetLedgerTip` returns a `Point`, **not** a `Tip`: there is no block number
+/// in the payload. The returned [`TipResult::block_no`] is therefore always
+/// `None`. Callers that need the block number should call
+/// [`N2CClient::query_block_no`] (`GetChainBlockNo`, top-level outer tag 2).
+///
+/// Dispatch-by-opcode: this function is specialised for tag 0 and does not
+/// attempt to handle the legacy `[[slot, hash], block_no]` `Tip` shape. That
+/// shape was previously emitted by dugite's own server as a bug — the server
+/// now also emits the bare-Point form, so there is no legacy form to parse.
+fn parse_ledger_tip_result(payload: &[u8]) -> Result<TipResult, NetworkError> {
     let mut dec = minicbor::Decoder::new(payload);
     strip_msg_result(&mut dec)?;
     strip_hfc_wrapper(&mut dec)?;
 
-    // Haskell `Tip` CBOR encoding (ouroboros-network):
-    //   TipGenesis  = [0, null]
-    //   Tip sl h bn = [[1, [sl, h]], bn]   -- discriminated BlockPoint form
-    //
-    // Dugite's own server sends the older compact form:
-    //   [[slot, hash], block_no]           -- no discriminator
-    //
-    // We detect which format we're in by checking whether the element
-    // following the first integer in the inner (Point) array is an array
-    // (Haskell form) or bytes (compact form).
-    let _ = dec.array(); // outer Tip array
-    let _ = dec.array(); // Point array: either [disc, [sl, h]] or [sl, h]
-
-    let first = dec
+    // Point: [slot, hash]
+    let point_len = dec
+        .array()
+        .map_err(|e| protocol_err(format!("bad ledger-tip point array: {e}")))?;
+    if point_len != Some(2) {
+        return Err(protocol_err(format!(
+            "GetLedgerTip Point must be array(2), got {point_len:?}"
+        )));
+    }
+    let slot = dec
         .u64()
-        .map_err(|e| protocol_err(format!("bad tip first field: {e}")))?;
+        .map_err(|e| protocol_err(format!("bad slot: {e}")))?;
+    let hash = dec
+        .bytes()
+        .map_err(|e| protocol_err(format!("bad hash: {e}")))?
+        .to_vec();
 
-    let (slot, hash) = match dec.datatype().unwrap_or(minicbor::data::Type::Undefined) {
-        minicbor::data::Type::Array => {
-            // Haskell form: first = discriminator (1), next = [slot, hash]
-            let _ = dec.array();
+    Ok(TipResult {
+        slot,
+        hash,
+        block_no: None,
+        epoch: 0,
+        era: 0,
+    })
+}
+
+/// Parse a `GetChainPoint` (top-level outer tag 3) MsgResult into a `(slot, hash)` pair.
+///
+/// Wire shape:
+/// ```text
+/// [4, [slot, hash]]   -- Point, top-level (no HFC wrapper)
+/// [4, []]             -- Point::Origin
+/// ```
+///
+/// Returns `None` for `Point::Origin`.
+#[allow(dead_code)] // exposed for future GetChainPoint callers and unit tests
+fn parse_chain_point_result(payload: &[u8]) -> Result<Option<(u64, Vec<u8>)>, NetworkError> {
+    let mut dec = minicbor::Decoder::new(payload);
+    strip_msg_result(&mut dec)?;
+    // Top-level query: no HFC wrapper. Use strip_hfc_wrapper defensively — it
+    // resets position if no `array(1)` is present, so top-level replies parse
+    // correctly.
+    strip_hfc_wrapper(&mut dec)?;
+
+    let point_len = dec
+        .array()
+        .map_err(|e| protocol_err(format!("bad chain-point array: {e}")))?;
+    match point_len {
+        Some(0) => Ok(None),
+        Some(2) => {
             let slot = dec
                 .u64()
                 .map_err(|e| protocol_err(format!("bad slot: {e}")))?;
@@ -864,29 +929,12 @@ fn parse_tip_result(payload: &[u8]) -> Result<TipResult, NetworkError> {
                 .bytes()
                 .map_err(|e| protocol_err(format!("bad hash: {e}")))?
                 .to_vec();
-            (slot, hash)
+            Ok(Some((slot, hash)))
         }
-        _ => {
-            // Compact form: first = slot, next = hash bytes
-            let hash = dec
-                .bytes()
-                .map_err(|e| protocol_err(format!("bad hash: {e}")))?
-                .to_vec();
-            (first, hash)
-        }
-    };
-
-    let block_no = dec
-        .u64()
-        .map_err(|e| protocol_err(format!("bad block_no: {e}")))?;
-
-    Ok(TipResult {
-        slot,
-        hash,
-        block_no,
-        epoch: 0,
-        era: 0,
-    })
+        other => Err(protocol_err(format!(
+            "GetChainPoint Point must be array(0|2), got {other:?}"
+        ))),
+    }
 }
 
 /// Parse a `GetEpochNo` MsgResult into a `u64`.
@@ -1442,42 +1490,85 @@ mod tests {
         assert_eq!(format_rational_decimal(75, 100), "0.75");
     }
 
+    /// GetLedgerTip bare-Point golden vector (issue #407).
+    ///
+    /// Captured from cardano-node 10.6.2, 43-byte payload:
+    /// ```text
+    /// 82 04 81 82 1a 06884258 5820
+    ///   344bc3f7b7b3686a181a3c73e4a4050122b888e1b596f2c3a398a6a7fc2c9602
+    /// ```
+    /// i.e. `[4, [[slot=109576792, hash]]]`.
+    ///
+    /// Prior to #407, `parse_tip_result` over-read the payload trying to decode
+    /// a legacy `Tip` shape `[[slot, hash], block_no]` and returned an error or
+    /// wrong data. The fix dispatches by query opcode: `GetLedgerTip` is parsed
+    /// specifically as a bare Point with `block_no = None`.
     #[test]
-    fn test_parse_tip_result() {
-        let mut buf = Vec::new();
-        let mut enc = minicbor::Encoder::new(&mut buf);
-        enc.array(2).unwrap();
-        enc.u32(4).unwrap(); // MsgResult tag
-        enc.array(1).unwrap(); // HFC success wrapper: array(1)[result]
-        enc.array(2).unwrap(); // [[slot, hash], block_no]
-        enc.array(2).unwrap();
-        enc.u64(12345).unwrap();
-        enc.bytes(&[0xab; 32]).unwrap();
-        enc.u64(100).unwrap();
+    fn test_parse_ledger_tip_bare_point_golden() {
+        let hash_hex = "344bc3f7b7b3686a181a3c73e4a4050122b888e1b596f2c3a398a6a7fc2c9602";
+        let expected_hash: Vec<u8> = (0..32)
+            .map(|i| u8::from_str_radix(&hash_hex[i * 2..i * 2 + 2], 16).unwrap())
+            .collect();
 
-        let result = parse_tip_result(&buf).unwrap();
-        assert_eq!(result.slot, 12345);
-        assert_eq!(result.hash, vec![0xab; 32]);
-        assert_eq!(result.block_no, 100);
+        // Build the captured 43-byte payload byte-for-byte.
+        let mut payload = vec![0x82, 0x04, 0x81, 0x82, 0x1a];
+        payload.extend_from_slice(&109_576_792u32.to_be_bytes());
+        payload.push(0x58);
+        payload.push(0x20);
+        payload.extend_from_slice(&expected_hash);
+        assert_eq!(payload.len(), 43);
+
+        let result = parse_ledger_tip_result(&payload).unwrap();
+        assert_eq!(result.slot, 109_576_792);
+        assert_eq!(result.hash, expected_hash);
+        assert_eq!(
+            result.block_no, None,
+            "GetLedgerTip does not carry block_no (use GetChainBlockNo)"
+        );
     }
 
     #[test]
-    fn test_parse_tip_result_no_hfc_wrapper() {
+    fn test_parse_ledger_tip_synthesised() {
         let mut buf = Vec::new();
         let mut enc = minicbor::Encoder::new(&mut buf);
         enc.array(2).unwrap();
         enc.u32(4).unwrap(); // MsgResult tag
-                             // No HFC wrapper — parser should handle unwrapped responses
-        enc.array(2).unwrap(); // [[slot, hash], block_no]
-        enc.array(2).unwrap();
+        enc.array(1).unwrap(); // HFC success wrapper
+        enc.array(2).unwrap(); // bare Point: [slot, hash]
         enc.u64(12345).unwrap();
         enc.bytes(&[0xab; 32]).unwrap();
-        enc.u64(100).unwrap();
 
-        let result = parse_tip_result(&buf).unwrap();
+        let result = parse_ledger_tip_result(&buf).unwrap();
         assert_eq!(result.slot, 12345);
         assert_eq!(result.hash, vec![0xab; 32]);
-        assert_eq!(result.block_no, 100);
+        assert_eq!(result.block_no, None);
+    }
+
+    /// `GetChainPoint` (top-level outer tag 3) is a Point without an HFC wrapper.
+    #[test]
+    fn test_parse_chain_point_specific() {
+        let mut buf = Vec::new();
+        let mut enc = minicbor::Encoder::new(&mut buf);
+        enc.array(2).unwrap();
+        enc.u32(4).unwrap(); // MsgResult tag
+        enc.array(2).unwrap(); // bare Point: [slot, hash]
+        enc.u64(999).unwrap();
+        enc.bytes(&[0xcd; 32]).unwrap();
+
+        let (slot, hash) = parse_chain_point_result(&buf).unwrap().unwrap();
+        assert_eq!(slot, 999);
+        assert_eq!(hash, vec![0xcd; 32]);
+    }
+
+    #[test]
+    fn test_parse_chain_point_origin() {
+        let mut buf = Vec::new();
+        let mut enc = minicbor::Encoder::new(&mut buf);
+        enc.array(2).unwrap();
+        enc.u32(4).unwrap(); // MsgResult tag
+        enc.array(0).unwrap(); // Point::Origin = []
+
+        assert_eq!(parse_chain_point_result(&buf).unwrap(), None);
     }
 
     #[test]

--- a/crates/dugite-node/src/node/n2c_query/encoding.rs
+++ b/crates/dugite-node/src/node/n2c_query/encoding.rs
@@ -50,7 +50,6 @@ pub fn encode_query_result(result: &QueryResult) -> Vec<u8> {
         // Top-level queries (no wrapping)
         QueryResult::SystemStart(_)
             | QueryResult::ChainBlockNo(_)
-            | QueryResult::ChainTip { .. }
             | QueryResult::ChainPoint { .. }
             // BlockQuery > QueryAnytime results (no wrapping)
             | QueryResult::CurrentEra(_)
@@ -62,6 +61,10 @@ pub fn encode_query_result(result: &QueryResult) -> Vec<u8> {
     if needs_either_mismatch {
         // HFC EitherMismatch success: array(1) containing just the result.
         // Array length 1 = success, length 2 = era mismatch.
+        //
+        // NOTE: `LedgerTip` is a BlockQuery > QueryIfCurrent result and
+        // therefore DOES take the HFC wrapper. Its absence from the exclusion
+        // list above is intentional.
         enc.array(1).ok();
     }
 
@@ -83,7 +86,6 @@ pub fn encode_query_result_payload(result: &QueryResult) -> Vec<u8> {
         result,
         QueryResult::SystemStart(_)
             | QueryResult::ChainBlockNo(_)
-            | QueryResult::ChainTip { .. }
             | QueryResult::ChainPoint { .. }
             | QueryResult::CurrentEra(_)
             | QueryResult::HardForkCurrentEra(_)
@@ -93,6 +95,9 @@ pub fn encode_query_result_payload(result: &QueryResult) -> Vec<u8> {
     if needs_either_mismatch {
         // HFC EitherMismatch success: array(1) containing just the result.
         // Array length 1 = success, length 2 = era mismatch.
+        //
+        // `LedgerTip` is a BlockQuery > QueryIfCurrent result and therefore
+        // DOES take the HFC wrapper (see comment in `encode_query_result`).
         enc.array(1).ok();
     }
 
@@ -112,18 +117,20 @@ pub(crate) fn encode_query_result_value(
         QueryResult::EpochNo(epoch) => {
             enc.u64(*epoch).ok();
         }
-        QueryResult::ChainTip {
-            slot,
-            hash,
-            block_no,
-        } => {
-            enc.array(2).ok();
-            // Point: [slot, hash]
+        QueryResult::LedgerTip { slot, hash } => {
+            // GetLedgerTip (Shelley BlockQuery tag 0) result is a bare Point:
+            //   [slot, hash]
+            //
+            // This matches cardano-node 10.6.2 wire (captured 43-byte payload,
+            // see issue #407):
+            //   82 04 81 82 1a <slot4> 58 20 <hash32>
+            //
+            // The outer `array(1)` HFC EitherMismatch success wrapper is added
+            // by `encode_query_result` because `LedgerTip` is not in the
+            // top-level-query exclusion list.
             enc.array(2).ok();
             enc.u64(*slot).ok();
             enc.bytes(hash).ok();
-            // Block number
-            enc.u64(*block_no).ok();
         }
         QueryResult::CurrentEra(era) => {
             enc.u32(*era).ok();
@@ -3008,7 +3015,7 @@ mod tests {
         );
     }
 
-    /// Top-level queries (SystemStart, ChainBlockNo, ChainTip) must NOT have the
+    /// Top-level queries (SystemStart, ChainBlockNo, ChainPoint) must NOT have the
     /// HFC EitherMismatch wrapper — Haskell encodes them as [4, result] directly.
     #[test]
     fn test_top_level_query_no_hfc_wrapper() {
@@ -3086,6 +3093,44 @@ mod tests {
             val, 42,
             "strip_wrappers must correctly expose inner payload"
         );
+    }
+
+    /// GetLedgerTip golden vector (issue #407).
+    ///
+    /// Captured from cardano-node 10.6.2, 43-byte payload:
+    ///   82 04 81 82 1a 06884258 5820 344bc3f7b7b3686a181a3c73e4a4050122b888e1b596f2c3a398a6a7fc2c9602
+    ///
+    /// Structure:
+    ///   82 04 — MsgResult [4, ...]
+    ///   81    — HFC EitherMismatch success wrapper array(1)
+    ///   82    — Point array(2)
+    ///   1a 06884258 — slot = 109_576_792
+    ///   5820 <32B> — hash bytes
+    ///
+    /// GetLedgerTip returns a bare Point, NOT a Tip — no block_no in the payload.
+    #[test]
+    fn test_ledger_tip_wire_format_bare_point() {
+        let hash_hex = "344bc3f7b7b3686a181a3c73e4a4050122b888e1b596f2c3a398a6a7fc2c9602";
+        let hash: Vec<u8> = (0..32)
+            .map(|i| u8::from_str_radix(&hash_hex[i * 2..i * 2 + 2], 16).unwrap())
+            .collect();
+        let result = QueryResult::LedgerTip {
+            slot: 109_576_792,
+            hash: hash.clone(),
+        };
+        let encoded = encode_query_result(&result);
+
+        let mut expected = vec![0x82, 0x04, 0x81, 0x82, 0x1a];
+        expected.extend_from_slice(&109_576_792u32.to_be_bytes());
+        expected.push(0x58);
+        expected.push(0x20);
+        expected.extend_from_slice(&hash);
+
+        assert_eq!(
+            encoded, expected,
+            "GetLedgerTip MsgResult must match the captured cardano-node 10.6.2 bare-Point wire format (issue #407)"
+        );
+        assert_eq!(encoded.len(), 43, "captured payload length is 43 bytes");
     }
 
     /// QueryAnytime result (CurrentEra) must NOT be wrapped in HFC EitherMismatch.

--- a/crates/dugite-node/src/node/n2c_query/mod.rs
+++ b/crates/dugite-node/src/node/n2c_query/mod.rs
@@ -439,16 +439,20 @@ impl QueryHandler {
         match query_tag {
             0 => {
                 // Tag 0: GetLedgerTip
+                //
+                // Wire shape (matches cardano-node 10.6.2, issue #407):
+                //   MsgResult: [4, [[slot, hash]]]
+                // i.e. HFC success wrapper (array(1)) + bare Point [slot, hash].
+                //
+                // GetLedgerTip returns a Point, NOT a Tip: there is no
+                // `block_no` in the response. Callers that need the block
+                // number must issue GetChainBlockNo (top-level outer tag 2).
                 debug!("Query: GetLedgerTip");
                 let (slot, hash) = match &self.state.tip.point {
                     Point::Origin => (0, vec![0u8; 32]),
                     Point::Specific(s, h) => (s.0, h.to_vec()),
                 };
-                QueryResult::ChainTip {
-                    slot,
-                    hash,
-                    block_no: self.state.block_number.0,
-                }
+                QueryResult::LedgerTip { slot, hash }
             }
             1 => {
                 // Tag 1: GetEpochNo
@@ -680,7 +684,7 @@ mod tests {
     }
 
     #[test]
-    fn test_query_handler_chain_tip() {
+    fn test_query_handler_ledger_tip() {
         let hash = Hash32::from_bytes([0xab; 32]);
         let mut handler = QueryHandler::new();
         handler.update_state(NodeStateSnapshot {
@@ -693,16 +697,11 @@ mod tests {
         });
 
         match query(&handler, 0) {
-            QueryResult::ChainTip {
-                slot,
-                hash: h,
-                block_no,
-            } => {
+            QueryResult::LedgerTip { slot, hash: h } => {
                 assert_eq!(slot, 12345);
                 assert_eq!(h, hash.to_vec());
-                assert_eq!(block_no, 100);
             }
-            other => panic!("Expected ChainTip, got {other:?}"),
+            other => panic!("Expected LedgerTip, got {other:?}"),
         }
     }
 

--- a/crates/dugite-node/src/node/n2c_query/types.rs
+++ b/crates/dugite-node/src/node/n2c_query/types.rs
@@ -6,15 +6,25 @@ use dugite_primitives::time::{BlockNo, EpochNo};
 #[allow(dead_code)] // variants constructed in trait impl methods (dynamic dispatch)
 pub enum QueryResult {
     EpochNo(u64),
-    ChainTip {
+    /// GetLedgerTip result (Shelley BlockQuery tag 0).
+    ///
+    /// Wire shape (MsgResult): `[4, [[slot, hash]]]`
+    ///
+    /// The outer `array(1)` is the HFC EitherMismatch success wrapper (this is
+    /// a BlockQuery > QueryIfCurrent), and the inner `[slot, hash]` is a bare
+    /// `Point` — **not** a `Tip`. GetLedgerTip deliberately does not include
+    /// `block_no`; callers who need it must issue `GetChainBlockNo` (top-level
+    /// outer tag 2) separately. See issue #407.
+    LedgerTip {
         slot: u64,
         hash: Vec<u8>,
-        block_no: u64,
     },
     CurrentEra(u32),
     SystemStart(String),
     ChainBlockNo(u64),
-    /// GetChainPoint result: Point encoding ([slot, hash] or [] for Origin)
+    /// GetChainPoint result: Point encoding ([slot, hash] or [] for Origin).
+    ///
+    /// Top-level query (outer tag 3) — no HFC wrapper.
     ChainPoint {
         slot: u64,
         hash: Vec<u8>,


### PR DESCRIPTION
## Summary

Fixes #407. `parse_tip_result` was over-reading `GetLedgerTip` responses because it assumed a legacy `Tip`-shaped result (`[[slot, hash], block_no]`) and hard-coded a second `dec.array()`. Real cardano-node 10.6.2 returns a bare `Point` `[slot, hash]` wrapped by the HFC EitherMismatch success `array(1)`, with no block number.

### Captured wire (43 bytes)

```
payload (43 bytes):
82 04 81 82 1a 06884258 5820 344bc3f7b7b3686a181a3c73e4a4050122b888e1b596f2c3a398a6a7fc2c9602
```

Structure:
- `82 04` — MsgResult `[4, ...]`
- `81` — HFC EitherMismatch success wrapper `array(1)` (this IS a BlockQuery > QueryIfCurrent)
- `82` — Point `array(2)`
- `1a 06884258` — slot = 109,576,792
- `58 20 <32B>` — block header hash

## Client fix (`crates/dugite-network/src/n2c_client.rs`)

Dispatch-by-opcode instead of peek-and-guess. We know from the caller which query we sent, so we know the exact response shape:

- `parse_ledger_tip_result` — handles the bare `Point` form for `GetLedgerTip` (Shelley BlockQuery tag 0). Strips MsgResult + HFC wrapper, then reads exactly one `array(2)` `[slot, hash]`. Returns `block_no: None` — `GetLedgerTip` does not carry a block number.
- `parse_chain_point_result` — handles `GetChainPoint` (top-level outer tag 3), which is top-level and emits `[slot, hash]` or `[]` (Origin) with no HFC wrapper.

`TipResult::block_no` is now `Option<u64>` and documented: `None` when populated from `GetLedgerTip`, must be back-filled via `GetChainBlockNo` (`query_block_no`) if the value is needed.

## Server fix (`crates/dugite-node/src/node/n2c_query/{encoding,mod,types}.rs`)

Dugite-node's server was ALSO wrong — two separate bugs that meant `cardano-cli query tip` against dugite-node would not have decoded even after the client fix. Shelley BlockQuery tag 0 dispatched to `QueryResult::ChainTip`, which:

1. Encoded `[[slot, hash], block_no]` — legacy Tip shape, not the bare Point that cardano-node emits.
2. Was excluded from the HFC `either_mismatch` wrapper list — so no `array(1)` success discriminator.

Introduce a new variant `QueryResult::LedgerTip { slot, hash }`:

- Dispatched from Shelley BlockQuery tag 0 (`mod.rs`).
- Encodes as bare `array(2) [slot, hash]` (`encoding.rs`).
- Goes through the HFC `either_mismatch` wrapper (NOT in the exclusion list) — `BlockQuery > QueryIfCurrent` always takes the success `array(1)`.

`ChainTip` variant removed (only user was the dispatcher and one test, both updated).

## CLI caller update

`crates/dugite-cli/src/commands/query.rs` had one site reading `tip.block_no` as a fallback. Updated to try `query_block_no()` first, fall back to `tip.block_no` (always `None` now), then `0`.

## Tests added

- `dugite-network::n2c_client::tests::test_parse_ledger_tip_bare_point_golden` — feeds the captured 43-byte payload verbatim through `parse_ledger_tip_result`, asserts slot=109576792, hash, and `block_no == None`.
- `dugite-network::n2c_client::tests::test_parse_ledger_tip_synthesised` — hand-built bare-Point payload.
- `dugite-network::n2c_client::tests::test_parse_chain_point_{specific,origin}` — tests the companion parser for the top-level `GetChainPoint`.
- `dugite-node::node::n2c_query::encoding::tests::test_ledger_tip_wire_format_bare_point` — builds `QueryResult::LedgerTip`, encodes, asserts **byte-for-byte** equality with the captured 43-byte payload.
- `dugite-node::node::n2c_query::tests::test_query_handler_ledger_tip` — dispatcher test (replaces the old `test_query_handler_chain_tip`).

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo nextest run -p dugite-network -p dugite-node` (800/800 passing, 1 skipped)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [ ] Smoke: `cardano-cli query tip --socket-path <dugite.sock> --testnet-magic 2` against running dugite-node (decoder round-trip verified by the byte-for-byte golden test; live validation deferred to CI / next soak run)