### PR TITLE
feat(uplc): cost models decode + wire-through (UPLC-9 part 2)

### DIFF
--- a/crates/dugite-uplc/src/cost_models.rs
+++ b/crates/dugite-uplc/src/cost_models.rs
@@ -1,0 +1,414 @@
+//! Plutus cost-models wire-format decoder.
+//!
+//! The ledger passes `cost_models_cbor` to [`crate::phase_two::eval_phase_two_raw`]
+//! as a CBOR map keyed by Plutus language version:
+//!
+//! ```text
+//! cost_models = { ? 0 => [* int]   ; PlutusV1
+//!               , ? 1 => [* int]   ; PlutusV2
+//!               , ? 2 => [* int]   ; PlutusV3
+//!               }
+//! ```
+//!
+//! Each value is a flat array of per-parameter cost coefficients in the
+//! canonical Plutus order (see `PlutusLedgerApi.Common.Versions` in the
+//! Haskell reference). Decoding here only lifts the bytes into typed
+//! `Vec<i64>` arrays — interpreting each entry against a particular
+//! builtin lives one layer up (UPLC-9 part 4, per-redeemer CEK eval).
+//!
+//! ## Sizing
+//!
+//! Canonical Plutus parameter counts (V1=166, V2=185, V3=297 as of
+//! PV11) are documented for reference but **not enforced** at the
+//! decode boundary. cardano-node accepts on-chain ParameterChange
+//! actions that grow or shrink the array as new builtins land (see
+//! e.g. CIP-0117 / CIP-0123) — the decoder must tolerate arrays of
+//! arbitrary size up to a defensive cap so adversarial cost models
+//! cannot trigger an unbounded `Vec::with_capacity`.
+//!
+//! ## Adversarial-input contract
+//!
+//! Every public entry in this module returns `Result` and never
+//! panics on malformed CBOR (per `lib.rs` §1). Length headers are
+//! sanity-clamped before any `Vec::with_capacity` (per §2). Recursion
+//! is bounded: we descend at most one level (top-level map → array
+//! per language). Unknown map keys are skipped rather than rejected,
+//! mirroring cardano-node's "future-language" tolerance.
+
+use crate::phase_two::PhaseTwoError;
+use minicbor::data::Type;
+use minicbor::Decoder;
+
+/// Defensive upper bound on the number of cost-model parameters per
+/// Plutus language version. The Haskell reference currently tops out
+/// at 297 (PlutusV3 at PV11); we pick a comfortable headroom so
+/// future builtins land without code changes, but small enough that
+/// an attacker cannot trick the decoder into an unbounded allocation.
+const MAX_PARAMS_PER_VERSION: usize = 1024;
+
+/// Defensive upper bound on the number of top-level map keys. The
+/// canonical encoding has at most three entries (V1/V2/V3). We allow
+/// a bit more to tolerate forward-compat ParameterChange actions
+/// that introduce a new language version, but reject any encoding
+/// that names hundreds of versions.
+const MAX_VERSIONS: usize = 16;
+
+/// CBOR map key for the V1 language. Matches `to_cbor` in
+/// `dugite_primitives::transaction::CostModels`.
+const KEY_V1: u32 = 0;
+const KEY_V2: u32 = 1;
+const KEY_V3: u32 = 2;
+
+/// Per-version cost-model coefficient arrays. Each `Vec<i64>` is the
+/// raw flat array of parameter values in Plutus canonical order.
+/// Versions absent from the wire encoding remain `None`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CostModels {
+    pub plutus_v1: Option<Vec<i64>>,
+    pub plutus_v2: Option<Vec<i64>>,
+    pub plutus_v3: Option<Vec<i64>>,
+}
+
+impl CostModels {
+    /// True if the wire encoding declared no Plutus version at all.
+    /// Callers (phase-2 evaluator) treat this as "no cost model
+    /// configured" and use the CEK machine's default per-step cost
+    /// constants from `machine::cost`.
+    pub fn is_empty(&self) -> bool {
+        self.plutus_v1.is_none() && self.plutus_v2.is_none() && self.plutus_v3.is_none()
+    }
+}
+
+/// Decode a cost-models CBOR blob into [`CostModels`].
+///
+/// Returns [`PhaseTwoError::CostModelDecode`] for any malformed CBOR
+/// (non-map top level, oversize length headers, non-integer entries,
+/// truncated input, etc.) so the caller can fail the tx cleanly
+/// without panicking.
+pub fn decode_cost_models_cbor(cbor: &[u8]) -> Result<CostModels, PhaseTwoError> {
+    let mut d = Decoder::new(cbor);
+    let map_len = d
+        .map()
+        .map_err(|e| PhaseTwoError::CostModelDecode(format!("expected top-level map: {e}")))?;
+    let mut out = CostModels::default();
+
+    // Strict caps: definite-length maps are checked against MAX_VERSIONS up
+    // front. Indefinite-length maps are walked entry-by-entry with the same
+    // cap enforced as we go.
+    match map_len {
+        Some(n) => {
+            let n_usize: usize = n.try_into().map_err(|_| {
+                PhaseTwoError::CostModelDecode(format!("map length {n} exceeds platform usize"))
+            })?;
+            if n_usize > MAX_VERSIONS {
+                return Err(PhaseTwoError::CostModelDecode(format!(
+                    "map length {n_usize} exceeds defensive cap {MAX_VERSIONS}"
+                )));
+            }
+            for _ in 0..n_usize {
+                consume_one_entry(&mut d, &mut out)?;
+            }
+        }
+        None => {
+            // Indefinite-length map: read until the break code.
+            let mut seen: usize = 0;
+            loop {
+                if d.datatype()
+                    .map_err(|e| PhaseTwoError::CostModelDecode(format!("peek datatype: {e}")))?
+                    == Type::Break
+                {
+                    d.skip().map_err(|e| {
+                        PhaseTwoError::CostModelDecode(format!("consume break: {e}"))
+                    })?;
+                    break;
+                }
+                if seen >= MAX_VERSIONS {
+                    return Err(PhaseTwoError::CostModelDecode(format!(
+                        "indefinite map exceeded defensive cap {MAX_VERSIONS}"
+                    )));
+                }
+                consume_one_entry(&mut d, &mut out)?;
+                seen += 1;
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Consume one (key, value) pair from the top-level map.
+///
+/// Known keys (0/1/2 → V1/V2/V3) populate the matching field on
+/// [`CostModels`]. Unknown keys are skipped — both the key (a single
+/// CBOR integer the decoder already consumed) and the value (which
+/// `skip` walks past in a single call).
+///
+/// Duplicate occurrences of the same known key overwrite the prior
+/// value; this matches the CBOR-canonical semantics that the **last**
+/// occurrence wins, and lines up with how `minicbor::Decoder::map`
+/// surfaces the entries.
+fn consume_one_entry(d: &mut Decoder<'_>, out: &mut CostModels) -> Result<(), PhaseTwoError> {
+    // The key may be encoded as any unsigned integer width. We accept
+    // u8/u16/u32 and reject anything broader (the keys are tiny enums).
+    let key = d
+        .u32()
+        .map_err(|e| PhaseTwoError::CostModelDecode(format!("map key not a small uint: {e}")))?;
+    match key {
+        KEY_V1 => out.plutus_v1 = Some(read_int_array(d, "V1")?),
+        KEY_V2 => out.plutus_v2 = Some(read_int_array(d, "V2")?),
+        KEY_V3 => out.plutus_v3 = Some(read_int_array(d, "V3")?),
+        unknown => {
+            // Forward-compat: skip the value associated with an unknown
+            // version key rather than rejecting the whole encoding.
+            tracing::debug!(
+                key = unknown,
+                "cost_models: skipping unknown language version key"
+            );
+            d.skip().map_err(|e| {
+                PhaseTwoError::CostModelDecode(format!("skipping unknown key {unknown}: {e}"))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a `[* int]` array, clamping the declared length against
+/// [`MAX_PARAMS_PER_VERSION`] before any allocation.
+fn read_int_array(d: &mut Decoder<'_>, label: &'static str) -> Result<Vec<i64>, PhaseTwoError> {
+    let arr_len = d
+        .array()
+        .map_err(|e| PhaseTwoError::CostModelDecode(format!("{label}: expected array: {e}")))?;
+    match arr_len {
+        Some(n) => {
+            let n_usize: usize = n.try_into().map_err(|_| {
+                PhaseTwoError::CostModelDecode(format!(
+                    "{label}: array length {n} exceeds platform usize"
+                ))
+            })?;
+            if n_usize > MAX_PARAMS_PER_VERSION {
+                return Err(PhaseTwoError::CostModelDecode(format!(
+                    "{label}: array length {n_usize} exceeds defensive cap \
+                     {MAX_PARAMS_PER_VERSION}"
+                )));
+            }
+            let mut out = Vec::with_capacity(n_usize);
+            for i in 0..n_usize {
+                let v = d.i64().map_err(|e| {
+                    PhaseTwoError::CostModelDecode(format!(
+                        "{label}[{i}]: not a signed integer: {e}"
+                    ))
+                })?;
+                out.push(v);
+            }
+            Ok(out)
+        }
+        None => {
+            // Indefinite array — walk to the break code, clamping as we go.
+            let mut out: Vec<i64> = Vec::new();
+            loop {
+                let ty = d
+                    .datatype()
+                    .map_err(|e| PhaseTwoError::CostModelDecode(format!("{label}: peek: {e}")))?;
+                if ty == Type::Break {
+                    d.skip().map_err(|e| {
+                        PhaseTwoError::CostModelDecode(format!("{label}: consume break: {e}"))
+                    })?;
+                    return Ok(out);
+                }
+                if out.len() >= MAX_PARAMS_PER_VERSION {
+                    return Err(PhaseTwoError::CostModelDecode(format!(
+                        "{label}: indefinite array exceeded defensive cap \
+                         {MAX_PARAMS_PER_VERSION}"
+                    )));
+                }
+                let v = d.i64().map_err(|e| {
+                    PhaseTwoError::CostModelDecode(format!(
+                        "{label}[{i}]: not a signed integer: {e}",
+                        i = out.len()
+                    ))
+                })?;
+                out.push(v);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build CBOR `map<u8, [int]>` matching the ledger's encoding.
+    fn build_map_cbor(entries: &[(u32, &[i64])]) -> Vec<u8> {
+        use minicbor::Encoder;
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        enc.map(entries.len() as u64).unwrap();
+        for (key, costs) in entries {
+            enc.u32(*key).unwrap();
+            enc.array(costs.len() as u64).unwrap();
+            for c in *costs {
+                enc.i64(*c).unwrap();
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn decodes_single_v3_entry() {
+        let cbor = build_map_cbor(&[(KEY_V3, &[1, 2, 3, -7])]);
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert!(cm.plutus_v1.is_none());
+        assert!(cm.plutus_v2.is_none());
+        assert_eq!(cm.plutus_v3.as_deref(), Some(&[1i64, 2, 3, -7][..]));
+        assert!(!cm.is_empty());
+    }
+
+    #[test]
+    fn decodes_all_three_versions() {
+        let v1 = vec![10i64; 50];
+        let v2 = vec![20i64; 60];
+        let v3 = vec![30i64; 70];
+        let cbor = build_map_cbor(&[(KEY_V1, &v1), (KEY_V2, &v2), (KEY_V3, &v3)]);
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(cm.plutus_v1.as_ref().map(|v| v.len()), Some(50));
+        assert_eq!(cm.plutus_v2.as_ref().map(|v| v.len()), Some(60));
+        assert_eq!(cm.plutus_v3.as_ref().map(|v| v.len()), Some(70));
+        assert_eq!(cm.plutus_v1.unwrap()[0], 10);
+        assert_eq!(cm.plutus_v2.unwrap()[0], 20);
+        assert_eq!(cm.plutus_v3.unwrap()[0], 30);
+    }
+
+    #[test]
+    fn empty_map_is_legal_and_yields_default() {
+        let cbor = build_map_cbor(&[]);
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert!(cm.is_empty());
+    }
+
+    #[test]
+    fn unknown_version_key_is_skipped_not_rejected() {
+        // Mix a real V2 entry with a future-version key (99). The decoder
+        // tolerates the unknown key but still surfaces the V2 entry.
+        let v2 = vec![1, 2, 3];
+        let cbor = build_map_cbor(&[(KEY_V2, &v2), (99, &[7, 8])]);
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(cm.plutus_v2.as_deref(), Some(&[1i64, 2, 3][..]));
+        assert!(cm.plutus_v1.is_none());
+        assert!(cm.plutus_v3.is_none());
+    }
+
+    #[test]
+    fn duplicate_known_key_last_wins() {
+        let cbor = build_map_cbor(&[(KEY_V1, &[1, 2]), (KEY_V1, &[9, 8, 7])]);
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(cm.plutus_v1.as_deref(), Some(&[9i64, 8, 7][..]));
+    }
+
+    #[test]
+    fn dugite_primitives_cost_models_roundtrip() {
+        use dugite_primitives::transaction::CostModels as PrimCostModels;
+        let prim = PrimCostModels {
+            plutus_v1: Some(vec![1, 2, 3]),
+            plutus_v2: None,
+            plutus_v3: Some(vec![100, 200, -300]),
+        };
+        let cbor = prim.to_cbor().unwrap();
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(cm.plutus_v1, prim.plutus_v1);
+        assert_eq!(cm.plutus_v2, prim.plutus_v2);
+        assert_eq!(cm.plutus_v3, prim.plutus_v3);
+    }
+
+    #[test]
+    fn rejects_non_map_top_level() {
+        // Array, not map.
+        let cbor = vec![0x80];
+        let err = decode_cost_models_cbor(&cbor).unwrap_err();
+        assert!(matches!(err, PhaseTwoError::CostModelDecode(_)));
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        let err = decode_cost_models_cbor(&[]).unwrap_err();
+        assert!(matches!(err, PhaseTwoError::CostModelDecode(_)));
+    }
+
+    #[test]
+    fn rejects_truncated_value_array() {
+        // Map(1) with key 0 → array(3) but only one int follows.
+        let cbor = vec![0xa1, 0x00, 0x83, 0x01];
+        let err = decode_cost_models_cbor(&cbor).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("V1["),
+            "expected per-element error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_string_value() {
+        // Map(1) with key 1 → text("oops").
+        let mut cbor = vec![0xa1, 0x01];
+        cbor.extend([0x64, b'o', b'o', b'p', b's']);
+        let err = decode_cost_models_cbor(&cbor).unwrap_err();
+        assert!(matches!(err, PhaseTwoError::CostModelDecode(_)));
+    }
+
+    #[test]
+    fn rejects_oversize_version_count() {
+        // Map(MAX_VERSIONS + 1) — declared length alone trips the cap.
+        use minicbor::Encoder;
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        enc.map((MAX_VERSIONS + 1) as u64).unwrap();
+        // We don't even bother encoding entries — the cap fires first.
+        let err = decode_cost_models_cbor(&buf).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("defensive cap"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_oversize_param_array() {
+        use minicbor::Encoder;
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        enc.map(1).unwrap();
+        enc.u32(KEY_V3).unwrap();
+        enc.array((MAX_PARAMS_PER_VERSION + 1) as u64).unwrap();
+        let err = decode_cost_models_cbor(&buf).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("V3") && msg.contains("defensive cap"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn indefinite_length_map_decodes() {
+        // Indefinite-length map with one V2 entry and a definite-length array.
+        let cbor = vec![0xbf, 0x01, 0x83, 0x01, 0x02, 0x03, 0xff];
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(cm.plutus_v2.as_deref(), Some(&[1i64, 2, 3][..]));
+    }
+
+    #[test]
+    fn indefinite_length_array_decodes() {
+        // Map(1) key V1, indefinite-length array [1, 2, 3].
+        let cbor = vec![0xa1, 0x00, 0x9f, 0x01, 0x02, 0x03, 0xff];
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(cm.plutus_v1.as_deref(), Some(&[1i64, 2, 3][..]));
+    }
+
+    #[test]
+    fn negative_costs_are_accepted() {
+        // PV-bumping ParameterChange actions can legitimately introduce
+        // negative coefficients in piecewise cost models (e.g., where a
+        // builtin's amortised cost has a y-intercept subtracted off).
+        let cbor = build_map_cbor(&[(KEY_V3, &[-1, -2, i64::MIN / 4])]);
+        let cm = decode_cost_models_cbor(&cbor).unwrap();
+        assert_eq!(
+            cm.plutus_v3.as_deref(),
+            Some(&[-1i64, -2, i64::MIN / 4][..])
+        );
+    }
+}

--- a/crates/dugite-uplc/src/lib.rs
+++ b/crates/dugite-uplc/src/lib.rs
@@ -43,6 +43,7 @@
 #![cfg_attr(not(test), deny(clippy::panic, clippy::todo, clippy::unimplemented))]
 
 pub mod builtin;
+pub mod cost_models;
 pub mod data;
 pub mod flat;
 pub mod machine;

--- a/crates/dugite-uplc/src/phase_two.rs
+++ b/crates/dugite-uplc/src/phase_two.rs
@@ -42,6 +42,7 @@
 //! `uplc = { git = aiken-lang/aiken.git }` workspace dep and the
 //! transitive `pallas-*` chain comes with it.
 
+use crate::cost_models::{decode_cost_models_cbor, CostModels};
 use crate::machine::cost::ExBudget;
 use dugite_primitives::transaction::{Transaction, TransactionInput, TransactionOutput};
 
@@ -65,7 +66,7 @@ pub struct SlotConfig {
 /// us aligned with the script-data-hash domain.
 //
 // Fields are read by tests in this module and will be consumed by UPLC-9
-// parts 2-4 (TxInfo population, ScriptContext build, CEK eval).
+// parts 3-4 (TxInfo population, ScriptContext build, CEK eval).
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct DecodedPhaseTwoInputs {
@@ -73,6 +74,11 @@ pub(crate) struct DecodedPhaseTwoInputs {
     pub tx: Transaction,
     /// The resolved UTxO entries: `(input, output, output_raw_cbor)` triples.
     pub utxos: Vec<(TransactionInput, TransactionOutput, Vec<u8>)>,
+    /// The per-Plutus-version cost-model coefficient arrays the ledger
+    /// supplied via `cost_models_cbor`. `None` when the caller passed
+    /// `cost_models_cbor: None` — the CEK machine falls back to its
+    /// per-step default cost from `machine::cost` in that case.
+    pub cost_models: Option<CostModels>,
 }
 
 /// Per-redeemer evaluation result. Returned by
@@ -151,7 +157,7 @@ impl RedeemerObserver for () {
 pub fn eval_phase_two_raw<O: RedeemerObserver>(
     tx_cbor: &[u8],
     utxos: &[(Vec<u8>, Vec<u8>)],
-    _cost_models_cbor: Option<&[u8]>,
+    cost_models_cbor: Option<&[u8]>,
     _initial_budget: (u64, u64),
     _slot_config: SlotConfig,
     _run_phase_one: bool,
@@ -160,7 +166,7 @@ pub fn eval_phase_two_raw<O: RedeemerObserver>(
     // Wire-up checklist before this returns Ok(...):
     //   1. Decode tx via dugite-serialization                ── DONE (UPLC-9 part 1)
     //   2. Decode UTxO entries                               ── DONE (UPLC-9 part 1)
-    //   3. Parse cost models per Plutus version              ── UPLC-9 part 2
+    //   3. Parse cost models per Plutus version              ── DONE (UPLC-9 part 2)
     //   4. Build per-version TxInfo                          ── UPLC-9 part 3
     //   5. For each redeemer:                                ── UPLC-9 part 4
     //      a. Resolve script (witness set or reference input)
@@ -168,12 +174,12 @@ pub fn eval_phase_two_raw<O: RedeemerObserver>(
     //      c. Build ScriptContext + encode to Data
     //      d. Apply args + evaluate via CEK with budget tracker
     //      e. Push RedeemerResult
-    let _decoded = decode_phase_two_inputs(tx_cbor, utxos)?;
+    let _decoded = decode_phase_two_inputs(tx_cbor, utxos, cost_models_cbor)?;
     Err(PhaseTwoError::NotImplemented)
 }
 
-/// Decode the wire-format inputs (`tx_cbor` + resolved-UTxO pairs) the ledger
-/// hands to [`eval_phase_two_raw`].
+/// Decode the wire-format inputs (`tx_cbor` + resolved-UTxO pairs + cost
+/// models) the ledger hands to [`eval_phase_two_raw`].
 ///
 /// The transaction is decoded by trying eras Conway → Babbage → Alonzo in turn
 /// (which covers every era that admits Plutus scripts). The first success
@@ -182,12 +188,17 @@ pub fn eval_phase_two_raw<O: RedeemerObserver>(
 /// era-agnostically (the `[tx_hash(32), index]` shape is era-invariant from
 /// Shelley onwards).
 ///
+/// `cost_models_cbor` is parsed via [`crate::cost_models::decode_cost_models_cbor`]
+/// when present. `None` means "no cost model configured" — downstream the CEK
+/// machine falls back to the per-step default cost from `machine::cost`.
+///
 /// On failure, returns a [`PhaseTwoError`] variant naming exactly which part
-/// could not be decoded (transaction body, input #N, or output #N) so the
-/// caller's logs surface the offending entry.
+/// could not be decoded (transaction body, input #N, output #N, or cost model)
+/// so the caller's logs surface the offending entry.
 pub(crate) fn decode_phase_two_inputs(
     tx_cbor: &[u8],
     utxos: &[(Vec<u8>, Vec<u8>)],
+    cost_models_cbor: Option<&[u8]>,
 ) -> Result<DecodedPhaseTwoInputs, PhaseTwoError> {
     let tx = decode_tx_multi_era(tx_cbor)?;
     let output_era_id = era_id_for_outputs(&tx);
@@ -200,9 +211,14 @@ pub(crate) fn decode_phase_two_inputs(
             .map_err(|e| PhaseTwoError::UtxoDecode(format!("utxo #{idx} output: {e}")))?;
         decoded_utxos.push((input, output, output_cbor.clone()));
     }
+    let cost_models = match cost_models_cbor {
+        Some(bytes) => Some(decode_cost_models_cbor(bytes)?),
+        None => None,
+    };
     Ok(DecodedPhaseTwoInputs {
         tx,
         utxos: decoded_utxos,
+        cost_models,
     })
 }
 
@@ -344,7 +360,7 @@ mod tests {
     #[test]
     fn decode_phase_two_inputs_lifts_minimal_conway_tx() {
         let tx_cbor = minimal_conway_tx_cbor();
-        let decoded = decode_phase_two_inputs(&tx_cbor, &[]).expect("decode");
+        let decoded = decode_phase_two_inputs(&tx_cbor, &[], None).expect("decode");
         assert_eq!(decoded.tx.era, Era::Conway);
         assert_eq!(decoded.tx.body.fee.0, 123_456);
         assert!(decoded.utxos.is_empty());
@@ -363,7 +379,7 @@ mod tests {
                 make_conway_map_output_cbor(2_500_000),
             ),
         ];
-        let decoded = decode_phase_two_inputs(&tx_cbor, &utxos).expect("decode");
+        let decoded = decode_phase_two_inputs(&tx_cbor, &utxos, None).expect("decode");
         assert_eq!(decoded.utxos.len(), 2);
         assert_eq!(decoded.utxos[0].0.index, 0);
         assert_eq!(decoded.utxos[0].1.value.coin.0, 1_000_000);
@@ -385,7 +401,7 @@ mod tests {
             ),
             (make_input_cbor(0x22, 1), vec![0xff]), // bogus
         ];
-        let err = decode_phase_two_inputs(&tx_cbor, &utxos).unwrap_err();
+        let err = decode_phase_two_inputs(&tx_cbor, &utxos, None).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("utxo #1 output"),
@@ -397,22 +413,73 @@ mod tests {
     fn decode_phase_two_inputs_reports_failing_input() {
         let tx_cbor = minimal_conway_tx_cbor();
         let utxos = vec![(vec![0xff], make_conway_map_output_cbor(1))];
-        let err = decode_phase_two_inputs(&tx_cbor, &utxos).unwrap_err();
+        let err = decode_phase_two_inputs(&tx_cbor, &utxos, None).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("utxo #0 input"), "got: {msg}");
     }
 
     #[test]
     fn decode_phase_two_inputs_rejects_empty_tx_cbor() {
-        let err = decode_phase_two_inputs(&[], &[]).unwrap_err();
+        let err = decode_phase_two_inputs(&[], &[], None).unwrap_err();
         assert!(matches!(err, PhaseTwoError::TxDecode(_)));
     }
 
     #[test]
     fn decode_phase_two_inputs_rejects_garbage_tx_cbor() {
         // None of the post-Alonzo era decoders accept a bare break byte.
-        let err = decode_phase_two_inputs(&[0xff], &[]).unwrap_err();
+        let err = decode_phase_two_inputs(&[0xff], &[], None).unwrap_err();
         assert!(matches!(err, PhaseTwoError::TxDecode(_)));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // cost_models wire-through (UPLC-9 part 2)
+    // ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_phase_two_inputs_threads_cost_models_when_supplied() {
+        use dugite_primitives::transaction::CostModels as PrimCostModels;
+        let prim = PrimCostModels {
+            plutus_v1: Some(vec![1, 2, 3]),
+            plutus_v2: Some(vec![4, 5]),
+            plutus_v3: Some(vec![6]),
+        };
+        let cm_cbor = prim.to_cbor().unwrap();
+        let tx_cbor = minimal_conway_tx_cbor();
+        let decoded = decode_phase_two_inputs(&tx_cbor, &[], Some(&cm_cbor)).expect("decode");
+        let cm = decoded.cost_models.expect("cost_models present");
+        assert_eq!(cm.plutus_v1.as_deref(), Some(&[1i64, 2, 3][..]));
+        assert_eq!(cm.plutus_v2.as_deref(), Some(&[4i64, 5][..]));
+        assert_eq!(cm.plutus_v3.as_deref(), Some(&[6i64][..]));
+    }
+
+    #[test]
+    fn decode_phase_two_inputs_none_cost_models_yields_none() {
+        let tx_cbor = minimal_conway_tx_cbor();
+        let decoded = decode_phase_two_inputs(&tx_cbor, &[], None).expect("decode");
+        assert!(decoded.cost_models.is_none());
+    }
+
+    #[test]
+    fn decode_phase_two_inputs_surfaces_cost_model_decode_failure() {
+        let tx_cbor = minimal_conway_tx_cbor();
+        // Bare break byte — not a map; decode_cost_models_cbor must fail.
+        let err = decode_phase_two_inputs(&tx_cbor, &[], Some(&[0xff])).unwrap_err();
+        assert!(matches!(err, PhaseTwoError::CostModelDecode(_)));
+    }
+
+    #[test]
+    fn eval_phase_two_raw_surfaces_cost_model_decode_failure() {
+        let tx_cbor = minimal_conway_tx_cbor();
+        let result = eval_phase_two_raw(
+            &tx_cbor,
+            &[],
+            Some(&[0xff]),
+            (1, 1),
+            default_slot_config(),
+            true,
+            &mut (),
+        );
+        assert!(matches!(result, Err(PhaseTwoError::CostModelDecode(_))));
     }
 
     // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Stacked on top of #583 (UPLC-9 part 1).**

## Summary
- New `crates/dugite-uplc/src/cost_models.rs` module exposes `decode_cost_models_cbor` + `CostModels { plutus_v1, plutus_v2, plutus_v3: Option<Vec<i64>> }`. Wire shape mirrors what `dugite_primitives::transaction::CostModels::to_cbor` emits — `map { 0 => [* int], 1 => [* int], 2 => [* int] }`.
- `eval_phase_two_raw` now threads `cost_models_cbor` through `decode_phase_two_inputs`. The parsed `CostModels` surfaces on `DecodedPhaseTwoInputs.cost_models`, ready for UPLC-9 parts 3-4 to consume.
- Decoder accepts both definite- and indefinite-length encodings, skips unknown language-version keys (future-compat for a hypothetical V4), and treats duplicate known keys as last-wins (canonical CBOR semantics).

## Defensive controls (per `lib.rs` §1-3)
- Top-level map clamped to `MAX_VERSIONS = 16`.
- Per-version array clamped to `MAX_PARAMS_PER_VERSION = 1024` (V3 currently tops out at 297).
- Map keys restricted to `u32`.
- Every parse error surfaces as `PhaseTwoError::CostModelDecode("…")` — never a panic.

## Tests
- `cost_models::tests` — 15 unit tests (single-version, all-three-versions, empty-map, unknown-key skip, duplicate-key last-wins, `CostModels::to_cbor` roundtrip, non-map rejection, truncated/garbage/string-value rejection, oversize caps, indef encodings, negative coefficients).
- `phase_two::tests` — 4 new wire-through tests including a top-level `eval_phase_two_raw` failure case.
- **All 210 dugite-uplc lib tests pass** (191 → 210).
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

## Test plan
- [x] `cargo test -p dugite-uplc --lib`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`