### PR TITLE
test(uplc): cross-validate PlutusData encoder vs pragma-org/uplc + fix indefinite-length bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "amaru-uplc"
+version = "0.1.0"
+source = "git+https://github.com/pragma-org/uplc.git?rev=fd5e970a5d9b345a2f0a43600e27be9827313c05#fd5e970a5d9b345a2f0a43600e27be9827313c05"
+dependencies = [
+ "append-only-vec",
+ "blst",
+ "bumpalo",
+ "chumsky",
+ "cryptoxide",
+ "divan",
+ "hamming",
+ "hex",
+ "minicbor 0.25.1",
+ "num",
+ "num-bigint",
+ "num-integer",
+ "once_cell",
+ "secp256k1 0.30.0",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +125,21 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "append-only-vec"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114736faba96bcd79595c700d03183f61357b9fbce14852515e59f3bee4ed4a"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "arraydeque"
@@ -265,6 +303,22 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -447,6 +501,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "1.0.0-alpha.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e82d74e6c83060ec269fe9e0d408d6de4a1645d525f9a0bbbb841ba4efd91ac"
+dependencies = [
+ "hashbrown 0.15.5",
+ "regex-automata 0.3.9",
+ "serde",
+ "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +570,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -541,6 +610,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
@@ -1058,6 +1133,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,8 +1517,10 @@ dependencies = [
 name = "dugite-uplc"
 version = "1.7.0"
 dependencies = [
+ "amaru-uplc",
  "blake2 0.10.6",
  "hex",
+ "minicbor 0.25.1",
  "minicbor 0.26.5",
  "num-bigint",
  "num-traits",
@@ -1956,6 +2058,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2002,6 +2106,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec 0.7.6",
+]
 
 [[package]]
 name = "hickory-proto"
@@ -2638,7 +2751,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.14",
 ]
 
 [[package]]
@@ -3006,6 +3119,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,6 +3141,15 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3039,6 +3175,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3113,6 +3260,15 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3535,10 +3691,20 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3635,6 +3801,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3855,8 +4023,19 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -3867,8 +4046,20 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -4131,7 +4322,18 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
 ]
 
 [[package]]
@@ -4139,6 +4341,15 @@ name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -4455,6 +4666,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,6 +4848,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
@@ -5037,7 +5271,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.4.14",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -5193,7 +5427,7 @@ dependencies = [
  "pallas-traverse",
  "peg",
  "pretty",
- "secp256k1",
+ "secp256k1 0.26.0",
  "serde",
  "serde_json",
  "strum 0.26.3",

--- a/crates/dugite-uplc/Cargo.toml
+++ b/crates/dugite-uplc/Cargo.toml
@@ -35,9 +35,28 @@ thiserror = { workspace = true }
 # Hex display for Data debug output.
 hex = { workspace = true }
 
+# Cross-validation only — pragma-org/uplc (`amaru-uplc`) is pinned at a
+# stable revision and used solely by `tests/cross_validate_*.rs` to
+# differential-test our codecs against another Rust UPLC implementation.
+# Gated behind the `cross-validate` feature so the default build never
+# pulls it in; production code MUST NOT reference it. This dependency is
+# never exposed in the runtime build, so it does not affect the
+# production dependency graph or the no-third-party-UPLC rule.
+amaru-uplc = { git = "https://github.com/pragma-org/uplc.git", rev = "fd5e970a5d9b345a2f0a43600e27be9827313c05", optional = true }
+# amaru-uplc uses minicbor 0.25; dugite-uplc itself uses 0.26 (workspace
+# default). Pull in 0.25 under a different package name so the
+# cross-validation tests can speak amaru-uplc's `Encode<()>` trait.
+minicbor_025 = { package = "minicbor", version = "0.25", default-features = false, features = ["std"], optional = true }
+
 [dev-dependencies]
 proptest = { workspace = true }
 serde_json = { workspace = true }
+
+[features]
+# Enables the cross-validation tests in `tests/cross_validate_*.rs`. The
+# CI workflow runs `cargo test --features cross-validate` on every PR
+# that touches `crates/dugite-uplc/`.
+cross-validate = ["dep:amaru-uplc", "dep:minicbor_025"]
 
 [lib]
 name = "dugite_uplc"

--- a/crates/dugite-uplc/src/data.rs
+++ b/crates/dugite-uplc/src/data.rs
@@ -127,21 +127,7 @@ fn encode_data<W: minicbor::encode::Write>(
             }
             Ok(())
         }
-        Data::List(items) => {
-            if items.len() <= DATA_CHUNK_LIMIT {
-                e.array(items.len() as u64)?;
-                for item in items {
-                    encode_data(e, item)?;
-                }
-            } else {
-                e.begin_array()?;
-                for item in items {
-                    encode_data(e, item)?;
-                }
-                e.end()?;
-            }
-            Ok(())
-        }
+        Data::List(items) => encode_list(e, items),
         Data::I(n) => encode_integer(e, n),
         Data::B(bs) => encode_bytes(e, bs),
     }
@@ -171,17 +157,35 @@ fn encode_args<W: minicbor::encode::Write>(
     e: &mut Encoder<W>,
     args: &[Data],
 ) -> Result<(), minicbor::encode::Error<W::Error>> {
-    // The args of a `Constr` are themselves a `List` shape — same
-    // 64-element cutoff between definite / indefinite-length array.
-    if args.len() <= DATA_CHUNK_LIMIT {
-        e.array(args.len() as u64)?;
-        for a in args {
-            encode_data(e, a)?;
-        }
+    // `Constr i ds` is encoded in Haskell as
+    //   `encodeTag t <> encode ds`
+    // where `encode ds` reuses the `Serialise [Data]` instance — see
+    // `encode_list` for the exact empty / non-empty split.
+    encode_list(e, args)
+}
+
+/// Encode a list of `Data` using the `Serialise [a]` rule from `cborg`:
+///
+/// ```text
+/// encodeList [] = encodeListLen 0
+/// encodeList xs = encodeListLenIndef <> foldr (\x r -> encode x <> r) encodeBreak xs
+/// ```
+///
+/// i.e. an empty list is `0x80` (definite length zero); a non-empty
+/// list is `0x9f <items> 0xff` (indefinite length). This empty / non-
+/// empty asymmetry is what cborg's `Codec.Serialise.Class.encodeList`
+/// produces, and reproducing it byte-for-byte is required for wire
+/// compatibility with cardano-node's PlutusData hashes.
+fn encode_list<W: minicbor::encode::Write>(
+    e: &mut Encoder<W>,
+    items: &[Data],
+) -> Result<(), minicbor::encode::Error<W::Error>> {
+    if items.is_empty() {
+        e.array(0)?;
     } else {
         e.begin_array()?;
-        for a in args {
-            encode_data(e, a)?;
+        for item in items {
+            encode_data(e, item)?;
         }
         e.end()?;
     }

--- a/crates/dugite-uplc/src/machine/mod.rs
+++ b/crates/dugite-uplc/src/machine/mod.rs
@@ -67,3 +67,56 @@ pub struct EvalResult {
     pub budget_consumed: ExBudget,
     pub logs: Vec<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ex_budget_default_is_zero() {
+        let b = ExBudget::default();
+        assert_eq!(b.cpu, 0);
+        assert_eq!(b.mem, 0);
+    }
+
+    #[test]
+    fn try_subtract_succeeds_when_in_budget() {
+        let mut b = ExBudget { cpu: 100, mem: 50 };
+        assert!(b.try_subtract(ExBudget { cpu: 40, mem: 30 }));
+        assert_eq!(b, ExBudget { cpu: 60, mem: 20 });
+    }
+
+    #[test]
+    fn try_subtract_succeeds_at_exact_zero() {
+        let mut b = ExBudget { cpu: 10, mem: 5 };
+        assert!(b.try_subtract(ExBudget { cpu: 10, mem: 5 }));
+        assert_eq!(b, ExBudget { cpu: 0, mem: 0 });
+    }
+
+    #[test]
+    fn try_subtract_fails_on_cpu_overshoot() {
+        let mut b = ExBudget { cpu: 10, mem: 100 };
+        let before = b;
+        assert!(!b.try_subtract(ExBudget { cpu: 11, mem: 5 }));
+        // Failed subtractions must not mutate state — the caller may
+        // want to retry with a different budget or surface a
+        // BudgetExhausted error using the pre-attempt remaining.
+        assert_eq!(b, before);
+    }
+
+    #[test]
+    fn try_subtract_fails_on_mem_overshoot() {
+        let mut b = ExBudget { cpu: 100, mem: 10 };
+        let before = b;
+        assert!(!b.try_subtract(ExBudget { cpu: 5, mem: 11 }));
+        assert_eq!(b, before);
+    }
+
+    #[test]
+    fn try_subtract_fails_if_either_dim_overshoots() {
+        let mut b = ExBudget { cpu: 5, mem: 5 };
+        let before = b;
+        assert!(!b.try_subtract(ExBudget { cpu: 10, mem: 10 }));
+        assert_eq!(b, before);
+    }
+}

--- a/crates/dugite-uplc/src/program.rs
+++ b/crates/dugite-uplc/src/program.rs
@@ -50,3 +50,58 @@ impl Program {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the `Program` placeholder API. The four
+    //! entry points must surface their unimplemented state as a typed
+    //! `Internal` error rather than a panic, so a caller that wires
+    //! `dugite-ledger` against this crate before UPLC-2 lands sees a
+    //! deterministic failure mode.
+    use super::*;
+    use crate::UplcError;
+
+    fn assert_internal_contains(err: &UplcError, needle: &str) {
+        match err {
+            UplcError::Internal(msg) => {
+                assert!(
+                    msg.contains(needle),
+                    "expected message to contain {needle:?}; got {msg}"
+                );
+            }
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_cbor_stub_returns_internal() {
+        let err = Program::from_cbor(&[]).unwrap_err();
+        assert_internal_contains(&err, "from_cbor");
+    }
+
+    #[test]
+    fn from_flat_stub_returns_internal() {
+        let err = Program::from_flat(&[]).unwrap_err();
+        assert_internal_contains(&err, "from_flat");
+    }
+
+    #[test]
+    fn to_cbor_stub_returns_internal() {
+        let p = Program {
+            version: (1, 1, 0),
+            term: Term::Error,
+        };
+        let err = p.to_cbor().unwrap_err();
+        assert_internal_contains(&err, "to_cbor");
+    }
+
+    #[test]
+    fn to_flat_stub_returns_internal() {
+        let p = Program {
+            version: (1, 0, 0),
+            term: Term::Error,
+        };
+        let err = p.to_flat().unwrap_err();
+        assert_internal_contains(&err, "to_flat");
+    }
+}

--- a/crates/dugite-uplc/src/term.rs
+++ b/crates/dugite-uplc/src/term.rs
@@ -293,3 +293,49 @@ impl BuiltinId {
         "<unimplemented>"
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the placeholder behaviour of `BuiltinId`.
+    //! These stubs are scheduled to be replaced when UPLC-4 lands the
+    //! builtin dispatch table; until then the tests guard the
+    //! placeholder contract so callers see a typed error rather than
+    //! a panic from any half-wired API.
+    use super::*;
+    use crate::UplcError;
+
+    #[test]
+    fn from_u8_is_internal_pending_table() {
+        // Until the dispatch table lands, every input — including the
+        // ones that will become valid `BuiltinId`s — must yield
+        // `Internal(...)`. We assert the error variant and that the
+        // raw byte is round-tripped into the message so future readers
+        // see exactly which input hit the stub.
+        for raw in [0u8, 1, 27, 86] {
+            let err = BuiltinId::from_u8(raw).unwrap_err();
+            match err {
+                UplcError::Internal(msg) => {
+                    assert!(
+                        msg.contains(&format!("raw={raw}")),
+                        "expected message to mention raw byte; got {msg}"
+                    );
+                }
+                other => panic!("expected Internal, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn name_is_unimplemented_placeholder() {
+        // Any `BuiltinId` returns the stable placeholder until the
+        // table lands. Pick a few variants to confirm the contract is
+        // uniform.
+        for id in [
+            BuiltinId::AddInteger,
+            BuiltinId::Sha2_256,
+            BuiltinId::Bls12_381_FinalVerify,
+        ] {
+            assert_eq!(id.name(), "<unimplemented>");
+        }
+    }
+}

--- a/crates/dugite-uplc/tests/cross_validate_data.rs
+++ b/crates/dugite-uplc/tests/cross_validate_data.rs
@@ -1,0 +1,248 @@
+//! Cross-validation: dugite-uplc PlutusData CBOR codec vs pragma-org/uplc.
+//!
+//! For each test input we construct a `dugite_uplc::Data`, encode it,
+//! feed the bytes through pragma-org/uplc's decoder, re-encode the
+//! pragma value, and assert byte-exact equality. This validates that
+//! the two implementations agree on every layer (encode, decode,
+//! re-encode of a decoded value) for canonical inputs produced by
+//! dugite-uplc.
+//!
+//! Run with `cargo test --features cross-validate`.
+
+#![cfg(feature = "cross-validate")]
+
+use dugite_uplc::Data;
+use num_bigint::BigInt;
+
+use amaru_uplc::arena::Arena;
+use amaru_uplc::data::PlutusData;
+
+fn dugite_encode(d: &Data) -> Vec<u8> {
+    d.to_cbor().expect("dugite-uplc encode")
+}
+
+fn pragma_encode(d: &PlutusData<'_>) -> Vec<u8> {
+    // amaru-uplc speaks minicbor 0.25; use that version's `to_vec`
+    // helper to encode through its `Encode` trait.
+    minicbor_025::to_vec(d).expect("amaru-uplc encode")
+}
+
+/// Encode via dugite, decode via pragma, re-encode via pragma, compare.
+/// Asserts that all three of (a) dugite's encoder, (b) pragma's decoder
+/// for canonical input, and (c) pragma's encoder produce mutually
+/// consistent bytes.
+fn assert_cross(input: &Data) {
+    let dbytes = dugite_encode(input);
+    let arena = Arena::new();
+    let pragma_view = PlutusData::from_cbor(&arena, &dbytes)
+        .unwrap_or_else(|e| panic!("pragma decode failed for {input:?}: {e}"));
+    let pbytes = pragma_encode(pragma_view);
+    assert_eq!(
+        dbytes, pbytes,
+        "encoders diverge for {input:?}\n  dugite : {dbytes:02x?}\n  pragma : {pbytes:02x?}"
+    );
+
+    // Also exercise dugite's decoder on the same bytes, and dugite's
+    // own re-encode round-trip.
+    let d_view = Data::from_cbor(&dbytes).expect("dugite decode round-trip");
+    let d_re = dugite_encode(&d_view);
+    assert_eq!(dbytes, d_re, "dugite re-encode not idempotent");
+}
+
+// ---------------------------------------------------------------------------
+// Integers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn integer_zero() {
+    assert_cross(&Data::I(BigInt::from(0)));
+}
+
+#[test]
+fn integer_small_positives() {
+    for n in [
+        1i64,
+        23,
+        24,
+        100,
+        255,
+        256,
+        65_535,
+        65_536,
+        1_000_000,
+        i64::MAX,
+    ] {
+        assert_cross(&Data::I(BigInt::from(n)));
+    }
+}
+
+#[test]
+fn integer_small_negatives() {
+    for n in [-1i64, -23, -24, -100, -256, -1_000_000, i64::MIN] {
+        assert_cross(&Data::I(BigInt::from(n)));
+    }
+}
+
+#[test]
+fn integer_positive_bignum() {
+    // 2^65 — requires the positive bignum tag.
+    let pos: BigInt = BigInt::from(1u64) << 65;
+    assert_cross(&Data::I(pos));
+}
+
+#[test]
+fn integer_negative_bignum() {
+    // -(2^65) — requires the negative bignum tag.
+    let pos: BigInt = BigInt::from(1u64) << 65;
+    let neg: BigInt = -pos;
+    assert_cross(&Data::I(neg));
+}
+
+// ---------------------------------------------------------------------------
+// ByteString
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bytestring_empty() {
+    assert_cross(&Data::B(vec![]));
+}
+
+#[test]
+fn bytestring_short() {
+    assert_cross(&Data::B(vec![0xde, 0xad, 0xbe, 0xef]));
+}
+
+#[test]
+fn bytestring_at_chunk_boundary() {
+    assert_cross(&Data::B((0..64u8).collect()));
+}
+
+#[test]
+fn bytestring_just_over_chunk_boundary() {
+    assert_cross(&Data::B((0..65u8).collect()));
+}
+
+#[test]
+fn bytestring_two_chunks() {
+    assert_cross(&Data::B((0..128u8).collect()));
+}
+
+#[test]
+fn bytestring_three_chunks() {
+    assert_cross(&Data::B((0..200u8).collect()));
+}
+
+// ---------------------------------------------------------------------------
+// Constr
+// ---------------------------------------------------------------------------
+
+#[test]
+fn constr_small_tags() {
+    for tag in [0u64, 1, 6] {
+        assert_cross(&Data::Constr(tag, vec![]));
+        assert_cross(&Data::Constr(tag, vec![Data::I(BigInt::from(42))]));
+    }
+}
+
+#[test]
+fn constr_medium_tags() {
+    for tag in [7u64, 50, 127] {
+        assert_cross(&Data::Constr(tag, vec![]));
+        assert_cross(&Data::Constr(tag, vec![Data::I(BigInt::from(42))]));
+    }
+}
+
+#[test]
+fn constr_large_tags() {
+    for tag in [128u64, 1000, u32::MAX as u64, u64::MAX] {
+        assert_cross(&Data::Constr(tag, vec![]));
+        assert_cross(&Data::Constr(tag, vec![Data::I(BigInt::from(1))]));
+    }
+}
+
+#[test]
+fn constr_many_fields() {
+    let fields: Vec<Data> = (0..10).map(|i| Data::I(BigInt::from(i))).collect();
+    assert_cross(&Data::Constr(0, fields));
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_empty() {
+    assert_cross(&Data::List(vec![]));
+}
+
+#[test]
+fn list_short() {
+    assert_cross(&Data::List(vec![
+        Data::I(BigInt::from(1)),
+        Data::I(BigInt::from(2)),
+    ]));
+}
+
+#[test]
+fn list_at_chunk_boundary() {
+    let items: Vec<Data> = (0..64).map(|i| Data::I(BigInt::from(i))).collect();
+    assert_cross(&Data::List(items));
+}
+
+#[test]
+fn list_indefinite_length() {
+    let items: Vec<Data> = (0..100).map(|i| Data::I(BigInt::from(i))).collect();
+    assert_cross(&Data::List(items));
+}
+
+// ---------------------------------------------------------------------------
+// Map
+// ---------------------------------------------------------------------------
+
+#[test]
+fn map_empty() {
+    assert_cross(&Data::Map(vec![]));
+}
+
+#[test]
+fn map_short() {
+    assert_cross(&Data::Map(vec![
+        (Data::B(vec![0x01]), Data::I(BigInt::from(10))),
+        (Data::B(vec![0x02]), Data::I(BigInt::from(20))),
+    ]));
+}
+
+// Note: pragma's decoder may treat duplicates differently; we only assert
+// dugite's behaviour for that case in unit tests, not here.
+
+// ---------------------------------------------------------------------------
+// Nested
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_constr_inside_list() {
+    assert_cross(&Data::List(vec![
+        Data::Constr(0, vec![Data::I(BigInt::from(1))]),
+        Data::Constr(1, vec![Data::I(BigInt::from(2))]),
+    ]));
+}
+
+#[test]
+fn nested_map_inside_constr() {
+    assert_cross(&Data::Constr(
+        3,
+        vec![Data::Map(vec![(
+            Data::B(b"k".to_vec()),
+            Data::List(vec![Data::I(BigInt::from(7))]),
+        )])],
+    ));
+}
+
+#[test]
+fn deeply_nested() {
+    let mut inner = Data::I(BigInt::from(99));
+    for i in 0..20 {
+        inner = Data::Constr(i % 7, vec![inner]);
+    }
+    assert_cross(&inner);
+}


### PR DESCRIPTION
## Summary

Adds differential testing against pragma-org/uplc (\`amaru-uplc\`) and surfaces a real wire-incompatibility bug in dugite's PlutusData encoder, now fixed in the same commit.

Stacked: \`uplc-3-cross-validation\` → \`uplc-2-flat-primitives\` (#559) → \`uplc-1-plutus-data\` (#558) → \`dugite-uplc-scaffold\` (#557) → \`main\`.

## What's in

1. \`amaru-uplc\` (pragma-org/uplc, rev fd5e970) added as an *optional* dependency, gated behind a new \`cross-validate\` cargo feature. The default build doesn't pull it in. Production runtime code MUST NOT reference it — production stays free of third-party UPLCs.
2. \`crates/dugite-uplc/tests/cross_validate_data.rs\` — 24 differential tests: for every shape of \`Data\`, encode via dugite, decode-then-re-encode via pragma, assert byte-exact equality. Also exercises dugite's own decoder + re-encode idempotence.

## Bug fix

The cross-validation immediately found a wire incompatibility:

* Before: dugite emitted **definite-length** CBOR arrays for short \`List\` values and short \`Constr\` field lists, with a 64-element cutoff.
* Haskell reality: \`Codec.Serialise.Class.encodeList\` always uses **indefinite-length** for non-empty lists and **definite length 0** (\`0x80\`) for empty lists. \`PlutusCore.Data.encodeData\` delegates to that instance for both \`List ds\` and \`Constr i ds\` fields.
* After: dugite matches Haskell byte-for-byte across the 24 cross-validation cases.

This was a real wire incompatibility — dugite-encoded txs would have mismatched body hashes with cardano-node for any tx carrying short \`Data\` lists or short \`Constr\` constructions (i.e. virtually every script-witnessed tx).

## Coverage

Test coverage on \`crates/dugite-uplc\` went from 82% lines / 67% functions to 89% lines / 79% functions:

| File | Before | After |
|---|---|---|
| machine/mod.rs | 0% | 100% |
| program.rs | 0% | 98% |
| term.rs | 0% | 96% |
| flat/bits.rs | 92% | 92% |
| data.rs | 82% | 83% |
| **TOTAL** | 82.05% | **88.62%** |

Added regression tests for the placeholder \`Program\` / \`BuiltinId\` / \`ExBudget\` stubs to enforce their typed-error contract (no panics from any half-wired API). Remaining uncovered lines in data.rs are encoder error-propagation paths reachable only via a failing \`minicbor::encode::Write\` impl; will land in a follow-up commit with a mock writer.

## Test plan

- [x] \`cargo nextest run -p dugite-uplc\` — 39 unit tests pass.
- [x] \`CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test --features cross-validate -p dugite-uplc --test cross_validate_data\` — 24 cross-validation tests pass.
- [x] \`cargo clippy -p dugite-uplc --features cross-validate --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo llvm-cov --package dugite-uplc --summary-only\` reports 88.62% lines.
- [ ] (next commit) failing-Write mock to cover encoder \`?\` branches → push to 100%.
- [ ] (next PR) IntersectMBO/plutus-conformance fixtures wired as integration tests.