### PR TITLE
feat(ledger): swap eval_phase_two_raw to dugite-uplc + drop aiken (UPLC-10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "once_cell",
- "secp256k1 0.30.0",
+ "secp256k1",
  "thiserror 1.0.69",
  "walkdir",
 ]
@@ -155,12 +155,6 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -232,12 +226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,12 +242,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
@@ -355,18 +337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,7 +363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.6",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -677,7 +647,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -751,21 +721,6 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1233,7 +1188,7 @@ name = "dugite-cli"
 version = "1.7.0"
 dependencies = [
  "anyhow",
- "bech32 0.11.1",
+ "bech32",
  "blake2 0.10.6",
  "clap",
  "dugite-consensus",
@@ -1372,6 +1327,7 @@ dependencies = [
  "dugite-lsm",
  "dugite-primitives",
  "dugite-serialization",
+ "dugite-uplc",
  "minicbor 0.26.5",
  "num-bigint",
  "num-rational",
@@ -1385,7 +1341,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
- "uplc",
 ]
 
 [[package]]
@@ -1465,7 +1420,7 @@ version = "1.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bech32 0.11.1",
+ "bech32",
  "bs58",
  "chrono",
  "clap",
@@ -1514,7 +1469,7 @@ dependencies = [
 name = "dugite-primitives"
 version = "1.7.0"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "blake2 0.10.6",
  "blake2b_simd",
  "bytes",
@@ -1903,12 +1858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,7 +2136,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
 ]
 
 [[package]]
@@ -2525,7 +2474,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width",
  "unit-prefix",
  "web-time",
 ]
@@ -2606,15 +2555,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2902,29 +2842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "miette-derive",
- "once_cell",
- "thiserror 1.0.69",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,7 +2853,6 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
 dependencies = [
- "half",
  "minicbor-derive 0.15.3",
 ]
 
@@ -3103,7 +3019,7 @@ checksum = "0399524c347d2e59663fb1251e72bb81affa69264a1deefb1c468f11660bf688"
 dependencies = [
  "anyhow",
  "async-trait",
- "bech32 0.11.1",
+ "bech32",
  "bincode 2.0.1",
  "blake2 0.10.6",
  "chrono",
@@ -3453,83 +3369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallas-addresses"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f5f4dd205316335bf8eef77227e01a8a00b1fd60503d807520e93dd0362d0e"
-dependencies = [
- "base58",
- "bech32 0.9.1",
- "crc",
- "cryptoxide",
- "hex",
- "pallas-codec",
- "pallas-crypto",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "pallas-codec"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2737b05f0dbb6d197feeb26ef15d2567e54833184bd469f5655a0537da89fa"
-dependencies = [
- "hex",
- "minicbor 0.25.1",
- "num-bigint",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "pallas-crypto"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0368945cd093e550febe36aef085431b1611c2e9196297cd70f4b21a4add054c"
-dependencies = [
- "cryptoxide",
- "hex",
- "pallas-codec",
- "rand_core 0.6.4",
- "serde",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "pallas-primitives"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2acde8875c43446194d387c60fe2d6a127e4f8384bef3dcabd5a04e9422429"
-dependencies = [
- "base58",
- "bech32 0.9.1",
- "hex",
- "log",
- "pallas-codec",
- "pallas-crypto",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "pallas-traverse"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab64895a0d94fed1ef2d99dd37e480ed0483e91eb98dcd2f94cc614fb9575173"
-dependencies = [
- "hex",
- "itertools 0.13.0",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
- "paste",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,39 +3390,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peg"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
-dependencies = [
- "peg-macros",
- "peg-runtime",
-]
-
-[[package]]
-name = "peg-macros"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
-dependencies = [
- "peg-runtime",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "peg-runtime"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "percent-encoding"
@@ -3773,18 +3579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
-dependencies = [
- "arrayvec 0.5.2",
- "log",
- "typed-arena",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,12 +3710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,7 +3834,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4097,7 +3885,7 @@ dependencies = [
  "strum 0.27.2",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4548,31 +4336,13 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
-dependencies = [
- "secp256k1-sys 0.8.2",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
-dependencies = [
- "cc",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -4961,15 +4731,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -4984,19 +4745,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5111,12 +4859,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -5580,12 +5322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5653,14 +5389,8 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5691,38 +5421,6 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
-name = "uplc"
-version = "1.1.21"
-source = "git+https://github.com/aiken-lang/aiken.git?rev=6806d52211fbb469ae13aa0e0290aeb6b9b3e8cf#6806d52211fbb469ae13aa0e0290aeb6b9b3e8cf"
-dependencies = [
- "bitvec",
- "blst",
- "cryptoxide",
- "hamming",
- "hex",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "k256",
- "miette",
- "num-bigint",
- "num-integer",
- "num-traits",
- "once_cell",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
- "pallas-traverse",
- "peg",
- "pretty",
- "secp256k1 0.26.0",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "url"
@@ -6421,15 +6119,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,6 @@ bech32 = "0.11"
 base16ct = { version = "0.2", features = ["alloc"] }
 bs58 = "0.5"
 bincode = "1"
-uplc = { git = "https://github.com/aiken-lang/aiken.git", rev = "6806d52211fbb469ae13aa0e0290aeb6b9b3e8cf" }
 crc32fast = "1"
 reqwest = { version = "0.12", features = ["rustls-tls", "stream", "json"], default-features = false }
 libc = "0.2"

--- a/crates/dugite-ledger/Cargo.toml
+++ b/crates/dugite-ledger/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = { workspace = true }
 minicbor = { workspace = true }
 sha3 = { workspace = true }
 bincode = { workspace = true }
-uplc = { workspace = true }
+dugite-uplc = { workspace = true }
 dugite-lsm = { workspace = true }
 rayon = { workspace = true, optional = true }
 

--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -1,7 +1,6 @@
 use crate::utxo::UtxoLookup;
 #[cfg(test)]
 use crate::utxo::UtxoSet;
-use crate::validation::{plutus_script_version_map, redeemer_script_version_map};
 use dugite_primitives::transaction::Transaction;
 use tracing::{debug, trace};
 
@@ -73,43 +72,6 @@ impl SlotConfig {
             zero_slot: 0,
             slot_length: 1_000,
         }
-    }
-}
-
-/// Decode the `(tag_byte, index)` from the CBOR-encoded `Redeemer`
-/// returned by `eval_phase_two_raw`.
-///
-/// The encoding is `array(4)[tag_uint, index_uint, data, ex_units]`.  We only
-/// need the first two elements.  The tag encoding matches the Cardano CDDL
-/// redeemer tag enumeration:
-///   0 = Spend, 1 = Mint, 2 = Cert, 3 = Reward, 4 = Vote, 5 = Propose.
-///
-/// Returns `None` if the bytes cannot be decoded (malformed CBOR or unexpected
-/// structure).  Callers treat `None` as "unknown version" and fall back to the
-/// permissive non-Unit check, which is the safe direction.
-fn decode_redeemer_tag_index(redeemer_cbor: &[u8]) -> Option<(u8, u32)> {
-    use minicbor::Decoder;
-    let mut dec = Decoder::new(redeemer_cbor);
-    // Expect an array of at least 2 elements.
-    let _len = dec.array().ok()?;
-    let tag = dec.u8().ok()?;
-    let index = dec.u32().ok()?;
-    Some((tag, index))
-}
-
-/// Map a `RedeemerTag` to its on-wire CBOR encoding byte, matching the values
-/// `decode_redeemer_tag_index` returns. This is the inverse used when looking
-/// the declared `ex_units` for a redeemer back up from a tag/index pair the
-/// uplc evaluator surfaced.
-fn redeemer_tag_byte(tag: &dugite_primitives::transaction::RedeemerTag) -> u8 {
-    use dugite_primitives::transaction::RedeemerTag::*;
-    match tag {
-        Spend => 0,
-        Mint => 1,
-        Cert => 2,
-        Reward => 3,
-        Vote => 4,
-        Propose => 5,
     }
 }
 
@@ -217,51 +179,29 @@ pub fn evaluate_plutus_scripts(
         "Evaluating Plutus scripts"
     );
 
-    let sc = (
-        slot_config.zero_time,
-        slot_config.zero_slot,
-        slot_config.slot_length,
-    );
-
-    // Build the script hash → language version map (1=V1, 2=V2, 3=V3) for all
-    // Plutus scripts available to this transaction (witness set + ref scripts).
-    let version_map = plutus_script_version_map(tx, utxo_set);
-
-    // Build the per-redeemer version map: (tag_byte, index) → language version.
+    // Dugite's in-house phase-2 evaluator. Replaces the
+    // `aiken-lang/uplc` crate.
     //
-    // `eval_phase_two_raw` returns one `(redeemer_cbor, EvalResult)` pair per
-    // executed redeemer.  The `redeemer_cbor` bytes are a CBOR-encoded
-    // `Redeemer`: `array(4)[tag_uint, index_uint, data, ex_units]`.  We decode
-    // the first two fields to recover (tag, index) and look up the language
-    // version from this map.
-    //
-    // Per Haskell's `evaluateScriptRestricting` (PlutusLedgerApi.Common.Eval):
-    // - V1 / V2: success = any non-error CEK result (term value is ignored).
-    // - V3: success = script returned exactly `Unit` (`()`); any other term
-    //   (Data, Bool, integer, …) is treated as `InvalidReturnValue`.
-    //
-    // By resolving each redeemer individually we avoid the prior bug where
-    // the transaction-wide `has_any_v3` flag applied the V3 Unit check to
-    // ALL redeemers when any V3 script was present — incorrectly rejecting
-    // valid V1/V2 scripts that return non-Unit in mixed-version transactions.
-    let redeemer_version_map = redeemer_script_version_map(tx, utxo_set, &version_map);
-
-    // SECURITY: wrap the third-party uplc / the legacy CBOR codec call in catch_unwind.
-    // Both crates have known panics on malformed input (the legacy CBOR codec flat
-    // decoder unwrap, uplc tx.rs:194 unwrap on Err(EndOfInput)). Without this
-    // guard, an adversary can craft a transaction whose witness-set Plutus
-    // script crashes the node — a remote DoS over TxSubmission2 / N2C.
-    // Treat any panic as a hard script-validation failure → tx is rejected,
-    // node keeps running. Requires panic = "unwind" in the release profile.
+    // The new API does V1/V2/V3 success classification + per-redeemer
+    // declared-budget enforcement internally and surfaces failures as
+    // typed `PhaseTwoError` variants. We still wrap the call in
+    // `catch_unwind` as a defense-in-depth measure: even though
+    // `dugite-uplc` is panic-free by contract (lib.rs §1), the catch
+    // unwind ensures any future regression cannot crash the node.
+    let dugite_slot_config = dugite_uplc::phase_two::SlotConfig {
+        network_start_unix_seconds: slot_config.zero_time / 1_000,
+        slot_zero_offset: slot_config.zero_slot,
+        slot_length_ms: slot_config.slot_length,
+    };
     let eval_outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        uplc::tx::eval_phase_two_raw(
+        dugite_uplc::phase_two::eval_phase_two_raw(
             tx_cbor,
             &utxo_pairs,
             cost_models_cbor,
             max_tx_ex_units,
-            sc,
+            dugite_slot_config,
             false, // don't run phase one (we already do our own phase 1 validation)
-            |_redeemer| {},
+            &mut (),
         )
     }));
     let eval_result = match eval_outcome {
@@ -274,114 +214,17 @@ pub fn evaluate_plutus_scripts(
                 "Plutus evaluator panicked on adversarial input — rejecting tx"
             );
             return Err(PlutusError::EvalFailed(format!(
-                "uplc/the legacy CBOR codec panic on malformed script: {msg}"
+                "dugite-uplc panic on malformed script: {msg}"
             )));
         }
     };
     match eval_result {
         Ok(results) => {
-            for (redeemer_bytes, eval_result) in &results {
-                let cost = eval_result.cost();
-
-                // Decode tag and index from the CBOR redeemer: array(4)[tag, idx, …]
-                // (or map-keyed `(tag, idx) => [data, ex_units]` in Conway).
-                let tag_idx = decode_redeemer_tag_index(redeemer_bytes);
-
-                // Determine whether this specific redeemer executes a V3 script.
-                let is_v3 = tag_idx
-                    .and_then(|(tag, idx)| redeemer_version_map.get(&(tag, idx)).copied())
-                    .map(|ver| ver == 3)
-                    .unwrap_or(false);
-
-                let script_failed = match &eval_result.result {
-                    Err(_) => true,
-                    Ok(term) => {
-                        if matches!(term, uplc::ast::Term::Error) {
-                            true
-                        } else if is_v3 && !term.is_unit() {
-                            // PlutusV3: only Unit is a valid return value.
-                            // Any other term is treated as InvalidReturnValue.
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                };
-                if script_failed {
-                    let err_msg = match &eval_result.result {
-                        Err(e) => format!("{e}"),
-                        Ok(term) if matches!(term, uplc::ast::Term::Error) => {
-                            format!("Script error: {term:?}")
-                        }
-                        Ok(term) => format!("PlutusV3 script returned non-Unit value: {term:?}"),
-                    };
-                    debug!(
-                        tx_hash = %tx.hash.to_hex(),
-                        error = %err_msg,
-                        logs = ?eval_result.logs(),
-                        "Plutus script failed"
-                    );
-                    return Err(PlutusError::EvalFailed(err_msg));
-                }
-
-                // Per-redeemer declared-budget enforcement.
-                //
-                // cardano-node's CEK evaluator halts the moment a redeemer's
-                // declared `ExUnits` (mem, steps) are overspent — producing a
-                // `PlutusFailure` and rejecting the transaction. The aiken
-                // `uplc` crate we link against runs each redeemer with the
-                // **tx-wide** budget passed to `eval_phase_two_raw` (the
-                // protocol `max_tx_ex_units`), NOT the per-redeemer declared
-                // `ex_units`. As a result `eval_phase_two_raw` happily
-                // completes evaluation as long as the tx max isn't blown,
-                // even when the redeemer's own declared budget is too low.
-                //
-                // We close that gap here by comparing the **actual** measured
-                // cost (`eval_result.cost()`) against the redeemer's
-                // **declared** `ex_units` from the input transaction. If the
-                // script genuinely needed more than its declared budget, the
-                // tx must be rejected — otherwise cardano-node will reject
-                // any block dugite forges containing it (Conway
-                // `ConwayUtxowFailure (UtxoFailure (UtxosFailure
-                // (ValidationTagMismatch (IsValid True) (FailedUnexpectedly
-                // (PlutusFailure …)))))`).
-                if let Some((tag, idx)) = tag_idx {
-                    let declared = tx
-                        .witness_set
-                        .redeemers
-                        .iter()
-                        .find(|r| redeemer_tag_byte(&r.tag) == tag && r.index == idx);
-                    if let Some(declared) = declared {
-                        let declared_mem = declared.ex_units.mem as i64;
-                        let declared_cpu = declared.ex_units.steps as i64;
-                        if cost.mem > declared_mem || cost.cpu > declared_cpu {
-                            let over_mem = cost.mem - declared_mem;
-                            let over_cpu = cost.cpu - declared_cpu;
-                            let err_msg = format!(
-                                "Plutus script overspent declared budget for redeemer \
-                                 (tag={tag}, index={idx}): actual=(mem={}, cpu={}), \
-                                 declared=(mem={}, cpu={}), overspent=(mem={}, cpu={})",
-                                cost.mem,
-                                cost.cpu,
-                                declared_mem,
-                                declared_cpu,
-                                over_mem.max(0),
-                                over_cpu.max(0),
-                            );
-                            debug!(
-                                tx_hash = %tx.hash.to_hex(),
-                                error = %err_msg,
-                                "Plutus script overspent declared ex_units — rejecting tx"
-                            );
-                            return Err(PlutusError::EvalFailed(err_msg));
-                        }
-                    }
-                }
-
+            for r in &results {
                 trace!(
                     tx_hash = %tx.hash.to_hex(),
-                    cpu = cost.cpu,
-                    mem = cost.mem,
+                    cpu = r.consumed.cpu,
+                    mem = r.consumed.mem,
                     "Plutus script passed"
                 );
             }
@@ -510,14 +353,55 @@ mod tests {
     /// transaction witness set).
     ///
     /// A Plutus script in the witness set is `CBOR_bytes(flat_encoded_program)`:
-    /// the `uplc` crate's `Program::to_cbor()` produces exactly this format.
+    /// `dugite_uplc::Program::to_cbor()` produces exactly this format.
+    ///
+    /// We map the small set of UPLC source patterns the test suite uses
+    /// to direct `dugite_uplc::Program` constructions. The original
+    /// implementation parsed a textual `(program …)` via aiken's
+    /// `uplc::parser`; dugite-uplc does not ship a textual parser
+    /// (production never needs one — scripts arrive as CBOR-flat on
+    /// the wire), so tests express the equivalent `Term` AST directly
+    /// here.
     fn build_script_cbor(uplc_src: &str) -> Vec<u8> {
-        let program = uplc::parser::program(uplc_src).expect("UPLC parse failed");
-        program
-            .to_debruijn()
-            .expect("DeBruijn conversion failed")
-            .to_cbor()
-            .expect("CBOR encode failed")
+        use dugite_uplc::term::{Constant, Term};
+        use dugite_uplc::Program;
+        let (version, term) = match uplc_src {
+            // V1/V2 always-succeeds: 3 lambdas around a Unit constant.
+            "(program 1.0.0 (lam _ (lam _ (lam _ (con unit ())))))" => (
+                (1, 0, 0),
+                Term::Lam(Box::new(Term::Lam(Box::new(Term::Lam(Box::new(
+                    Term::Const(Constant::Unit),
+                )))))),
+            ),
+            // V3 always-succeeds: 1 lambda around a Unit constant.
+            "(program 1.1.0 (lam _ (con unit ())))" => {
+                ((1, 1, 0), Term::Lam(Box::new(Term::Const(Constant::Unit))))
+            }
+            // V2 single-arg "always-succeeds" (used by tests that confirm
+            // the V3 Unit-check doesn't bleed into V2 evaluation).
+            "(program 1.0.0 (lam _ (con unit ())))" => {
+                ((1, 0, 0), Term::Lam(Box::new(Term::Const(Constant::Unit))))
+            }
+            // V3 returns integer 42 — used by tests that verify the V3
+            // non-Unit-return rejection path.
+            "(program 1.1.0 (lam _ (con integer 42)))" => (
+                (1, 1, 0),
+                Term::Lam(Box::new(Term::Const(Constant::Integer(42.into())))),
+            ),
+            // V1/V2 returns integer 42 — used by tests that verify
+            // non-Error returns are accepted for V1/V2.
+            "(program 1.0.0 (lam _ (lam _ (lam _ (con integer 42)))))" => (
+                (1, 0, 0),
+                Term::Lam(Box::new(Term::Lam(Box::new(Term::Lam(Box::new(
+                    Term::Const(Constant::Integer(42.into())),
+                )))))),
+            ),
+            // V1/V2 always-fails.
+            "(program 1.0.0 (error))" => ((1, 0, 0), Term::Error),
+            other => panic!("build_script_cbor: unsupported test script: {other:?}"),
+        };
+        let program = Program { version, term };
+        program.to_cbor().expect("CBOR encode failed")
     }
 
     /// Compute the PlutusV2 script hash for a script in witness-set encoding.
@@ -819,12 +703,12 @@ mod tests {
         enc.array(1).expect("infallible");
         enc.bytes(script_cbor).expect("infallible");
 
-        // key 5: redeemers — array(1) [[Spend, 0, Unit, [steps, mem]]]
+        // key 5: redeemers — array(1) [[Spend, 0, Unit, [mem, steps]]]
         // Each redeemer: array(4) [tag, index, data, ex_units]
         // - tag 0 = Spend
         // - index 0 (first input)
         // - data = Unit = d87980 (Constr tag 0 with empty list, CBOR alternate format)
-        // - ex_units = array(2) [steps, mem]
+        // - ex_units = array(2) [mem, steps]  (CDDL order: mem first)
         enc.u8(5).expect("infallible");
         enc.array(1).expect("infallible");
         enc.array(4).expect("infallible");
@@ -836,8 +720,8 @@ mod tests {
         enc.tag(minicbor::data::Tag::new(121)).expect("infallible");
         enc.array(0).expect("infallible");
         enc.array(2).expect("infallible");
-        enc.u64(ex_units_steps).expect("infallible");
         enc.u64(ex_units_mem).expect("infallible");
+        enc.u64(ex_units_steps).expect("infallible");
 
         // ----------------------------------------------------------------
         // [2] is_valid = true
@@ -1155,13 +1039,8 @@ mod tests {
         use dugite_primitives::value::Value;
 
         // Build always-succeeds V1 validator
-        let script_text = "(program 1.0.0 (lam _ (lam _ (lam _ (con unit ())))))";
-        let program = uplc::parser::program(script_text).expect("UPLC parse failed");
-        let script_cbor = program
-            .to_debruijn()
-            .expect("DeBruijn conversion failed")
-            .to_cbor()
-            .expect("CBOR encode failed");
+        let script_cbor =
+            build_script_cbor("(program 1.0.0 (lam _ (lam _ (lam _ (con unit ())))))");
 
         // V1 script hash: blake2b_224(0x01 || script_bytes)
         let v1_script_hash: [u8; 28] = {
@@ -1418,51 +1297,13 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 7: decode_redeemer_tag_index — round-trip sanity check
+    // (Removed) `decode_redeemer_tag_index` round-trip test
     //
-    // Verifies that we can recover (tag, index) from the CBOR redeemer bytes
-    // produced by our own `build_conway_tx_cbor` helper (which encodes the
-    // witness-set redeemer in the same `array(4)[tag, idx, data, ex_units]`
-    // format that `eval_phase_two_raw` returns).  This exercises the function
-    // used in the per-redeemer V3 Unit-check path.
+    // The helper was only used to look up the per-redeemer language
+    // version after aiken-uplc's `eval_phase_two_raw` returned. The new
+    // `dugite_uplc::phase_two::eval_phase_two_raw` resolves the version
+    // internally per redeemer, so the helper + this test are obsolete.
     // -----------------------------------------------------------------------
-    #[test]
-    fn test_decode_redeemer_tag_index() {
-        use minicbor::Encoder;
-
-        // Build a redeemer CBOR manually: array(4)[tag=0, idx=3, data=unit, ex_units]
-        let mut buf = Vec::new();
-        let mut enc = Encoder::new(&mut buf);
-        enc.array(4).expect("infallible");
-        enc.u8(0).expect("infallible"); // Spend = 0
-        enc.u32(3).expect("infallible"); // index 3
-        enc.tag(minicbor::data::Tag::new(121)).expect("infallible");
-        enc.array(0).expect("infallible"); // Unit datum
-        enc.array(2).expect("infallible");
-        enc.u64(1000).expect("infallible"); // steps
-        enc.u64(500).expect("infallible"); // mem
-
-        let result = decode_redeemer_tag_index(&buf);
-        assert_eq!(result, Some((0u8, 3u32)), "Expected (tag=0 Spend, index=3)");
-
-        // Mint redeemer at index 1
-        let mut buf2 = Vec::new();
-        let mut enc2 = Encoder::new(&mut buf2);
-        enc2.array(4).expect("infallible");
-        enc2.u8(1).expect("infallible"); // Mint = 1
-        enc2.u32(1).expect("infallible");
-        enc2.tag(minicbor::data::Tag::new(121)).expect("infallible");
-        enc2.array(0).expect("infallible");
-        enc2.array(2).expect("infallible");
-        enc2.u64(0).expect("infallible");
-        enc2.u64(0).expect("infallible");
-
-        assert_eq!(decode_redeemer_tag_index(&buf2), Some((1u8, 1u32)));
-
-        // Malformed CBOR must return None
-        assert_eq!(decode_redeemer_tag_index(&[0xFF, 0xAB]), None);
-        assert_eq!(decode_redeemer_tag_index(&[]), None);
-    }
 
     // -----------------------------------------------------------------------
     // Test: Cross-validation — always-succeeds V2 with real cost model
@@ -1579,8 +1420,8 @@ mod tests {
         enc.tag(minicbor::data::Tag::new(121)).expect("infallible");
         enc.array(0).expect("infallible"); // Unit redeemer data
         enc.array(2).expect("infallible");
-        enc.u64(ex_units_steps).expect("infallible");
         enc.u64(ex_units_mem).expect("infallible");
+        enc.u64(ex_units_steps).expect("infallible");
 
         enc.bool(true).expect("infallible");
         enc.null().expect("infallible");


### PR DESCRIPTION
**Stacked on top of #595 (UPLC-9 part 4c).** Final step: removes the \`aiken-lang/uplc\` dependency.

## Summary
- \`crates/dugite-ledger/src/plutus.rs::evaluate_plutus_scripts\` now calls \`dugite_uplc::phase_two::eval_phase_two_raw\`. The new evaluator does V1/V2/V3 success classification + per-redeemer declared-budget enforcement internally, so ~150 lines of now-redundant per-redeemer plumbing (\`version_map\`, \`redeemer_version_map\`, \`decode_redeemer_tag_index\`, \`redeemer_tag_byte\`, V3 Unit-check, manual budget comparison) are deleted.
- \`build_script_cbor\` (test helper) is rewritten to use \`dugite_uplc::Program::to_cbor()\` (from #592) — no more \`uplc::parser::program\`. The five test scripts the suite uses are now expressed as direct \`Term\` ASTs in a small match table.
- Fixed a long-hidden encoding bug: \`build_conway_tx_cbor\` and \`build_conway_tx_cbor_v3\` were writing redeemer \`ex_units\` as \`[steps, mem]\` rather than the CDDL-mandated \`[mem, steps]\`. The bug was masked by aiken-uplc not enforcing per-redeemer budgets; the new evaluator catches it. With the encoding fixed, \`test_evaluate_exunits_ordering\` passes.
- \`Cargo.toml\` (root): remove \`uplc = { git = … aiken … }\`.
- \`crates/dugite-ledger/Cargo.toml\`: swap \`uplc\` → \`dugite-uplc\`.
- \`Cargo.lock\` shrinks by 340+ lines — entire aiken / pallas-* transitive chain pulled out.

## Verification
- \`cargo build --all-targets\` — clean.
- \`cargo clippy --all-targets -- -D warnings\` — clean.
- \`cargo fmt --all -- --check\` — clean.
- \`cargo test -p dugite-ledger --lib\` — **1266/1266 pass.**
- \`cargo test -p dugite-uplc --lib\` — **296/296 pass.**
- \`cargo test --workspace\` — everything green except one pre-existing mithril flake (\`test_download_snapshot_force_sequential_env_var\`) which passes when run alone, unrelated to UPLC.

Goal "complete UPLC phase-2 and drop aiken-uplc" achieved end-to-end.