### PR TITLE
fix(ledger): dump epoch state pre-boundary, mirror Haskell timing (#615f)

### DIFF
--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -228,6 +228,46 @@ impl LedgerState {
                     conway_genesis: self.conway_genesis_init.as_ref(),
                     tx_index: 0,
                 };
+                // #615f: per-epoch-boundary full-state dump fires BEFORE
+                // process_epoch_transition so it captures the END of the
+                // just-ending epoch (matching Haskell's `currentEpoch=N`
+                // last-block-of-N emission).  The post-boundary dump used
+                // to label as `next_epoch` but reflected start-of-N+1
+                // state, which is an OFF-BY-ONE relative to Haskell's
+                // splitter (which takes last-per-epoch).
+                //
+                // We compute the upcoming RUPD here (without applying it)
+                // so the dumper can expose `rewards.total_distributed`
+                // as the rewards ABOUT TO BE applied at this boundary —
+                // mirroring Haskell's `rewardUpdate` JSON field which
+                // shows the queued (un-applied) RUPD.
+                //
+                // The boundary handler then runs and computes the same
+                // RUPD again — compute_reward_update is pure, so this
+                // double-compute is wasteful but byte-exact correct.
+                #[cfg(feature = "epoch-state-debug")]
+                {
+                    let upcoming_rupd = crate::state::rewards::compute_reward_update(
+                        &self.epochs.prev_protocol_params,
+                        self.epochs.prev_d,
+                        self.epochs.prev_protocol_version_major,
+                        self.epochs.snapshots.go.as_ref(),
+                        &self.epochs.snapshots.bprev_blocks_by_pool,
+                        self.epochs.snapshots.ss_fee,
+                        self.epochs.reserves,
+                        self.epochs.treasury,
+                        &self.certs.reward_accounts,
+                        self.epoch_length,
+                        self.shelley_transition_epoch,
+                    );
+                    crate::state::epoch_state_debug::maybe_dump(
+                        self,
+                        self.epoch.0,
+                        block.slot().0,
+                        Some(&upcoming_rupd),
+                    );
+                }
+
                 epoch_rules.process_epoch_transition(
                     next_epoch,
                     &epoch_ctx,
@@ -238,27 +278,6 @@ impl LedgerState {
                     &mut self.consensus,
                 )?;
                 self.epoch = next_epoch;
-
-                // Tasks #21/#22/#23: per-epoch-boundary full-state dump.
-                // No-op unless the crate is built with `--features
-                // epoch-state-debug` AND `DUGITE_EPOCH_STATE_DUMP=<dir>`
-                // is set at runtime.  Called immediately after the
-                // boundary handler so reward/treasury/reserve scalars
-                // reflect the post-boundary state, matching what
-                // `cardano-cli debug log-epoch-state` would emit on the
-                // Haskell side.
-                #[cfg(feature = "epoch-state-debug")]
-                crate::state::epoch_state_debug::maybe_dump(
-                    self,
-                    next_epoch.0,
-                    block.slot().0,
-                    // `pending_reward_update` was take()-d by the boundary
-                    // handler before this dump fires, so passing it here
-                    // always yielded None (Bug 3).  Pass `None` so the
-                    // dumper falls through to `last_applied_rupd`, which
-                    // the handler populated during the boundary.
-                    None,
-                );
             }
         }
 

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -502,11 +502,15 @@ pub fn capture(
         scalars: Scalars {
             reserves: state.epochs.reserves.0,
             treasury: state.epochs.treasury.0,
-            // Bug 1 fix: `state.utxo.epoch_fees` is reset to 0 by
-            // `process_epoch_transition` before this dump fires; read the
-            // snapshotted just-closed-epoch fee pot from `ss_fee`
-            // (Haskell's `currentEpochState.esLState.utxoState.fees`).
-            fees: state.epochs.snapshots.ss_fee.0,
+            // #615f: the dump now fires PRE-boundary (see apply.rs), so
+            // `state.utxo.epoch_fees` is the live accumulator for the
+            // just-ending epoch — exactly matching Haskell's
+            // `currentEpochState.esLState.utxoState.fees` at the last block
+            // of epoch N.  (Prior to #615f the dump fired post-boundary
+            // where `utxo.epoch_fees` had been zeroed, so #615c switched
+            // to `snapshots.ss_fee` — that's the previous epoch's fees,
+            // and gave a one-epoch off-by-one against Haskell.)
+            fees: state.utxo.epoch_fees.0,
             // Bug 2 fix: Haskell reports `utxoState.deposited` which is
             // the COMBINED stake-key + pool-registration deposit total.
             // Stake-key portion is `total_stake_key_deposits` (3 keys × 2
@@ -712,9 +716,12 @@ mod tests {
         assert_eq!(dump.protocol_version.major, 10);
         assert_eq!(dump.scalars.reserves, 10_000_000);
         assert_eq!(dump.scalars.treasury, 20_000);
-        // Bug 1: fees come from snapshot `ss_fee` (123) not the
-        // post-boundary-reset `utxo.epoch_fees` (999_999).
-        assert_eq!(dump.scalars.fees, 123);
+        // #615f: fees come from the LIVE `utxo.epoch_fees` (999_999), not
+        // the snapshotted `ss_fee` (which is the PREVIOUS epoch's fees).
+        // The dump now fires PRE-boundary (apply.rs), so `utxo.epoch_fees`
+        // is the just-ending epoch's running fee total — matching Haskell's
+        // `utxoState.fees` at the last block of epoch N.
+        assert_eq!(dump.scalars.fees, 999_999);
         assert_eq!(dump.pools.registered, 1);
         assert_eq!(dump.pools.retiring, 1);
         assert_eq!(dump.pools.retired_this_epoch, 1);
@@ -722,17 +729,17 @@ mod tests {
         assert_eq!(dump.governance.cc_threshold_den, 1);
     }
 
-    /// Bug 1: `scalars.fees` must read from the snapshot `ss_fee`, not
-    /// `utxo.epoch_fees` (which `process_epoch_transition` zeroes
-    /// before the dump fires).
+    /// #615f: `scalars.fees` must read from the LIVE `utxo.epoch_fees`
+    /// (the running accumulator for the just-ending epoch) — matching
+    /// Haskell's `utxoState.fees` at end of epoch N.  `ss_fee` is the
+    /// PREVIOUS epoch's fees and was the wrong source (#615c regression).
     #[test]
-    fn capture_reads_fees_from_ss_fee_not_live_epoch_fees() {
+    fn capture_reads_fees_from_live_utxo_epoch_fees() {
         let mut state = make_state();
-        // Simulate the post-boundary state: handler has reset
-        // `utxo.epoch_fees` but `ss_fee` retains the just-closed epoch's
-        // total.
-        state.utxo.epoch_fees = Lovelace(0);
-        state.epochs.snapshots.ss_fee = Lovelace(7_777_777);
+        state.utxo.epoch_fees = Lovelace(7_777_777);
+        // `ss_fee` is the previous epoch's snapshotted fees — should be
+        // IGNORED by the dump because the dump now fires pre-boundary.
+        state.epochs.snapshots.ss_fee = Lovelace(0);
         let dump = capture(&state, 5, 10, None);
         assert_eq!(dump.scalars.fees, 7_777_777);
     }


### PR DESCRIPTION
Off-by-one fix: dugite's per-epoch dump fired AFTER process_epoch_transition (post-RUPD-applied, post-snapshot-rotation), so dugite's epoch=N file matched Haskell's epoch=N-1 file across treasury/reserves/fees/deposits_stake/total_distributed.

Haskell's splitter takes the LAST per-epoch cardano-cli emit (= last block of N, pre-boundary). dugite now mirrors that by:

1. Moving the dump call to BEFORE process_epoch_transition.
2. Labelling with self.epoch (just-ending epoch, matching Haskell's currentEpoch=N).
3. Computing the upcoming RUPD via compute_reward_update (pure function — double-compute is wasteful but correct) and passing it as rupd_override so rewards.total_distributed reflects the about-to-apply rewards (matching Haskell's rewardUpdate JSON field).

Verification: 1430/1430 dugite-ledger tests pass; live preview sync with rebuilt binary will produce aligned dumps.

Surfaced by #615 epoch-diff harness post-#615b/#615d.