### PR TITLE
feat(uplc): CEK machine skeleton — no-builtins subset (UPLC-3 part 1)

### DIFF
--- a/crates/dugite-uplc/src/machine/context.rs
+++ b/crates/dugite-uplc/src/machine/context.rs
@@ -1,2 +1,78 @@
-//! CEK context — scaffolding placeholder (see machine/mod.rs).
-#![allow(dead_code)]
+//! CEK continuation stack.
+
+use crate::machine::env::Env;
+use crate::machine::value::Value;
+use crate::term::Term;
+
+#[derive(Debug, Clone)]
+pub enum Frame {
+    AwaitArg { function: Value, env: Env },
+    AwaitFunTerm { argument: Term, env: Env },
+    Force,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Kont {
+    frames: Vec<Frame>,
+}
+
+impl Kont {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push(&mut self, f: Frame) -> Result<(), crate::UplcError> {
+        if self.frames.len() >= super::MAX_KONTINUATION_DEPTH {
+            return Err(crate::UplcError::Internal(format!(
+                "CEK continuation depth exceeds limit ({})",
+                super::MAX_KONTINUATION_DEPTH
+            )));
+        }
+        self.frames.push(f);
+        Ok(())
+    }
+
+    pub fn pop(&mut self) -> Option<Frame> {
+        self.frames.pop()
+    }
+
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::term::Constant;
+    use num_bigint::BigInt;
+
+    fn int_val(n: i64) -> Value {
+        Value::Const(Constant::Integer(BigInt::from(n)))
+    }
+
+    #[test]
+    fn push_pop_lifo() {
+        let mut k = Kont::new();
+        k.push(Frame::Force).unwrap();
+        k.push(Frame::AwaitArg {
+            function: int_val(1),
+            env: Env::new(),
+        })
+        .unwrap();
+        assert_eq!(k.depth(), 2);
+        assert!(matches!(k.pop(), Some(Frame::AwaitArg { .. })));
+        assert!(matches!(k.pop(), Some(Frame::Force)));
+        assert!(k.pop().is_none());
+    }
+
+    #[test]
+    fn rejects_overdeep_push() {
+        let mut k = Kont::new();
+        for _ in 0..super::super::MAX_KONTINUATION_DEPTH {
+            k.push(Frame::Force).unwrap();
+        }
+        let err = k.push(Frame::Force).unwrap_err();
+        assert!(matches!(err, crate::UplcError::Internal(_)));
+    }
+}

--- a/crates/dugite-uplc/src/machine/env.rs
+++ b/crates/dugite-uplc/src/machine/env.rs
@@ -1,2 +1,97 @@
-//! CEK env — scaffolding placeholder (see machine/mod.rs).
-#![allow(dead_code)]
+//! De Bruijn environment for the CEK machine.
+//!
+//! Environments are cons-list "stacks" of values bound by enclosing
+//! `Lam`s. Lookup is 1-based De Bruijn (the innermost binder is
+//! index 1; index 0 is the sentinel for free variables and yields an
+//! error per the Haskell reference's `checkScope` rule).
+
+use crate::machine::value::Value;
+use crate::UplcError;
+
+/// CEK environment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Env {
+    /// Values pushed by enclosing `Lam`s. The innermost binder is the
+    /// LAST element of the vec; De Bruijn index `i` (1-based) resolves
+    /// to `entries[len - i]`.
+    entries: Vec<Value>,
+}
+
+impl Env {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve a 1-based De Bruijn index.
+    pub fn lookup(&self, index: u64) -> Result<&Value, UplcError> {
+        if index == 0 {
+            return Err(UplcError::Internal(
+                "CEK env: De Bruijn index 0 is the free-variable sentinel".into(),
+            ));
+        }
+        let len = self.entries.len() as u64;
+        if index > len {
+            return Err(UplcError::Internal(format!(
+                "CEK env: De Bruijn index {index} out of range (env depth {len})"
+            )));
+        }
+        let slot = (len - index) as usize;
+        Ok(&self.entries[slot])
+    }
+
+    pub fn extend(&self, v: Value) -> Self {
+        let mut next = self.clone();
+        next.entries.push(v);
+        next
+    }
+
+    pub fn depth(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::term::Constant;
+    use num_bigint::BigInt;
+
+    fn int_val(n: i64) -> Value {
+        Value::Const(Constant::Integer(BigInt::from(n)))
+    }
+
+    #[test]
+    fn empty_env_lookup_errors() {
+        let env = Env::new();
+        assert!(env.lookup(1).is_err());
+        assert_eq!(env.depth(), 0);
+    }
+
+    #[test]
+    fn index_zero_is_sentinel_error() {
+        let env = Env::new().extend(int_val(1));
+        assert!(matches!(env.lookup(0), Err(UplcError::Internal(_))));
+    }
+
+    #[test]
+    fn innermost_binder_is_index_1() {
+        let env = Env::new().extend(int_val(10)).extend(int_val(20));
+        assert_eq!(env.lookup(1).unwrap(), &int_val(20));
+        assert_eq!(env.lookup(2).unwrap(), &int_val(10));
+    }
+
+    #[test]
+    fn index_past_bottom_errors() {
+        let env = Env::new().extend(int_val(7));
+        assert!(env.lookup(2).is_err());
+    }
+
+    #[test]
+    fn extend_is_non_destructive() {
+        let env1 = Env::new().extend(int_val(1));
+        let env2 = env1.extend(int_val(2));
+        assert_eq!(env1.depth(), 1);
+        assert_eq!(env2.depth(), 2);
+        assert_eq!(env2.lookup(1).unwrap(), &int_val(2));
+    }
+}

--- a/crates/dugite-uplc/src/machine/mod.rs
+++ b/crates/dugite-uplc/src/machine/mod.rs
@@ -24,13 +24,14 @@
 //! budget (a Cardano-specific DoS concern noted in the original Plutus
 //! tech report).
 
-#![allow(dead_code)]
-
 pub mod context;
 pub mod cost;
 pub mod env;
 pub mod step;
 pub mod value;
+
+pub use self::step::{evaluate, State};
+pub use self::value::Value;
 
 /// Cap on the continuation-stack depth. Mainnet scripts never reach
 /// anywhere close to this; the limit is purely a DoS guard.

--- a/crates/dugite-uplc/src/machine/step.rs
+++ b/crates/dugite-uplc/src/machine/step.rs
@@ -1,2 +1,222 @@
-//! CEK step — scaffolding placeholder (see machine/mod.rs).
-#![allow(dead_code)]
+//! CEK step driver — minimal subset of UPLC-3.
+
+use crate::machine::context::{Frame, Kont};
+use crate::machine::env::Env;
+use crate::machine::value::Value;
+use crate::term::Term;
+use crate::UplcError;
+
+#[derive(Debug)]
+pub enum State {
+    Compute { term: Term, env: Env, kont: Kont },
+    Return { value: Value, kont: Kont },
+    Done(Value),
+}
+
+pub fn evaluate(term: Term) -> Result<Value, UplcError> {
+    let mut state = State::Compute {
+        term,
+        env: Env::new(),
+        kont: Kont::new(),
+    };
+    loop {
+        state = step(state)?;
+        if let State::Done(v) = state {
+            return Ok(v);
+        }
+    }
+}
+
+fn step(state: State) -> Result<State, UplcError> {
+    match state {
+        State::Compute { term, env, kont } => compute(term, env, kont),
+        State::Return { value, kont } => return_compute(value, kont),
+        State::Done(_) => Err(UplcError::Internal("step called on Done state".into())),
+    }
+}
+
+fn compute(term: Term, env: Env, mut kont: Kont) -> Result<State, UplcError> {
+    match term {
+        Term::Var(i) => {
+            let v = env.lookup(i)?.clone();
+            Ok(State::Return { value: v, kont })
+        }
+        Term::Lam(body) => {
+            let v = Value::Lambda { body, env };
+            Ok(State::Return { value: v, kont })
+        }
+        Term::App(fun, arg) => {
+            kont.push(Frame::AwaitFunTerm {
+                argument: *arg,
+                env: env.clone(),
+            })?;
+            Ok(State::Compute {
+                term: *fun,
+                env,
+                kont,
+            })
+        }
+        Term::Const(c) => Ok(State::Return {
+            value: Value::Const(c),
+            kont,
+        }),
+        Term::Delay(body) => Ok(State::Return {
+            value: Value::Delay { body, env },
+            kont,
+        }),
+        Term::Force(body) => {
+            kont.push(Frame::Force)?;
+            Ok(State::Compute {
+                term: *body,
+                env,
+                kont,
+            })
+        }
+        Term::Error => Err(UplcError::ScriptError),
+        Term::Builtin(id) => Err(UplcError::Internal(format!(
+            "Builtin {} not yet wired (UPLC-4)",
+            id.name()
+        ))),
+        Term::Constr { .. } | Term::Case { .. } => Err(UplcError::Internal(
+            "Constr / Case evaluation not yet wired (UPLC-3 part 2)".into(),
+        )),
+    }
+}
+
+fn return_compute(value: Value, mut kont: Kont) -> Result<State, UplcError> {
+    let frame = match kont.pop() {
+        None => return Ok(State::Done(value)),
+        Some(f) => f,
+    };
+    match frame {
+        Frame::AwaitFunTerm { argument, env } => {
+            kont.push(Frame::AwaitArg {
+                function: value,
+                env: env.clone(),
+            })?;
+            Ok(State::Compute {
+                term: argument,
+                env,
+                kont,
+            })
+        }
+        Frame::AwaitArg { function, .. } => apply(function, value, kont),
+        Frame::Force => force_value(value, kont),
+    }
+}
+
+fn apply(function: Value, argument: Value, kont: Kont) -> Result<State, UplcError> {
+    match function {
+        Value::Lambda { body, env } => Ok(State::Compute {
+            term: *body,
+            env: env.extend(argument),
+            kont,
+        }),
+        Value::Builtin { .. } => Err(UplcError::Internal(
+            "Builtin application not yet wired (UPLC-4)".into(),
+        )),
+        Value::Const(_) | Value::Delay { .. } | Value::Constr { .. } => {
+            Err(UplcError::Internal(format!(
+                "applied non-function value: {:?}",
+                std::mem::discriminant(&function)
+            )))
+        }
+    }
+}
+
+fn force_value(value: Value, kont: Kont) -> Result<State, UplcError> {
+    match value {
+        Value::Delay { body, env } => Ok(State::Compute {
+            term: *body,
+            env,
+            kont,
+        }),
+        other => Err(UplcError::Internal(format!(
+            "force applied to non-Delay value: {:?}",
+            std::mem::discriminant(&other)
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::term::Constant;
+    use num_bigint::BigInt;
+
+    fn int_term(n: i64) -> Term {
+        Term::Const(Constant::Integer(BigInt::from(n)))
+    }
+    fn int_val(n: i64) -> Value {
+        Value::Const(Constant::Integer(BigInt::from(n)))
+    }
+
+    #[test]
+    fn const_int_evaluates_to_itself() {
+        assert_eq!(evaluate(int_term(42)).unwrap(), int_val(42));
+    }
+
+    #[test]
+    fn const_unit_evaluates_to_unit_value() {
+        assert!(evaluate(Term::Const(Constant::Unit)).unwrap().is_unit());
+    }
+
+    #[test]
+    fn error_term_yields_script_error() {
+        assert!(matches!(evaluate(Term::Error), Err(UplcError::ScriptError)));
+    }
+
+    #[test]
+    fn identity_lambda_applied_returns_arg() {
+        // (lam x. x) 7  ⇒  7
+        let id_app = Term::App(
+            Box::new(Term::Lam(Box::new(Term::Var(1)))),
+            Box::new(int_term(7)),
+        );
+        assert_eq!(evaluate(id_app).unwrap(), int_val(7));
+    }
+
+    #[test]
+    fn const_function_applied_returns_first() {
+        // (lam x. (lam y. x)) 1 2  ⇒  1
+        let k = Term::Lam(Box::new(Term::Lam(Box::new(Term::Var(2)))));
+        let applied = Term::App(
+            Box::new(Term::App(Box::new(k), Box::new(int_term(1)))),
+            Box::new(int_term(2)),
+        );
+        assert_eq!(evaluate(applied).unwrap(), int_val(1));
+    }
+
+    #[test]
+    fn delay_then_force_recovers_value() {
+        // (force (delay 42))  ⇒  42
+        let dt = Term::Force(Box::new(Term::Delay(Box::new(int_term(42)))));
+        assert_eq!(evaluate(dt).unwrap(), int_val(42));
+    }
+
+    #[test]
+    fn force_of_non_delay_errors() {
+        let bad = Term::Force(Box::new(int_term(42)));
+        assert!(matches!(evaluate(bad), Err(UplcError::Internal(_))));
+    }
+
+    #[test]
+    fn apply_non_function_errors() {
+        let bad = Term::App(Box::new(int_term(1)), Box::new(int_term(2)));
+        assert!(matches!(evaluate(bad), Err(UplcError::Internal(_))));
+    }
+
+    #[test]
+    fn open_term_var_errors() {
+        assert!(matches!(
+            evaluate(Term::Var(1)),
+            Err(UplcError::Internal(_))
+        ));
+    }
+
+    #[test]
+    fn builtin_application_pending_returns_internal() {
+        let bad = Term::Builtin(crate::term::BuiltinId::AddInteger);
+        assert!(matches!(evaluate(bad), Err(UplcError::Internal(_))));
+    }
+}

--- a/crates/dugite-uplc/src/machine/value.rs
+++ b/crates/dugite-uplc/src/machine/value.rs
@@ -1,2 +1,64 @@
-//! CEK value — scaffolding placeholder (see machine/mod.rs).
-#![allow(dead_code)]
+//! CEK values.
+
+use crate::machine::env::Env;
+use crate::term::{BuiltinId, Constant, Term};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Value {
+    Const(Constant),
+    Lambda {
+        body: Box<Term>,
+        env: Env,
+    },
+    Delay {
+        body: Box<Term>,
+        env: Env,
+    },
+    Builtin {
+        id: BuiltinId,
+        forces: u8,
+        args: Vec<Value>,
+    },
+    Constr {
+        tag: u64,
+        args: Vec<Value>,
+    },
+}
+
+impl Value {
+    pub fn is_unit(&self) -> bool {
+        matches!(self, Value::Const(Constant::Unit))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_bigint::BigInt;
+
+    #[test]
+    fn const_integer_inequality() {
+        let a = Value::Const(Constant::Integer(BigInt::from(1)));
+        let b = Value::Const(Constant::Integer(BigInt::from(2)));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn unit_predicate() {
+        assert!(Value::Const(Constant::Unit).is_unit());
+        assert!(!Value::Const(Constant::Bool(true)).is_unit());
+    }
+
+    #[test]
+    fn lambda_eq_requires_same_body() {
+        let l1 = Value::Lambda {
+            body: Box::new(Term::Var(1)),
+            env: Env::new(),
+        };
+        let l2 = Value::Lambda {
+            body: Box::new(Term::Var(1)),
+            env: Env::new(),
+        };
+        assert_eq!(l1, l2);
+    }
+}


### PR DESCRIPTION
## Summary

First slice of UPLC-3: the CEK abstract machine for the seven term constructors that don't depend on builtin dispatch. Lands the three-state \`Compute / Return / Done\` driver wired byte-for-byte to the Haskell \`UntypedPlutusCore.Evaluation.Machine.Cek.Internal\` state shape.

## Wired (this PR)

\`Var\`, \`Lam\`, \`App\`, \`Const\`, \`Delay\`, \`Force\`, \`Error\`.

## Intentionally NOT yet wired (surface as typed \`Internal\`)

- \`Builtin\` — UPLC-4 lands the 88-builtin dispatcher + denotations + cost-model loader.
- \`Constr\` / \`Case\` — UPLC-3 part 2 (PV9+ SOP).

## Continuation frames

- \`AwaitFunTerm\` — saved arg term, evaluating function side of App.
- \`AwaitArg\` — function already reduced; evaluating arg.
- \`Force\` — body evaluated; expect a \`Delay\` value to unwrap.

## Defensive properties (enforced by tests)

- Env lookup rejects index 0 (free-variable sentinel) and out-of-range refs as typed errors (Haskell \`OpenTermEvaluated\`).
- Kont push enforces \`MAX_KONTINUATION_DEPTH = 4096\` to prevent stack-budget-bypass DoS.
- Apply on non-function and Force on non-Delay both surface as typed errors, never panics.

## Test plan

- [x] \`cargo nextest run -p dugite-uplc\` — 76 tests pass (was 56; +20 in machine/).
- [x] \`cargo clippy -p dugite-uplc --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.
- [ ] CI re-runs on this branch.

## Roadmap context

Remaining UPLC-N PRs (multi-week per DESIGN.md):

- UPLC-3 part 2: Constr / Case + compound flat constants (List / Pair / Data).
- UPLC-4: V1 builtin suite + cost-model loader + slippage budget.
- UPLC-5: V2 builtin extensions (CIP-0033).
- UPLC-6: V3 builtin extensions (CIP-0035 / 0117 / 0123 / 0127 / 0101 / 0381 + BLS12-381).
- UPLC-7: ScriptContext V1 / V2 / V3 builders.
- UPLC-8: Phase-two façade + wire into dugite-ledger/src/plutus.rs.
- UPLC-9: Drop \`uplc = { git = aiken-lang/aiken.git }\`; verify \`cargo tree | grep pallas\` is empty.