### PR TITLE
fix(monitor): distinguish catch-up from stall in tip-age pill (#519)

### DIFF
--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -2163,8 +2163,7 @@ pub fn validate_transaction_with_pools(
                     ..
                 } => Some(*pool_hash),
                 dugite_primitives::transaction::Certificate::PoolRetirement {
-                    pool_hash,
-                    ..
+                    pool_hash, ..
                 } => Some(*pool_hash),
                 _ => None,
             };

--- a/crates/dugite-monitor/src/app.rs
+++ b/crates/dugite-monitor/src/app.rs
@@ -34,6 +34,52 @@ pub enum NodeStatus {
     Offline,
 }
 
+/// Tip-age display state derived from the combination of sync progress,
+/// tip age, and whether the block number is advancing between polls.
+///
+/// This 4-state enum resolves the ambiguity where a freshly-imported
+/// Mithril snapshot starts with a legitimately large tip age that is
+/// *expected* (the node is catching up) versus the same large tip age
+/// when the node is at-tip but stuck (a real problem).
+///
+/// | sync_progress | tip_age   | block advancing | State       |
+/// |---------------|-----------|-----------------|-------------|
+/// | ≥ 99.90 %     | < 120 s   | —               | AtTip       |
+/// | ≥ 99.90 %     | ≥ 120 s   | —               | Stale       |
+/// | < 99.90 %     | any       | yes             | CatchingUp  |
+/// | < 99.90 %     | any       | no              | Stuck       |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TipState {
+    /// Node is at the chain tip and tip age is fresh (< 120 s). Green.
+    AtTip,
+    /// Node is at the chain tip but tip age is stale (≥ 120 s).
+    /// This is a real problem — the node may be disconnected. Red.
+    Stale,
+    /// Node is below 99.9 % sync and the block number is advancing
+    /// between polls. This is the expected catch-up state. Yellow.
+    CatchingUp,
+    /// Node is below 99.9 % sync and the block number has **not**
+    /// advanced since the last poll. Possible stall. Red.
+    Stuck,
+}
+
+impl TipState {
+    /// Short human-readable label for the state.
+    pub fn label(self) -> &'static str {
+        match self {
+            TipState::AtTip => "At tip",
+            TipState::Stale => "Stale",
+            TipState::CatchingUp => "Catching up",
+            TipState::Stuck => "Stuck",
+        }
+    }
+
+    /// Whether this state represents a problem that needs attention.
+    pub fn is_problem(self) -> bool {
+        matches!(self, TipState::Stale | TipState::Stuck)
+    }
+}
+
 /// The sync state of the node, as inferred from Prometheus metrics.
 ///
 /// Used by the TUI header pill and status-bar colour coding.  The variants
@@ -404,6 +450,14 @@ pub struct App {
     pub block_rate_history: VecDeque<u64>,
     /// Last `dugite_blocks_applied` value, used to compute per-poll deltas.
     prev_blocks_applied: u64,
+    /// Last `dugite_block_number` value seen, used to detect block advancement
+    /// between successive polls (for the tip-state 4-state matrix).
+    prev_block_number: u64,
+    /// Whether `dugite_block_number` advanced in the most recent poll.
+    ///
+    /// Initialised to `true` so the first sample does not incorrectly report
+    /// "Stuck" before any data has been received.
+    pub block_number_advancing: bool,
     /// Ring-buffer of CPU utilisation samples (one per poll).
     ///
     /// Each entry is the CPU percentage scaled by 10 (e.g. 475 means 47.5 %).
@@ -445,6 +499,8 @@ impl App {
             rtt_bands: RttBands::default(),
             block_rate_history: VecDeque::with_capacity(BLOCK_HISTORY_LEN),
             prev_blocks_applied: 0,
+            prev_block_number: 0,
+            block_number_advancing: true,
             cpu_pct_history: VecDeque::with_capacity(CPU_HISTORY_LEN),
             theme_idx: monokai_idx,
             should_quit: false,
@@ -517,6 +573,19 @@ impl App {
         // Initialise on first call (or after a reset) so prev is correct next poll.
         if blocks_applied > 0 {
             self.prev_blocks_applied = blocks_applied;
+        }
+
+        // Track block_number advancement for the tip-state 4-state matrix.
+        //
+        // We only update `block_number_advancing` once we have seen at least
+        // one non-zero block_number, so the very first successful poll does not
+        // falsely report "Stuck".
+        let block_number = snapshot.get_u64("dugite_block_number");
+        if self.prev_block_number > 0 {
+            self.block_number_advancing = block_number > self.prev_block_number;
+        }
+        if block_number > 0 {
+            self.prev_block_number = block_number;
         }
 
         // Record CPU utilisation sample.
@@ -673,6 +742,43 @@ impl App {
             SyncState::Stalled
         } else {
             SyncState::Syncing
+        }
+    }
+
+    /// Determine the tip display state using the 4-state matrix.
+    ///
+    /// Composes `sync_progress_percent`, `tip_age_seconds`, and whether the
+    /// block number has advanced since the last poll to produce an unambiguous
+    /// display state for the tip-age pill:
+    ///
+    /// | sync_progress | tip_age   | block advancing | State       |
+    /// |---------------|-----------|-----------------|-------------|
+    /// | ≥ 99.90 %     | < 120 s   | —               | AtTip       |
+    /// | ≥ 99.90 %     | ≥ 120 s   | —               | Stale       |
+    /// | < 99.90 %     | any       | yes             | CatchingUp  |
+    /// | < 99.90 %     | any       | no              | Stuck       |
+    ///
+    /// This resolves the ambiguity where a freshly-imported Mithril snapshot
+    /// legitimately starts with a large `tip_age` while catching up, but that
+    /// same large `tip_age` would indicate a real stall at 99.9 %+ sync.
+    pub fn tip_state(&self) -> TipState {
+        let pct = self.metrics.get("dugite_sync_progress_percent") / 100.0;
+        let tip_age = self.metrics.get_u64("dugite_tip_age_seconds");
+
+        if pct >= 99.9 {
+            // Node is at (or very near) tip.
+            if tip_age < 120 {
+                TipState::AtTip
+            } else {
+                TipState::Stale
+            }
+        } else {
+            // Node is still catching up.
+            if self.block_number_advancing {
+                TipState::CatchingUp
+            } else {
+                TipState::Stuck
+            }
         }
     }
 
@@ -1275,5 +1381,125 @@ mod tests {
             1,
             "offline snapshot must not push a CPU sample"
         );
+    }
+
+    // ---- TipState 4-state matrix tests ----
+
+    #[test]
+    fn test_tip_state_at_tip() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 9990.0),
+            ("dugite_tip_age_seconds", 60.0),
+            ("dugite_block_number", 1000.0),
+        ]));
+        assert_eq!(app.tip_state(), TipState::AtTip);
+        assert!(!app.tip_state().is_problem());
+        assert!(!app.tip_state().is_problem());
+        assert_eq!(app.tip_state().label(), "At tip");
+    }
+
+    #[test]
+    fn test_tip_state_stale_at_tip_but_old() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 9990.0),
+            ("dugite_tip_age_seconds", 120.0),
+            ("dugite_block_number", 1000.0),
+        ]));
+        assert_eq!(app.tip_state(), TipState::Stale);
+        assert!(app.tip_state().is_problem());
+        assert!(app.tip_state().is_problem());
+        assert_eq!(app.tip_state().label(), "Stale");
+    }
+
+    #[test]
+    fn test_tip_state_catching_up_block_advancing() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        // Seed prev_block_number.
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 5000.0),
+            ("dugite_tip_age_seconds", 57_600.0),
+            ("dugite_block_number", 1000.0),
+        ]));
+        // Second poll: block_number advanced.
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 5001.0),
+            ("dugite_tip_age_seconds", 57_580.0),
+            ("dugite_block_number", 1050.0),
+        ]));
+        assert_eq!(app.tip_state(), TipState::CatchingUp);
+        assert!(!app.tip_state().is_problem());
+        assert!(!app.tip_state().is_problem());
+        assert_eq!(app.tip_state().label(), "Catching up");
+    }
+
+    #[test]
+    fn test_tip_state_stuck_block_not_advancing() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        // Seed prev_block_number.
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 5000.0),
+            ("dugite_tip_age_seconds", 57_600.0),
+            ("dugite_block_number", 1000.0),
+        ]));
+        // Second poll: block_number did NOT advance (same value).
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 5000.0),
+            ("dugite_tip_age_seconds", 57_620.0),
+            ("dugite_block_number", 1000.0),
+        ]));
+        assert_eq!(app.tip_state(), TipState::Stuck);
+        assert!(app.tip_state().is_problem());
+        assert!(app.tip_state().is_problem());
+        assert_eq!(app.tip_state().label(), "Stuck");
+    }
+
+    /// First poll must not falsely report Stuck (block_number_advancing
+    /// defaults to true so no comparison can be made yet).
+    #[test]
+    fn test_tip_state_first_poll_not_stuck() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 5000.0),
+            ("dugite_tip_age_seconds", 50_000.0),
+            ("dugite_block_number", 1.0),
+        ]));
+        assert_eq!(
+            app.tip_state(),
+            TipState::CatchingUp,
+            "first poll must be CatchingUp, not Stuck"
+        );
+    }
+
+    /// Boundary: exactly 99.9% with tip_age == 119 => AtTip.
+    #[test]
+    fn test_tip_state_exact_boundary_at_tip() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 9990.0), // 99.90%
+            ("dugite_tip_age_seconds", 119.0),        // just below 120s threshold
+            ("dugite_block_number", 500.0),
+        ]));
+        assert_eq!(app.tip_state(), TipState::AtTip);
+    }
+
+    /// Boundary: exactly 99.9% with tip_age == 120 => Stale.
+    #[test]
+    fn test_tip_state_exact_boundary_stale() {
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        app.update_metrics(make_snapshot(vec![
+            ("dugite_sync_progress_percent", 9990.0), // 99.90%
+            ("dugite_tip_age_seconds", 120.0),        // exactly 120s threshold
+            ("dugite_block_number", 500.0),
+        ]));
+        assert_eq!(app.tip_state(), TipState::Stale);
     }
 }

--- a/crates/dugite-monitor/src/ui.rs
+++ b/crates/dugite-monitor/src/ui.rs
@@ -33,7 +33,7 @@
 //! ├──────────────────────── Footer (1 line) ───────────────────────────────────┘
 //! ```
 
-use crate::app::{App, NodeStatus};
+use crate::app::{App, NodeStatus, TipState};
 
 use crate::layout::{compute_layout, LayoutMode};
 use crate::theme::Theme;
@@ -156,13 +156,25 @@ fn render_header(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         format!(" {} {:.2}% ", sync_state.label(), pct)
     };
 
-    // Tip age indicator: check mark / warning / X based on age brackets.
-    // Requirements: green check <20s, warning 20-60s, red X >60s.
-    let (tip_icon, tip_age_col) = tip_age_indicator(theme, tip_age);
+    // Tip age indicator: 4-state pill derived from sync_progress + tip_age +
+    // block_number advancement.  This distinguishes healthy catch-up (yellow)
+    // from a real stall (red) even when tip_age is large.
+    let tip_state = app.tip_state();
+    let (tip_icon, tip_age_col) = tip_age_indicator(theme, tip_age, tip_state);
+    // For non-AtTip states, show the state label alongside the age so operators
+    // can immediately tell whether a large tip age is a healthy catch-up or a
+    // real stall (e.g. ">> Catching up 15h 0m" vs "XX Stale 3m 0s").
     let tip_str = if tip_age == 0 {
         format!("{} --", tip_icon)
-    } else {
+    } else if tip_state == TipState::AtTip {
         format!("{} {}", tip_icon, format_tip_age(tip_age))
+    } else {
+        format!(
+            "{} {} {}",
+            tip_icon,
+            tip_state.label(),
+            format_tip_age(tip_age)
+        )
     };
 
     let mut spans = vec![
@@ -218,13 +230,14 @@ fn render_header(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         Span::styled("Net ", Style::default().fg(theme.muted)),
         Span::styled(network, Style::default().fg(theme.accent)),
         sep_spaced(theme),
-        // Tip age with colored indicator icon.
+        // Tip age with colored indicator icon.  Bold when the state signals
+        // a problem (Stale or Stuck) to draw the operator's attention.
         Span::styled("Tip ", Style::default().fg(theme.muted)),
         Span::styled(
             tip_str,
             Style::default()
                 .fg(tip_age_col)
-                .add_modifier(if tip_age >= 120 {
+                .add_modifier(if tip_state.is_problem() {
                     Modifier::BOLD
                 } else {
                     Modifier::empty()
@@ -585,11 +598,12 @@ fn render_chain_panel(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
 
     let col_w = inner.width.saturating_sub(2) as usize;
 
-    // Tip age with indicator icon (<20s green check, 20-60s warning, >60s red X).
+    // Tip age with 4-state indicator (AtTip/CatchingUp/Stale/Stuck).
     // Humanised to days/hours/minutes/seconds (matches the header-bar
     // tip-diff indicator) so a multi-day bulk sync doesn't display as a
     // six-figure raw-seconds count.
-    let (tip_icon, tip_age_col) = tip_age_indicator(theme, tip_age);
+    let tip_state = app.tip_state();
+    let (tip_icon, tip_age_col) = tip_age_indicator(theme, tip_age, tip_state);
     let tip_str = format!("{} {}", tip_icon, format_tip_age(tip_age));
 
     // Compute how many text rows we can fit before the mempool gauge row.
@@ -605,7 +619,7 @@ fn render_chain_panel(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
             tip_age_col,
             theme,
             col_w,
-            tip_age >= 120,
+            tip_state.is_problem(),
         ),
         kv_aligned("Density", &density_str, theme.info, theme, col_w),
         kv_aligned(
@@ -1708,22 +1722,30 @@ fn sep_spaced(theme: &Theme) -> Span<'static> {
 // Color and indicator helpers
 // ---------------------------------------------------------------------------
 
-/// Return (icon_str, color) for tip-age display.
+/// Return (icon_str, color, label) for tip-age display using the 4-state matrix.
 ///
-/// Thresholds per requirements:
-///   - < 60s    => green check indicator (within one slot interval)
-///   - 60-120s  => warning indicator
-///   - > 120s   => red X indicator
-fn tip_age_indicator(theme: &Theme, tip_age_secs: u64) -> (&'static str, Color) {
+/// The icon and colour are chosen based on [`TipState`], which composes
+/// `sync_progress_percent`, `tip_age_seconds`, and whether the block number
+/// is advancing between polls:
+///
+/// | TipState   | icon | colour  | meaning                          |
+/// |------------|------|---------|----------------------------------|
+/// | AtTip      | OK   | green   | at tip, fresh                    |
+/// | Stale      | XX   | red     | at tip but age ≥ 120 s (problem) |
+/// | CatchingUp | >>   | yellow  | below 99.9%, block advancing     |
+/// | Stuck      | !!   | red     | below 99.9%, not advancing       |
+///
+/// Falls back to the legacy tip-age-only thresholds when no TipState can be
+/// derived (e.g. tip_age_secs == 0 meaning no data yet).
+fn tip_age_indicator(theme: &Theme, tip_age_secs: u64, state: TipState) -> (&'static str, Color) {
     if tip_age_secs == 0 {
-        // No data yet — neutral display.
-        ("-", theme.muted)
-    } else if tip_age_secs < 60 {
-        ("OK", theme.success)
-    } else if tip_age_secs < 120 {
-        ("!!", theme.warning)
-    } else {
-        ("XX", theme.error)
+        // No data yet — neutral display regardless of state.
+        return ("-", theme.muted);
+    }
+    match state {
+        TipState::AtTip => ("OK", theme.success),
+        TipState::CatchingUp => (">>", theme.warning),
+        TipState::Stale | TipState::Stuck => ("XX", theme.error),
     }
 }
 
@@ -1863,37 +1885,171 @@ mod tests {
     #[test]
     fn test_tip_age_indicator_thresholds() {
         let theme = &crate::theme::THEME_MONOKAI;
-        // 0 => neutral (no data)
-        let (icon_0, col_0) = tip_age_indicator(theme, 0);
+
+        // tip_age == 0 => no data sentinel (muted, regardless of TipState)
+        let (icon_0, col_0) = tip_age_indicator(theme, 0, TipState::AtTip);
         assert_eq!(icon_0, "-");
         assert_eq!(col_0, theme.muted);
 
-        // <60s => success (green OK)
-        let (icon_5, col_5) = tip_age_indicator(theme, 5);
-        assert_eq!(icon_5, "OK");
-        assert_eq!(col_5, theme.success);
+        // AtTip => green OK
+        let (icon_at, col_at) = tip_age_indicator(theme, 5, TipState::AtTip);
+        assert_eq!(icon_at, "OK");
+        assert_eq!(col_at, theme.success);
 
-        let (icon_59, col_59) = tip_age_indicator(theme, 59);
-        assert_eq!(icon_59, "OK");
-        assert_eq!(col_59, theme.success);
+        // CatchingUp => yellow >>
+        let (icon_cu, col_cu) = tip_age_indicator(theme, 86_400, TipState::CatchingUp);
+        assert_eq!(icon_cu, ">>");
+        assert_eq!(col_cu, theme.warning);
 
-        // 60-120s => warning
-        let (icon_60, col_60) = tip_age_indicator(theme, 60);
-        assert_eq!(icon_60, "!!");
-        assert_eq!(col_60, theme.warning);
+        // Stale => red XX
+        let (icon_stale, col_stale) = tip_age_indicator(theme, 300, TipState::Stale);
+        assert_eq!(icon_stale, "XX");
+        assert_eq!(col_stale, theme.error);
 
-        let (icon_119, col_119) = tip_age_indicator(theme, 119);
-        assert_eq!(icon_119, "!!");
-        assert_eq!(col_119, theme.warning);
+        // Stuck => red XX
+        let (icon_stuck, col_stuck) = tip_age_indicator(theme, 600, TipState::Stuck);
+        assert_eq!(icon_stuck, "XX");
+        assert_eq!(col_stuck, theme.error);
+    }
 
-        // >=120s => error (red X)
-        let (icon_120, col_120) = tip_age_indicator(theme, 120);
-        assert_eq!(icon_120, "XX");
-        assert_eq!(col_120, theme.error);
+    /// 4-state matrix: verify all four cells of the issue's display matrix
+    /// using App::tip_state() driven by fake metric snapshots.
+    #[test]
+    fn test_tip_state_four_state_matrix() {
+        use crate::app::{App, NodeStatus};
+        use crate::metrics::MetricsSnapshot;
+        use std::collections::HashMap;
 
-        let (icon_300, col_300) = tip_age_indicator(theme, 300);
-        assert_eq!(icon_300, "XX");
-        assert_eq!(col_300, theme.error);
+        fn make_snap(values: Vec<(&str, f64)>) -> MetricsSnapshot {
+            MetricsSnapshot {
+                values: values
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect(),
+                histogram_buckets: HashMap::new(),
+                string_labels: HashMap::new(),
+                connected: true,
+                error: None,
+            }
+        }
+
+        // Row 1: sync >= 99.90%, tip_age < 120 => AtTip (green)
+        {
+            let mut app = App::new();
+            app.node_status = NodeStatus::Online;
+            app.update_metrics(make_snap(vec![
+                ("dugite_sync_progress_percent", 9990.0),
+                ("dugite_tip_age_seconds", 60.0),
+                ("dugite_block_number", 100.0),
+            ]));
+            assert_eq!(
+                app.tip_state(),
+                TipState::AtTip,
+                "sync>=99.9%, tip<120 => AtTip"
+            );
+            assert!(!app.tip_state().is_problem());
+        }
+
+        // Row 2: sync >= 99.90%, tip_age >= 120 => Stale (red)
+        {
+            let mut app = App::new();
+            app.node_status = NodeStatus::Online;
+            app.update_metrics(make_snap(vec![
+                ("dugite_sync_progress_percent", 9990.0),
+                ("dugite_tip_age_seconds", 300.0),
+                ("dugite_block_number", 200.0),
+            ]));
+            assert_eq!(
+                app.tip_state(),
+                TipState::Stale,
+                "sync>=99.9%, tip>=120 => Stale"
+            );
+            assert!(app.tip_state().is_problem());
+        }
+
+        // Row 3: sync < 99.90%, block_number advancing => CatchingUp (yellow)
+        {
+            let mut app = App::new();
+            app.node_status = NodeStatus::Online;
+            // First poll seeds prev_block_number.
+            app.update_metrics(make_snap(vec![
+                ("dugite_sync_progress_percent", 5000.0),
+                ("dugite_tip_age_seconds", 57_600.0),
+                ("dugite_block_number", 1000.0),
+            ]));
+            // Second poll: block_number advanced.
+            app.update_metrics(make_snap(vec![
+                ("dugite_sync_progress_percent", 5001.0),
+                ("dugite_tip_age_seconds", 57_595.0),
+                ("dugite_block_number", 1050.0),
+            ]));
+            assert_eq!(
+                app.tip_state(),
+                TipState::CatchingUp,
+                "sync<99.9%, block advancing => CatchingUp"
+            );
+            assert!(!app.tip_state().is_problem());
+        }
+
+        // Row 4: sync < 99.90%, block_number NOT advancing => Stuck (red)
+        {
+            let mut app = App::new();
+            app.node_status = NodeStatus::Online;
+            // First poll seeds prev_block_number.
+            app.update_metrics(make_snap(vec![
+                ("dugite_sync_progress_percent", 5000.0),
+                ("dugite_tip_age_seconds", 57_600.0),
+                ("dugite_block_number", 1000.0),
+            ]));
+            // Second poll: block_number did NOT advance.
+            app.update_metrics(make_snap(vec![
+                ("dugite_sync_progress_percent", 5000.0),
+                ("dugite_tip_age_seconds", 57_610.0),
+                ("dugite_block_number", 1000.0),
+            ]));
+            assert_eq!(
+                app.tip_state(),
+                TipState::Stuck,
+                "sync<99.9%, block not advancing => Stuck"
+            );
+            assert!(app.tip_state().is_problem());
+        }
+    }
+
+    /// First poll should never show Stuck even though prev_block_number is 0.
+    #[test]
+    fn test_tip_state_first_poll_not_stuck() {
+        use crate::app::{App, NodeStatus};
+        use crate::metrics::MetricsSnapshot;
+        use std::collections::HashMap;
+
+        fn make_snap(values: Vec<(&str, f64)>) -> MetricsSnapshot {
+            MetricsSnapshot {
+                values: values
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect(),
+                histogram_buckets: HashMap::new(),
+                string_labels: HashMap::new(),
+                connected: true,
+                error: None,
+            }
+        }
+
+        let mut app = App::new();
+        app.node_status = NodeStatus::Online;
+        // First and only poll — prev_block_number is still 0.
+        app.update_metrics(make_snap(vec![
+            ("dugite_sync_progress_percent", 5000.0),
+            ("dugite_tip_age_seconds", 50_000.0),
+            ("dugite_block_number", 1.0),
+        ]));
+        // Should be CatchingUp (block_number_advancing defaults to true).
+        assert_eq!(
+            app.tip_state(),
+            TipState::CatchingUp,
+            "first poll should not show Stuck"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Introduces a `TipState` enum with 4 states (`AtTip`, `CatchingUp`, `Stale`, `Stuck`) that composes `sync_progress_percent`, `tip_age_seconds`, and whether `dugite_block_number` is advancing between polls.
- Updates the tip-age pill in the header and chain panel to render colour + icon from `TipState` rather than tip-age alone — resolving the ambiguity where a fresh Mithril import shows red "XX 15h" identically to a real stall.
- No new metrics introduced; only existing ones are composed.

**Display matrix implemented:**

| `sync_progress_percent` | `tip_age_seconds` | block advancing | Display |
|--|--|--|--|
| ≥ 99.90% | < 120 s | — | green `OK <age>` (AtTip) |
| ≥ 99.90% | ≥ 120 s | — | red `XX Stale <age>` (Stale) |
| < 99.90% | any | yes | yellow `>> Catching up <age>` (CatchingUp) |
| < 99.90% | any | no | red `XX Stuck <age>` (Stuck) |

## Files touched

- `crates/dugite-monitor/src/app.rs` — `TipState` enum, `App::tip_state()`, `prev_block_number` tracking in `update_metrics()`
- `crates/dugite-monitor/src/ui.rs` — `tip_age_indicator` takes `TipState`, both header and chain-panel call sites updated

## Tests added

- `app::tests::test_tip_state_at_tip`
- `app::tests::test_tip_state_stale_at_tip_but_old`
- `app::tests::test_tip_state_catching_up_block_advancing`
- `app::tests::test_tip_state_stuck_block_not_advancing`
- `app::tests::test_tip_state_first_poll_not_stuck`
- `app::tests::test_tip_state_exact_boundary_at_tip`
- `app::tests::test_tip_state_exact_boundary_stale`
- `ui::tests::test_tip_age_indicator_thresholds` (updated for new signature)
- `ui::tests::test_tip_state_four_state_matrix`
- `ui::tests::test_tip_state_first_poll_not_stuck`

Closes #519