### PR TITLE
feat(uplc): V3 TxInfo populator (UPLC-9 part 3d)

### DIFF
--- a/crates/dugite-uplc/src/lib.rs
+++ b/crates/dugite-uplc/src/lib.rs
@@ -48,6 +48,7 @@ pub mod data;
 pub mod flat;
 pub mod machine;
 pub mod phase_two;
+pub mod populate_v3;
 pub mod program;
 pub mod script_context;
 pub mod term;

--- a/crates/dugite-uplc/src/populate_v3.rs
+++ b/crates/dugite-uplc/src/populate_v3.rs
@@ -1,0 +1,390 @@
+//! V3 `TxInfo` builder — assembles a [`TxInfoV3`] from a decoded
+//! [`Transaction`] plus the resolved-UTxO map.
+//!
+//! ## Scope
+//!
+//! This module lands the structural V3 builder using the translation
+//! helpers from [`crate::tx_info_populate`]. Fields populated here:
+//!
+//! - inputs / reference_inputs (resolved against the UTxO map)
+//! - outputs
+//! - fee
+//! - mint
+//! - valid_range
+//! - signatories (28-byte unpadded)
+//! - datums (from witness set, hashed)
+//! - txid (= tx.hash)
+//! - current_treasury / treasury_donation
+//!
+//! Fields **deferred to later UPLC-9 parts**:
+//!
+//! - certificates → `Vec<TxCert>` ─ UPLC-9 part 3e
+//! - votes / proposal_procedures ─ UPLC-9 part 3e
+//! - redeemers map ─ UPLC-9 part 3f
+//!
+//! Those remain `Vec::new()` / `None` here so the V3 builder is
+//! reviewable in isolation. Plutus scripts that don't consult those
+//! fields (the common case for fresh deployments) already see a
+//! complete-enough context; scripts that do will progressively
+//! pick up the missing pieces as the follow-on PRs land.
+
+use crate::phase_two::{PhaseTwoError, SlotConfig};
+use crate::script_context::{GovActionId, ProposalProcedure, TxInfoV3, Vote, Voter};
+use crate::tx_info_populate::{
+    datums_to_plutus, inputs_to_txininfos, mint_to_plutus, output_to_plutus,
+    required_signers_to_plutus_padded, tx_hash_to_array, valid_range_to_posix,
+};
+use dugite_primitives::transaction::{
+    Transaction as PrimTransaction, TransactionInput as PrimTxIn, TransactionOutput as PrimTxOut,
+};
+use num_bigint::BigInt;
+
+/// Build a [`TxInfoV3`] from a decoded transaction + resolved-UTxO
+/// triples + the network's slot config.
+///
+/// `resolved` must contain every input referenced by `tx.body.inputs`
+/// and `tx.body.reference_inputs` (the same set
+/// [`crate::phase_two::decode_phase_two_inputs`] hands back). Missing
+/// entries surface as [`PhaseTwoError::UtxoDecode`] from the input
+/// resolver.
+pub fn populate_tx_info_v3(
+    tx: &PrimTransaction,
+    resolved: &[(PrimTxIn, PrimTxOut, Vec<u8>)],
+    slot_config: &SlotConfig,
+) -> Result<TxInfoV3, PhaseTwoError> {
+    let inputs = inputs_to_txininfos(&tx.body.inputs, resolved)?;
+    let reference_inputs = inputs_to_txininfos(&tx.body.reference_inputs, resolved)?;
+    let outputs: Vec<_> = tx
+        .body
+        .outputs
+        .iter()
+        .map(output_to_plutus)
+        .collect::<Result<_, _>>()?;
+    let mint = mint_to_plutus(&tx.body.mint);
+    let valid_range = valid_range_to_posix(
+        tx.body.validity_interval_start.map(|s| s.0),
+        tx.body.ttl.map(|s| s.0),
+        slot_config,
+    )?;
+    let signatories = required_signers_to_plutus_padded(&tx.body.required_signers);
+    let datums = datums_to_plutus(&tx.witness_set.plutus_data)?;
+
+    Ok(TxInfoV3 {
+        inputs,
+        reference_inputs,
+        outputs,
+        fee: BigInt::from(tx.body.fee.0),
+        mint,
+        valid_range,
+        signatories,
+        // Filled by UPLC-9 part 3f (redeemers map).
+        redeemers: Vec::new(),
+        datums,
+        txid: tx_hash_to_array(&tx.hash),
+        // Filled by UPLC-9 part 3e (governance + certs).
+        votes: Vec::<(Voter, Vec<(GovActionId, Vote)>)>::new(),
+        proposal_procedures: Vec::<ProposalProcedure>::new(),
+        current_treasury: tx.body.treasury_value.map(|v| BigInt::from(v.0)),
+        treasury_donation: tx.body.donation.map(|v| BigInt::from(v.0)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::script_context::{Credential as PlCredential, OutputDatum as PlOutputDatum};
+    use dugite_primitives::address::{Address as PrimAddress, EnterpriseAddress};
+    use dugite_primitives::credentials::Credential as PrimCred;
+    use dugite_primitives::era::Era;
+    use dugite_primitives::hash::Hash;
+    use dugite_primitives::network::NetworkId;
+    use dugite_primitives::time::SlotNo;
+    use dugite_primitives::transaction::{
+        OutputDatum as PrimOutputDatum, PlutusData as PrimPlutusData, Transaction, TransactionBody,
+        TransactionInput, TransactionOutput, TransactionWitnessSet,
+    };
+    use dugite_primitives::value::{Lovelace, Value};
+    use std::collections::BTreeMap;
+
+    fn h28(b: u8) -> dugite_primitives::hash::Hash28 {
+        Hash::<28>([b; 28])
+    }
+
+    fn h32(b: u8) -> dugite_primitives::hash::Hash<32> {
+        Hash::<32>([b; 32])
+    }
+
+    fn enterprise_output(lovelace: u64) -> TransactionOutput {
+        TransactionOutput {
+            address: PrimAddress::Enterprise(EnterpriseAddress {
+                network: NetworkId::Testnet,
+                payment: PrimCred::VerificationKey(h28(0x88)),
+            }),
+            value: Value::lovelace(lovelace),
+            datum: PrimOutputDatum::None,
+            script_ref: None,
+            is_legacy: false,
+            raw_cbor: None,
+        }
+    }
+
+    fn empty_witness_set() -> TransactionWitnessSet {
+        TransactionWitnessSet {
+            vkey_witnesses: vec![],
+            native_scripts: vec![],
+            bootstrap_witnesses: vec![],
+            plutus_v1_scripts: vec![],
+            plutus_v2_scripts: vec![],
+            plutus_v3_scripts: vec![],
+            plutus_data: vec![],
+            redeemers: vec![],
+            raw_redeemers_cbor: None,
+            raw_plutus_data_cbor: None,
+            original_script_data_hash: None,
+        }
+    }
+
+    fn minimal_tx_body(
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<TransactionOutput>,
+        fee: u64,
+    ) -> TransactionBody {
+        TransactionBody {
+            inputs,
+            outputs,
+            fee: Lovelace(fee),
+            ttl: None,
+            certificates: vec![],
+            withdrawals: BTreeMap::new(),
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            mint: BTreeMap::new(),
+            script_data_hash: None,
+            collateral: vec![],
+            required_signers: vec![],
+            network_id: None,
+            collateral_return: None,
+            total_collateral: None,
+            reference_inputs: vec![],
+            update: None,
+            voting_procedures: BTreeMap::new(),
+            proposal_procedures: vec![],
+            treasury_value: None,
+            donation: None,
+        }
+    }
+
+    fn build_tx(body: TransactionBody, witness_set: TransactionWitnessSet) -> Transaction {
+        Transaction {
+            hash: h32(0xab),
+            era: Era::Conway,
+            body,
+            witness_set,
+            is_valid: true,
+            auxiliary_data: None,
+            raw_cbor: None,
+            raw_body_cbor: None,
+            raw_witness_cbor: None,
+        }
+    }
+
+    fn slot_cfg() -> SlotConfig {
+        SlotConfig {
+            network_start_unix_seconds: 1_666_656_000,
+            slot_zero_offset: 0,
+            slot_length_ms: 1_000,
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Happy path
+    // ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn populate_tx_info_v3_minimal_tx_yields_empty_collections() {
+        let tx = build_tx(
+            minimal_tx_body(vec![], vec![], 170_000),
+            empty_witness_set(),
+        );
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.fee, BigInt::from(170_000));
+        assert_eq!(info.txid, [0xab; 32]);
+        assert!(info.inputs.is_empty());
+        assert!(info.reference_inputs.is_empty());
+        assert!(info.outputs.is_empty());
+        assert!(info.datums.is_empty());
+        assert!(info.redeemers.is_empty()); // deferred to part 3f
+        assert!(info.votes.is_empty()); // deferred to part 3e
+        assert!(info.proposal_procedures.is_empty()); // deferred to part 3e
+        assert_eq!(info.current_treasury, None);
+        assert_eq!(info.treasury_donation, None);
+        assert_eq!(info.valid_range.lower, None);
+        assert_eq!(info.valid_range.upper, None);
+    }
+
+    #[test]
+    fn populate_tx_info_v3_resolves_inputs() {
+        let input = TransactionInput {
+            transaction_id: h32(0xcc),
+            index: 7,
+        };
+        let body = minimal_tx_body(vec![input.clone()], vec![], 1);
+        let tx = build_tx(body, empty_witness_set());
+        let resolved = vec![(input.clone(), enterprise_output(500_000), vec![])];
+
+        let info = populate_tx_info_v3(&tx, &resolved, &slot_cfg()).unwrap();
+        assert_eq!(info.inputs.len(), 1);
+        assert_eq!(info.inputs[0].out_ref.tx_id, [0xcc; 32]);
+        assert_eq!(info.inputs[0].out_ref.idx, 7);
+        assert_eq!(
+            info.inputs[0].resolved.value.policies[0].1[0].1,
+            BigInt::from(500_000)
+        );
+    }
+
+    #[test]
+    fn populate_tx_info_v3_resolves_reference_inputs_too() {
+        let ref_in = TransactionInput {
+            transaction_id: h32(0xdd),
+            index: 1,
+        };
+        let mut body = minimal_tx_body(vec![], vec![], 1);
+        body.reference_inputs = vec![ref_in.clone()];
+        let tx = build_tx(body, empty_witness_set());
+        let resolved = vec![(ref_in, enterprise_output(99), vec![])];
+
+        let info = populate_tx_info_v3(&tx, &resolved, &slot_cfg()).unwrap();
+        assert_eq!(info.reference_inputs.len(), 1);
+        assert_eq!(info.reference_inputs[0].out_ref.tx_id, [0xdd; 32]);
+    }
+
+    #[test]
+    fn populate_tx_info_v3_translates_outputs() {
+        let body = minimal_tx_body(
+            vec![],
+            vec![enterprise_output(2_500_000), enterprise_output(1_000_000)],
+            1,
+        );
+        let tx = build_tx(body, empty_witness_set());
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.outputs.len(), 2);
+        assert!(matches!(
+            info.outputs[0].address.payment,
+            PlCredential::PubKey(_)
+        ));
+        assert_eq!(info.outputs[0].datum, PlOutputDatum::None);
+        assert_eq!(
+            info.outputs[0].value.policies[0].1[0].1,
+            BigInt::from(2_500_000)
+        );
+    }
+
+    #[test]
+    fn populate_tx_info_v3_translates_mint() {
+        let mut policy_assets = BTreeMap::new();
+        policy_assets.insert(
+            dugite_primitives::value::AssetName::new(b"X".to_vec()).unwrap(),
+            42i64,
+        );
+        let mut mint = BTreeMap::new();
+        mint.insert(h28(0x11), policy_assets);
+        let mut body = minimal_tx_body(vec![], vec![], 1);
+        body.mint = mint;
+        let tx = build_tx(body, empty_witness_set());
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.mint.policies.len(), 1);
+        assert_eq!(info.mint.policies[0].0, [0x11; 28]);
+        assert_eq!(info.mint.policies[0].1[0].1, BigInt::from(42));
+    }
+
+    #[test]
+    fn populate_tx_info_v3_translates_valid_range() {
+        let mut body = minimal_tx_body(vec![], vec![], 1);
+        body.validity_interval_start = Some(SlotNo(10));
+        body.ttl = Some(SlotNo(20));
+        let tx = build_tx(body, empty_witness_set());
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.valid_range.lower, Some(1_666_656_010_000));
+        assert_eq!(info.valid_range.upper, Some(1_666_656_020_000));
+    }
+
+    #[test]
+    fn populate_tx_info_v3_unpads_required_signers_to_28_bytes() {
+        // Required signer stored as Hash<32> with last 4 bytes zero.
+        let padded = {
+            let mut bytes = [0u8; 32];
+            for (i, slot) in bytes.iter_mut().take(28).enumerate() {
+                *slot = (i + 1) as u8;
+            }
+            Hash::<32>(bytes)
+        };
+        let mut body = minimal_tx_body(vec![], vec![], 1);
+        body.required_signers = vec![padded];
+        let tx = build_tx(body, empty_witness_set());
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.signatories.len(), 1);
+        let expected: [u8; 28] = std::array::from_fn(|i| (i + 1) as u8);
+        assert_eq!(info.signatories[0], expected);
+    }
+
+    #[test]
+    fn populate_tx_info_v3_hashes_witness_set_datums() {
+        // Each datum surfaces with its blake2b_256 hash and the
+        // translated `Data`.
+        let mut witness_set = empty_witness_set();
+        witness_set.plutus_data = vec![PrimPlutusData::Integer(BigInt::from(7))];
+        let tx = build_tx(minimal_tx_body(vec![], vec![], 1), witness_set);
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.datums.len(), 1);
+        let (h, d) = &info.datums[0];
+        // Reconstruct hash independently for the pin.
+        let manual_cbor = d.to_cbor().unwrap();
+        let manual_hash = dugite_primitives::hash::blake2b_256(&manual_cbor).0;
+        assert_eq!(h, &manual_hash);
+    }
+
+    #[test]
+    fn populate_tx_info_v3_populates_treasury_fields_when_present() {
+        let mut body = minimal_tx_body(vec![], vec![], 1);
+        body.treasury_value = Some(Lovelace(1_000_000_000));
+        body.donation = Some(Lovelace(50_000));
+        let tx = build_tx(body, empty_witness_set());
+        let info = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap();
+        assert_eq!(info.current_treasury, Some(BigInt::from(1_000_000_000)));
+        assert_eq!(info.treasury_donation, Some(BigInt::from(50_000)));
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Error propagation
+    // ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn populate_tx_info_v3_surfaces_missing_input() {
+        let input = TransactionInput {
+            transaction_id: h32(0x99),
+            index: 0,
+        };
+        let body = minimal_tx_body(vec![input], vec![], 1);
+        let tx = build_tx(body, empty_witness_set());
+        let err = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap_err();
+        assert!(matches!(err, PhaseTwoError::UtxoDecode(_)));
+    }
+
+    #[test]
+    fn populate_tx_info_v3_surfaces_byron_output_failure() {
+        let mut body = minimal_tx_body(vec![], vec![], 1);
+        body.outputs = vec![TransactionOutput {
+            address: PrimAddress::Byron(dugite_primitives::address::ByronAddress {
+                payload: vec![],
+            }),
+            value: Value::lovelace(1),
+            datum: PrimOutputDatum::None,
+            script_ref: None,
+            is_legacy: false,
+            raw_cbor: None,
+        }];
+        let tx = build_tx(body, empty_witness_set());
+        let err = populate_tx_info_v3(&tx, &[], &slot_cfg()).unwrap_err();
+        assert!(matches!(err, PhaseTwoError::Internal(_)));
+    }
+}

--- a/crates/dugite-uplc/src/tx_info_populate.rs
+++ b/crates/dugite-uplc/src/tx_info_populate.rs
@@ -387,6 +387,92 @@ pub fn inputs_to_txininfos(
     Ok(out)
 }
 
+/// Translate a 32-byte padded required-signer hash back to its
+/// 28-byte Plutus `PubKeyHash`.
+///
+/// `dugite_primitives::TransactionBody::required_signers` stores each
+/// 28-byte addr_keyhash padded to 32 bytes via
+/// `Hash28::to_hash32_padded()` (the trailing 4 bytes are zero). The
+/// padding is purely an internal representation choice; the on-chain
+/// value is the 28-byte prefix. Plutus validators observe the 28-byte
+/// `PubKeyHash` directly, so we unpad here.
+fn padded_signer_to_pubkeyhash(h: &dugite_primitives::hash::Hash<32>) -> PubKeyHash {
+    let mut out = [0u8; 28];
+    out.copy_from_slice(&h.0[..28]);
+    out
+}
+
+/// Translate the full `required_signers` field (`Vec<Hash<32>>` —
+/// each entry is a 28-byte addr_keyhash padded to 32 bytes) into the
+/// Plutus `signatories` list (`Vec<PubKeyHash>`).
+pub fn required_signers_to_plutus_padded(
+    signers: &[dugite_primitives::hash::Hash<32>],
+) -> Vec<PubKeyHash> {
+    signers.iter().map(padded_signer_to_pubkeyhash).collect()
+}
+
+/// Translate the resolved-UTxO triples that
+/// [`crate::phase_two::decode_phase_two_inputs`] produces back into
+/// the `(PrimTxIn, PrimTxOut, Vec<u8>)` shape this module's helpers
+/// expect. The translation is a no-op `clone` — kept as a named
+/// helper so call sites read clearly.
+pub fn resolved_utxos(
+    triples: &[(PrimTxIn, PrimTxOut, Vec<u8>)],
+) -> Vec<(PrimTxIn, PrimTxOut, Vec<u8>)> {
+    triples.to_vec()
+}
+
+/// Compute the blake2b_256 hash of the canonical CBOR encoding of
+/// `data`. This is the same datum-hash domain used by the ledger to
+/// match `OutputDatum::DatumHash(h)` references back to inline-datum
+/// payloads in the tx witness set.
+fn datum_hash(data: &Data) -> Result<[u8; 32], PhaseTwoError> {
+    let cbor = data
+        .to_cbor()
+        .map_err(|e| PhaseTwoError::Internal(format!("datum_hash: data.to_cbor: {e}")))?;
+    Ok(dugite_primitives::hash::blake2b_256(&cbor).0)
+}
+
+/// Extract the witness-set's `plutus_data` list into the
+/// `Vec<([u8; 32], Data)>` shape TxInfoV3/V2 expose. Each entry is
+/// `(blake2b_256(canonical_cbor(d)), d)`.
+///
+/// Per CLAUDE.md / `lib.rs` §1, this never panics on malformed Data —
+/// the upstream CBOR decoder produced typed `PlutusData` values, so
+/// the only failure mode is the in-house `Data::to_cbor` encoder
+/// itself, which we surface as `PhaseTwoError::Internal`.
+pub fn datums_to_plutus(
+    plutus_data: &[PrimPlutusData],
+) -> Result<Vec<([u8; 32], Data)>, PhaseTwoError> {
+    let mut out: Vec<([u8; 32], Data)> = Vec::with_capacity(plutus_data.len());
+    for d in plutus_data {
+        let translated = plutus_data_to_data(d);
+        let h = datum_hash(&translated)?;
+        out.push((h, translated));
+    }
+    Ok(out)
+}
+
+/// Translate the V1/V2 `withdrawals` map into the
+/// `Vec<(StakingCredential, BigInt)>` shape Plutus TxInfo exposes.
+/// Iteration order matches the BTreeMap iteration order (lex by
+/// reward_account bytes), which is the canonical wire order.
+pub fn withdrawals_to_plutus(
+    wdrl: &BTreeMap<Vec<u8>, dugite_primitives::value::Lovelace>,
+) -> Result<Vec<(StakingCredential, BigInt)>, PhaseTwoError> {
+    let mut out = Vec::with_capacity(wdrl.len());
+    for (reward_account, amount) in wdrl {
+        // Reuse withdrawal_to_plutus by reconstructing a Withdrawal here so we
+        // share the exact reward-address parsing/validation path.
+        let w = PrimWithdrawal {
+            reward_account: reward_account.clone(),
+            amount: *amount,
+        };
+        out.push(withdrawal_to_plutus(&w)?);
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Stacked on top of #587 (UPLC-9 part 3c).** `populate_tx_info_v3(tx, resolved_utxos, slot_config)` assembles a full `TxInfoV3` using every helper landed in 3a-3c. Populates inputs/ref_inputs/outputs/fee/mint/valid_range/signatories/datums/txid/treasury. Deliberately leaves certs/votes/proposals/redeemers as empty Vec — those land in parts 3e/3f. 11 new tests + 257 total. Helpers added in tx_info_populate.rs: `required_signers_to_plutus_padded`, `datums_to_plutus`, `withdrawals_to_plutus`, `resolved_utxos`.