### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "bech32 0.11.1",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-config"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-conformance"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "dugite-crypto",
  "dugite-ledger",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-consensus"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-crypto"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "curve25519-dalek 3.2.0 (git+https://github.com/iquerejeta/curve25519-dalek?branch=ietf03_vrf_compat_ell2)",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-golden-tests"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "dugite-crypto",
  "dugite-network",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-integration-tests"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "dugite-consensus",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-ledger"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode 1.3.3",
  "criterion",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-lsm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-mempool"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-monitor"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-network"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-node"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-primitives"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bech32 0.11.1",
  "blake2 0.10.6",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-serialization"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-storage"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bytes",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/michaeljfazio/dugite"


### PR DESCRIPTION
## Summary

- Bumps workspace version `1.6.0` → `1.7.0` in `Cargo.toml` and regenerates `Cargo.lock`.
- No code changes — this PR is purely the version stamp for the v1.7.0 release.

## Changes since v1.6.0

- **#533** (`d7abdf453`) — `feat(network): CSJ state machine module — #334 Phase A`. New self-contained `jumping.rs` module (~852 lines, 32 unit tests). Pure state machine; not yet wired into live ChainSync. Closes #334 Phase A; remaining Phases B–F tracked in #527–#532 under epic #480.
- **#534** (`0b606a604`) — `feat(network): DNS SRV resolution for relay topology (#474 item 3)`. Implements Haskell cardano-node SRV-first DNS strategy (`_cardano._tcp.<host>`) for topology access points. Falls back to A/AAAA when no SRV records. Backward compatible with existing topology JSON.

## Known limitations (release notes)

- CSJ Phase A landed but not yet wired — Phases B–F tracked in #527–#532 under epic #480.
- DNS SRV resolution is active code but `_cardano._tcp.` records are rarely published; A/AAAA fallback is the active path in practice.
- **Issue #535**: `ConsensusMode` JSON config field is loaded but not wired to the runtime gate. Workaround: pass `--consensus-mode genesis` on the CLI.

## Validation completed

- Preview 10-min soak: PASS (10 hot peers, +1132 blocks, tip live, 0 errors)
- Preprod 10-min soak: PASS (13 hot peers, +43 blocks, tip live, 0 errors)
- Local devnet 30-min soak (Genesis mode): PASS — 363 canonical blocks, 100% tip parity, 0 ERRORs, 0 panics; Phase-1 tx validation: 43 txs submitted, 17 accepted / 26 rejected

## Test plan

- [ ] CI passes (build-and-test, clippy, fmt, integration-offline, release-binaries)
- [ ] `git log v1.6.0..v1.7.0 --oneline` shows exactly 3 commits (2 feature + version bump)
- [ ] Release artifacts attach to the GitHub release page (linux x86_64, linux aarch64, macOS x86_64, macOS aarch64)