### PR TITLE
fix(scripts): preserve mithril archive on retry, refuse ENOSPC (#518)

### DIFF
--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -2163,8 +2163,7 @@ pub fn validate_transaction_with_pools(
                     ..
                 } => Some(*pool_hash),
                 dugite_primitives::transaction::Certificate::PoolRetirement {
-                    pool_hash,
-                    ..
+                    pool_hash, ..
                 } => Some(*pool_hash),
                 _ => None,
             };

--- a/scripts/run/bp-mainnet.sh
+++ b/scripts/run/bp-mainnet.sh
@@ -37,7 +37,18 @@ done
 # Import Mithril snapshot if database is empty
 if [[ ! -d "./db-mainnet/immutable" ]]; then
     echo "Database empty. Importing Mithril snapshot (~35 GB, may take 30+ minutes)..."
-    "$BIN" mithril-import --network-magic 764824073 --database-path ./db-mainnet
+    # On failure, retry once — but refuse if the disk is full (ENOSPC), and
+    # preserve the snapshot archive so the retry can reuse it.
+    IMPORT_CMD=("$BIN" mithril-import --network-magic 764824073 --database-path ./db-mainnet)
+    if ! IMPORT_OUTPUT=$("${IMPORT_CMD[@]}" 2>&1); then
+        printf '%s\n' "$IMPORT_OUTPUT" >&2
+        if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
+            echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
+            exit 1
+        fi
+        echo "mithril-import failed; retrying once (archive cache preserved)..."
+        "${IMPORT_CMD[@]}"
+    fi
 fi
 
 CMD=(

--- a/scripts/run/bp-preprod.sh
+++ b/scripts/run/bp-preprod.sh
@@ -37,7 +37,18 @@ done
 # Import Mithril snapshot if database is empty
 if [[ ! -d "./db-preprod/immutable" ]]; then
     echo "Database empty. Importing Mithril snapshot..."
-    "$BIN" mithril-import --network-magic 1 --database-path ./db-preprod
+    # On failure, retry once — but refuse if the disk is full (ENOSPC), and
+    # preserve the snapshot archive so the retry can reuse it.
+    IMPORT_CMD=("$BIN" mithril-import --network-magic 1 --database-path ./db-preprod)
+    if ! IMPORT_OUTPUT=$("${IMPORT_CMD[@]}" 2>&1); then
+        printf '%s\n' "$IMPORT_OUTPUT" >&2
+        if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
+            echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
+            exit 1
+        fi
+        echo "mithril-import failed; retrying once (archive cache preserved)..."
+        "${IMPORT_CMD[@]}"
+    fi
 fi
 
 CMD=(

--- a/scripts/run/bp-preview.sh
+++ b/scripts/run/bp-preview.sh
@@ -37,7 +37,18 @@ done
 # Import Mithril snapshot if database is empty
 if [[ ! -d "./db-preview/immutable" ]]; then
     echo "Database empty. Importing Mithril snapshot..."
-    "$BIN" mithril-import --network-magic 2 --database-path ./db-preview
+    # On failure, retry once — but refuse if the disk is full (ENOSPC), and
+    # preserve the snapshot archive so the retry can reuse it.
+    IMPORT_CMD=("$BIN" mithril-import --network-magic 2 --database-path ./db-preview)
+    if ! IMPORT_OUTPUT=$("${IMPORT_CMD[@]}" 2>&1); then
+        printf '%s\n' "$IMPORT_OUTPUT" >&2
+        if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
+            echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
+            exit 1
+        fi
+        echo "mithril-import failed; retrying once (archive cache preserved)..."
+        "${IMPORT_CMD[@]}"
+    fi
 fi
 
 CMD=(

--- a/scripts/run/relay-mainnet.sh
+++ b/scripts/run/relay-mainnet.sh
@@ -27,14 +27,22 @@ fi
 
 if [[ ! -d "./db-mainnet/immutable" ]]; then
     echo "Database empty. Importing Mithril snapshot (~35 GB, may take 30+ minutes)..."
-    # On failure (stale partial extract, transient network blip) wipe the
-    # dugite-mithril work dir and retry once so unattended soak / Ralph-loop
-    # runs don't die on a single recoverable error.
-    if ! "$BIN" mithril-import --network-magic 764824073 --database-path ./db-mainnet; then
-        WORK_DIR="${TMPDIR:-/tmp}/dugite-mithril"
-        echo "mithril-import failed; clearing $WORK_DIR and retrying once..."
-        rm -rf "$WORK_DIR"
-        "$BIN" mithril-import --network-magic 764824073 --database-path ./db-mainnet
+    # On failure, retry once — but refuse if the disk is full (ENOSPC), and
+    # preserve the snapshot archive so the retry can reuse it.
+    #
+    # The archive is content-addressed (snapshot-<digest>.tar.zst) and dugite-node
+    # skips the download when the file exists with the expected size.  The extract
+    # directory is auto-wiped by the sentinel logic inside dugite-node when a
+    # previous extraction was interrupted, so we do NOT rm -rf the work directory.
+    IMPORT_CMD=("$BIN" mithril-import --network-magic 764824073 --database-path ./db-mainnet)
+    if ! IMPORT_OUTPUT=$("${IMPORT_CMD[@]}" 2>&1); then
+        printf '%s\n' "$IMPORT_OUTPUT" >&2
+        if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
+            echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
+            exit 1
+        fi
+        echo "mithril-import failed; retrying once (archive cache preserved)..."
+        "${IMPORT_CMD[@]}"
     fi
 fi
 

--- a/scripts/run/relay-preprod.sh
+++ b/scripts/run/relay-preprod.sh
@@ -23,7 +23,18 @@ fi
 
 if [[ ! -d "./db-preprod/immutable" ]]; then
     echo "Database empty. Importing Mithril snapshot..."
-    "$BIN" mithril-import --network-magic 1 --database-path ./db-preprod
+    # On failure, retry once — but refuse if the disk is full (ENOSPC), and
+    # preserve the snapshot archive so the retry can reuse it.
+    IMPORT_CMD=("$BIN" mithril-import --network-magic 1 --database-path ./db-preprod)
+    if ! IMPORT_OUTPUT=$("${IMPORT_CMD[@]}" 2>&1); then
+        printf '%s\n' "$IMPORT_OUTPUT" >&2
+        if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
+            echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
+            exit 1
+        fi
+        echo "mithril-import failed; retrying once (archive cache preserved)..."
+        "${IMPORT_CMD[@]}"
+    fi
 fi
 
 CMD=(

--- a/scripts/run/relay-preview.sh
+++ b/scripts/run/relay-preview.sh
@@ -28,7 +28,18 @@ fi
 # Import Mithril snapshot if database is empty
 if [[ ! -d "./db-preview/immutable" ]]; then
     echo "Database empty. Importing Mithril snapshot..."
-    "$BIN" mithril-import --network-magic 2 --database-path ./db-preview
+    # On failure, retry once — but refuse if the disk is full (ENOSPC), and
+    # preserve the snapshot archive so the retry can reuse it.
+    IMPORT_CMD=("$BIN" mithril-import --network-magic 2 --database-path ./db-preview)
+    if ! IMPORT_OUTPUT=$("${IMPORT_CMD[@]}" 2>&1); then
+        printf '%s\n' "$IMPORT_OUTPUT" >&2
+        if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
+            echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
+            exit 1
+        fi
+        echo "mithril-import failed; retrying once (archive cache preserved)..."
+        "${IMPORT_CMD[@]}"
+    fi
 fi
 
 CMD=(


### PR DESCRIPTION
## Summary

- **ENOSPC detection:** First-attempt stderr is captured; if it contains `no space left on device` or `ENOSPC` (case-insensitive), the script prints a clear "disk full" message and exits 1 — no retry, no wasted I/O.
- **Drop the `rm -rf` entirely:** The buggy `rm -rf "$WORK_DIR"` in `relay-mainnet.sh` nuked the 53 GB archive cache before retrying. Investigation confirmed this is unnecessary: `download_snapshot()` in `mithril.rs` already skips the download when `snapshot-<digest>.tar.zst` exists with the right byte count; `extract_archive()` auto-wipes only the stale *extract directory* (sentinel-based, issue #509) without touching the archive. Dropping the rm lets a re-run reuse both the archive and any already-completed extraction.
- **Applied consistently to all six launchers:** `relay-{mainnet,preview,preprod}` and `bp-{mainnet,preview,preprod}`. The four non-mainnet scripts previously had no retry at all; they now all share the corrected shape.
- Also fixes a pre-existing `rustfmt` diff in `dugite-ledger/validation/mod.rs` required for CI green.

## rm strategy decision

**Dropped entirely.** The Rust-level sentinel (`extract_archive` checks for `.dugite-extracted`) already handles the stale-extract case without touching the archive. Narrowing to `rm -rf extract-*` would have been safe too, but dropping is cleaner — it removes the script's responsibility for a detail the binary already manages.

## ENOSPC detection approach

```bash
if printf '%s\n' "$IMPORT_OUTPUT" | grep -qi "no space left on device\|ENOSPC"; then
    echo "ERROR: mithril-import failed: disk full (ENOSPC). Free up space and retry." >&2
    exit 1
fi
```

Both the kernel error string ("No space left on device") and the errno symbol (ENOSPC) are matched case-insensitively. This covers Linux and macOS.

## Scripts updated

- `scripts/run/relay-mainnet.sh` — replaced buggy `rm -rf` + retry with corrected shape
- `scripts/run/relay-preview.sh` — added retry with ENOSPC guard (was no-retry before)
- `scripts/run/relay-preprod.sh` — added retry with ENOSPC guard (was no-retry before)
- `scripts/run/bp-mainnet.sh` — added retry with ENOSPC guard (was no-retry before)
- `scripts/run/bp-preview.sh` — added retry with ENOSPC guard (was no-retry before)
- `scripts/run/bp-preprod.sh` — added retry with ENOSPC guard (was no-retry before)

## Manual test plan

- **ENOSPC simulation:** Run `fallocate -l 50G /tmp/filler` (Linux) or `mkfile 50g /tmp/filler` (macOS) to fill the disk, then run `relay-mainnet.sh`. Expected: import fails, script prints "disk full (ENOSPC)" and exits 1 without retrying. Clean up with `rm /tmp/filler`.
- **Generic failure with archive reuse:** Let mithril-import download the archive, then kill it during extraction (Ctrl-C). Re-run: the script retries; dugite-node should log "snapshot archive already downloaded, skipping" and proceed from the extraction step, saving 40+ minutes.
- **Digest mismatch / corrupted extract:** Manually corrupt a file in the extract dir, delete the sentinel. Re-run: dugite-node wipes the extract dir and re-extracts from the intact archive — no re-download.

Closes #518