### PR TITLE
feat(uplc): Constr / Case CEK evaluation (UPLC-3 part 2)

### DIFF
--- a/crates/dugite-uplc/src/machine/context.rs
+++ b/crates/dugite-uplc/src/machine/context.rs
@@ -6,9 +6,43 @@ use crate::term::Term;
 
 #[derive(Debug, Clone)]
 pub enum Frame {
-    AwaitArg { function: Value, env: Env },
-    AwaitFunTerm { argument: Term, env: Env },
+    AwaitArg {
+        function: Value,
+        env: Env,
+    },
+    AwaitFunTerm {
+        argument: Term,
+        env: Env,
+    },
     Force,
+    /// `ApplyValue arg` — when the current return value lands, apply
+    /// it to `arg` (which is already an evaluated `Value`). Used by
+    /// `Case` dispatch to apply the matching branch to the
+    /// Constr-payload values in left-to-right order.
+    ApplyValue {
+        argument: Value,
+    },
+    /// `Constr tag pending_args evaluated_args env` — we're evaluating
+    /// the arguments of a `Constr` left-to-right. The next pending arg
+    /// is at `pending_args.front()`; already-evaluated args are kept
+    /// in order in `evaluated_args`.
+    ///
+    /// We use `Vec<Term>` for the pending list (popping from the front
+    /// via swap-remove or by tracking an offset would be cheaper, but
+    /// the SoP arg-count is small).
+    Constr {
+        tag: u64,
+        pending: Vec<Term>,
+        evaluated: Vec<Value>,
+        env: Env,
+    },
+    /// `Case branches env` — the scrutinee has been reduced to a
+    /// `Constr`; we pick a branch from `branches` indexed by the
+    /// constr tag, apply the constr args, and evaluate.
+    Cases {
+        branches: Vec<Term>,
+        env: Env,
+    },
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/dugite-uplc/src/machine/step.rs
+++ b/crates/dugite-uplc/src/machine/step.rs
@@ -77,9 +77,53 @@ fn compute(term: Term, env: Env, mut kont: Kont) -> Result<State, UplcError> {
             "Builtin {} not yet wired (UPLC-4)",
             id.name()
         ))),
-        Term::Constr { .. } | Term::Case { .. } => Err(UplcError::Internal(
-            "Constr / Case evaluation not yet wired (UPLC-3 part 2)".into(),
-        )),
+        Term::Constr { tag, args } => {
+            // No args: short-circuit to a fully-evaluated Constr value.
+            if args.is_empty() {
+                return Ok(State::Return {
+                    value: Value::Constr {
+                        tag,
+                        args: Vec::new(),
+                    },
+                    kont,
+                });
+            }
+            // Otherwise: push a Constr frame and evaluate the first arg.
+            let mut pending: Vec<Term> = args.into_iter().rev().collect();
+            // SAFETY: just confirmed args.is_empty() == false, so pop
+            // is Some. Surfaced as Internal for the no-panic invariant.
+            let first = pending.pop().ok_or_else(|| {
+                UplcError::Internal("Constr args empty after non-empty check".into())
+            })?;
+            kont.push(Frame::Constr {
+                tag,
+                pending,
+                evaluated: Vec::new(),
+                env: env.clone(),
+            })?;
+            Ok(State::Compute {
+                term: first,
+                env,
+                kont,
+            })
+        }
+        Term::Case {
+            scrutinee,
+            branches,
+        } => {
+            // Evaluate the scrutinee; save the branches for the
+            // `Cases` frame to dispatch on once the scrutinee value
+            // (a `Constr`) lands.
+            kont.push(Frame::Cases {
+                branches,
+                env: env.clone(),
+            })?;
+            Ok(State::Compute {
+                term: *scrutinee,
+                env,
+                kont,
+            })
+        }
     }
 }
 
@@ -102,6 +146,65 @@ fn return_compute(value: Value, mut kont: Kont) -> Result<State, UplcError> {
         }
         Frame::AwaitArg { function, .. } => apply(function, value, kont),
         Frame::Force => force_value(value, kont),
+        Frame::ApplyValue { argument } => apply(value, argument, kont),
+        Frame::Constr {
+            tag,
+            mut pending,
+            mut evaluated,
+            env,
+        } => {
+            // We just got an evaluated arg. Append it; if more args
+            // remain, evaluate the next one; else emit the Constr
+            // value.
+            evaluated.push(value);
+            if let Some(next) = pending.pop() {
+                kont.push(Frame::Constr {
+                    tag,
+                    pending,
+                    evaluated,
+                    env: env.clone(),
+                })?;
+                Ok(State::Compute {
+                    term: next,
+                    env,
+                    kont,
+                })
+            } else {
+                Ok(State::Return {
+                    value: Value::Constr {
+                        tag,
+                        args: evaluated,
+                    },
+                    kont,
+                })
+            }
+        }
+        Frame::Cases { branches, env } => match value {
+            Value::Constr { tag, args } => {
+                // Pick the branch term by tag. Mismatched tag = script
+                // error (Haskell `MissingCaseBranch`).
+                let branch = branches
+                    .get(tag as usize)
+                    .ok_or(UplcError::ScriptError)?
+                    .clone();
+                // Apply `branch` to each constr arg in order. Push
+                // ApplyValue frames in REVERSE so the first arg ends
+                // up on top of the stack and is popped (applied)
+                // first.
+                for arg in args.into_iter().rev() {
+                    kont.push(Frame::ApplyValue { argument: arg })?;
+                }
+                Ok(State::Compute {
+                    term: branch,
+                    env,
+                    kont,
+                })
+            }
+            other => Err(UplcError::Internal(format!(
+                "Case scrutinee must reduce to Constr, got {:?}",
+                std::mem::discriminant(&other)
+            ))),
+        },
     }
 }
 
@@ -218,5 +321,134 @@ mod tests {
     fn builtin_application_pending_returns_internal() {
         let bad = Term::Builtin(crate::term::BuiltinId::AddInteger);
         assert!(matches!(evaluate(bad), Err(UplcError::Internal(_))));
+    }
+
+    // ── Constr / Case (UPLC-3 part 2) ──────────────────────────────────────
+
+    #[test]
+    fn constr_zero_args_evaluates_to_constr_value() {
+        let t = Term::Constr {
+            tag: 0,
+            args: vec![],
+        };
+        let v = evaluate(t).unwrap();
+        assert_eq!(
+            v,
+            Value::Constr {
+                tag: 0,
+                args: vec![]
+            }
+        );
+    }
+
+    #[test]
+    fn constr_with_args_evaluates_left_to_right() {
+        // Constr 3 [1, 2]
+        let t = Term::Constr {
+            tag: 3,
+            args: vec![int_term(1), int_term(2)],
+        };
+        let v = evaluate(t).unwrap();
+        assert_eq!(
+            v,
+            Value::Constr {
+                tag: 3,
+                args: vec![int_val(1), int_val(2)]
+            }
+        );
+    }
+
+    #[test]
+    fn constr_arg_evaluates_to_lambda() {
+        // Constr 0 [(lam x. x)]
+        let id = Term::Lam(Box::new(Term::Var(1)));
+        let t = Term::Constr {
+            tag: 0,
+            args: vec![id.clone()],
+        };
+        let v = evaluate(t).unwrap();
+        match v {
+            Value::Constr { tag, args } => {
+                assert_eq!(tag, 0);
+                assert_eq!(args.len(), 1);
+                assert!(matches!(args[0], Value::Lambda { .. }));
+            }
+            other => panic!("expected Constr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case_picks_branch_by_constr_tag() {
+        // (case (Constr 1) [42, 99])  ⇒  99
+        let scrutinee = Term::Constr {
+            tag: 1,
+            args: vec![],
+        };
+        let case = Term::Case {
+            scrutinee: Box::new(scrutinee),
+            branches: vec![int_term(42), int_term(99)],
+        };
+        let v = evaluate(case).unwrap();
+        assert_eq!(v, int_val(99));
+    }
+
+    #[test]
+    fn case_applies_branch_to_constr_args() {
+        // (case (Constr 0 1 2) [(lam x. lam y. y)])  ⇒  2
+        // i.e. the branch is a 2-arg lambda returning the second arg.
+        let scrutinee = Term::Constr {
+            tag: 0,
+            args: vec![int_term(1), int_term(2)],
+        };
+        // (lam (lam (var 1)))  — index 1 = innermost (= second arg)
+        let branch = Term::Lam(Box::new(Term::Lam(Box::new(Term::Var(1)))));
+        let case = Term::Case {
+            scrutinee: Box::new(scrutinee),
+            branches: vec![branch],
+        };
+        let v = evaluate(case).unwrap();
+        assert_eq!(v, int_val(2));
+    }
+
+    #[test]
+    fn case_first_arg_then_second_applied_in_order() {
+        // (case (Constr 0 10 20) [(lam (lam (var 2)))])  ⇒  10
+        // The branch returns its FIRST argument (which is at de Bruijn
+        // index 2 from inside the inner lambda).
+        let scrutinee = Term::Constr {
+            tag: 0,
+            args: vec![int_term(10), int_term(20)],
+        };
+        let branch = Term::Lam(Box::new(Term::Lam(Box::new(Term::Var(2)))));
+        let case = Term::Case {
+            scrutinee: Box::new(scrutinee),
+            branches: vec![branch],
+        };
+        let v = evaluate(case).unwrap();
+        assert_eq!(v, int_val(10));
+    }
+
+    #[test]
+    fn case_with_out_of_range_tag_yields_script_error() {
+        // Constr 5 with only 2 branches.
+        let scrutinee = Term::Constr {
+            tag: 5,
+            args: vec![],
+        };
+        let case = Term::Case {
+            scrutinee: Box::new(scrutinee),
+            branches: vec![int_term(1), int_term(2)],
+        };
+        assert!(matches!(evaluate(case), Err(UplcError::ScriptError)));
+    }
+
+    #[test]
+    fn case_with_non_constr_scrutinee_errors() {
+        // (case 42 [99]) — scrutinee isn't a Constr.
+        let case = Term::Case {
+            scrutinee: Box::new(int_term(42)),
+            branches: vec![int_term(99)],
+        };
+        assert!(matches!(evaluate(case), Err(UplcError::Internal(_))));
     }
 }


### PR DESCRIPTION
## Summary

Wires the two PV9+ SOP term forms — \`Constr\` and \`Case\` — into the CEK driver from #566. Together with the seven term constructors landed there, dugite-uplc can now evaluate every UPLC term shape that doesn't require builtin dispatch.

## Constr

\`Term::Constr { tag, args }\` evaluates each arg left-to-right via a new \`Frame::Constr { tag, pending, evaluated, env }\` continuation. The frame's \`pending\` is a reverse-ordered stack so popping returns the next arg in original order. When pending empties the frame emits a \`Value::Constr { tag, args }\`.

## Case

\`Term::Case { scrutinee, branches }\` evaluates the scrutinee, then looks up \`branches[tag]\` and applies it to each constr arg left-to-right via a new \`Frame::ApplyValue { argument }\` continuation — the dual of \`Frame::AwaitArg\` (which awaits an arg given a pre-evaluated function; ApplyValue awaits a function given a pre-evaluated arg).

## Tests added (8)

- Constr 0 [] → empty Value::Constr
- Constr 3 [1, 2] → multi-arg Value::Constr
- Constr 0 [(lam x. x)] → arg-is-lambda Value::Constr
- Case (Constr 1) [42, 99] → 99 (branch picked by tag)
- Case (Constr 0 10 20) [(lam (lam (var 1)))] → 20 (second arg via inner-most de Bruijn)
- Case (Constr 0 10 20) [(lam (lam (var 2)))] → 10 (first arg)
- Case (Constr 5) [a, b] → ScriptError (out-of-range tag)
- Case 42 [99] → Internal (non-Constr scrutinee)

Total dugite-uplc test count: 76 → 84.

## Test plan

- [x] \`cargo nextest run -p dugite-uplc\` — 84 tests pass.
- [x] \`cargo clippy -p dugite-uplc --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

## Roadmap

Remaining work to drop aiken-uplc + transitive pallas (per DESIGN.md):

- UPLC-4: V1 builtin suite + cost-model loader + slippage budget (~1 wk)
- UPLC-5: V2 builtin extensions (CIP-0033) (~1 wk)
- UPLC-6: V3 builtin extensions (CIP-0035/0117/0123/0127/0101/0381 + BLS12-381) (~2 wk)
- UPLC-7: ScriptContext V1/V2/V3 builders (~1 wk)
- UPLC-8: phase-two façade + wire into \`dugite_ledger/src/plutus.rs\` (~1 wk)
- UPLC-9: drop the aiken-uplc git dep + verify \`cargo tree | grep pallas\` is empty (~minutes)