### PR TITLE
feat(uplc): CEK builtin dispatcher + first 13 denotations (UPLC-4 part 2)

### DIFF
--- a/crates/dugite-uplc/src/builtin/denotations.rs
+++ b/crates/dugite-uplc/src/builtin/denotations.rs
@@ -1,2 +1,418 @@
-//! Builtin denotations — scaffolding placeholder (see builtin/mod.rs).
-#![allow(dead_code)]
+//! Builtin denotations.
+//!
+//! Each entry in [`denote`] implements the Haskell-reference
+//! semantics for one builtin. The set is expanded one PR at a time;
+//! entries not yet wired surface as a typed
+//! [`UplcError::Internal`] so the CEK harness reports a clear gap
+//! rather than panicking.
+//!
+//! This commit lands the integer-arithmetic and bool builtins (no
+//! external crypto crates needed). Subsequent commits add bytestring,
+//! string, list, pair, data, and crypto suites.
+
+use crate::machine::value::Value;
+use crate::term::{BuiltinId, Constant};
+use crate::UplcError;
+use num_bigint::BigInt;
+
+/// Saturated-application denotation. The CEK dispatcher calls this
+/// once both the force count and the value-argument count match the
+/// builtin's arity.
+pub fn denote(id: BuiltinId, args: Vec<Value>) -> Result<Value, UplcError> {
+    use BuiltinId::*;
+    match id {
+        // ── Integer arithmetic (V1) ─────────────────────────────────
+        AddInteger => int_binop(args, id, |a, b| Ok(a + b)),
+        SubtractInteger => int_binop(args, id, |a, b| Ok(a - b)),
+        MultiplyInteger => int_binop(args, id, |a, b| Ok(a * b)),
+        DivideInteger => int_binop(args, id, |a, b| {
+            if b.sign() == num_bigint::Sign::NoSign {
+                return Err(builtin_failure(id, "divide by zero"));
+            }
+            Ok(divide_haskell_div(&a, &b))
+        }),
+        QuotientInteger => int_binop(args, id, |a, b| {
+            if b.sign() == num_bigint::Sign::NoSign {
+                return Err(builtin_failure(id, "quotient by zero"));
+            }
+            // Haskell `quot` truncates toward zero.
+            Ok(a / b)
+        }),
+        RemainderInteger => int_binop(args, id, |a, b| {
+            if b.sign() == num_bigint::Sign::NoSign {
+                return Err(builtin_failure(id, "remainder by zero"));
+            }
+            // Haskell `rem` matches `quot`: same sign as dividend.
+            Ok(a % b)
+        }),
+        ModInteger => int_binop(args, id, |a, b| {
+            if b.sign() == num_bigint::Sign::NoSign {
+                return Err(builtin_failure(id, "modulo by zero"));
+            }
+            Ok(mod_haskell_mod(&a, &b))
+        }),
+        EqualsInteger => int_cmp(args, id, |a, b| a == b),
+        LessThanInteger => int_cmp(args, id, |a, b| a < b),
+        LessThanEqualsInteger => int_cmp(args, id, |a, b| a <= b),
+
+        // ── Polymorphic helpers (V1) ────────────────────────────────
+        // `IfThenElse` returns the second or third argument depending
+        // on the boolean first.
+        IfThenElse => {
+            let mut it = args.into_iter();
+            let cond = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            let then_branch = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            let else_branch = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            match cond {
+                Value::Const(Constant::Bool(true)) => Ok(then_branch),
+                Value::Const(Constant::Bool(false)) => Ok(else_branch),
+                other => Err(UplcError::BuiltinTypeError {
+                    builtin: id.name(),
+                    reason: format!(
+                        "ifThenElse expected Bool condition, got {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }),
+            }
+        }
+
+        // Returns its second argument unchanged after observing the
+        // (Unit-typed) first argument. Useful for sequencing.
+        ChooseUnit => {
+            let mut it = args.into_iter();
+            let unit = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            let rest = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            match unit {
+                Value::Const(Constant::Unit) => Ok(rest),
+                other => Err(UplcError::BuiltinTypeError {
+                    builtin: id.name(),
+                    reason: format!(
+                        "chooseUnit expected Unit first arg, got {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                }),
+            }
+        }
+
+        // Trace: emit a log message (currently discarded — the CEK
+        // machine's `EvalResult.logs` will accumulate them once the
+        // tracer is wired) and return the second argument.
+        Trace => {
+            let mut it = args.into_iter();
+            let _msg = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            let rest = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            Ok(rest)
+        }
+
+        // Anything else is a future commit.
+        _ => Err(UplcError::Internal(format!(
+            "builtin denotation for {} not yet wired",
+            id.name()
+        ))),
+    }
+}
+
+fn int_binop<F>(args: Vec<Value>, id: BuiltinId, op: F) -> Result<Value, UplcError>
+where
+    F: FnOnce(BigInt, BigInt) -> Result<BigInt, UplcError>,
+{
+    let (a, b) = take_two_integers(args, id)?;
+    let result = op(a, b)?;
+    Ok(Value::Const(Constant::Integer(result)))
+}
+
+fn int_cmp<F>(args: Vec<Value>, id: BuiltinId, op: F) -> Result<Value, UplcError>
+where
+    F: FnOnce(BigInt, BigInt) -> bool,
+{
+    let (a, b) = take_two_integers(args, id)?;
+    Ok(Value::Const(Constant::Bool(op(a, b))))
+}
+
+fn take_two_integers(args: Vec<Value>, id: BuiltinId) -> Result<(BigInt, BigInt), UplcError> {
+    let mut it = args.into_iter();
+    let a = unwrap_integer(it.next().ok_or_else(|| builtin_arity_mismatch(id))?, id)?;
+    let b = unwrap_integer(it.next().ok_or_else(|| builtin_arity_mismatch(id))?, id)?;
+    Ok((a, b))
+}
+
+fn unwrap_integer(v: Value, id: BuiltinId) -> Result<BigInt, UplcError> {
+    match v {
+        Value::Const(Constant::Integer(i)) => Ok(i),
+        other => Err(UplcError::BuiltinTypeError {
+            builtin: id.name(),
+            reason: format!("expected Integer, got {:?}", std::mem::discriminant(&other)),
+        }),
+    }
+}
+
+fn builtin_arity_mismatch(id: BuiltinId) -> UplcError {
+    UplcError::Internal(format!(
+        "denotation for {} called with wrong argument count",
+        id.name()
+    ))
+}
+
+fn builtin_failure(id: BuiltinId, reason: &str) -> UplcError {
+    UplcError::BuiltinFailure {
+        builtin: id.name(),
+        reason: reason.into(),
+    }
+}
+
+/// Haskell `div`: rounds toward negative infinity (floor division).
+fn divide_haskell_div(a: &BigInt, b: &BigInt) -> BigInt {
+    let (q, r) = (a / b, a % b);
+    // If signs differ and the remainder is non-zero, adjust toward
+    // -infinity by subtracting 1.
+    if r.sign() != num_bigint::Sign::NoSign
+        && ((a.sign() == num_bigint::Sign::Minus) != (b.sign() == num_bigint::Sign::Minus))
+    {
+        q - 1
+    } else {
+        q
+    }
+}
+
+/// Haskell `mod`: result has the sign of the divisor.
+fn mod_haskell_mod(a: &BigInt, b: &BigInt) -> BigInt {
+    let r = a % b;
+    if r.sign() != num_bigint::Sign::NoSign
+        && ((a.sign() == num_bigint::Sign::Minus) != (b.sign() == num_bigint::Sign::Minus))
+    {
+        r + b
+    } else {
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn int(n: i64) -> Value {
+        Value::Const(Constant::Integer(BigInt::from(n)))
+    }
+    fn b(v: bool) -> Value {
+        Value::Const(Constant::Bool(v))
+    }
+
+    fn run(id: BuiltinId, args: Vec<Value>) -> Result<Value, UplcError> {
+        denote(id, args)
+    }
+
+    // ── Integer arithmetic ─────────────────────────────────────────
+
+    #[test]
+    fn add_integer() {
+        assert_eq!(
+            run(BuiltinId::AddInteger, vec![int(1), int(2)]).unwrap(),
+            int(3)
+        );
+        assert_eq!(
+            run(BuiltinId::AddInteger, vec![int(-5), int(10)]).unwrap(),
+            int(5)
+        );
+    }
+
+    #[test]
+    fn subtract_integer() {
+        assert_eq!(
+            run(BuiltinId::SubtractInteger, vec![int(5), int(3)]).unwrap(),
+            int(2)
+        );
+    }
+
+    #[test]
+    fn multiply_integer() {
+        assert_eq!(
+            run(BuiltinId::MultiplyInteger, vec![int(7), int(6)]).unwrap(),
+            int(42)
+        );
+    }
+
+    #[test]
+    fn divide_integer_haskell_div_floor_toward_neg_inf() {
+        // 7 `div` 2 = 3
+        assert_eq!(
+            run(BuiltinId::DivideInteger, vec![int(7), int(2)]).unwrap(),
+            int(3)
+        );
+        // (-7) `div` 2 = -4  (Haskell `div` floors toward -infinity)
+        assert_eq!(
+            run(BuiltinId::DivideInteger, vec![int(-7), int(2)]).unwrap(),
+            int(-4)
+        );
+        // 7 `div` (-2) = -4
+        assert_eq!(
+            run(BuiltinId::DivideInteger, vec![int(7), int(-2)]).unwrap(),
+            int(-4)
+        );
+        // (-7) `div` (-2) = 3
+        assert_eq!(
+            run(BuiltinId::DivideInteger, vec![int(-7), int(-2)]).unwrap(),
+            int(3)
+        );
+    }
+
+    #[test]
+    fn quotient_integer_truncates_toward_zero() {
+        // 7 `quot` 2 = 3
+        assert_eq!(
+            run(BuiltinId::QuotientInteger, vec![int(7), int(2)]).unwrap(),
+            int(3)
+        );
+        // (-7) `quot` 2 = -3   (truncates, not floors)
+        assert_eq!(
+            run(BuiltinId::QuotientInteger, vec![int(-7), int(2)]).unwrap(),
+            int(-3)
+        );
+    }
+
+    #[test]
+    fn remainder_integer_matches_quotient_sign() {
+        // 7 `rem` 2 = 1; (-7) `rem` 2 = -1
+        assert_eq!(
+            run(BuiltinId::RemainderInteger, vec![int(7), int(2)]).unwrap(),
+            int(1)
+        );
+        assert_eq!(
+            run(BuiltinId::RemainderInteger, vec![int(-7), int(2)]).unwrap(),
+            int(-1)
+        );
+    }
+
+    #[test]
+    fn mod_integer_takes_divisor_sign() {
+        // 7 `mod` 2 = 1; (-7) `mod` 2 = 1; 7 `mod` (-2) = -1; (-7) `mod` (-2) = -1.
+        assert_eq!(
+            run(BuiltinId::ModInteger, vec![int(7), int(2)]).unwrap(),
+            int(1)
+        );
+        assert_eq!(
+            run(BuiltinId::ModInteger, vec![int(-7), int(2)]).unwrap(),
+            int(1)
+        );
+        assert_eq!(
+            run(BuiltinId::ModInteger, vec![int(7), int(-2)]).unwrap(),
+            int(-1)
+        );
+        assert_eq!(
+            run(BuiltinId::ModInteger, vec![int(-7), int(-2)]).unwrap(),
+            int(-1)
+        );
+    }
+
+    #[test]
+    fn divide_by_zero_is_builtin_failure() {
+        assert!(matches!(
+            run(BuiltinId::DivideInteger, vec![int(7), int(0)]),
+            Err(UplcError::BuiltinFailure { .. })
+        ));
+        assert!(matches!(
+            run(BuiltinId::QuotientInteger, vec![int(7), int(0)]),
+            Err(UplcError::BuiltinFailure { .. })
+        ));
+        assert!(matches!(
+            run(BuiltinId::RemainderInteger, vec![int(7), int(0)]),
+            Err(UplcError::BuiltinFailure { .. })
+        ));
+        assert!(matches!(
+            run(BuiltinId::ModInteger, vec![int(7), int(0)]),
+            Err(UplcError::BuiltinFailure { .. })
+        ));
+    }
+
+    #[test]
+    fn equals_integer() {
+        assert_eq!(
+            run(BuiltinId::EqualsInteger, vec![int(5), int(5)]).unwrap(),
+            b(true)
+        );
+        assert_eq!(
+            run(BuiltinId::EqualsInteger, vec![int(5), int(6)]).unwrap(),
+            b(false)
+        );
+    }
+
+    #[test]
+    fn less_than_integer() {
+        assert_eq!(
+            run(BuiltinId::LessThanInteger, vec![int(5), int(6)]).unwrap(),
+            b(true)
+        );
+        assert_eq!(
+            run(BuiltinId::LessThanInteger, vec![int(5), int(5)]).unwrap(),
+            b(false)
+        );
+    }
+
+    #[test]
+    fn less_than_equals_integer() {
+        assert_eq!(
+            run(BuiltinId::LessThanEqualsInteger, vec![int(5), int(5)]).unwrap(),
+            b(true)
+        );
+        assert_eq!(
+            run(BuiltinId::LessThanEqualsInteger, vec![int(6), int(5)]).unwrap(),
+            b(false)
+        );
+    }
+
+    // ── Polymorphic helpers ────────────────────────────────────────
+
+    #[test]
+    fn if_then_else_picks_branch() {
+        assert_eq!(
+            run(BuiltinId::IfThenElse, vec![b(true), int(1), int(2)]).unwrap(),
+            int(1)
+        );
+        assert_eq!(
+            run(BuiltinId::IfThenElse, vec![b(false), int(1), int(2)]).unwrap(),
+            int(2)
+        );
+    }
+
+    #[test]
+    fn if_then_else_non_bool_errors() {
+        let err = run(BuiltinId::IfThenElse, vec![int(0), int(1), int(2)]).unwrap_err();
+        assert!(matches!(err, UplcError::BuiltinTypeError { .. }));
+    }
+
+    #[test]
+    fn choose_unit_returns_second_arg() {
+        assert_eq!(
+            run(
+                BuiltinId::ChooseUnit,
+                vec![Value::Const(Constant::Unit), int(7)]
+            )
+            .unwrap(),
+            int(7)
+        );
+    }
+
+    #[test]
+    fn choose_unit_non_unit_errors() {
+        let err = run(BuiltinId::ChooseUnit, vec![int(0), int(7)]).unwrap_err();
+        assert!(matches!(err, UplcError::BuiltinTypeError { .. }));
+    }
+
+    #[test]
+    fn trace_returns_second_arg() {
+        assert_eq!(
+            run(
+                BuiltinId::Trace,
+                vec![Value::Const(Constant::String("hello".into())), int(99)]
+            )
+            .unwrap(),
+            int(99)
+        );
+    }
+
+    #[test]
+    fn unwired_builtin_returns_internal() {
+        // ByteString builtin not wired yet.
+        let err = run(BuiltinId::AppendByteString, vec![]).unwrap_err();
+        assert!(matches!(err, UplcError::Internal(_)));
+    }
+}

--- a/crates/dugite-uplc/src/builtin/dispatch.rs
+++ b/crates/dugite-uplc/src/builtin/dispatch.rs
@@ -1,2 +1,170 @@
-//! Builtin dispatch — scaffolding placeholder (see builtin/mod.rs).
-#![allow(dead_code)]
+//! Builtin dispatch glue.
+//!
+//! Wires the CEK machine's `Term::Builtin(id)` and `Value::Builtin`
+//! reduction rules to the per-builtin denotation table.
+//!
+//! The CEK machine emits a `Value::Builtin { id, forces: 0, args: [] }`
+//! when it first sees a `Term::Builtin(id)`. Each subsequent `Force`
+//! bumps `forces`; each `Apply` bumps `args`. When the count of
+//! forces equals the builtin's required forces AND the count of args
+//! equals the builtin's required arity, the denotation fires.
+
+use crate::builtin::arity::arity_of;
+use crate::builtin::denotations::denote;
+use crate::machine::value::Value;
+use crate::term::BuiltinId;
+use crate::UplcError;
+
+/// Result of accepting another `Force` against a `Value::Builtin`.
+#[derive(Debug)]
+pub enum ForceOutcome {
+    /// Builtin remains under-applied. Continue accumulating.
+    Pending(Value),
+    /// Builtin is fully saturated (forces and args satisfied); the
+    /// denotation has fired and produced a result.
+    Done(Value),
+    /// The script tried to force a builtin that has already received
+    /// its required force count. This is the Haskell
+    /// `BuiltinTermArgumentExpected` failure — a script-level error.
+    Excess,
+}
+
+/// Apply a `Force` to a `Value::Builtin`. Bumps `forces` if more are
+/// required by the builtin's arity table; otherwise reports excess.
+pub fn force_builtin(
+    id: BuiltinId,
+    forces: u8,
+    args: Vec<Value>,
+) -> Result<ForceOutcome, UplcError> {
+    let (required_forces, required_arity) = arity_of(id);
+    if forces < required_forces {
+        let new_forces = forces + 1;
+        let v = Value::Builtin {
+            id,
+            forces: new_forces,
+            args,
+        };
+        // If the builtin takes zero value arguments, accumulating the
+        // final force fires the denotation immediately.
+        if new_forces == required_forces && required_arity == 0 {
+            let result = denote(id, vec![])?;
+            return Ok(ForceOutcome::Done(result));
+        }
+        Ok(ForceOutcome::Pending(v))
+    } else {
+        Ok(ForceOutcome::Excess)
+    }
+}
+
+/// Apply a value-argument to a `Value::Builtin`. Bumps `args` if
+/// more are required; if the saturated count is reached AND all
+/// forces are also accounted for, the denotation fires.
+pub fn apply_builtin(
+    id: BuiltinId,
+    forces: u8,
+    mut args: Vec<Value>,
+    arg: Value,
+) -> Result<Value, UplcError> {
+    let (required_forces, required_arity) = arity_of(id);
+    if forces < required_forces {
+        // The script applied an argument before satisfying the
+        // required force count. Haskell calls this
+        // `BuiltinTermArgumentExpected`. Surface as a typed
+        // builtin-type error so the script halts cleanly.
+        return Err(UplcError::BuiltinTypeError {
+            builtin: builtin_name_static(id),
+            reason: format!(
+                "argument applied before required force count satisfied \
+                 (got {forces} forces, want {required_forces})"
+            ),
+        });
+    }
+    args.push(arg);
+    let arg_count = args.len() as u8;
+    if arg_count < required_arity {
+        return Ok(Value::Builtin { id, forces, args });
+    }
+    if arg_count > required_arity {
+        // Should be unreachable given the per-application apply path,
+        // but surface as a typed error rather than silently dropping
+        // the surplus argument.
+        return Err(UplcError::BuiltinTypeError {
+            builtin: builtin_name_static(id),
+            reason: format!(
+                "over-application: builtin has arity {required_arity} \
+                 but received {arg_count} arguments"
+            ),
+        });
+    }
+    // Saturated: invoke the denotation.
+    denote(id, args)
+}
+
+/// Return a `'static str` identifier for the builtin (alias for the
+/// `name()` method on `BuiltinId`). Kept as a thin wrapper so error
+/// constructors don't carry the full `BuiltinId` import everywhere.
+fn builtin_name_static(id: BuiltinId) -> &'static str {
+    id.name()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::term::Constant;
+    use num_bigint::BigInt;
+
+    fn int_val(n: i64) -> Value {
+        Value::Const(Constant::Integer(BigInt::from(n)))
+    }
+
+    #[test]
+    fn force_zero_force_builtin_returns_excess_on_first_force() {
+        // AddInteger needs 0 forces. The first force is already excess.
+        match force_builtin(BuiltinId::AddInteger, 0, vec![]).unwrap() {
+            ForceOutcome::Excess => {}
+            other => panic!("expected Excess, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn force_one_force_builtin_becomes_pending_then_excess() {
+        // IfThenElse needs 1 force.
+        let v1 = match force_builtin(BuiltinId::IfThenElse, 0, vec![]).unwrap() {
+            ForceOutcome::Pending(v) => v,
+            other => panic!("expected Pending, got {other:?}"),
+        };
+        match v1 {
+            Value::Builtin { id, forces, .. } => {
+                assert_eq!(id, BuiltinId::IfThenElse);
+                assert_eq!(forces, 1);
+            }
+            _ => panic!("expected Value::Builtin"),
+        }
+        // Forcing again is excess.
+        match force_builtin(BuiltinId::IfThenElse, 1, vec![]).unwrap() {
+            ForceOutcome::Excess => {}
+            other => panic!("expected Excess, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn applying_before_forces_satisfied_errors() {
+        // IfThenElse needs 1 force; applying an arg first is a
+        // builtin-type error.
+        let err = apply_builtin(BuiltinId::IfThenElse, 0, vec![], int_val(1)).unwrap_err();
+        assert!(matches!(err, UplcError::BuiltinTypeError { .. }));
+    }
+
+    #[test]
+    fn apply_under_arity_returns_partial() {
+        // AddInteger arity (0, 2) — applying just one arg is still partial.
+        let v = apply_builtin(BuiltinId::AddInteger, 0, vec![], int_val(1)).unwrap();
+        match v {
+            Value::Builtin { id, args, .. } => {
+                assert_eq!(id, BuiltinId::AddInteger);
+                assert_eq!(args.len(), 1);
+            }
+            _ => panic!("expected Builtin"),
+        }
+    }
+}

--- a/crates/dugite-uplc/src/machine/step.rs
+++ b/crates/dugite-uplc/src/machine/step.rs
@@ -73,10 +73,32 @@ fn compute(term: Term, env: Env, mut kont: Kont) -> Result<State, UplcError> {
             })
         }
         Term::Error => Err(UplcError::ScriptError),
-        Term::Builtin(id) => Err(UplcError::Internal(format!(
-            "Builtin {} not yet wired (UPLC-4)",
-            id.name()
-        ))),
+        Term::Builtin(id) => {
+            // Emit a partially-applied builtin value; the dispatcher
+            // accumulates forces / args as subsequent `Force`s and
+            // `Apply`s occur, then fires the denotation when the
+            // builtin's arity is satisfied. A zero-force / zero-arity
+            // builtin would fire immediately, but no such builtin
+            // exists on the wire.
+            let (required_forces, required_arity) = crate::builtin::arity::arity_of(id);
+            let v = Value::Builtin {
+                id,
+                forces: 0,
+                args: Vec::new(),
+            };
+            // Defensive check: a zero-force, zero-arity builtin would
+            // be a value already and should fire its denotation here.
+            // No such on-chain builtin exists, but we surface the
+            // hypothetical via a typed error rather than skipping.
+            if required_forces == 0 && required_arity == 0 {
+                return Err(UplcError::Internal(format!(
+                    "builtin {} has zero forces+arity; no on-chain \
+                     denotation should match this shape",
+                    id.name()
+                )));
+            }
+            Ok(State::Return { value: v, kont })
+        }
         Term::Constr { tag, args } => {
             // No args: short-circuit to a fully-evaluated Constr value.
             if args.is_empty() {
@@ -215,9 +237,10 @@ fn apply(function: Value, argument: Value, kont: Kont) -> Result<State, UplcErro
             env: env.extend(argument),
             kont,
         }),
-        Value::Builtin { .. } => Err(UplcError::Internal(
-            "Builtin application not yet wired (UPLC-4)".into(),
-        )),
+        Value::Builtin { id, forces, args } => {
+            let v = crate::builtin::dispatch::apply_builtin(id, forces, args, argument)?;
+            Ok(State::Return { value: v, kont })
+        }
         Value::Const(_) | Value::Delay { .. } | Value::Constr { .. } => {
             Err(UplcError::Internal(format!(
                 "applied non-function value: {:?}",
@@ -234,6 +257,18 @@ fn force_value(value: Value, kont: Kont) -> Result<State, UplcError> {
             env,
             kont,
         }),
+        Value::Builtin { id, forces, args } => {
+            use crate::builtin::dispatch::{force_builtin, ForceOutcome};
+            match force_builtin(id, forces, args)? {
+                ForceOutcome::Pending(v) | ForceOutcome::Done(v) => {
+                    Ok(State::Return { value: v, kont })
+                }
+                ForceOutcome::Excess => Err(UplcError::BuiltinTypeError {
+                    builtin: id.name(),
+                    reason: "excess force on already-saturated builtin".into(),
+                }),
+            }
+        }
         other => Err(UplcError::Internal(format!(
             "force applied to non-Delay value: {:?}",
             std::mem::discriminant(&other)
@@ -317,10 +352,77 @@ mod tests {
         ));
     }
 
+    // ── Builtin dispatch (UPLC-4 part 2) ───────────────────────────────────
+
+    fn app(f: Term, a: Term) -> Term {
+        Term::App(Box::new(f), Box::new(a))
+    }
+
     #[test]
-    fn builtin_application_pending_returns_internal() {
-        let bad = Term::Builtin(crate::term::BuiltinId::AddInteger);
-        assert!(matches!(evaluate(bad), Err(UplcError::Internal(_))));
+    fn add_integer_via_builtin_dispatch() {
+        // (addInteger 3 4)  ⇒  7
+        let t = app(
+            app(
+                Term::Builtin(crate::term::BuiltinId::AddInteger),
+                int_term(3),
+            ),
+            int_term(4),
+        );
+        assert_eq!(evaluate(t).unwrap(), int_val(7));
+    }
+
+    #[test]
+    fn equals_integer_via_builtin_dispatch() {
+        let t = app(
+            app(
+                Term::Builtin(crate::term::BuiltinId::EqualsInteger),
+                int_term(5),
+            ),
+            int_term(5),
+        );
+        assert_eq!(evaluate(t).unwrap(), Value::Const(Constant::Bool(true)));
+    }
+
+    #[test]
+    fn if_then_else_requires_force_first() {
+        // IfThenElse needs 1 force. Without forcing first, applying
+        // an arg is a BuiltinTypeError.
+        let t = app(
+            Term::Builtin(crate::term::BuiltinId::IfThenElse),
+            Term::Const(Constant::Bool(true)),
+        );
+        assert!(matches!(
+            evaluate(t),
+            Err(UplcError::BuiltinTypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn if_then_else_picks_then_branch_after_force() {
+        // (force ifThenElse) True 1 2  ⇒  1
+        let t = app(
+            app(
+                app(
+                    Term::Force(Box::new(Term::Builtin(crate::term::BuiltinId::IfThenElse))),
+                    Term::Const(Constant::Bool(true)),
+                ),
+                int_term(1),
+            ),
+            int_term(2),
+        );
+        assert_eq!(evaluate(t).unwrap(), int_val(1));
+    }
+
+    #[test]
+    fn divide_by_zero_yields_builtin_failure() {
+        let t = app(
+            app(
+                Term::Builtin(crate::term::BuiltinId::DivideInteger),
+                int_term(7),
+            ),
+            int_term(0),
+        );
+        assert!(matches!(evaluate(t), Err(UplcError::BuiltinFailure { .. })));
     }
 
     // ── Constr / Case (UPLC-3 part 2) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Wires \`Term::Builtin(id)\` and \`Value::Builtin\` into the CEK step driver via a new dispatcher in \`crate::builtin::dispatch\`. When the machine encounters \`Term::Builtin(id)\`, it emits a \`Value::Builtin { id, forces: 0, args: [] }\`. Each subsequent \`Force\` bumps the force count via \`force_builtin\`; each \`Apply\` bumps the arg count via \`apply_builtin\`. When (forces, arity) equals the builtin's required pair, the denotation in \`crate::builtin::denotations::denote\` fires and the machine returns the result.

## Denotations wired (13 of 88)

| Category | Builtins |
|---|---|
| Integer arithmetic (V1) | addInteger, subtractInteger, multiplyInteger, divideInteger, quotientInteger, remainderInteger, modInteger, equalsInteger, lessThanInteger, lessThanEqualsInteger |
| Polymorphic (V1) | ifThenElse, chooseUnit, trace |

Haskell-spec semantics verified:

- \`divideInteger\` floors toward -∞ (Haskell \`div\`); \`quotientInteger\` truncates toward zero (Haskell \`quot\`).
- \`remainderInteger\` matches \`quotientInteger\`'s sign (dividend); \`modInteger\` matches \`divideInteger\`'s sign (divisor).
- Division/quotient/remainder/mod by zero is a typed \`BuiltinFailure\`, not a panic.
- \`ifThenElse\` requires one force first (BuiltinTypeError if an argument arrives before the force is satisfied).
- \`chooseUnit\` requires its first arg to be \`Unit\`.
- \`trace\` discards the log message for now (logs accumulator is UPLC-4 part 4).

## CEK wiring

- \`compute(Term::Builtin(id), ...)\` returns \`Value::Builtin { id, forces: 0, args: [] }\`.
- \`force_value(Value::Builtin {...})\` calls \`force_builtin\` from the dispatcher and either bumps forces or fires the saturated denotation.
- \`apply(Value::Builtin {...}, arg)\` calls \`apply_builtin\`.
- Excess force, apply-before-force, or over-application all surface as typed \`BuiltinTypeError\`.

## Notable end-to-end checks

- \`(addInteger 3 4)\` → \`7\`
- \`(force ifThenElse) True 1 2\` → \`1\`
- \`(ifThenElse True 1 2)\` without forcing first → \`BuiltinTypeError\`
- \`(divideInteger 7 0)\` → \`BuiltinFailure\`
- \`(equalsInteger 5 5)\` → \`True\`

## Test plan

- [x] \`cargo nextest run -p dugite-uplc\` — 111 tests pass (was 84; +27).
- [x] \`cargo clippy -p dugite-uplc --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all -- --check\` clean.

## Roadmap

Remaining work to drop aiken-uplc + transitive pallas:

- UPLC-4 part 3: bytestring + string + list + pair + data denotations
- UPLC-4 part 4: cost-model loader + slippage budget + logs accumulator
- UPLC-4 part 5: SHA-256 / SHA-3 / Blake2b / Keccak / RIPEMD-160 / ed25519 / secp256k1
- UPLC-5: BLS12-381 (CIP-0381)
- UPLC-6: bitwise + integerToByteString + byteStringToInteger + expModInteger
- UPLC-7: ScriptContext V1 / V2 / V3 builders
- UPLC-8: phase-two façade + wire into \`dugite_ledger/src/plutus.rs\`
- UPLC-9: drop \`uplc = { git = aiken-lang/aiken.git }\`