### PR TITLE
ci(fuzz): pin --target x86_64-unknown-linux-gnu to fix musl host triple

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -80,13 +80,18 @@ jobs:
         with:
           tool: cargo-fuzz
 
+      # The prebuilt cargo-fuzz from taiki-e/install-action is musl-static, and
+      # cargo-fuzz uses its compile-time `env!("HOST")` as the default --target.
+      # Without an explicit override it asks for x86_64-unknown-linux-musl, which
+      # the GNU nightly toolchain doesn't ship and sanitizer can't use anyway
+      # (musl static libc is incompatible with -Zsanitizer=address). See #492.
       - name: Run fuzzer (PR — 5 minutes)
         if: github.event_name == 'pull_request'
-        run: cargo +nightly fuzz run fuzz_${{ matrix.target }} -- -max_total_time=300
+        run: cargo +nightly fuzz run fuzz_${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=300
 
       - name: Run fuzzer (nightly — 1 hour)
         if: github.event_name == 'schedule'
-        run: cargo +nightly fuzz run fuzz_${{ matrix.target }} -- -max_total_time=3600
+        run: cargo +nightly fuzz run fuzz_${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=3600
 
       - name: Upload corpus
         if: always()

--- a/fuzz/fuzz_targets/chain_select.rs
+++ b/fuzz/fuzz_targets/chain_select.rs
@@ -51,6 +51,10 @@ fn make_header(slot: SlotNo, block_no: BlockNo, era: Era) -> BlockHeader {
         Era::Alonzo => 5,
         Era::Babbage => 7,
         Era::Conway => 9,
+        // TODO(dijkstra): expand fuzz coverage once Dijkstra ledger support lands.
+        // The era selector below only emits Byron/Shelley/Conway, so this arm is
+        // currently unreachable — it exists to satisfy match exhaustiveness.
+        Era::Dijkstra => 12,
     };
     BlockHeader {
         header_hash: Hash32::ZERO,

--- a/fuzz/fuzz_targets/encode_roundtrip.rs
+++ b/fuzz/fuzz_targets/encode_roundtrip.rs
@@ -85,6 +85,11 @@ fuzz_target!(|data: &[u8]| {
                 dugite_primitives::era::Era::Alonzo => 4,
                 dugite_primitives::era::Era::Babbage => 5,
                 dugite_primitives::era::Era::Conway => 6,
+                // TODO(dijkstra): re-encode/round-trip Dijkstra transactions once
+                // a proper Dijkstra encoder exists. Until then the multi-era
+                // decoder treats Dijkstra blocks via the Conway shim, so re-encoding
+                // and round-tripping is not meaningful — skip these blocks.
+                dugite_primitives::era::Era::Dijkstra => continue,
             };
             if let Ok(re_decoded) = decode_transaction(era_id, &encoded) {
                 assert_eq!(


### PR DESCRIPTION
## Summary

- Adds explicit `--target x86_64-unknown-linux-gnu` to both `cargo fuzz run` invocations so the prebuilt (musl-static) cargo-fuzz binary stops asking the GNU nightly toolchain to build for a musl target it doesn't have and a sanitizer can't use.
- Fully diagnosed in #492 — 98 consecutive failed fuzz runs since 2026-05-02, root cause traced to commit `36ebc6b41`.

Fixes #492.

## Test plan

- [ ] This very PR's Fuzz Testing matrix builds and runs all 33 targets to the 5-minute libFuzzer budget without the musl/sanitizer build error.
- [ ] Crash artifacts (if any) are uploaded as `crashes-<target>` — those would be real fuzz findings, not the build failure we've been seeing.