### PR TITLE
feat(uplc): Program flat/CBOR codec wired (UPLC-9 part 3g)

### DIFF
--- a/crates/dugite-uplc/src/program.rs
+++ b/crates/dugite-uplc/src/program.rs
@@ -11,7 +11,10 @@
 //! This module handles the CBOR ↔ flat-bytes boundary; the flat ↔ AST
 //! boundary lives in `crate::flat`.
 
+use crate::flat::bits::{BitReader, BitWriter};
+use crate::flat::term::{decode_term, encode_term};
 use crate::term::Term;
+use crate::UplcError;
 
 /// A complete UPLC program: a language version triple plus a body.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,86 +25,150 @@ pub struct Program {
 
 impl Program {
     /// Decode a CBOR-wrapped flat-encoded UPLC program.
-    pub fn from_cbor(_bytes: &[u8]) -> Result<Self, crate::UplcError> {
-        Err(crate::UplcError::Internal(
-            "Program::from_cbor not yet implemented".to_string(),
-        ))
+    ///
+    /// The wire shape is a single CBOR byte-string (major type 2) whose
+    /// payload is the flat-encoded program. The witness-set wire entry
+    /// for a Plutus script is exactly these bytes (see
+    /// `crate::tx_info_populate::script_ref_hash`).
+    pub fn from_cbor(bytes: &[u8]) -> Result<Self, UplcError> {
+        use minicbor::Decoder;
+        let mut d = Decoder::new(bytes);
+        let inner = d
+            .bytes()
+            .map_err(|e| UplcError::FlatDecode(format!("CBOR-bytes wrapper: {e}")))?;
+        Self::from_flat(inner)
     }
 
     /// Decode a raw flat-encoded UPLC program (no CBOR wrapper).
-    pub fn from_flat(_bytes: &[u8]) -> Result<Self, crate::UplcError> {
-        Err(crate::UplcError::Internal(
-            "Program::from_flat not yet implemented".to_string(),
-        ))
+    ///
+    /// Layout: `version_major (Natural), version_minor (Natural),
+    /// version_patch (Natural), term, filler`. Returns
+    /// `UplcError::FlatDecode` on any truncation / malformedness.
+    pub fn from_flat(bytes: &[u8]) -> Result<Self, UplcError> {
+        let mut r = BitReader::new(bytes);
+        let major = r.read_natural_u64()?;
+        let minor = r.read_natural_u64()?;
+        let patch = r.read_natural_u64()?;
+        let term = decode_term(&mut r)?;
+        // The flat encoding pads to a byte boundary with a 1-bit prefix
+        // followed by 0-bit fillers. `read_filler` enforces that the
+        // trailing bits match this shape.
+        r.read_filler()?;
+        Ok(Program {
+            version: (major, minor, patch),
+            term,
+        })
     }
 
     /// Encode the program as `(major, minor, patch, flat-encoded term)`
-    /// then wrap in a CBOR byte-string.
-    pub fn to_cbor(&self) -> Result<Vec<u8>, crate::UplcError> {
-        Err(crate::UplcError::Internal(
-            "Program::to_cbor not yet implemented".to_string(),
-        ))
+    /// and wrap in a CBOR byte-string.
+    pub fn to_cbor(&self) -> Result<Vec<u8>, UplcError> {
+        use minicbor::Encoder;
+        let flat = self.to_flat()?;
+        let mut out = Vec::with_capacity(flat.len() + 4);
+        let mut e = Encoder::new(&mut out);
+        e.bytes(&flat)
+            .map_err(|err| UplcError::Internal(format!("CBOR encode: {err}")))?;
+        Ok(out)
     }
 
     /// Encode the program as raw flat bytes (no CBOR wrapper).
-    pub fn to_flat(&self) -> Result<Vec<u8>, crate::UplcError> {
-        Err(crate::UplcError::Internal(
-            "Program::to_flat not yet implemented".to_string(),
-        ))
+    pub fn to_flat(&self) -> Result<Vec<u8>, UplcError> {
+        let mut w = BitWriter::new();
+        w.write_natural_u64(self.version.0)?;
+        w.write_natural_u64(self.version.1)?;
+        w.write_natural_u64(self.version.2)?;
+        encode_term(&mut w, &self.term)?;
+        w.write_filler();
+        Ok(w.finish())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    //! Regression tests for the `Program` placeholder API. The four
-    //! entry points must surface their unimplemented state as a typed
-    //! `Internal` error rather than a panic, so a caller that wires
-    //! `dugite-ledger` against this crate before UPLC-2 lands sees a
-    //! deterministic failure mode.
     use super::*;
-    use crate::UplcError;
-
-    fn assert_internal_contains(err: &UplcError, needle: &str) {
-        match err {
-            UplcError::Internal(msg) => {
-                assert!(
-                    msg.contains(needle),
-                    "expected message to contain {needle:?}; got {msg}"
-                );
-            }
-            other => panic!("expected Internal, got {other:?}"),
-        }
-    }
+    use crate::term::{Constant, Term};
 
     #[test]
-    fn from_cbor_stub_returns_internal() {
-        let err = Program::from_cbor(&[]).unwrap_err();
-        assert_internal_contains(&err, "from_cbor");
-    }
-
-    #[test]
-    fn from_flat_stub_returns_internal() {
-        let err = Program::from_flat(&[]).unwrap_err();
-        assert_internal_contains(&err, "from_flat");
-    }
-
-    #[test]
-    fn to_cbor_stub_returns_internal() {
+    fn round_trips_through_flat_with_error_body() {
         let p = Program {
             version: (1, 1, 0),
             term: Term::Error,
         };
-        let err = p.to_cbor().unwrap_err();
-        assert_internal_contains(&err, "to_cbor");
+        let flat = p.to_flat().unwrap();
+        let back = Program::from_flat(&flat).unwrap();
+        assert_eq!(back, p);
     }
 
     #[test]
-    fn to_flat_stub_returns_internal() {
+    fn round_trips_through_flat_with_const_integer_body() {
         let p = Program {
             version: (1, 0, 0),
+            term: Term::Const(Constant::Integer(num_bigint::BigInt::from(42))),
+        };
+        let flat = p.to_flat().unwrap();
+        let back = Program::from_flat(&flat).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn round_trips_through_flat_with_nested_app() {
+        let p = Program {
+            version: (1, 1, 0),
+            term: Term::App(
+                Box::new(Term::Lam(Box::new(Term::Var(0)))),
+                Box::new(Term::Const(Constant::Integer(num_bigint::BigInt::from(7)))),
+            ),
+        };
+        let flat = p.to_flat().unwrap();
+        let back = Program::from_flat(&flat).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn round_trips_through_cbor_wrapped_form() {
+        let p = Program {
+            version: (1, 1, 0),
+            term: Term::Const(Constant::Integer(num_bigint::BigInt::from(123))),
+        };
+        let cbor = p.to_cbor().unwrap();
+        // CBOR-bytes wrapper: first byte's major type must be 2 (binary string).
+        assert_eq!(cbor[0] & 0xe0, 0x40);
+        let back = Program::from_cbor(&cbor).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn from_cbor_rejects_non_bytes_top_level() {
+        // `0x80` = array(0) → not a CBOR byte string.
+        let err = Program::from_cbor(&[0x80]).unwrap_err();
+        assert!(matches!(err, UplcError::FlatDecode(_)));
+    }
+
+    #[test]
+    fn from_flat_rejects_empty_input() {
+        // No version bytes at all.
+        let err = Program::from_flat(&[]).unwrap_err();
+        assert!(matches!(err, UplcError::FlatDecode(_)));
+    }
+
+    #[test]
+    fn from_cbor_rejects_truncated_inner_flat() {
+        use minicbor::Encoder;
+        // Wrap a single byte that cannot be a complete flat program.
+        let mut buf = Vec::new();
+        Encoder::new(&mut buf).bytes(&[0x00]).unwrap();
+        let err = Program::from_cbor(&buf).unwrap_err();
+        assert!(matches!(err, UplcError::FlatDecode(_)));
+    }
+
+    #[test]
+    fn version_triple_is_preserved_through_roundtrip() {
+        let p = Program {
+            version: (3, 4, 5),
             term: Term::Error,
         };
-        let err = p.to_flat().unwrap_err();
-        assert_internal_contains(&err, "to_flat");
+        let back = Program::from_flat(&p.to_flat().unwrap()).unwrap();
+        assert_eq!(back.version, (3, 4, 5));
     }
 }


### PR DESCRIPTION
**Stacked on top of #590 (UPLC-9 part 3f).** Wires `Program::from_cbor / from_flat / to_cbor / to_flat` through the existing `flat::term::{decode_term, encode_term}` + `flat::bits::{BitReader, BitWriter}`. They were placeholder Internal-returning stubs; now they round-trip Plutus scripts byte-exactly. Tx witness-set Plutus-script payloads can finally be lifted into a typed Term ready for CEK evaluation. 8 new tests (replacing 4 placeholder ones) + 285 total.