### PR TITLE
feat(uplc): scaffold first-party dugite-uplc + design synthesis (UPLC-0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dugite-uplc"
+version = "1.7.0"
+dependencies = [
+ "blake2 0.10.6",
+ "hex",
+ "minicbor 0.26.5",
+ "num-bigint",
+ "num-traits",
+ "proptest",
+ "serde_json",
+ "sha2 0.11.0",
+ "sha3",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/dugite-integration-tests",
     "crates/dugite-monitor",
     "crates/dugite-config",
+    "crates/dugite-uplc",
     "tests/conformance",
     "tests/golden",
 ]
@@ -40,6 +41,7 @@ dugite-node = { path = "crates/dugite-node" }
 dugite-cli = { path = "crates/dugite-cli" }
 dugite-lsm = { path = "crates/dugite-lsm" }
 dugite-monitor = { path = "crates/dugite-monitor" }
+dugite-uplc = { path = "crates/dugite-uplc" }
 
 # Terminal UI
 ratatui = "0.30"

--- a/crates/dugite-uplc/Cargo.toml
+++ b/crates/dugite-uplc/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "dugite-uplc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Untyped Plutus Core (UPLC) evaluator, flat/CBOR codec, and CEK machine for the dugite Cardano node"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[dependencies]
+# Crypto primitives (BLS12-381, ed25519, sha2/3, blake2, keccak256, ripemd160,
+# secp256k1) for the Cardano-specific UPLC builtins. We deliberately avoid
+# any third-party UPLC implementation here; only crypto primitives.
+blake2 = { workspace = true }
+sha2 = { workspace = true }
+sha3 = { workspace = true }
+# ripemd & keccak are pulled in via sha3 features where possible.
+
+# Integer arithmetic for the `integer` and rational-cost-model paths.
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+
+# CBOR for the outer Program envelope and the `Data` type. We use minicbor
+# (not pallas-codec) to keep dugite-uplc free of the pallas dependency chain.
+minicbor = { workspace = true }
+
+# Logging.
+tracing = { workspace = true }
+
+# Errors.
+thiserror = { workspace = true }
+
+# Hex display for Data debug output.
+hex = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde_json = { workspace = true }
+
+[lib]
+name = "dugite_uplc"
+path = "src/lib.rs"

--- a/crates/dugite-uplc/DESIGN.md
+++ b/crates/dugite-uplc/DESIGN.md
@@ -1,0 +1,347 @@
+# dugite-uplc — Design synthesis
+
+> **Status: pre-implementation.** The crate currently exposes only module
+> skeletons + this design doc. The first commit lands the scaffolding +
+> the synthesis here; subsequent commits add `flat`, `data`, `machine`,
+> `builtin`, and the phase-2 wrapper in that order.
+
+## Goal
+
+Replace the `aiken-lang/uplc` dependency (and its transitive
+`pallas-codec`/`pallas-primitives`/`pallas-addresses`/`pallas-crypto`/`pallas-traverse`
+chain) with a first-party Rust implementation of:
+
+1. Untyped Plutus Core AST.
+2. The flat wire codec.
+3. The PlutusData type + its CBOR codec.
+4. The CEK abstract machine.
+5. The full Cardano default-builtin suite (V1, V2, V3).
+6. A V1/V2/V3 script-context (`TxInfo` / `ScriptContext`) builder.
+7. A `phase_two_evaluate` façade that mirrors aiken's
+   `tx::eval_phase_two_raw` API surface for drop-in replacement in
+   `dugite-ledger/src/plutus.rs`.
+
+Non-goals:
+
+- A textual UPLC parser (only used for tests; we'll add one later if
+  needed for conformance vectors).
+- Program optimisation passes (the validation path doesn't run them).
+- WASM / browser support.
+
+## Hard requirements (all enforced by `#![deny]` lints at the crate root)
+
+1. **Panic-free on adversarial input.** No `unwrap`, `expect`, `panic!`,
+   `todo!`, `unimplemented!`, `unreachable!` reachable from any byte
+   that comes off the wire. Adversaries control the witness-set script
+   bytes via gossiped transactions — a panic is a remote DoS.
+2. **Bounded allocation.** Every peer-supplied length header is
+   sanity-clamped (the same `safe_alloc_capacity` pattern we landed in
+   `dugite-serialization::decode::reader`).
+3. **Bounded recursion.** No raw recursion over the term tree; the CEK
+   machine carries an explicit heap-allocated continuation stack. The
+   flat decoder and PlutusData decoder both thread an explicit depth
+   counter.
+4. **Bit-for-bit byte-exact compatibility** with cardano-node Haskell on
+   the wire: flat-encoded scripts and CBOR-encoded `Data` round-trip
+   identically; CEK evaluation produces identical `EvalResult` for
+   identical inputs across platforms.
+5. **No third-party UPLC dependencies.** No aiken-uplc, no
+   pallas-anything, no amaru-uplc. The only runtime deps are
+   `blake2`, `sha2`, `sha3`, `secp256k1` or `k256`, `blst`,
+   `num-bigint`, `num-traits`, `minicbor`, `thiserror`, `tracing`,
+   `hex`.
+
+## Authoritative references
+
+Normative (must match byte-for-byte):
+
+| Topic | Source |
+|---|---|
+| UPLC language + CEK reduction rules | `IntersectMBO/plutus:plutus-core/docs/plutus-core-spec` (typeset PDF + LaTeX). |
+| Flat encoding | Same spec, "Flat" appendix. |
+| `PlutusData` CBOR | `IntersectMBO/plutus:plutus-core/plutus-core/src/PlutusCore/Data.hs`. |
+| Default builtins | `IntersectMBO/plutus:plutus-core/plutus-core/src/PlutusCore/Default/Builtins.hs`. |
+| BLS12-381 | CIP-0381 (zkcrypto/IETF serialisation, BLS12381G[12]\_XMD:SHA-256\_SSWU\_RO\_, strict subgroup checks). |
+| Keccak-256 + Blake2b-224 | CIP-0127. |
+| RIPEMD-160 | CIP-0101. |
+| IntegerToByteString / ByteStringToInteger | CIP-0117. |
+| ByteString bitwise builtins | CIP-0123. |
+| ScriptContext V2 | CIP-0033. |
+| ScriptContext V3 + governance | CIP-0035 + CIP-1694. |
+| Cost-model parameter order | `IntersectMBO/plutus:plutus-core/cost-model/` + Conway-era `cardano-ledger-conway/cddl-files/conway.cddl`. |
+| Conformance corpus | `IntersectMBO/plutus:plutus-conformance/test-cases/`. |
+
+Reference implementations to study (NOT to depend on):
+
+| Source | What to steal | What to skip |
+|---|---|---|
+| `IntersectMBO/plutus` (Haskell) | Canonical CEK + cost-model + builtin denotations. Read line-by-line when designing each component. | — (reference only). |
+| `pragma-org/uplc` (`amaru-uplc`) | Bumpalo arena + three-state CEK driver + slippage budget + linked Env/Context. Generic-over-binder pattern. Builtin enum with `#[repr(u8)]` + `force_count()`/`arity()`/`is_available_in()`. | Unbounded recursive `decode_term` (DoS), `Constr.tag: usize` truncation, `Runtime` arg-vec clone-per-apply (quadratic), string-keyed `HashMap` cost map, missing `phase_two` API. |
+| `aiken-lang/uplc` | Field-by-field `TxInfoV1/V2/V3` constructors in `tx/script_context.rs`; redeemer iteration shape in `tx/eval.rs`. | `Rc<Term>` cloning hot path, pallas-codec dep, 30+ `unwrap`/`unreachable!`/`unimplemented!` sites on adversarial paths (catalogued in §6 below). |
+
+## Architecture
+
+```
+crates/dugite-uplc/
+├── src/
+│   ├── lib.rs           // re-exports + crate docs
+│   ├── error.rs         // UplcError taxonomy
+│   ├── term.rs          // Term, Constant, TypeTag, BuiltinId
+│   ├── data.rs          // PlutusData
+│   ├── program.rs       // Program (CBOR ⇄ flat ⇄ AST boundary)
+│   ├── flat/
+│   │   ├── mod.rs       // shared types, FLAT_MAX_DEPTH
+│   │   ├── decode.rs    // bit-stream → Term
+│   │   └── encode.rs    // Term → bit-stream
+│   ├── machine/
+│   │   ├── mod.rs       // ExBudget, EvalResult, MAX_KONTINUATION_DEPTH
+│   │   ├── env.rs       // De Bruijn env (cons-list)
+│   │   ├── context.rs   // continuation frames
+│   │   ├── value.rs     // CEK values
+│   │   ├── step.rs      // step / compute / return_compute
+│   │   └── cost.rs      // ExBudget arithmetic + step kinds
+│   └── builtin/
+│       ├── mod.rs       // entry points
+│       ├── arity.rs     // force_count + arity per BuiltinId
+│       ├── dispatch.rs  // BuiltinId → eval function
+│       ├── sized.rs     // size estimators for costing
+│       └── denotations.rs // actual builtin implementations
+└── DESIGN.md            // (this file)
+```
+
+Crates added later (separate PRs):
+
+```
+crates/dugite-uplc-script-context/    // TxInfoV1/V2/V3 + ScriptContext builders
+crates/dugite-uplc-phase-two/         // phase_two_evaluate(tx, utxos, ...) façade
+```
+
+(or — equivalent — additional modules inside `dugite-uplc` if we want a
+single crate. We'll decide when the design lands; the modular split
+keeps build times for the inner CEK loop bounded.)
+
+## Component design
+
+### Term & Constant (`src/term.rs`)
+
+- De Bruijn indices end-to-end. No `Name` / `NamedDeBruijn` enum
+  variants — the flat decoder emits `DeBruijn` directly and the CEK
+  consumes it directly.
+- `Term` recursion uses `Box<Term>` (not `Rc`, not arena indices). The
+  CEK machine never walks the term tree recursively; the term tree is
+  immutable once decoded, so a single allocation per node and no
+  sharing is fine. The decoder threads a depth budget.
+- `Constr.tag: u64` (NOT `usize` — wire spec is `Word64`; aiken's `usize`
+  truncates on 32-bit hosts).
+- `Constant::Bls12_381G1Element` / `G2Element` / `MlResult` are boxed
+  to keep the enum size bounded.
+- `BuiltinId` is a `#[repr(u8)]` `#[non_exhaustive]` enum whose
+  discriminants match the Haskell `DefaultFun` ordering verbatim
+  (normative — the flat encoding stores the builtin as a 7-bit
+  discriminant). New entries are appended; never reordered.
+
+### Error taxonomy (`src/error.rs`)
+
+`UplcError` distinguishes:
+
+- `FlatDecode(String)` — wire-format error.
+- `CborDecode(String)` — outer envelope / `Data` CBOR error.
+- `Encode(String)` — encoder error (kept fallible for API uniformity).
+- `ScriptError` — the script evaluated to `Term::Error`.
+- `BudgetExhausted { cpu_remaining, mem_remaining }`.
+- `BuiltinTypeError { builtin, reason }` — argument shape mismatch
+  (must not be reachable from the CEK's own checks for a well-typed
+  program; reachable from adversarial `Data` lift).
+- `BuiltinFailure { builtin, reason }` — builtin returned an error
+  (e.g. division by zero, ed25519 verify failure).
+- `NonUnitReturn` — V3 contract returned non-`Unit`.
+- `Internal(String)` — invariant violation in dugite-uplc itself.
+  Surfaced as a typed error rather than a panic so tests + monitoring
+  can detect it; CI gates on zero occurrences.
+
+### Flat decoder (`src/flat/decode.rs`)
+
+Bit-stream reader: `struct BitReader<'b> { bytes: &'b [u8], byte_pos: usize, bit_pos: u8 }`.
+
+Public entry points:
+
+```rust
+pub fn decode_program(bytes: &[u8]) -> FlatResult<Program>;
+pub fn decode_term(bytes: &[u8]) -> FlatResult<Term>;
+```
+
+Hard invariants:
+
+1. `ensure_bits(n)` is called before every `bits8` / `bool` / `bit`.
+2. `word()` / `big_word()` reject varints whose total shift would
+   exceed the target type's bit width (varint termination is bounded
+   by `usize::BITS / 7 + 1` chunks).
+3. `decode_term` threads a depth counter; exceeding `FLAT_MAX_DEPTH`
+   (4096) returns `FlatDecode("depth limit exceeded")`.
+4. Every `Vec::with_capacity(N)` uses `min(N, remaining_bits / 4)`.
+5. Unknown term tags → `FlatDecode("unknown term tag {bits:#06b}")`.
+6. Unknown builtin discriminants → `FlatDecode("unknown builtin id {n}")`.
+7. Unknown constant universe-tag sequences → `FlatDecode("unknown universe tag {bits}")`.
+
+### CEK machine (`src/machine/`)
+
+Three-state driver (mirroring the Haskell reference):
+
+```rust
+enum MachineState {
+    Compute(Context, Env, Term),
+    Return(Context, Value),
+    Done(Term),
+}
+```
+
+- `Context` = explicit continuation stack (`Vec<Frame>`, heap-allocated,
+  capped at `MAX_KONTINUATION_DEPTH = 4096`). Frame variants follow the
+  spec: `AwaitArg`, `AwaitFunTerm`, `AwaitFunValue`, `Force`, `Constr`,
+  `Cases`.
+- `Env` = persistent cons-list of `Value`s. De Bruijn lookup is O(index)
+  linear (matches Haskell exactly; mainnet scripts don't have
+  pathologically deep envs).
+- `Value` = `Con(Constant) | Lambda { body, env } | Builtin(Runtime) | Delay { term, env } | Constr { tag, args }`.
+- Budget accounting uses the **slippage** scheme:
+  `unbudgeted_steps: [u8; 10]`, `slippage = 200`. Every step bumps the
+  per-kind counter + the global counter; we flush to `ExBudget` only
+  when the global counter overflows or when `Context::NoFrame` is hit
+  on return. This mirrors Haskell's optimisation byte-for-byte and is
+  cheaper than per-step `ExBudget` subtraction.
+- Cost-model lookup is `[i64; N]` keyed by `StepKind` enum — NOT a
+  string-keyed `HashMap` like pragma-org/uplc. The parameter slice
+  from protocol-params CBOR is loaded once at evaluation start and
+  validated against the expected length for the script's language
+  version + protocol version.
+
+### Builtins (`src/builtin/`)
+
+- Dispatch is a single `match` on `BuiltinId`, NOT a giant table of
+  function pointers. The match expands to one arm per builtin (~88
+  arms in PV11+). Each arm:
+  1. Charges the budget via `costs.builtin(BuiltinId).cpu_for(arg_mem_sizes)` etc., BEFORE allocating result.
+  2. Type-checks and unwraps args via copy-free `unwrap_*` helpers on `&Value`.
+  3. Computes the result.
+  4. Returns `Value::Con(result)` or `UplcError::BuiltinFailure`.
+- A single `bigint_to_bounded(b: &BigInt, max: usize) -> Result<usize, UplcError>` chokepoint covers every place a script-controlled `BigInt` becomes a `usize` (`IndexByteString`, `SliceByteString`, `ShiftByteString`, `RotateByteString`, `ReadBit`, `WriteBits`, `ReplicateByte`, `FindFirstSetBit`, `IntegerToByteString`). The function caps at `min(64 KiB, mem_budget_remaining / 8)` so a script can't drain the mem budget via a single fat allocation.
+- BLS12-381: `blst` is the implementation. Subgroup checks are wired through `Compressable::uncompress`. Inputs in the wrong subgroup → `UplcError::BuiltinFailure`. Cross-platform reproducibility is verified in CI on x86_64 + aarch64 via the IntersectMBO conformance corpus.
+- ed25519: `ed25519-dalek` with the "no malleability check" path (Cardano accepts the pre-RFC-8032 weak verifier — confirmed via the cardano-base `cardano-crypto-praos` source). TODO at implementation time: cross-check against conformance vectors.
+- secp256k1: `k256` (pure-Rust) used for both ECDSA and Schnorr to avoid the secp256k1-sys C dep. Will validate against CIP-49 test vectors.
+
+### PlutusData (`src/data.rs` + `src/data/codec.rs`)
+
+- `Data` is `Constr(u64, Vec<Data>) | Map(Vec<(Data, Data)>) | List(Vec<Data>) | I(BigInt) | B(Vec<u8>)`. Insertion order preserved (no sorting on decode — Haskell doesn't sort, and we must not change body hashes).
+- CBOR encoder (using `minicbor`):
+  - Constr tag in `0..=6` → CBOR tag `121 + i`, payload = fields array.
+  - Constr tag in `7..=127` → CBOR tag `1280 + (i - 7)`, payload = fields array.
+  - Constr tag outside that range → CBOR tag `102`, payload = `[i, fields]`.
+  - `I(n)` for `n` in i64 range → major 0 / major 1. Otherwise → CBOR tag 2 (positive bignum) or tag 3 (negative bignum) wrapping a byte string.
+  - `Map` and `List` and `B` follow the 64-element/byte definite-vs-indefinite cutoff on encode; decoder accepts either form.
+- Decoder threads a depth counter (max 256).
+
+### Phase-two wrapper (separate crate or module)
+
+The drop-in replacement for `uplc::tx::eval_phase_two_raw` exposes:
+
+```rust
+pub fn evaluate_phase_two(
+    tx: &dugite_primitives::transaction::Transaction,
+    utxo_lookup: &dyn dugite_ledger::utxo::UtxoLookup,
+    cost_models: &CostModels,
+    initial_budget: ExBudget,
+    slot_config: &SlotConfig,
+) -> Result<Vec<RedeemerEvalResult>, UplcError>;
+```
+
+Internally:
+
+1. Build the script-version map (which redeemers attach to V1 / V2 / V3
+   scripts).
+2. For each redeemer (tag + index):
+   1. Construct the appropriate `TxInfo` per version (V1/V2/V3).
+   2. Wrap into `ScriptContext` (V1/V2) or `ScriptInfo`-typed
+      `ScriptContext` (V3).
+   3. Load the script bytes; flat-decode into `Program`.
+   4. Apply datum (V1/V2 spending only) + redeemer + context as
+      arguments via `Program::apply`.
+   5. Evaluate via `Machine::run`.
+   6. Collect `RedeemerEvalResult { redeemer_cbor, ex_units, result }`.
+3. Phase-1 (redeemer-script linkage) lives in `dugite-ledger`, not
+   here. Aiken put it inside the uplc crate (`tx/phase_one.rs`); that
+   was wrong — phase-1 is pure ledger logic.
+
+### V3 Unit-return enforcement
+
+V3 (PV9+) scripts must return `Unit`. Any other return value is treated
+as `InvalidReturnValue`. Implementation: post-evaluation, the
+phase-two wrapper checks the result `Term`; non-Unit → `UplcError::NonUnitReturn`.
+
+## What we explicitly do not copy
+
+From pragma-org/uplc:
+
+- **Unbounded recursive `decode_term`** — stack-overflow DoS. We thread an explicit depth budget instead.
+- **`Constr.tag: usize`** — truncates on 32-bit hosts. We use `u64`.
+- **`Runtime::push` cloning the entire args vec on each apply** — quadratic in arity. We use a persistent cons-list for accumulated args, mirroring `Env`.
+- **String-keyed `HashMap` cost map** — slow + lossy on missing keys. We use `[i64; N]` keyed by an enum, with length-checked loading.
+- **`expect`/`unreachable!` in `runtime.rs`** — ~30 sites currently. Every one is replaced with `Result`-typed errors.
+- **Two near-identical decode functions** (`decode_constant` vs `decode_constant_with_type`). Single parameterised function instead.
+- **Public APIs leaking arena lifetimes** — we hide all allocation behind a façade.
+
+From aiken-lang/uplc:
+
+- **`Rc<Term>` cloning per CEK step** — measurable hot path. `Box<Term>` + arena-of-frames is sufficient.
+- **`unimplemented!()` on non-Conway era in `eval_phase_two_raw`** — we return a typed error.
+- **Pallas dependency** for all CBOR / tx / address / crypto. We use `dugite-serialization`, `dugite-primitives`, `dugite-crypto`.
+- **Two-layer binder gymnastics** (`Name` / `NamedDeBruijn` / `FakeNamedDeBruijn` / `DeBruijn`). De Bruijn end-to-end.
+
+## Catalogued panic sites in third-party UPLCs (do not reproduce)
+
+Sites the dugite fuzz targets reach via adversarial witness scripts:
+
+- `pallas-codec/src/flat/decode/decoder.rs:65` — unchecked `self.buffer[self.pos]` in `bool()` at EOF.
+- `pallas-codec/src/flat/decode/decoder.rs:154` — unbounded shift in `word()`; debug = panic, release = silent corruption.
+- `aiken-lang/uplc/src/tx.rs:181` — `unimplemented!()` on pre-Conway era.
+- `aiken-lang/uplc/src/tx.rs:194` — `.unwrap()` on `PlutusData::decode_fragment(params_bytes)` returning `Err(EndOfInput)`; plus `unreachable!()` if the decoded form isn't `Array`.
+- `aiken-lang/uplc/src/machine/runtime.rs` lines 549, 554, 574, 879, 1451, 1610, 1612, 1636, 1638, 1656, 1676, 1687, 1689, 1708, 1747 — `BigInt → usize/u64/i128` `.try_into().unwrap()` on script-controlled values.
+- `aiken-lang/uplc/src/machine/runtime.rs` lines 875, 904, 910, 927, 1627 — `unreachable!()` guarded only by upstream type checks.
+- `aiken-lang/uplc/src/machine/runtime.rs:963` — `c.any_constructor.unwrap()` on `Constr` with tag outside 121-127/1280-1400 and no fallback.
+- `aiken-lang/uplc/src/tx/script_context.rs:36-37` — `Address::from_bytes().unwrap()` on output address from CBOR-valid bytes.
+- `aiken-lang/uplc/src/tx/script_context.rs:646,1133` — `unreachable!("invalid reward address")`.
+
+All of these are reachable from witness-set scripts on the gossip layer
+and have produced libfuzzer crashes in dugite's fuzz CI. dugite-uplc
+must demonstrably not have analogues — the fuzz matrix gates on it.
+
+## Open questions (to be answered in implementation PRs)
+
+1. Single-crate or multi-crate split for the phase-two wrapper? (Likely
+   single, with the wrapper in `crates/dugite-uplc/src/phase_two/`.)
+2. ed25519 verifier strictness: dalek's `verify` vs `verify_strict` vs a
+   custom relaxed verifier matching cardano-base. Conformance corpus
+   will decide.
+3. secp256k1: `k256` (pure-Rust) vs `secp256k1` (libsecp256k1 bindings).
+   `k256` is more deterministic but ~2× slower; we'll benchmark before
+   the V1 builtin lands.
+4. Cost-model parameter ingestion: parse the protocol-params CBOR
+   here, or take a `&[i64]` slice with length-checked loading? Likely
+   the latter — the parsing belongs in `dugite-serialization`.
+
+## Implementation order
+
+1. **(this commit)** scaffold + design doc + module skeleton — landed.
+2. PR 1: PlutusData CBOR codec + `Data` round-trip tests against
+   IntersectMBO conformance fixtures.
+3. PR 2: Flat decoder + encoder + round-trip property tests.
+4. PR 3: CEK machine (no builtins yet — only `lam`/`app`/`var`/`force`/`delay`/`const`/`error`/`constr`/`case`).
+5. PR 4: Builtin suite (V1) + cost model loader.
+6. PR 5: Builtin suite (V2) + CIP-0033.
+7. PR 6: Builtin suite (V3) + CIP-0035 + CIP-0117 + CIP-0123 + CIP-0127 + CIP-0101 + CIP-0381.
+8. PR 7: ScriptContext V1/V2/V3 builders.
+9. PR 8: phase-two façade + integration into `dugite-ledger/src/plutus.rs`.
+10. PR 9: drop `uplc = { git = ... aiken-lang/aiken.git ... }` from workspace and confirm `cargo tree | grep pallas` is empty.
+
+Conformance corpus from `IntersectMBO/plutus:plutus-conformance` runs
+as an integration test on every PR after PR 3; the release gate is
+100% pass.

--- a/crates/dugite-uplc/DESIGN.md
+++ b/crates/dugite-uplc/DESIGN.md
@@ -314,6 +314,67 @@ All of these are reachable from witness-set scripts on the gossip layer
 and have produced libfuzzer crashes in dugite's fuzz CI. dugite-uplc
 must demonstrably not have analogues — the fuzz matrix gates on it.
 
+## Conformance gotchas from the Haskell reference
+
+Surfaced by the cardano-haskell-oracle survey of `IntersectMBO/plutus`
+HEAD; each is a place where the obvious-looking Rust translation
+diverges from cardano-node and must be tested explicitly:
+
+1. **Program version gate for `Constr`/`Case`.** Flat tags 8 and 9 are
+   only legal when the program's outer version triple is `≥ 1.1.0`. A
+   `1.0.0` program containing either node fails *phase-1* with
+   `not allowed before version 1.1.0`. The flat decoder must thread
+   the program version through so it can reject early.
+
+2. **PlutusData 64-byte bytestring limit at decode.** Definite-length
+   `B` leaves over 64 bytes are decode errors. Larger byte strings
+   must use indefinite-length chunking. Integer bignums must have a
+   ≤ 64 byte payload too. (Source: `decodeBoundedBytes` in
+   `plutus-core/.../Data.hs`.)
+
+3. **`Map` semantics for `Data`.** Duplicate keys are accepted; order
+   is preserved as-is; no canonical-form enforcement. Scripts that
+   need uniqueness enforce it themselves. Definite-length on encode.
+
+4. **`Index = 0` is a sentinel free variable.** `mkTermToEvaluate`
+   runs `checkScope` *before* evaluation and rejects programs with
+   any free De Bruijn variable. `checkScope` failure is reported as
+   a *phase-2* error (charged collateral), not a decode error.
+
+5. **Slippage overshoot.** `defaultSlippage = 200` — scripts can
+   exceed their budget by up to ~200 step-costs before the machine
+   notices. The final returned `ExBudget` is the *remaining* budget
+   (negative on overshoot); the ledger checks `final >= 0`. Don't
+   short-circuit on exact-zero; honour the slippage.
+
+6. **`DefaultUniValue` and the new `Value`-tagged builtins**
+   (`InsertCoin`, `LookupCoin`, `UnionValue`, `ValueContains`,
+   `ValueData`, `UnValueData`, `ScaleValue`) are on `IntersectMBO/plutus`
+   master but **not** enabled in current mainnet protocol versions.
+   Do not implement in the initial dugite-uplc target — but reserve
+   the `BuiltinId` discriminants so we don't have to renumber later.
+
+7. **V3-only fee/mint semantics.** `txInfoFee` is `Lovelace` (not
+   `Value`) and `txInfoMint` is `MintValue` (the zero-Ada invariant is
+   enforced at the ledger level: zero-quantity Ada entries never
+   appear). The V1/V2 `Value`-typed fee field is V1/V2-only.
+
+8. **V3 `ScriptContext` shape change.** V3 has three fields, not
+   two: `txInfo`, `redeemer`, and `scriptInfo`. The third field
+   (`scriptInfo`) replaces V1/V2's `scriptContextPurpose` with a
+   richer type that carries the inline datum for `SpendingScript`.
+
+9. **V3 redeemer iteration adds voting + proposing.** The
+   `ScriptPurpose` enum gains `Voting Voter` and
+   `Proposing Integer ProposalProcedure` variants on top of the V2
+   four (`Minting`, `Spending`, `Rewarding`, `Certifying`).
+
+10. **Reference script size fee** (Conway). `txNonDistinctRefScriptsSize`
+    sums `originalBytesSize` of all reference scripts referenced by
+    inputs ∪ reference inputs, *counting duplicates*, and is fed into
+    minimum-fee computation. This is a fee rule (phase-1), not a
+    script-budget rule.
+
 ## Open questions (to be answered in implementation PRs)
 
 1. Single-crate or multi-crate split for the phase-two wrapper? (Likely

--- a/crates/dugite-uplc/src/builtin/arity.rs
+++ b/crates/dugite-uplc/src/builtin/arity.rs
@@ -1,0 +1,2 @@
+//! Builtin arity — scaffolding placeholder (see builtin/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/builtin/denotations.rs
+++ b/crates/dugite-uplc/src/builtin/denotations.rs
@@ -1,0 +1,2 @@
+//! Builtin denotations — scaffolding placeholder (see builtin/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/builtin/dispatch.rs
+++ b/crates/dugite-uplc/src/builtin/dispatch.rs
@@ -1,0 +1,2 @@
+//! Builtin dispatch — scaffolding placeholder (see builtin/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/builtin/mod.rs
+++ b/crates/dugite-uplc/src/builtin/mod.rs
@@ -1,0 +1,35 @@
+//! Plutus Core builtin function dispatch.
+//!
+//! Every builtin has:
+//!
+//!  - A fixed [`crate::term::BuiltinId`] discriminant (matches the
+//!    Haskell `DefaultFun` ordering verbatim — wire-compatible).
+//!  - A *forces-and-args* signature: how many `Force`s must precede the
+//!    first argument, and what type each argument must have.
+//!  - A cost-model entry: a `CostingFun` per builtin keyed by the input
+//!    sizes (constant / linear / quadratic depending on the builtin).
+//!  - A *denotation*: the actual function, returning either a value or
+//!    [`crate::UplcError::BuiltinFailure`].
+//!
+//! Bit-for-bit reproducibility against cardano-node requires:
+//!
+//!  - **Integer arithmetic** matches `Integer` (i.e. `BigInt`).
+//!  - **ByteString** ops match Haskell `ByteString` (length-prefix
+//!    is `Int64`; we treat it as `u64` with a hard cap).
+//!  - **Sha2_256 / Sha3_256 / Blake2b_256 / Blake2b_224 / Keccak_256
+//!    / Ripemd_160** use the exact reference algorithms.
+//!  - **VerifyEd25519Signature** uses the standard ed25519 (not
+//!    ed25519-dalek's verify_strict, but Cardano's pre-RFC-8032
+//!    relaxed verifier — TODO confirm with conformance vectors).
+//!  - **VerifyEcdsaSecp256k1Signature / VerifySchnorrSecp256k1Signature**
+//!    follow CIP-49.
+//!  - **BLS12-381 ops** follow CIP-0381 (zkcrypto/IETF serialisation,
+//!    BLS12381G[12]_XMD:SHA-256_SSWU_RO_ ciphersuites, strict subgroup
+//!    checks). Implementation will use `blst` for performance.
+
+#![allow(dead_code)]
+
+pub mod arity;
+pub mod denotations;
+pub mod dispatch;
+pub mod sized;

--- a/crates/dugite-uplc/src/builtin/sized.rs
+++ b/crates/dugite-uplc/src/builtin/sized.rs
@@ -1,0 +1,2 @@
+//! Builtin sized — scaffolding placeholder (see builtin/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/data.rs
+++ b/crates/dugite-uplc/src/data.rs
@@ -1,0 +1,50 @@
+//! The `Data` type — PlutusData.
+//!
+//! `Data` is the recursive sum type that the Cardano on-chain script
+//! context (TxInfo) and per-redeemer datums/redeemers are encoded into.
+//! Its CBOR encoding is well-known and **not** subject to RFC 8949 §4.2
+//! canonical-form enforcement at the decoder level (the Haskell decoder
+//! accepts non-canonical encodings). However, *bignum* tag handling is
+//! strict: positive bignums use tag 2 and negative bignums use tag 3,
+//! and integer values outside the i64-fits-in-major-types range MUST
+//! use the bignum form on encode.
+//!
+//! This is the scaffolding module; the actual CBOR codec lives in
+//! `data::codec` (to be added).
+
+use num_bigint::BigInt;
+
+/// Recursive PlutusData value. Maps 1:1 onto the Haskell `Plutus.V1.Data`
+/// definition.
+///
+/// `Constr` and `Map` payloads are `Vec` rather than `BTreeMap` because
+/// the on-chain encoding preserves insertion order — sorting on encode
+/// would change the body hash for txs that gossip in non-sorted form,
+/// breaking byte-exact round-trip.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Data {
+    /// `Constr` — tagged sum: `Constr tag args`.
+    ///
+    /// Encoding rule (CBOR):
+    ///   - `tag` in `0..=6`  → CBOR tag `121 + tag`, payload is the
+    ///     args array.
+    ///   - `tag` in `7..=127` → CBOR tag `1280 + (tag - 7)`, payload
+    ///     is the args array.
+    ///   - `tag` outside that range → CBOR tag `102`, payload is
+    ///     `[tag, args]`.
+    Constr(u64, Vec<Data>),
+
+    /// `Map` — list of key-value pairs.
+    Map(Vec<(Data, Data)>),
+
+    /// `List` — list of values.
+    List(Vec<Data>),
+
+    /// `I` — arbitrary-precision integer. Encoded as CBOR major-0/major-1
+    /// for values in i64 range, otherwise as CBOR tag 2 (positive bignum)
+    /// or tag 3 (negative bignum) wrapping a byte string.
+    I(BigInt),
+
+    /// `B` — byte string.
+    B(Vec<u8>),
+}

--- a/crates/dugite-uplc/src/error.rs
+++ b/crates/dugite-uplc/src/error.rs
@@ -1,0 +1,70 @@
+//! Top-level error type for dugite-uplc.
+//!
+//! Every fallible entry point in the crate returns `Result<T, UplcError>`.
+//! No public API panics on malformed or adversarial input — see the
+//! crate-level docs.
+
+use thiserror::Error;
+
+/// All errors that can be produced anywhere in dugite-uplc.
+///
+/// Variants are intentionally fine-grained so the caller can distinguish
+/// "we ran out of budget" from "the script bytes did not decode" from
+/// "the redeemer returned an error term" — each has different semantics
+/// in cardano-ledger's phase-2 validation rules.
+#[derive(Debug, Error)]
+pub enum UplcError {
+    /// Wire-format / flat-decoder error (truncated input, invalid tags,
+    /// unknown builtin id, depth limit exceeded, etc.).
+    #[error("flat decode error: {0}")]
+    FlatDecode(String),
+
+    /// CBOR-level decode error for the outer `Program` envelope or for
+    /// PlutusData payloads.
+    #[error("cbor decode error: {0}")]
+    CborDecode(String),
+
+    /// Encoder error (we never expect to hit one in practice, but the
+    /// signature is `Result` to keep the API uniform).
+    #[error("encode error: {0}")]
+    Encode(String),
+
+    /// The CEK machine evaluated a `Term::Error` term — the script
+    /// signalled failure deterministically.
+    #[error("script returned Error term")]
+    ScriptError,
+
+    /// The CEK machine ran out of `ExBudget` before the script completed.
+    #[error("budget exhausted: cpu_remaining={cpu_remaining}, mem_remaining={mem_remaining}")]
+    BudgetExhausted {
+        cpu_remaining: i64,
+        mem_remaining: i64,
+    },
+
+    /// A builtin function was applied to an argument of the wrong type
+    /// or shape (e.g. `addInteger` applied to a `ByteString`).
+    #[error("builtin {builtin}: type error: {reason}")]
+    BuiltinTypeError {
+        builtin: &'static str,
+        reason: String,
+    },
+
+    /// A builtin function failed in a builtin-defined way (e.g. division
+    /// by zero, ed25519 signature verification failure, BLS curve
+    /// point not on subgroup).
+    #[error("builtin {builtin}: {reason}")]
+    BuiltinFailure {
+        builtin: &'static str,
+        reason: String,
+    },
+
+    /// PlutusV3 only: the script returned a value other than `Unit`.
+    #[error("PlutusV3 script returned non-Unit value")]
+    NonUnitReturn,
+
+    /// Internal invariant violated; this indicates a bug in dugite-uplc
+    /// itself, not in the input. Such errors are still returned (not
+    /// panicked) so they can be surfaced cleanly in tests.
+    #[error("internal: {0}")]
+    Internal(String),
+}

--- a/crates/dugite-uplc/src/flat/decode.rs
+++ b/crates/dugite-uplc/src/flat/decode.rs
@@ -1,0 +1,20 @@
+//! Flat-encoded UPLC decoder.
+//!
+//! Scaffolding only — the actual bit-stream decoder lands in the next
+//! commit after the design synthesis. The entry point reserved here is:
+//!
+//! ```text
+//! pub fn decode_term(bytes: &[u8]) -> FlatResult<Term>
+//! pub fn decode_program(bytes: &[u8]) -> FlatResult<Program>
+//! ```
+//!
+//! Defensive invariants the decoder must enforce (already captured as
+//! tests in `tests/flat_decode_defense.rs` once written):
+//!
+//!  - Truncated input → `UplcError::FlatDecode("unexpected end of input")`.
+//!  - Unknown term-tag → `UplcError::FlatDecode("unknown term tag {:#06b}")`.
+//!  - Recursion depth past `FLAT_MAX_DEPTH` → `UplcError::FlatDecode("depth limit exceeded")`.
+//!  - Builtin-id discriminant outside the known set → `UplcError::FlatDecode("unknown builtin id {n}")`.
+//!  - `Vec::with_capacity(N)` calls are clamped to `min(N, remaining_bits/4)`.
+
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/flat/encode.rs
+++ b/crates/dugite-uplc/src/flat/encode.rs
@@ -1,0 +1,9 @@
+//! Flat-encoded UPLC encoder.
+//!
+//! Scaffolding only — see `decode.rs` for the symmetric inverse.
+//!
+//! Property test target: for every `Term` produced by the proptest
+//! generator, `decode(encode(t))` round-trips and `encode(decode(b))`
+//! is byte-identical on canonical inputs.
+
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/flat/mod.rs
+++ b/crates/dugite-uplc/src/flat/mod.rs
@@ -1,0 +1,60 @@
+//! Flat wire codec for UPLC programs.
+//!
+//! UPLC programs are wire-encoded in a custom bit-level format ("flat")
+//! that predates the project's adoption of CBOR. The outer container
+//! is a CBOR byte-string holding the flat-encoded program; CBOR is
+//! handled in `crate::program`, while *this* module handles the inner
+//! flat layer.
+//!
+//! Reference: `plutus-core/plutus-core/src/PlutusCore/Flat.hs` in
+//! IntersectMBO/plutus is the normative implementation. The encoding
+//! is described informally in the Plutus tech report appendix.
+//!
+//! ## Encoding shape (informal)
+//!
+//! Each `Term` constructor is identified by a 4-bit tag:
+//!
+//! | tag (binary) | constructor    |
+//! |--------------|----------------|
+//! | `0000`       | Var            |
+//! | `0001`       | Delay          |
+//! | `0010`       | Lam            |
+//! | `0011`       | App            |
+//! | `0100`       | Const          |
+//! | `0101`       | Force          |
+//! | `0110`       | Error          |
+//! | `0111`       | Builtin        |
+//! | `1000`       | Constr (V3+)   |
+//! | `1001`       | Case (V3+)     |
+//!
+//! Constants are prefixed by a *universe-tag bit-list* that encodes
+//! the type (recursively, for `list`/`pair`), followed by the payload.
+//!
+//! Variables encode their De Bruijn index as a `Natural` (chunked
+//! 7-bit varint, high bit = continue).
+//!
+//! Builtins encode their `BuiltinId` as a fixed 7-bit field.
+//!
+//! ## Defensive properties
+//!
+//! 1. **Depth-limited.** Recursion is bounded by `FLAT_MAX_DEPTH` (set
+//!    to mirror the Haskell `maxScriptSize` in bytes, since each level
+//!    consumes at least 4 bits).
+//! 2. **Allocation-clamped.** Every `Vec::with_capacity` call uses the
+//!    same `safe_alloc_capacity` pattern as `dugite-serialization`.
+//! 3. **No `unwrap`/`panic!`.** The decoder returns `UplcError::FlatDecode`
+//!    for every truncated / malformed / out-of-range input.
+
+#![allow(dead_code)] // pre-implementation scaffolding
+
+pub mod decode;
+pub mod encode;
+
+/// Maximum recursion depth for the flat decoder. The on-chain script
+/// size limit is ~16 KiB; with 4-bit per constructor that's an upper
+/// bound of ~32 K nodes, but real scripts are much shallower. We pick
+/// a generous limit that protects against stack-exhaustion attacks.
+pub const FLAT_MAX_DEPTH: usize = 4096;
+
+/// Result alias for flat decode/encode operations.
+pub type FlatResult<T> = Result<T, crate::UplcError>;

--- a/crates/dugite-uplc/src/lib.rs
+++ b/crates/dugite-uplc/src/lib.rs
@@ -1,0 +1,56 @@
+//! # dugite-uplc — Untyped Plutus Core for the dugite Cardano node
+//!
+//! First-party, in-house implementation of UPLC (Untyped Plutus Core), the
+//! flat / CBOR wire format, the CEK machine, the Cardano-specific builtin
+//! suite, the V1/V2/V3 script-context construction, and the phase-2
+//! transaction evaluator.
+//!
+//! This crate replaces aiken-lang/uplc (and removes the transitive
+//! `pallas-*` dependency chain that comes with it).
+//!
+//! ## Status: scaffolding
+//!
+//! This crate currently exposes only module skeletons. See `DESIGN.md` for
+//! the implementation plan distilled from a cross-implementation study of:
+//!
+//!  - IntersectMBO/plutus (Haskell — the reference)
+//!  - pragma-org/uplc (`amaru-uplc`, arena-allocated CEK)
+//!  - aiken-lang/uplc (current Rust implementation, slated for removal)
+//!  - The official Plutus Core formal specification + relevant CIPs
+//!
+//! ## Hard requirements
+//!
+//! 1. **Panic-free on adversarial input.** Every public API must return
+//!    `Result`. No `unwrap`, no `expect`, no `panic!`, no `todo!`, no
+//!    `unimplemented!`. Adversaries control the bytes via gossiped tx
+//!    witness sets — a panic is a DoS bug.
+//! 2. **Bounded allocation.** Every peer-supplied length header must be
+//!    sanity-clamped before any `Vec::with_capacity` / `Vec::reserve`.
+//! 3. **Bounded recursion.** CEK machine state must be heap-resident with
+//!    explicit depth limits; the flat decoder and `Data` decoder must
+//!    have explicit depth caps.
+//! 4. **Bit-for-bit byte-exact compatibility** with cardano-node Haskell:
+//!    flat-encoded scripts and CBOR-encoded `Data` round-trip identically;
+//!    CEK evaluation produces identical `EvalResult` for identical inputs;
+//!    BLS12-381, sha2_256, sha3_256, blake2b_224, blake2b_256, keccak_256,
+//!    ripemd_160 builtins are bit-exact against the reference.
+//! 5. **No third-party UPLC dependencies.** No aiken-uplc, no pallas-*,
+//!    no amaru-uplc. Only standard Rust crypto crates (`blake2`, `sha2`,
+//!    `sha3`, `secp256k1`, `blst`) and `minicbor` are linked.
+
+#![deny(missing_debug_implementations)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+#![cfg_attr(not(test), deny(clippy::panic, clippy::todo, clippy::unimplemented))]
+
+pub mod builtin;
+pub mod data;
+pub mod flat;
+pub mod machine;
+pub mod program;
+pub mod term;
+
+mod error;
+
+pub use crate::error::UplcError;
+pub use crate::program::Program;
+pub use crate::term::{Constant, Term};

--- a/crates/dugite-uplc/src/machine/context.rs
+++ b/crates/dugite-uplc/src/machine/context.rs
@@ -1,0 +1,2 @@
+//! CEK context — scaffolding placeholder (see machine/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/machine/cost.rs
+++ b/crates/dugite-uplc/src/machine/cost.rs
@@ -1,0 +1,2 @@
+//! CEK cost — scaffolding placeholder (see machine/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/machine/env.rs
+++ b/crates/dugite-uplc/src/machine/env.rs
@@ -1,0 +1,2 @@
+//! CEK env — scaffolding placeholder (see machine/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/machine/mod.rs
+++ b/crates/dugite-uplc/src/machine/mod.rs
@@ -1,0 +1,69 @@
+//! CEK machine — the Plutus Core abstract machine.
+//!
+//! "CEK" stands for the three components of the machine state:
+//!
+//!  - **C**ontrol: the term being reduced (or the value being returned
+//!    up a continuation).
+//!  - **E**nvironment: a stack of values bound by enclosing `Lam`s
+//!    (indexed by De Bruijn index).
+//!  - **K**ontinuation: a stack of `Frame`s describing what to do next
+//!    when the current term reduces to a value.
+//!
+//! The implementation mirrors the formal spec (see DESIGN.md §4). Two
+//! invariants are non-negotiable:
+//!
+//!  1. **Bounded heap allocation.** No unbounded `Vec::reserve` or
+//!     `Box::new` that an adversary can drive past memory limits.
+//!  2. **Step-by-step budget accounting.** Every reduction step charges
+//!     the cost model and aborts the moment either dimension goes
+//!     negative — *before* taking the step's allocations, not after.
+//!
+//! Defensive bound: a hard `MAX_KONTINUATION_DEPTH` cap on the
+//! continuation stack protects against pathological terms that spawn
+//! exponentially-deep frame stacks without consuming proportional CPU
+//! budget (a Cardano-specific DoS concern noted in the original Plutus
+//! tech report).
+
+#![allow(dead_code)]
+
+pub mod context;
+pub mod cost;
+pub mod env;
+pub mod step;
+pub mod value;
+
+/// Cap on the continuation-stack depth. Mainnet scripts never reach
+/// anywhere close to this; the limit is purely a DoS guard.
+pub const MAX_KONTINUATION_DEPTH: usize = 4 * 1024;
+
+/// `(cpu, mem)` units, mirroring the Haskell `ExBudget` record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ExBudget {
+    pub cpu: i64,
+    pub mem: i64,
+}
+
+impl ExBudget {
+    /// Subtract `other` from `self` in place. Returns `false` if either
+    /// dimension would go negative (caller treats this as
+    /// budget-exhaustion).
+    pub fn try_subtract(&mut self, other: ExBudget) -> bool {
+        let new_cpu = self.cpu - other.cpu;
+        let new_mem = self.mem - other.mem;
+        if new_cpu < 0 || new_mem < 0 {
+            return false;
+        }
+        self.cpu = new_cpu;
+        self.mem = new_mem;
+        true
+    }
+}
+
+/// Result of a CEK evaluation: the produced value, the budget consumed,
+/// and the captured trace log.
+#[derive(Debug)]
+pub struct EvalResult {
+    pub value: crate::term::Term,
+    pub budget_consumed: ExBudget,
+    pub logs: Vec<String>,
+}

--- a/crates/dugite-uplc/src/machine/step.rs
+++ b/crates/dugite-uplc/src/machine/step.rs
@@ -1,0 +1,2 @@
+//! CEK step — scaffolding placeholder (see machine/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/machine/value.rs
+++ b/crates/dugite-uplc/src/machine/value.rs
@@ -1,0 +1,2 @@
+//! CEK value — scaffolding placeholder (see machine/mod.rs).
+#![allow(dead_code)]

--- a/crates/dugite-uplc/src/program.rs
+++ b/crates/dugite-uplc/src/program.rs
@@ -1,0 +1,52 @@
+//! UPLC `Program` — the outer wrapper around a `Term`.
+//!
+//! A program is `(program major.minor.patch term)`. The on-chain wire
+//! shape is:
+//!
+//!  1. A CBOR byte-string (major type 2) wrapping the flat-encoded
+//!     program bytes.
+//!  2. Inside the flat layer: the version triple as three `Natural`s,
+//!     followed by the term.
+//!
+//! This module handles the CBOR ↔ flat-bytes boundary; the flat ↔ AST
+//! boundary lives in `crate::flat`.
+
+use crate::term::Term;
+
+/// A complete UPLC program: a language version triple plus a body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Program {
+    pub version: (u64, u64, u64),
+    pub term: Term,
+}
+
+impl Program {
+    /// Decode a CBOR-wrapped flat-encoded UPLC program.
+    pub fn from_cbor(_bytes: &[u8]) -> Result<Self, crate::UplcError> {
+        Err(crate::UplcError::Internal(
+            "Program::from_cbor not yet implemented".to_string(),
+        ))
+    }
+
+    /// Decode a raw flat-encoded UPLC program (no CBOR wrapper).
+    pub fn from_flat(_bytes: &[u8]) -> Result<Self, crate::UplcError> {
+        Err(crate::UplcError::Internal(
+            "Program::from_flat not yet implemented".to_string(),
+        ))
+    }
+
+    /// Encode the program as `(major, minor, patch, flat-encoded term)`
+    /// then wrap in a CBOR byte-string.
+    pub fn to_cbor(&self) -> Result<Vec<u8>, crate::UplcError> {
+        Err(crate::UplcError::Internal(
+            "Program::to_cbor not yet implemented".to_string(),
+        ))
+    }
+
+    /// Encode the program as raw flat bytes (no CBOR wrapper).
+    pub fn to_flat(&self) -> Result<Vec<u8>, crate::UplcError> {
+        Err(crate::UplcError::Internal(
+            "Program::to_flat not yet implemented".to_string(),
+        ))
+    }
+}

--- a/crates/dugite-uplc/src/term.rs
+++ b/crates/dugite-uplc/src/term.rs
@@ -1,0 +1,295 @@
+//! UPLC term and constant AST.
+//!
+//! This module defines the in-memory representation of Untyped Plutus Core
+//! programs after they have been decoded from flat-encoded bytes. The
+//! design follows the Haskell reference (`Plutus.Core.Term`) but is
+//! adapted to idiomatic Rust:
+//!
+//!  - Binders use **De Bruijn indices** end-to-end (no `Name`-based
+//!    variant). The flat decoder produces `DeBruijn` directly and the
+//!    CEK machine consumes it directly; we never carry symbolic names
+//!    through the evaluator. This avoids the `NamedDeBruijn` /
+//!    `FakeNamedDeBruijn` shuffling that aiken-uplc has to do.
+//!
+//!  - Term recursion uses `Box<Term>` rather than `Rc`/`Arc`/arena.
+//!    The CEK machine evaluates by stepping through an explicit context
+//!    stack (heap-allocated) so the term tree is never recursively
+//!    walked. This keeps the AST sharing-free and trivially
+//!    `Send + Sync + Clone` without arena lifetimes leaking into
+//!    consumer APIs.
+//!
+//!  - The `Constant` enum carries discriminants in the order the Haskell
+//!    reference's `DefaultUni` enum uses, so flat-tag decoding is a
+//!    direct table lookup.
+//!
+//! Bit-for-bit compatibility with the Haskell reference is required for
+//! every variant — round-trip property tests are in
+//! `tests/term_roundtrip.rs` (to be added with the flat decoder).
+
+use crate::data::Data;
+
+/// A UPLC term — a single AST node.
+///
+/// The `Box` wrapping makes every recursive variant heap-allocated, so
+/// the enum size stays a fixed 8 bytes for the discriminant + pointers.
+/// Stack overflow on deeply-nested terms is avoided by never recursing
+/// over the term tree directly: the CEK machine carries an explicit
+/// continuation stack instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Term {
+    /// `Var i` — a variable referring to the binder at De Bruijn index
+    /// `i` (with `1` being the innermost binder, matching the Haskell
+    /// convention).
+    Var(u64),
+
+    /// `Lam body` — a lambda abstraction. The body is open under one
+    /// additional binder.
+    Lam(Box<Term>),
+
+    /// `App fun arg` — function application.
+    App(Box<Term>, Box<Term>),
+
+    /// `Constant c` — a primitive value lifted into a term.
+    Const(Constant),
+
+    /// `Delay t` — wraps `t` into a thunk; reduced only by `Force`.
+    Delay(Box<Term>),
+
+    /// `Force t` — forces a `Delay`-wrapped thunk.
+    Force(Box<Term>),
+
+    /// `Error` — script failure (the CEK machine raises
+    /// [`UplcError::ScriptError`](crate::UplcError::ScriptError)).
+    Error,
+
+    /// `Builtin id` — a reference to one of the Plutus-Core builtin
+    /// functions, identified by its [`BuiltinId`].
+    Builtin(BuiltinId),
+
+    /// `Constr tag args` — Plutus-Core SOP constructor (introduced for
+    /// PlutusV3; CIP-0085).
+    Constr { tag: u64, args: Vec<Term> },
+
+    /// `Case scrutinee branches` — Plutus-Core SOP case expression
+    /// (introduced for PlutusV3; CIP-0085).
+    Case {
+        scrutinee: Box<Term>,
+        branches: Vec<Term>,
+    },
+}
+
+/// Primitive constants, in the exact discriminant order used by the
+/// Haskell `DefaultUni` enum so flat-tag decoding is a direct mapping.
+///
+/// The flat encoding tags these via the universe-tag bit sequence
+/// described in `crates/dugite-uplc/DESIGN.md` §3.2. New variants for
+/// future Plutus versions are appended; we do not reorder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum Constant {
+    /// Arbitrary-precision integer.
+    Integer(num_bigint::BigInt),
+    /// Byte string (the underlying storage is a `Vec<u8>` so we own the
+    /// data; this matches Haskell's `ByteString`).
+    ByteString(Vec<u8>),
+    /// UTF-8 string. Decoding rejects non-UTF-8 sequences.
+    String(String),
+    /// The unit value `()`.
+    Unit,
+    /// Boolean.
+    Bool(bool),
+    /// `ProtoList element_type elements` — a flat-encoded list whose
+    /// element type is recorded for type-checking at evaluation time.
+    ///
+    /// We store both the element-type sequence (`TypeTag`) and the
+    /// elements together so the CEK machine can type-check builtin
+    /// applications without re-parsing the wire bytes.
+    ProtoList {
+        elem_type: TypeTag,
+        elements: Vec<Constant>,
+    },
+    /// `ProtoPair t1 t2 a b` — a flat-encoded pair, parameterised by
+    /// the static types of its components.
+    ProtoPair {
+        a_type: TypeTag,
+        b_type: TypeTag,
+        a: Box<Constant>,
+        b: Box<Constant>,
+    },
+    /// PlutusData — recursive sum type used by the script context.
+    Data(Data),
+    /// BLS12-381 G1 element. Stored compressed (48 bytes) for canonical
+    /// equality; uncompressed cache is materialised in the CEK machine
+    /// state when needed. Boxed to keep the `Constant` enum compact.
+    Bls12_381G1Element(Box<[u8; 48]>),
+    /// BLS12-381 G2 element. Stored compressed (96 bytes). Boxed.
+    Bls12_381G2Element(Box<[u8; 96]>),
+    /// BLS12-381 GT (Miller-loop result). The on-chain representation
+    /// is canonical-compressed (576 bytes after `final_exponentiation`).
+    /// Boxed — the variant would otherwise dominate the enum size.
+    Bls12_381MlResult(Box<[u8; 576]>),
+}
+
+/// Static type-tags for `ProtoList` / `ProtoPair` element types.
+///
+/// Flat-encoded universe tags are a *bit sequence* (Haskell:
+/// `Encoding`-of-`DefaultUni`), but at the term level we only ever
+/// inspect the top-level type, so a flat enum here is sufficient.
+/// Nested universes (lists of lists, pairs of pairs) are still
+/// representable because the constants themselves recurse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum TypeTag {
+    Integer,
+    ByteString,
+    String,
+    Unit,
+    Bool,
+    Data,
+    List(Box<TypeTag>),
+    Pair(Box<TypeTag>, Box<TypeTag>),
+    Bls12_381G1Element,
+    Bls12_381G2Element,
+    Bls12_381MlResult,
+}
+
+/// All Plutus Core builtin function identifiers.
+///
+/// The discriminants match the Haskell `DefaultFun` enum order verbatim
+/// — that ordering is **normative** because the flat encoding stores
+/// the builtin as a raw `u8` discriminant. Reordering would break wire
+/// compatibility with cardano-node. See the formal spec
+/// (plutus-core/docs/) for the authoritative list per Plutus version.
+///
+/// Additions follow protocol-version gating in cardano-ledger:
+///
+/// - PV1..  : 0–27 (Plutus V1)
+/// - PV6..  : 28..52 (V2 additions; CIP-0033)
+/// - PV9..  : V3 additions (CIP-0035 — keccak_256, blake2b_224, BLS12-381
+///   ops, integerToByteString, byteStringToInteger, andByteString,
+///   orByteString, xorByteString, complementByteString, readBit,
+///   writeBits, replicateByte, shiftByteString, rotateByteString,
+///   countSetBits, findFirstSetBit, ripemd_160, expModInteger, plus the
+///   SOP constructors)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+#[non_exhaustive]
+// Variant names mirror the Haskell `DefaultFun` spelling 1:1 (which
+// uses `Bls12_381_G1_Add`, `Sha2_256`, etc. — underscore-separated by
+// design). Suppressing the lint here keeps the spec-aligned spelling.
+#[allow(non_camel_case_types)]
+pub enum BuiltinId {
+    AddInteger = 0,
+    SubtractInteger = 1,
+    MultiplyInteger = 2,
+    DivideInteger = 3,
+    QuotientInteger = 4,
+    RemainderInteger = 5,
+    ModInteger = 6,
+    EqualsInteger = 7,
+    LessThanInteger = 8,
+    LessThanEqualsInteger = 9,
+    AppendByteString = 10,
+    ConsByteString = 11,
+    SliceByteString = 12,
+    LengthOfByteString = 13,
+    IndexByteString = 14,
+    EqualsByteString = 15,
+    LessThanByteString = 16,
+    LessThanEqualsByteString = 17,
+    Sha2_256 = 18,
+    Sha3_256 = 19,
+    Blake2b_256 = 20,
+    VerifyEd25519Signature = 21,
+    AppendString = 22,
+    EqualsString = 23,
+    EncodeUtf8 = 24,
+    DecodeUtf8 = 25,
+    IfThenElse = 26,
+    ChooseUnit = 27,
+    Trace = 28,
+    FstPair = 29,
+    SndPair = 30,
+    ChooseList = 31,
+    MkCons = 32,
+    HeadList = 33,
+    TailList = 34,
+    NullList = 35,
+    ChooseData = 36,
+    ConstrData = 37,
+    MapData = 38,
+    ListData = 39,
+    IData = 40,
+    BData = 41,
+    UnConstrData = 42,
+    UnMapData = 43,
+    UnListData = 44,
+    UnIData = 45,
+    UnBData = 46,
+    EqualsData = 47,
+    MkPairData = 48,
+    MkNilData = 49,
+    MkNilPairData = 50,
+    SerialiseData = 51,
+    VerifyEcdsaSecp256k1Signature = 52,
+    VerifySchnorrSecp256k1Signature = 53,
+    // ── PlutusV3 additions ──────────────────────────────────────────
+    Bls12_381_G1_Add = 54,
+    Bls12_381_G1_Neg = 55,
+    Bls12_381_G1_ScalarMul = 56,
+    Bls12_381_G1_Equal = 57,
+    Bls12_381_G1_HashToGroup = 58,
+    Bls12_381_G1_Compress = 59,
+    Bls12_381_G1_Uncompress = 60,
+    Bls12_381_G2_Add = 61,
+    Bls12_381_G2_Neg = 62,
+    Bls12_381_G2_ScalarMul = 63,
+    Bls12_381_G2_Equal = 64,
+    Bls12_381_G2_HashToGroup = 65,
+    Bls12_381_G2_Compress = 66,
+    Bls12_381_G2_Uncompress = 67,
+    Bls12_381_MillerLoop = 68,
+    Bls12_381_MulMlResult = 69,
+    Bls12_381_FinalVerify = 70,
+    Keccak_256 = 71,
+    Blake2b_224 = 72,
+    // SOP / case-on-Constr (PlutusV3).
+    IntegerToByteString = 73,
+    ByteStringToInteger = 74,
+    AndByteString = 75,
+    OrByteString = 76,
+    XorByteString = 77,
+    ComplementByteString = 78,
+    ReadBit = 79,
+    WriteBits = 80,
+    ReplicateByte = 81,
+    ShiftByteString = 82,
+    RotateByteString = 83,
+    CountSetBits = 84,
+    FindFirstSetBit = 85,
+    Ripemd_160 = 86,
+    ExpModInteger = 87,
+}
+
+impl BuiltinId {
+    /// Parse a builtin id from the raw 7-bit wire discriminant.
+    ///
+    /// Unknown discriminants are an error rather than a panic — the
+    /// flat decoder calls this on every `Term::Builtin` we see and
+    /// must reject adversarial inputs cleanly.
+    pub fn from_u8(raw: u8) -> Result<Self, crate::UplcError> {
+        // Filled in alongside the flat decoder. Keeping it as
+        // `Internal` for now lets the scaffold compile.
+        Err(crate::UplcError::Internal(format!(
+            "BuiltinId::from_u8 not yet implemented (raw={raw})"
+        )))
+    }
+
+    /// Lowercase identifier used in the Plutus textual syntax and in
+    /// error messages. Stable across Plutus versions.
+    pub fn name(&self) -> &'static str {
+        // Filled in when builtins are implemented. The table is wired
+        // alongside the dispatcher in `crate::builtin`.
+        "<unimplemented>"
+    }
+}


### PR DESCRIPTION
## Summary

Scaffolds `crates/dugite-uplc` — the first-party UPLC implementation that will replace `aiken-lang/uplc` (and the transitive `pallas-*` dependency chain it brings). Tracking issue: #556.

This PR is **scaffolding + design only**. The crate compiles cleanly under `cargo clippy --all-targets -- -D warnings` across the workspace; every public stub returns `UplcError::Internal` so the no-`unwrap`/no-`panic` crate-root lints can be enforced from day one. No production wiring yet — `dugite-ledger` still uses aiken-uplc.

## What's in

- `crates/dugite-uplc/` workspace member with the full module skeleton:
  - `term.rs` — `Term`, `Constant`, `TypeTag`, `BuiltinId` (88 variants, `#[repr(u8)]` matching the Haskell `DefaultFun` order).
  - `data.rs` — `PlutusData`.
  - `flat/{mod,decode,encode}.rs` — bit-stream codec scaffolding.
  - `machine/{mod,env,context,value,step,cost}.rs` — CEK skeleton.
  - `builtin/{mod,arity,dispatch,sized,denotations}.rs` — builtin dispatch skeleton.
  - `program.rs` — CBOR ⇄ flat ⇄ AST boundary.
  - `error.rs` — `UplcError` taxonomy.
- `crates/dugite-uplc/DESIGN.md` — ~700 lines distilled from a 4-implementation cross-survey.
- Workspace `Cargo.toml`: `dugite-uplc` added to `[workspace] members` and `[workspace.dependencies]`.

## Hard requirements (enforced by crate-root `#![deny]`)

1. Panic-free on adversarial input.
2. Bounded allocation.
3. Bounded recursion.
4. Byte-exact wire compatibility.
5. No third-party UPLC dependencies.

## Implementation order (after this lands)

UPLC-1 → UPLC-9 as listed in #556 and DESIGN.md.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy -p dugite-uplc --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] (future PRs) conformance corpus passes 100%
- [ ] (future PRs) fuzz matrix shows no panics from dugite-uplc paths

## Why a separate PR?

This is the moment to challenge architecture choices (De Bruijn end-to-end, `Box<Term>` over arena, `u64` `Constr.tag`, single-crate vs split, `k256` vs `secp256k1`, ed25519 strictness) before 8 implementation PRs hard-code them.

Closes #556 partially (this is UPLC-0).