### PR TITLE
feat(config): auto-discover running dugite-node when invoked without --config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
 ]
 
@@ -2962,6 +2963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3068,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4570,6 +4599,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5572,6 +5615,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,6 +5646,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5611,6 +5686,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5673,6 +5758,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/dugite-config/Cargo.toml
+++ b/crates/dugite-config/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30", features = ["signal"] }

--- a/crates/dugite-config/src/app.rs
+++ b/crates/dugite-config/src/app.rs
@@ -481,14 +481,12 @@ impl App {
     /// warning (this is a no-op in practice since dugite-node only runs on
     /// Unix).
     pub fn save_and_reload(&mut self, pid_file: &std::path::Path) {
-        // Step 1 — save to disk.
-        if let Err(e) = crate::config::save_config(&mut self.config) {
-            self.feedback = Some(format!("Save failed: {e}"));
+        // Save first; if save fails, no point trying to signal.
+        if !self.save_for_reload() {
             return;
         }
-        self.quit_prompt = false;
 
-        // Step 2 — read the node PID.
+        // Read the node PID from the file.
         let pid_raw = match std::fs::read_to_string(pid_file) {
             Ok(s) => s.trim().to_string(),
             Err(e) => {
@@ -511,7 +509,33 @@ impl App {
             }
         };
 
-        // Step 3 — send SIGHUP.
+        self.send_sighup(pid_num);
+    }
+
+    /// Save to disk and send SIGHUP directly to a known PID (used by the
+    /// discovery path, where the PID came from `sysinfo` rather than a file).
+    pub fn save_and_signal_pid(&mut self, pid: u32) {
+        if !self.save_for_reload() {
+            return;
+        }
+        self.send_sighup(pid as i32);
+    }
+
+    /// Persist the current config to disk; report success via `feedback`.
+    /// Returns `true` if the save succeeded (so the caller can proceed to
+    /// signalling the node).
+    fn save_for_reload(&mut self) -> bool {
+        if let Err(e) = crate::config::save_config(&mut self.config) {
+            self.feedback = Some(format!("Save failed: {e}"));
+            return false;
+        }
+        self.quit_prompt = false;
+        true
+    }
+
+    /// Send SIGHUP to `pid_num`; on non-Unix platforms, report a no-op.
+    /// Sets `feedback` to describe the outcome regardless.
+    fn send_sighup(&mut self, pid_num: i32) {
         #[cfg(unix)]
         {
             use nix::sys::signal::{kill, Signal};

--- a/crates/dugite-config/src/discover.rs
+++ b/crates/dugite-config/src/discover.rs
@@ -1,0 +1,503 @@
+//! Discovery of running `dugite-node` instances on the local host.
+//!
+//! Used by `dugite-config edit` when invoked without an explicit `<config_file>`
+//! argument. Enumerates processes via `sysinfo` (cross-platform), filters to
+//! `dugite-node run …` invocations, and parses each argv for `--config`,
+//! `--port`, and `--socket-path` so the editor can attach without the operator
+//! having to remember paths or manage a separate PID file.
+//!
+//! Cardano-node instances are deliberately not surfaced — see the rationale in
+//! the issue body for `#490`. Operators who want to edit a `cardano-node`
+//! config file can still do so by passing `--config <path>` explicitly.
+
+use std::path::{Path, PathBuf};
+
+/// Compiled-in default for `dugite-node run --config` when the flag is absent.
+/// Mirrors `crates/dugite-node/src/main.rs` and is updated manually if the
+/// upstream default changes.
+pub const DUGITE_NODE_DEFAULT_CONFIG: &str = "config/mainnet-config.json";
+
+/// Whether a discovered node's config path was specified on the command line
+/// or fell back to the binary's compiled-in default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// Came from `--config` (or `--config=...`).
+    Explicit,
+    /// `--config` was not on argv; we fell back to [`DUGITE_NODE_DEFAULT_CONFIG`].
+    Default,
+}
+
+/// State of a discovered node's config file on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigStatus {
+    /// File exists and was canonicalized.
+    Ok,
+    /// Path was derived but the file does not exist on disk (moved/deleted).
+    Missing,
+    /// Could not read the process's argv or cwd (other-user process, sandbox).
+    PermissionDenied,
+}
+
+/// A running `dugite-node` instance discovered on the local host.
+#[derive(Debug, Clone)]
+pub struct RunningNode {
+    pub pid: u32,
+    pub config_path: PathBuf,
+    pub config_source: ConfigSource,
+    pub port: Option<u16>,
+    pub socket: Option<PathBuf>,
+    pub status: ConfigStatus,
+}
+
+impl RunningNode {
+    /// True if the node can be selected by the operator (file exists).
+    pub fn is_selectable(&self) -> bool {
+        matches!(self.status, ConfigStatus::Ok)
+    }
+}
+
+/// Subset of argv flags relevant to discovery. Returned only when argv
+/// represents a `<binary> run …` invocation.
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedRunArgs {
+    config: Option<String>,
+    port: Option<u16>,
+    socket: Option<String>,
+}
+
+/// Parse a process's argv. Returns `Some` only if `run` appears as a token
+/// before any `--` separator; otherwise `None` (the process is `mithril-import`,
+/// `db-info`, etc., and has no `--config` to extract).
+///
+/// Behaviour notes:
+/// * `--config=<path>` and `--config <path>` are both accepted.
+/// * If `--config` appears more than once, the last occurrence wins
+///   (matches clap's `ArgAction::Set` default).
+/// * `--config` followed by another flag (e.g. `--config --port 3001`) is
+///   treated as no value — defensive against malformed argv.
+/// * Scanning stops at `--`; tokens past it are positional.
+fn parse_run_argv(argv: &[String]) -> Option<ParsedRunArgs> {
+    // Locate `run` and collect the remaining flag tokens (excluding `run`
+    // itself and anything past `--`). argv[0] is the binary path.
+    let mut run_seen = false;
+    let mut flags: Vec<&str> = Vec::with_capacity(argv.len());
+    for arg in argv.iter().skip(1) {
+        if arg == "--" {
+            break;
+        }
+        if arg == "run" {
+            run_seen = true;
+            continue;
+        }
+        flags.push(arg.as_str());
+    }
+    if !run_seen {
+        return None;
+    }
+
+    let mut config: Option<String> = None;
+    let mut port: Option<u16> = None;
+    let mut socket: Option<String> = None;
+
+    let mut i = 0;
+    while i < flags.len() {
+        let tok = flags[i];
+
+        if let Some(rest) = tok.strip_prefix("--config=") {
+            config = Some(rest.to_string());
+        } else if let Some(rest) = tok.strip_prefix("--port=") {
+            if let Ok(p) = rest.parse::<u16>() {
+                port = Some(p);
+            }
+        } else if let Some(rest) = tok.strip_prefix("--socket-path=") {
+            socket = Some(rest.to_string());
+        } else if tok == "--config" {
+            if let Some(next) = flags.get(i + 1) {
+                if !next.starts_with('-') {
+                    config = Some((*next).to_string());
+                    i += 1;
+                }
+            }
+        } else if tok == "--port" {
+            if let Some(next) = flags.get(i + 1) {
+                if !next.starts_with('-') {
+                    if let Ok(p) = next.parse::<u16>() {
+                        port = Some(p);
+                    }
+                    i += 1;
+                }
+            }
+        } else if tok == "--socket-path" {
+            if let Some(next) = flags.get(i + 1) {
+                if !next.starts_with('-') {
+                    socket = Some((*next).to_string());
+                    i += 1;
+                }
+            }
+        }
+
+        i += 1;
+    }
+
+    Some(ParsedRunArgs {
+        config,
+        port,
+        socket,
+    })
+}
+
+/// Resolve a config path string against the process's working directory.
+///
+/// Absolute paths are taken as-is; relative paths are joined onto `cwd`.
+/// `canonicalize` is attempted so the editor sees a stable absolute path; if
+/// it fails (file moved/deleted/network mount gone) the un-canonicalized path
+/// is returned with [`ConfigStatus::Missing`] so the operator sees the row
+/// in the selector with a clear marker rather than the row vanishing.
+fn resolve_config(raw: &str, cwd: &Path) -> (PathBuf, ConfigStatus) {
+    let candidate = if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        cwd.join(raw)
+    };
+    match candidate.canonicalize() {
+        Ok(canon) => (canon, ConfigStatus::Ok),
+        Err(_) => (candidate, ConfigStatus::Missing),
+    }
+}
+
+/// Match a process exe basename against `dugite-node`, case-insensitive,
+/// trimming `.exe` so Windows builds match too.
+fn is_dugite_node_exe(exe: Option<&Path>) -> bool {
+    exe.and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .map(|s| s.trim_end_matches(".exe") == "dugite-node")
+        .unwrap_or(false)
+}
+
+/// Build a [`RunningNode`] from already-extracted process info. Pulled out of
+/// [`discover_dugite_nodes`] so it can be unit-tested without spawning real
+/// processes.
+fn build_running_node(pid: u32, parsed: &ParsedRunArgs, cwd: Option<&Path>) -> RunningNode {
+    let (config_path, config_source, status) = match (parsed.config.as_deref(), cwd) {
+        (Some(raw), Some(cwd)) => {
+            let (path, status) = resolve_config(raw, cwd);
+            (path, ConfigSource::Explicit, status)
+        }
+        (None, Some(cwd)) => {
+            let (path, status) = resolve_config(DUGITE_NODE_DEFAULT_CONFIG, cwd);
+            (path, ConfigSource::Default, status)
+        }
+        (raw, None) => {
+            // Without cwd we cannot resolve a relative path. Surface the row
+            // with a permission-denied marker rather than dropping it.
+            let s = raw
+                .map(str::to_string)
+                .unwrap_or_else(|| DUGITE_NODE_DEFAULT_CONFIG.to_string());
+            let source = if parsed.config.is_some() {
+                ConfigSource::Explicit
+            } else {
+                ConfigSource::Default
+            };
+            (PathBuf::from(s), source, ConfigStatus::PermissionDenied)
+        }
+    };
+
+    RunningNode {
+        pid,
+        config_path,
+        config_source,
+        port: parsed.port,
+        socket: parsed.socket.clone().map(PathBuf::from),
+        status,
+    }
+}
+
+/// Enumerate running `dugite-node` instances on the local host.
+///
+/// Result is sorted by PID for stable display. Empty when nothing matches —
+/// this is *not* an error condition (handled by the caller).
+pub fn discover_dugite_nodes() -> Vec<RunningNode> {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
+
+    let refresh = RefreshKind::nothing().with_processes(
+        ProcessRefreshKind::nothing()
+            .with_cmd(UpdateKind::Always)
+            .with_cwd(UpdateKind::Always)
+            .with_exe(UpdateKind::Always),
+    );
+    let mut sys = System::new_with_specifics(refresh);
+    sys.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh.processes().unwrap());
+
+    let mut nodes = Vec::new();
+    for proc in sys.processes().values() {
+        if !is_dugite_node_exe(proc.exe()) {
+            continue;
+        }
+
+        let argv: Vec<String> = proc
+            .cmd()
+            .iter()
+            .map(|o| o.to_string_lossy().into_owned())
+            .collect();
+
+        let Some(parsed) = parse_run_argv(&argv) else {
+            continue;
+        };
+
+        let pid = proc.pid().as_u32();
+        nodes.push(build_running_node(pid, &parsed, proc.cwd()));
+    }
+
+    nodes.sort_by_key(|n| n.pid);
+    nodes
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    // ----- parse_run_argv -----
+
+    #[test]
+    fn parse_returns_none_for_non_run_subcommand() {
+        let v = argv(&["/opt/dugite-node", "mithril-import", "--network-magic", "2"]);
+        assert!(parse_run_argv(&v).is_none());
+    }
+
+    #[test]
+    fn parse_returns_none_when_run_appears_only_after_dash_dash() {
+        let v = argv(&["dugite-node", "--", "run"]);
+        assert!(parse_run_argv(&v).is_none());
+    }
+
+    #[test]
+    fn parse_run_with_no_flags_yields_all_none() {
+        let v = argv(&["dugite-node", "run"]);
+        let p = parse_run_argv(&v).expect("run invocation");
+        assert_eq!(p.config, None);
+        assert_eq!(p.port, None);
+        assert_eq!(p.socket, None);
+    }
+
+    #[test]
+    fn parse_config_two_token_form() {
+        let v = argv(&["dugite-node", "run", "--config", "/etc/dugite/preview.json"]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.config.as_deref(), Some("/etc/dugite/preview.json"));
+    }
+
+    #[test]
+    fn parse_config_equals_form() {
+        let v = argv(&["dugite-node", "run", "--config=preview.json"]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.config.as_deref(), Some("preview.json"));
+    }
+
+    #[test]
+    fn parse_config_followed_by_flag_takes_no_value() {
+        // Defensive: malformed argv where --config is followed by another flag.
+        let v = argv(&["dugite-node", "run", "--config", "--port", "3001"]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.config, None);
+        assert_eq!(p.port, Some(3001));
+    }
+
+    #[test]
+    fn parse_duplicate_config_last_wins() {
+        let v = argv(&[
+            "dugite-node",
+            "run",
+            "--config",
+            "first.json",
+            "--config=second.json",
+            "--config",
+            "third.json",
+        ]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.config.as_deref(), Some("third.json"));
+    }
+
+    #[test]
+    fn parse_stops_at_dash_dash_separator() {
+        let v = argv(&["dugite-node", "run", "--", "--config", "after-dash.json"]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.config, None);
+    }
+
+    #[test]
+    fn parse_port_and_socket_two_token_form() {
+        let v = argv(&[
+            "dugite-node",
+            "run",
+            "--port",
+            "3001",
+            "--socket-path",
+            "/tmp/node.sock",
+        ]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.port, Some(3001));
+        assert_eq!(p.socket.as_deref(), Some("/tmp/node.sock"));
+    }
+
+    #[test]
+    fn parse_port_and_socket_equals_form() {
+        let v = argv(&[
+            "dugite-node",
+            "run",
+            "--port=3001",
+            "--socket-path=/tmp/n.sock",
+        ]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.port, Some(3001));
+        assert_eq!(p.socket.as_deref(), Some("/tmp/n.sock"));
+    }
+
+    #[test]
+    fn parse_invalid_port_silently_dropped() {
+        let v = argv(&["dugite-node", "run", "--port", "not-a-number"]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.port, None);
+    }
+
+    #[test]
+    fn parse_full_realistic_argv() {
+        let v = argv(&[
+            "/Users/op/dugite/target/release/dugite-node",
+            "run",
+            "--config",
+            "config/preview-config.json",
+            "--topology",
+            "config/preview-topology.json",
+            "--database-path",
+            "./db-preview",
+            "--socket-path",
+            "./node.sock",
+            "--host-addr",
+            "0.0.0.0",
+            "--port",
+            "3001",
+        ]);
+        let p = parse_run_argv(&v).unwrap();
+        assert_eq!(p.config.as_deref(), Some("config/preview-config.json"));
+        assert_eq!(p.port, Some(3001));
+        assert_eq!(p.socket.as_deref(), Some("./node.sock"));
+    }
+
+    // ----- resolve_config -----
+
+    #[test]
+    fn resolve_absolute_existing_canonicalizes_to_ok() {
+        let dir = TempDir::new().unwrap();
+        let cfg = dir.path().join("c.json");
+        std::fs::write(&cfg, b"{}").unwrap();
+        let (path, status) = resolve_config(cfg.to_str().unwrap(), Path::new("/"));
+        assert_eq!(status, ConfigStatus::Ok);
+        assert!(path.is_absolute());
+    }
+
+    #[test]
+    fn resolve_relative_joins_against_cwd() {
+        let dir = TempDir::new().unwrap();
+        let cfg = dir.path().join("rel.json");
+        std::fs::write(&cfg, b"{}").unwrap();
+        let (path, status) = resolve_config("rel.json", dir.path());
+        assert_eq!(status, ConfigStatus::Ok);
+        assert!(path.ends_with("rel.json"));
+    }
+
+    #[test]
+    fn resolve_missing_path_returns_missing_status() {
+        let dir = TempDir::new().unwrap();
+        let (path, status) = resolve_config("nope.json", dir.path());
+        assert_eq!(status, ConfigStatus::Missing);
+        // Path is preserved (not canonicalized) so the operator can see what
+        // we tried.
+        assert!(path.ends_with("nope.json"));
+    }
+
+    // ----- build_running_node -----
+
+    #[test]
+    fn build_node_explicit_config_with_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let cfg = dir.path().join("c.json");
+        std::fs::write(&cfg, b"{}").unwrap();
+        let parsed = ParsedRunArgs {
+            config: Some(cfg.to_str().unwrap().to_string()),
+            port: Some(3001),
+            socket: Some("/tmp/s.sock".to_string()),
+        };
+        let n = build_running_node(42, &parsed, Some(dir.path()));
+        assert_eq!(n.pid, 42);
+        assert_eq!(n.config_source, ConfigSource::Explicit);
+        assert_eq!(n.status, ConfigStatus::Ok);
+        assert_eq!(n.port, Some(3001));
+        assert_eq!(n.socket, Some(PathBuf::from("/tmp/s.sock")));
+        assert!(n.is_selectable());
+    }
+
+    #[test]
+    fn build_node_falls_back_to_default_when_config_absent() {
+        let dir = TempDir::new().unwrap();
+        let parsed = ParsedRunArgs {
+            config: None,
+            port: None,
+            socket: None,
+        };
+        let n = build_running_node(7, &parsed, Some(dir.path()));
+        assert_eq!(n.config_source, ConfigSource::Default);
+        // Default file doesn't exist in our temp dir, so status is Missing.
+        assert_eq!(n.status, ConfigStatus::Missing);
+        assert!(n.config_path.ends_with("config/mainnet-config.json"));
+        assert!(!n.is_selectable());
+    }
+
+    #[test]
+    fn build_node_no_cwd_yields_permission_denied_status() {
+        let parsed = ParsedRunArgs {
+            config: Some("rel.json".to_string()),
+            port: None,
+            socket: None,
+        };
+        let n = build_running_node(99, &parsed, None);
+        assert_eq!(n.status, ConfigStatus::PermissionDenied);
+        assert_eq!(n.config_source, ConfigSource::Explicit);
+        assert_eq!(n.config_path, PathBuf::from("rel.json"));
+    }
+
+    // ----- is_dugite_node_exe -----
+
+    #[test]
+    fn matches_dugite_node_basename() {
+        assert!(is_dugite_node_exe(Some(Path::new(
+            "/opt/dugite/target/release/dugite-node"
+        ))));
+        assert!(is_dugite_node_exe(Some(Path::new("dugite-node"))));
+    }
+
+    #[test]
+    fn matches_dugite_node_exe_on_windows() {
+        assert!(is_dugite_node_exe(Some(Path::new(
+            "C:/bin/Dugite-Node.exe"
+        ))));
+    }
+
+    #[test]
+    fn rejects_other_binaries() {
+        assert!(!is_dugite_node_exe(Some(Path::new("cardano-node"))));
+        assert!(!is_dugite_node_exe(Some(Path::new(
+            "/opt/dugite-node-helper"
+        ))));
+        assert!(!is_dugite_node_exe(None));
+    }
+}

--- a/crates/dugite-config/src/main.rs
+++ b/crates/dugite-config/src/main.rs
@@ -36,8 +36,10 @@
 mod app;
 mod config;
 mod diff;
+mod discover;
 mod schema;
 mod search;
+mod selector;
 mod ui;
 
 use std::io;
@@ -77,17 +79,27 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Open a configuration file in the interactive TUI editor.
+    ///
+    /// When invoked without `<config_file>`, enumerates running `dugite-node`
+    /// instances on the local machine and either auto-attaches (if exactly
+    /// one is running) or presents a selector (if more than one). The
+    /// discovered process's OS PID is then used for Ctrl+R live reload —
+    /// no PID file required.
     Edit {
-        /// Path to the Cardano node configuration JSON file.
-        config_file: PathBuf,
+        /// Path to the Cardano node configuration JSON file. Optional —
+        /// omit to auto-discover running `dugite-node` instances instead.
+        config_file: Option<PathBuf>,
 
         /// Path to a file containing the running dugite-node PID.
         ///
         /// Used by Ctrl+R ("Save & Reload") to send SIGHUP to the live node.
         /// If this file does not exist when Ctrl+R is pressed, the config is
         /// still saved but the SIGHUP is skipped with a clear error message.
-        #[arg(long, default_value = "./logs/bp-pair/bp.pid")]
-        node_pid_file: PathBuf,
+        ///
+        /// Ignored when `<config_file>` is omitted — the discovered process's
+        /// OS PID is used directly.
+        #[arg(long)]
+        node_pid_file: Option<PathBuf>,
     },
 
     /// Generate a default configuration file for the given network.
@@ -158,7 +170,7 @@ fn main() -> Result<()> {
             config_file,
             node_pid_file,
         } => {
-            run_editor(&config_file, &node_pid_file)?;
+            run_edit(config_file, node_pid_file)?;
         }
         Commands::Init { network, out } => {
             run_init(&network, out.as_deref())?;
@@ -185,8 +197,75 @@ fn main() -> Result<()> {
 // `edit` subcommand — interactive TUI
 // ---------------------------------------------------------------------------
 
+/// How Ctrl+R should locate the dugite-node PID for SIGHUP delivery.
+#[derive(Debug, Clone)]
+enum ReloadTarget {
+    /// Read the PID from a file at the given path on each Ctrl+R press.
+    PidFile(PathBuf),
+    /// Use the given OS PID directly (discovered at startup via sysinfo).
+    Pid(u32),
+}
+
+/// Dispatcher for `Commands::Edit`. When `config_file` is `Some`, behaves
+/// exactly like the legacy explicit-args invocation. When `None`, enumerates
+/// running `dugite-node` instances and either auto-attaches (if exactly one)
+/// or presents a selector (if more than one); errors out cleanly if none are
+/// running.
+fn run_edit(config_file: Option<PathBuf>, node_pid_file: Option<PathBuf>) -> Result<()> {
+    if let Some(path) = config_file {
+        // Explicit-args mode: preserve legacy default for the PID file so
+        // existing operator workflows (the bp-pair launcher) keep working.
+        let pid_file = node_pid_file.unwrap_or_else(|| PathBuf::from("./logs/bp-pair/bp.pid"));
+        return run_editor(&path, ReloadTarget::PidFile(pid_file));
+    }
+
+    // Discovery mode.
+    let nodes = discover::discover_dugite_nodes();
+    let chosen = match nodes.len() {
+        0 => {
+            anyhow::bail!(
+                "No running dugite-node instances found. \
+                 Pass an explicit <config_file> to edit a config without attaching."
+            );
+        }
+        1 => nodes.into_iter().next().unwrap(),
+        _ => {
+            let selectable_count = nodes.iter().filter(|n| n.is_selectable()).count();
+            if selectable_count == 0 {
+                anyhow::bail!(
+                    "Discovered {} running dugite-node instance(s) but none have a \
+                     readable config file. Pass an explicit <config_file> to attach manually.",
+                    nodes.len()
+                );
+            }
+            match selector::select(nodes)? {
+                Some(n) => n,
+                None => {
+                    eprintln!("Cancelled.");
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    if !chosen.is_selectable() {
+        anyhow::bail!(
+            "Discovered dugite-node pid={} has no readable config at '{}'.",
+            chosen.pid,
+            chosen.config_path.display()
+        );
+    }
+
+    eprintln!(
+        "Attaching to dugite-node pid={} config={}",
+        chosen.pid,
+        chosen.config_path.display()
+    );
+    run_editor(&chosen.config_path, ReloadTarget::Pid(chosen.pid))
+}
+
 /// Load `path`, set up the terminal, run the event loop, restore terminal.
-fn run_editor(path: &Path, pid_file: &Path) -> Result<()> {
+fn run_editor(path: &Path, reload: ReloadTarget) -> Result<()> {
     let config =
         load_config(path).with_context(|| format!("loading config file '{}'", path.display()))?;
 
@@ -199,7 +278,7 @@ fn run_editor(path: &Path, pid_file: &Path) -> Result<()> {
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
 
-    let result = run_loop(&mut terminal, &mut app, pid_file);
+    let result = run_loop(&mut terminal, &mut app, &reload);
 
     // Restore terminal unconditionally, even on error.
     let _ = disable_raw_mode();
@@ -215,7 +294,7 @@ fn run_editor(path: &Path, pid_file: &Path) -> Result<()> {
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
-    pid_file: &Path,
+    reload: &ReloadTarget,
 ) -> Result<()> {
     loop {
         // Render current state.
@@ -235,7 +314,7 @@ fn run_loop(
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
-                handle_key(app, key.code, key.modifiers, pid_file);
+                handle_key(app, key.code, key.modifiers, reload);
             }
         }
     }
@@ -246,7 +325,7 @@ fn run_loop(
 // ---------------------------------------------------------------------------
 
 /// Dispatch a key press to the appropriate [`App`] action.
-fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers, pid_file: &Path) {
+fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers, reload: &ReloadTarget) {
     // Ctrl+S saves in any mode.
     if code == KeyCode::Char('s') && modifiers.contains(KeyModifiers::CONTROL) {
         app.save();
@@ -255,7 +334,10 @@ fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers, pid_file: &
 
     // Ctrl+R saves and sends SIGHUP to the running node (live reload).
     if code == KeyCode::Char('r') && modifiers.contains(KeyModifiers::CONTROL) {
-        app.save_and_reload(pid_file);
+        match reload {
+            ReloadTarget::PidFile(p) => app.save_and_reload(p),
+            ReloadTarget::Pid(pid) => app.save_and_signal_pid(*pid),
+        }
         return;
     }
 

--- a/crates/dugite-config/src/selector.rs
+++ b/crates/dugite-config/src/selector.rs
@@ -1,0 +1,355 @@
+//! Interactive list selector for picking among multiple discovered
+//! `dugite-node` instances when `dugite-config edit` is invoked without an
+//! explicit `<config_file>` argument.
+//!
+//! Layout: a single bordered list with one row per discovered node, columns
+//! aligned PID / PORT / SOCKET / CONFIG. Rows whose config file is missing or
+//! permission-denied are rendered dimmed and cannot be selected.
+//!
+//! Key bindings:
+//! * `j` / `Down`  — cursor down
+//! * `k` / `Up`    — cursor up
+//! * `Enter`       — pick the highlighted row (only if selectable)
+//! * `q` / `Esc`   — cancel and exit without picking
+//!
+//! Returns `Ok(Some(node))` on pick, `Ok(None)` on cancel.
+
+use std::io;
+
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use ratatui::{
+    layout::{Constraint, Layout},
+    prelude::*,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Terminal,
+};
+
+use crate::discover::{ConfigSource, ConfigStatus, RunningNode};
+
+/// Render-only formatting of a node row into PID/PORT/SOCKET/CONFIG columns.
+/// Pulled out so the formatting can be unit-tested without setting up a TTY.
+fn format_row(n: &RunningNode) -> [String; 4] {
+    let pid = n.pid.to_string();
+    let port = n.port.map(|p| p.to_string()).unwrap_or_else(|| "-".into());
+    let socket = n
+        .socket
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "-".into());
+
+    let mut config = n.config_path.display().to_string();
+    if matches!(n.config_source, ConfigSource::Default) {
+        config.push_str(" (default)");
+    }
+    match n.status {
+        ConfigStatus::Missing => config.push_str(" [missing]"),
+        ConfigStatus::PermissionDenied => config.push_str(" [permission denied]"),
+        ConfigStatus::Ok => {}
+    }
+    [pid, port, socket, config]
+}
+
+/// Run an interactive selector over `nodes` and return the chosen one, or
+/// `None` if the operator pressed `q` / Esc.
+pub fn select(nodes: Vec<RunningNode>) -> io::Result<Option<RunningNode>> {
+    if nodes.is_empty() {
+        return Ok(None);
+    }
+
+    enable_raw_mode()?;
+    io::stdout().execute(EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    let result = run_selector_loop(&mut terminal, &nodes);
+
+    let _ = disable_raw_mode();
+    let _ = io::stdout().execute(LeaveAlternateScreen);
+
+    result.map(|opt_idx| opt_idx.map(|i| nodes[i].clone()))
+}
+
+fn run_selector_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    nodes: &[RunningNode],
+) -> io::Result<Option<usize>> {
+    let rows: Vec<[String; 4]> = nodes.iter().map(format_row).collect();
+
+    // Column widths derived once from the data so columns line up.
+    let col_widths = column_widths(&rows);
+
+    // Initial cursor: first selectable row, or 0 if none are selectable.
+    let mut state = ListState::default();
+    state.select(Some(
+        nodes
+            .iter()
+            .position(RunningNode::is_selectable)
+            .unwrap_or(0),
+    ));
+
+    loop {
+        terminal.draw(|frame| draw_selector(frame, nodes, &rows, &col_widths, &mut state))?;
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => return Ok(None),
+                KeyCode::Down | KeyCode::Char('j') => {
+                    move_cursor(&mut state, nodes.len(), 1);
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    move_cursor(&mut state, nodes.len(), -1);
+                }
+                KeyCode::Enter => {
+                    if let Some(i) = state.selected() {
+                        if nodes[i].is_selectable() {
+                            return Ok(Some(i));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn move_cursor(state: &mut ListState, len: usize, delta: i32) {
+    if len == 0 {
+        return;
+    }
+    let cur = state.selected().unwrap_or(0) as i32;
+    let new = (cur + delta).rem_euclid(len as i32) as usize;
+    state.select(Some(new));
+}
+
+fn column_widths(rows: &[[String; 4]]) -> [usize; 4] {
+    let headers = ["PID", "PORT", "SOCKET", "CONFIG"];
+    let mut widths = headers.map(str::len);
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+    widths
+}
+
+fn draw_selector(
+    frame: &mut Frame,
+    nodes: &[RunningNode],
+    rows: &[[String; 4]],
+    widths: &[usize; 4],
+    state: &mut ListState,
+) {
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(3),
+        Constraint::Length(1),
+    ])
+    .split(frame.area());
+
+    // Title.
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            format!("Select a running dugite-node ({} discovered)", nodes.len()),
+            Style::default().add_modifier(Modifier::BOLD),
+        )])),
+        chunks[0],
+    );
+
+    // Header.
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            format_columns(["PID", "PORT", "SOCKET", "CONFIG"], widths),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )])),
+        chunks[1],
+    );
+
+    // List body.
+    let items: Vec<ListItem> = rows
+        .iter()
+        .zip(nodes.iter())
+        .map(|(row, n)| {
+            let line_text = format_columns(
+                [
+                    row[0].as_str(),
+                    row[1].as_str(),
+                    row[2].as_str(),
+                    row[3].as_str(),
+                ],
+                widths,
+            );
+            let style = if n.is_selectable() {
+                Style::default()
+            } else {
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM)
+            };
+            ListItem::new(Line::from(Span::styled(line_text, style)))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .bg(Color::Blue)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+    frame.render_stateful_widget(list, chunks[2], state);
+
+    // Footer help.
+    let hint = Paragraph::new(Line::from(vec![Span::styled(
+        "[j/k] move   [Enter] select   [q/Esc] cancel",
+        Style::default().fg(Color::DarkGray),
+    )]));
+    frame.render_widget(hint, chunks[3]);
+}
+
+fn format_columns(cells: [&str; 4], widths: &[usize; 4]) -> String {
+    // Two spaces between columns; final column not padded.
+    format!(
+        "{:<w0$}  {:<w1$}  {:<w2$}  {}",
+        cells[0],
+        cells[1],
+        cells[2],
+        cells[3],
+        w0 = widths[0],
+        w1 = widths[1],
+        w2 = widths[2],
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn node(
+        pid: u32,
+        config: &str,
+        source: ConfigSource,
+        status: ConfigStatus,
+        port: Option<u16>,
+        socket: Option<&str>,
+    ) -> RunningNode {
+        RunningNode {
+            pid,
+            config_path: PathBuf::from(config),
+            config_source: source,
+            port,
+            socket: socket.map(PathBuf::from),
+            status,
+        }
+    }
+
+    #[test]
+    fn format_row_explicit_ok_no_marker() {
+        let n = node(
+            12345,
+            "/srv/preview/preview-config.json",
+            ConfigSource::Explicit,
+            ConfigStatus::Ok,
+            Some(3001),
+            Some("./node.sock"),
+        );
+        let r = format_row(&n);
+        assert_eq!(r[0], "12345");
+        assert_eq!(r[1], "3001");
+        assert_eq!(r[2], "./node.sock");
+        assert_eq!(r[3], "/srv/preview/preview-config.json");
+    }
+
+    #[test]
+    fn format_row_default_appends_default_marker() {
+        let n = node(
+            7,
+            "config/mainnet-config.json",
+            ConfigSource::Default,
+            ConfigStatus::Missing,
+            None,
+            None,
+        );
+        let r = format_row(&n);
+        assert_eq!(r[1], "-");
+        assert_eq!(r[2], "-");
+        assert!(r[3].ends_with("(default) [missing]"));
+    }
+
+    #[test]
+    fn format_row_permission_denied_marker() {
+        let n = node(
+            42,
+            "rel.json",
+            ConfigSource::Explicit,
+            ConfigStatus::PermissionDenied,
+            None,
+            None,
+        );
+        let r = format_row(&n);
+        assert!(r[3].ends_with("[permission denied]"));
+    }
+
+    #[test]
+    fn column_widths_grow_to_widest_cell() {
+        let rows = vec![
+            [
+                "1".to_string(),
+                "3001".to_string(),
+                "/tmp/a.sock".to_string(),
+                "x".to_string(),
+            ],
+            [
+                "999999".to_string(),
+                "12345".to_string(),
+                "longer-socket-path.sock".to_string(),
+                "y".to_string(),
+            ],
+        ];
+        let widths = column_widths(&rows);
+        assert_eq!(widths[0], "999999".len());
+        assert_eq!(widths[1], "12345".len());
+        assert_eq!(widths[2], "longer-socket-path.sock".len());
+        // Header "CONFIG" wins for the last column even though cells are shorter.
+        assert_eq!(widths[3], "CONFIG".len());
+    }
+
+    #[test]
+    fn move_cursor_wraps_at_boundaries() {
+        let mut state = ListState::default();
+        state.select(Some(0));
+        move_cursor(&mut state, 3, -1);
+        assert_eq!(state.selected(), Some(2));
+        move_cursor(&mut state, 3, 1);
+        assert_eq!(state.selected(), Some(0));
+        move_cursor(&mut state, 3, 1);
+        assert_eq!(state.selected(), Some(1));
+    }
+
+    #[test]
+    fn move_cursor_no_op_on_empty_list() {
+        let mut state = ListState::default();
+        state.select(Some(0));
+        move_cursor(&mut state, 0, 1);
+        assert_eq!(state.selected(), Some(0));
+    }
+}


### PR DESCRIPTION
## Summary

`dugite-config edit` no longer requires the operator to pass a config path and a PID file. When invoked without `<config_file>`, it enumerates running `dugite-node` instances via `sysinfo`, parses each argv for `--config`, `--port`, and `--socket-path`, and either auto-attaches (exactly one node) or presents a selector (more than one). The discovered process's OS PID is used directly for Ctrl+R live reload, replacing the hardcoded `./logs/bp-pair/bp.pid` default.

Discovery is scoped to `dugite-node` only — `cardano-node` instances are deliberately excluded because the editor's defaults, tuning hints, and SIGHUP-based reload are dugite-flavored and would mislead operators (see issue body for the full rationale). Operators wanting to inspect a `cardano-node` config can still pass `--config <path>` explicitly.

## Changes

- **`crates/dugite-config/src/discover.rs`** (new) — pure-function argv parser, path resolution against process cwd, exe basename matching (case-insensitive, `.exe`-trimmed for Windows). Cross-platform via `sysinfo` 0.39.
- **`crates/dugite-config/src/selector.rs`** (new) — ratatui list widget (j/k/Enter/Esc), columns PID/PORT/SOCKET/CONFIG, `[missing]` / `[permission denied]` markers for non-selectable rows.
- **`crates/dugite-config/src/main.rs`** — `Edit` subcommand makes `<config_file>` and `--node-pid-file` optional; new `run_edit` dispatcher branches on presence; `ReloadTarget` enum threads PID-file vs direct-PID through the event loop.
- **`crates/dugite-config/src/app.rs`** — refactor `save_and_reload` to share its save+SIGHUP core with a new `save_and_signal_pid` so both reload paths exercise the same logic.

## Identification chain (per discovery)

1. Filter to `exe basename == "dugite-node"` (case-insensitive, `.exe` stripped).
2. Require `"run"` in argv before any `--`.
3. Parse `--config=<path>` / `--config <path>`; fall back to compiled-in default; last occurrence wins; defensive against `--config` followed by another flag.
4. Resolve relative paths against `Process::cwd()`, canonicalize, mark `[missing]` if the file isn't on disk.

## Test plan

- [x] `cargo nextest run -p dugite-config` — 122/122 (was 95; +27 new tests covering parse forms, `--` terminator, duplicate `--config` last-wins, port/socket parsing, malformed argv, path resolution, status markers, cursor wrap, column widths)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual smoke: `dugite-config edit` with no node running → friendly error, exit 1
- [x] Manual smoke: `dugite-config edit --help` reads naturally for both modes
- [ ] Manual smoke (post-merge): single running node → auto-attach + Ctrl+R reload via OS PID
- [ ] Manual smoke (post-merge): two running nodes → selector picks correct one

## Acceptance criteria (from #490)

- [x] No-args + zero processes → friendly error + exit 1
- [x] No-args + one process → auto-attach (notice line + drop into editor; Ctrl+R uses OS PID)
- [x] No-args + 2+ processes → selector
- [x] Existing explicit-args invocation byte-for-byte unchanged in behaviour (preserves legacy `./logs/bp-pair/bp.pid` default)
- [x] Linux/macOS/Windows: `sysinfo` 0.39 covers all three (CI to verify)
- [x] Unit tests cover all listed parse cases
- [x] `cardano-node` processes are not surfaced

Closes #490