### PR TITLE
fix(node): release chainsync channel across warm→hot promotion (#516)

### DIFF
--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -2163,8 +2163,7 @@ pub fn validate_transaction_with_pools(
                     ..
                 } => Some(*pool_hash),
                 dugite_primitives::transaction::Certificate::PoolRetirement {
-                    pool_hash,
-                    ..
+                    pool_hash, ..
                 } => Some(*pool_hash),
                 _ => None,
             };

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -14,6 +14,19 @@
 //! The key invariant is **one TCP connection per peer**. Temperature transitions
 //! only add/remove protocol tasks on the existing mux, never create new connections.
 //!
+//! # Architecture Divergence: Hot → Warm Demotion
+//!
+//! Dugite's `MuxChannel` is **single-use**: when `start_hot_protocols` is called,
+//! the three client channels (ChainSync, BlockFetch, TxSubmission2) are moved via
+//! `Option::take` into the spawned tasks.  When those tasks exit, the channels are
+//! dropped.  Unlike Haskell's `MiniProtocolState` (which is reusable), there is no
+//! way to re-acquire the channels without opening a fresh `PeerConnection`.
+//!
+//! Therefore, Hot → Warm demotion in dugite **closes the TCP connection** rather
+//! than just stopping the hot protocol tasks.  The peer manager is updated to cold
+//! and the next governor tick will reconnect (Cold → Warm → Hot) with fresh channels.
+//! See: `demote_to_warm` and issue #516 for full details.
+//!
 //! ## Duplex Connections (Simultaneous Open)
 //!
 //! When we already have an outbound connection to a peer and they connect inbound
@@ -695,11 +708,42 @@ impl ConnectionLifecycleManager {
         Ok(())
     }
 
-    /// Demote a hot peer to warm: stop ChainSync + BlockFetch + TxSubmission2.
+    /// Demote a hot peer to warm (close connection + disconnect).
     ///
-    /// This is the Hot -> Warm transition from Haskell's `PeerStateActions`.
-    /// Only the hot protocol tasks are stopped; the mux and KeepAlive continue
-    /// running. The peer can be re-promoted to hot later without reconnecting.
+    /// # Architecture divergence from Haskell
+    ///
+    /// Haskell's `PeerStateActions` keeps the TCP connection alive across Hot→Warm
+    /// transitions, stopping only the hot mini-protocols and reusing the existing
+    /// mux connection for later re-promotion.
+    ///
+    /// Dugite cannot replicate this because `MuxChannel` is **single-use**: it wraps
+    /// an `mpsc::Receiver` that is moved into the hot protocol task when `start_hot_protocols`
+    /// is called.  When the task exits (either cleanly or via cancellation), the receiver
+    /// is dropped and the channel slot can never be reclaimed — `subscribe()` routes are
+    /// baked into `Mux::run()` at connection-open time and cannot be re-registered on a
+    /// running mux.
+    ///
+    /// Attempting to re-promote a Hot→Warm-demoted peer on the same connection therefore
+    /// always fails with `PeerConnectionError::ChannelUnavailable("chainsync")`, producing
+    /// the churn loop observed in #516:
+    ///
+    /// ```text
+    /// DemoteToWarm → channels consumed/dropped → peer is Warm
+    /// PromoteToHot → start_hot_protocols → chainsync_client_channel.take() = None → Err
+    /// handle_governor_action PromoteToHot failure → closes connection → peer is Cold
+    /// PromoteToWarm → reconnect → inline promote_to_hot → Success
+    /// next hot-churn DemoteToWarm → channels consumed → repeat forever
+    /// ```
+    ///
+    /// **Fix**: on Hot→Warm demotion we immediately close the entire TCP connection
+    /// (equivalent to a Warm→Cold transition at the connection layer).  The peer
+    /// manager is updated to cold via `peer_disconnected()`.  On the next governor tick,
+    /// a fresh TCP connection is established (`PromoteToWarm`) giving new `MuxChannel`
+    /// instances, and `PromoteToHot` succeeds.
+    ///
+    /// The observable difference is one extra reconnect latency (~RTT) per hot-churn
+    /// cycle, which is acceptable given that hot churn fires at most every 10 minutes
+    /// and mainnet tip-following nodes almost never trigger it.
     ///
     /// # Errors
     ///
@@ -709,17 +753,27 @@ impl ConnectionLifecycleManager {
         addr: SocketAddr,
         peer_manager: &mut NodePeerManager,
     ) -> Result<(), LifecycleError> {
-        // Hot protocols run on the outbound connection of a duplex pair.
-        let cid = self
-            .find_outbound_cid(addr)
-            .or_else(|| self.find_any_cid(addr))
-            .ok_or(LifecycleError::NotConnected(addr))?;
+        // Close ALL connections to this remote (covers duplex pairs).
+        let cids: Vec<ConnectionId> = self
+            .connections
+            .keys()
+            .filter(|c| c.remote == addr)
+            .copied()
+            .collect();
+        if cids.is_empty() {
+            return Err(LifecycleError::NotConnected(addr));
+        }
 
-        let conn = self.connections.get_mut(&cid).unwrap();
+        info!(%addr, "demoting hot -> warm: closing connection (single-use channel constraint)");
 
-        info!(%cid, "demoting hot -> warm: stopping sync protocols");
+        // Mark as terminating before shutdown so metrics see an orderly exit.
+        peer_manager.mark_terminating(&addr);
 
-        conn.stop_hot_protocols().await;
+        for cid in &cids {
+            if let Some(mut conn) = self.connections.remove(cid) {
+                conn.shutdown().await;
+            }
+        }
 
         // Clear candidate chain state for this peer (no longer syncing).
         {
@@ -727,17 +781,11 @@ impl ConnectionLifecycleManager {
             chains.remove(&addr);
         }
 
-        // Update peer manager: hot -> warm.
-        peer_manager.inner.demote_to_warm(&addr);
+        // Update peer manager to cold (not warm) — a fresh connection is required
+        // before hot protocols can run again.
+        peer_manager.peer_disconnected(&addr);
 
-        // Update connection state: active → idle (outbound or inbound).
-        if peer_manager.is_inbound(&addr) {
-            peer_manager.mark_inbound_idle(&addr);
-        } else {
-            peer_manager.mark_outbound_idle(&addr);
-        }
-
-        info!(%cid, "hot -> warm complete");
+        info!(%addr, "hot -> warm complete (connection closed; will reconnect)");
         Ok(())
     }
 

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -3153,6 +3153,19 @@ impl Node {
                             for action in actions {
                                 match action {
                                     dugite_network::peer::governor::GovernorAction::PromoteToWarm(_) => {} // handled above
+                                    dugite_network::peer::governor::GovernorAction::PromoteToHot(addr) => {
+                                        // Dispatch the promotion, then unconditionally clear
+                                        // in_progress_promote_warm so the governor can re-evaluate
+                                        // this peer on the next tick (#516).  Without this call the
+                                        // governor's HashSet grows without bound and peers that were
+                                        // once promoted via handle_governor_action can never be
+                                        // re-promoted by the governor after a subsequent demotion.
+                                        lifecycle.handle_governor_action(
+                                            dugite_network::peer::governor::GovernorAction::PromoteToHot(addr),
+                                            &mut pm,
+                                        ).await;
+                                        governor.promotion_warm_completed(&addr);
+                                    }
                                     other => {
                                         lifecycle.handle_governor_action(other, &mut pm).await;
                                     }

--- a/crates/dugite-node/src/node/networking.rs
+++ b/crates/dugite-node/src/node/networking.rs
@@ -551,23 +551,6 @@ impl NodePeerManager {
         }
     }
 
-    /// Transition an active outbound connection back to idle.
-    ///
-    /// Called when demoting hot → warm on an outbound connection.
-    /// `OutboundDup` → `OutboundIdle(Duplex)`, `OutboundUni` → `OutboundIdle(Unidirectional)`.
-    pub fn mark_outbound_idle(&mut self, addr: &SocketAddr) {
-        if let Some(state) = self.conn_states.get(addr) {
-            let new_state = match state {
-                ConnectionState::OutboundDup => ConnectionState::OutboundIdle(DataFlow::Duplex),
-                ConnectionState::OutboundUni => {
-                    ConnectionState::OutboundIdle(DataFlow::Unidirectional)
-                }
-                _ => return,
-            };
-            self.conn_states.insert(*addr, new_state);
-        }
-    }
-
     /// Transition an inbound idle connection to active (responder protocols running).
     ///
     /// Called when promoting warm → hot on an inbound connection.
@@ -576,20 +559,6 @@ impl NodePeerManager {
         if let Some(state) = self.conn_states.get(addr) {
             let new_state = match state {
                 ConnectionState::InboundIdle(df) => ConnectionState::InboundState(*df),
-                _ => return,
-            };
-            self.conn_states.insert(*addr, new_state);
-        }
-    }
-
-    /// Transition an active inbound connection back to idle.
-    ///
-    /// Called when demoting hot → warm on an inbound connection.
-    /// `InboundState(df)` → `InboundIdle(df)`.
-    pub fn mark_inbound_idle(&mut self, addr: &SocketAddr) {
-        if let Some(state) = self.conn_states.get(addr) {
-            let new_state = match state {
-                ConnectionState::InboundState(df) => ConnectionState::InboundIdle(*df),
                 _ => return,
             };
             self.conn_states.insert(*addr, new_state);

--- a/crates/dugite-node/src/node/peer_connection.rs
+++ b/crates/dugite-node/src/node/peer_connection.rs
@@ -809,6 +809,23 @@ impl PeerConnection {
     pub fn has_hot_protocols(&self) -> bool {
         !self.hot_tasks.is_empty()
     }
+
+    /// Check whether the hot client protocol channels are still available for use.
+    ///
+    /// Returns `true` only if ALL three hot client channels (ChainSync, BlockFetch,
+    /// TxSubmission2) are present.  Once `start_hot_protocols` has been called,
+    /// all three channels are moved (`Option::take`) into their respective tasks
+    /// and this method returns `false` — the channels cannot be reclaimed without
+    /// closing the TCP connection and opening a fresh `PeerConnection`.
+    ///
+    /// Used as a pre-flight check in `promote_to_hot` to detect the warm→hot
+    /// promotion race (#516) early and emit a clear diagnostic before returning
+    /// `PeerConnectionError::ChannelUnavailable`.
+    pub fn has_hot_client_channels(&self) -> bool {
+        self.chainsync_client_channel.is_some()
+            && self.blockfetch_client_channel.is_some()
+            && self.txsubmission_client_channel.is_some()
+    }
 }
 
 /// Errors specific to `PeerConnection` lifecycle operations.
@@ -895,6 +912,66 @@ impl PeerConnection {
             server_tasks: Vec::new(),
         }
     }
+
+    /// Create a `PeerConnection` with **fake but present** hot client channels.
+    ///
+    /// Each channel is backed by a disconnected `mpsc` pair (the sender side is
+    /// kept alive for the lifetime of this helper).  The channels are functional
+    /// enough for `start_hot_protocols` / `has_hot_client_channels` checks; they
+    /// will return `MuxError::BearerClosed` on the first actual `recv()`.
+    ///
+    /// Used by regression tests for the warm→hot promotion race (#516).
+    pub(crate) fn fake_with_hot_channels(addr: SocketAddr) -> Self {
+        use std::sync::atomic::AtomicUsize;
+        use tokio::sync::mpsc;
+
+        fn make_channel(protocol_id: u16) -> MuxChannel {
+            // Shared egress queue — the sender end is kept alive by the channel itself.
+            let (egress_tx, _egress_rx) = mpsc::channel(32);
+            // Ingress: receiver lives inside MuxChannel; sender dropped immediately so
+            // recv() returns BearerClosed, mimicking a closed connection.
+            let (_ingress_tx, ingress_rx) = mpsc::channel(32);
+            MuxChannel::new(
+                protocol_id,
+                dugite_network::mux::segment::Direction::InitiatorDir,
+                egress_tx,
+                ingress_rx,
+                65536,
+                std::sync::Arc::new(AtomicUsize::new(0)),
+            )
+        }
+
+        let local_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mux_handle = tokio::spawn(async { Ok::<(), MuxError>(()) });
+
+        use dugite_network::protocol::{
+            PROTOCOL_N2N_BLOCKFETCH, PROTOCOL_N2N_CHAINSYNC, PROTOCOL_N2N_KEEPALIVE,
+            PROTOCOL_N2N_TXSUBMISSION,
+        };
+
+        Self {
+            addr,
+            local_addr,
+            direction: PeerConnectionDirection::Outbound,
+            version: 0,
+            network_magic: 0,
+            chainsync_client_channel: Some(make_channel(PROTOCOL_N2N_CHAINSYNC)),
+            blockfetch_client_channel: Some(make_channel(PROTOCOL_N2N_BLOCKFETCH)),
+            txsubmission_client_channel: Some(make_channel(PROTOCOL_N2N_TXSUBMISSION)),
+            keepalive_client_channel: Some(make_channel(PROTOCOL_N2N_KEEPALIVE)),
+            peersharing_client_channel: None,
+            chainsync_server_channel: None,
+            blockfetch_server_channel: None,
+            txsubmission_server_channel: None,
+            keepalive_server_channel: None,
+            peersharing_server_channel: None,
+            mux_handle,
+            cancel: tokio_util::sync::CancellationToken::new(),
+            warm_tasks: Vec::new(),
+            hot_tasks: Vec::new(),
+            server_tasks: Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -930,5 +1007,107 @@ mod tests {
     fn default_constants() {
         assert_eq!(DEFAULT_INGRESS_LIMIT, 64 * 1024 * 1024);
         assert_eq!(DEFAULT_CONNECT_TIMEOUT, Duration::from_secs(10));
+    }
+
+    // ── warm→hot promotion race regression tests (#516) ─────────────────────
+    //
+    // Root cause: `MuxChannel` is single-use.  Once `start_hot_protocols`
+    // moves the three client channels into their tasks, the `Option` fields are
+    // `None`.  Any subsequent `start_hot_protocols` call (e.g. after a
+    // governor-initiated Hot→Warm demotion followed by a PromoteToHot action)
+    // fails with `ChannelUnavailable("chainsync")`, producing the churn loop
+    // observed in the soak logs (#516).
+    //
+    // The fix is to close the TCP connection entirely on Hot→Warm demotion so
+    // that the next PromoteToWarm creates a fresh `PeerConnection` (and fresh
+    // channels).  These tests pin the channel-lifecycle invariants so a
+    // regression in the fix path is caught immediately.
+
+    /// Fresh connection: all hot client channels are present.
+    #[tokio::test]
+    async fn hot_channels_available_on_fresh_connection() {
+        let addr: SocketAddr = "10.0.0.1:3001".parse().unwrap();
+        let conn = PeerConnection::fake_with_hot_channels(addr);
+        assert!(
+            conn.has_hot_client_channels(),
+            "fresh connection must have all hot client channels available"
+        );
+    }
+
+    /// After `start_hot_protocols`, channels are consumed: subsequent call fails.
+    ///
+    /// This is the exact precondition that caused the churn loop in #516.
+    /// Without the `demote_to_warm` fix, a Hot→Warm demotion left channels
+    /// consumed, making the next `PromoteToHot` fail with ChannelUnavailable.
+    #[tokio::test]
+    async fn start_hot_protocols_consumes_channels_second_call_fails() {
+        let addr: SocketAddr = "10.0.0.2:3001".parse().unwrap();
+        let mut conn = PeerConnection::fake_with_hot_channels(addr);
+
+        assert!(
+            conn.has_hot_client_channels(),
+            "channels must be Some before first promotion"
+        );
+
+        // Protocol task factories that immediately return without reading/writing.
+        fn noop_fn() -> ProtocolTaskFn {
+            Box::new(move |_ch, _cancel| Box::pin(async {}))
+        }
+
+        // First promotion succeeds and consumes the channels.
+        conn.start_hot_protocols(noop_fn(), noop_fn(), noop_fn())
+            .expect("first start_hot_protocols must succeed");
+
+        assert!(
+            !conn.has_hot_client_channels(),
+            "channels must be None after start_hot_protocols (they were moved into tasks)"
+        );
+
+        // Second promotion — simulates PromoteToHot on a demoted-but-not-reconnected
+        // connection — must fail with ChannelUnavailable.
+        let err = conn
+            .start_hot_protocols(noop_fn(), noop_fn(), noop_fn())
+            .expect_err("second start_hot_protocols must fail (channels already consumed)");
+
+        assert!(
+            matches!(err, PeerConnectionError::ChannelUnavailable("chainsync")),
+            "expected ChannelUnavailable(\"chainsync\"), got: {err}"
+        );
+
+        // The error message must contain the string observed in the soak logs (#516).
+        assert!(
+            err.to_string()
+                .contains("chainsync channel unavailable (already taken)"),
+            "error Display must match the log string from #516: {err}"
+        );
+    }
+
+    /// After `stop_hot_protocols`, channels remain `None` — confirming that
+    /// stopping tasks does NOT restore channels and that reconnection is required.
+    ///
+    /// This pins the invariant that motivates the `demote_to_warm` fix:
+    /// closing the TCP connection on Hot→Warm is necessary because there
+    /// is no way to recover channels after the tasks have consumed them.
+    #[tokio::test]
+    async fn stop_hot_protocols_does_not_restore_channels() {
+        let addr: SocketAddr = "10.0.0.3:3001".parse().unwrap();
+        let mut conn = PeerConnection::fake_with_hot_channels(addr);
+
+        fn noop_fn() -> ProtocolTaskFn {
+            Box::new(move |_ch, _cancel| Box::pin(async {}))
+        }
+
+        conn.start_hot_protocols(noop_fn(), noop_fn(), noop_fn())
+            .expect("start_hot_protocols must succeed");
+
+        // Wait for the no-op tasks to exit naturally.
+        conn.stop_hot_protocols().await;
+
+        assert!(
+            !conn.has_hot_client_channels(),
+            "channels must remain None after stop_hot_protocols — \
+             stopping tasks does not restore consumed channels; \
+             reconnection is the only recovery path"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `MuxChannel` is single-use. After `start_hot_protocols` moves ChainSync/BlockFetch/TxSubmission2 channels into tasks via `Option::take`, the channels are gone forever. A governor-initiated `DemoteToWarm` (hot churn) left the connection with consumed (`None`) channels while the peer-manager showed `Warm`. The next `PromoteToHot` always failed with `chainsync channel unavailable (already taken)`, producing a churn loop: demotion → PromoteToHot failure → reconnect → re-promote → next demotion → repeat.
- **Secondary bug**: `governor.promotion_warm_completed()` was never called after `handle_governor_action(PromoteToHot)`, so `in_progress_promote_warm` grew without bound and could permanently suppress re-promotion.
- **Fix**: `demote_to_warm` now closes the TCP connection entirely (reconnect gives fresh channels). `promotion_warm_completed` is called after every `PromoteToHot` dispatch.

## Changes

**`connection_lifecycle.rs`**: `demote_to_warm` changed to close all connections and call `peer_disconnected` (cold), not just stop hot tasks. Updated module doc to explain the architecture divergence from Haskell.

**`mod.rs`**: Governor action dispatch loop now calls `governor.promotion_warm_completed(&addr)` after every `PromoteToHot` action.

**`networking.rs`**: Removed `mark_outbound_idle` / `mark_inbound_idle` (dead code — only called from the old `demote_to_warm` path).

**`peer_connection.rs`**: Added `has_hot_client_channels()` pre-flight check + `fake_with_hot_channels()` test helper + 3 regression tests.

## Regression tests

| Test | What it pins |
|------|--------------|
| `hot_channels_available_on_fresh_connection` | Fresh `PeerConnection` has all hot channels available |
| `start_hot_protocols_consumes_channels_second_call_fails` | Second `start_hot_protocols` call on same connection fails with exact soak-log error string |
| `stop_hot_protocols_does_not_restore_channels` | `stop_hot_protocols` does not restore consumed channels; reconnect is the only recovery path |

## Observed vs expected

**Before**: Multiple peers simultaneously failing `warn failed to promote warm -> hot addr=X error=chainsync channel unavailable (already taken)` every hot-churn cycle (~10 min). Peers reconnect and repeat.

**After**: Hot churn demotes to cold (closes TCP). Next governor tick reconnects with fresh channels. `PromoteToHot` succeeds. No churn.

## Tradeoff

Hot→Warm demotion now costs one extra reconnect latency (~RTT) per churn cycle vs. Haskell's keep-TCP-alive semantics. Hot churn fires at most every 10 minutes; at tip this is infrequent. The alternative (reusable `MuxChannel`) would require rearchitecting the mux to return channels from tasks — deferred as future work.

Closes #516