### PR TITLE
fix(ledger): MIR rewards apply via pending dsIRewards map, drained at epoch boundary (#631)

### DIFF
--- a/crates/dugite-ledger/src/eras/alonzo.rs
+++ b/crates/dugite-ledger/src/eras/alonzo.rs
@@ -337,6 +337,10 @@ fn make_empty_cert_sub() -> CertSubState {
             stake_map: HashMap::new(),
         },
         script_stake_credentials: HashSet::new(),
+        pending_mir_reserves: std::collections::HashMap::new(),
+        pending_mir_treasury: std::collections::HashMap::new(),
+        pending_mir_delta_reserves: 0,
+        pending_mir_delta_treasury: 0,
     }
 }
 
@@ -441,6 +445,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
 

--- a/crates/dugite-ledger/src/eras/babbage.rs
+++ b/crates/dugite-ledger/src/eras/babbage.rs
@@ -333,6 +333,10 @@ fn make_empty_cert_sub() -> CertSubState {
             stake_map: HashMap::new(),
         },
         script_stake_credentials: HashSet::new(),
+        pending_mir_reserves: std::collections::HashMap::new(),
+        pending_mir_treasury: std::collections::HashMap::new(),
+        pending_mir_delta_reserves: 0,
+        pending_mir_delta_treasury: 0,
     }
 }
 
@@ -437,6 +441,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
 

--- a/crates/dugite-ledger/src/eras/byron.rs
+++ b/crates/dugite-ledger/src/eras/byron.rs
@@ -1208,6 +1208,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: std::collections::HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
 

--- a/crates/dugite-ledger/src/eras/common.rs
+++ b/crates/dugite-ledger/src/eras/common.rs
@@ -769,6 +769,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
 

--- a/crates/dugite-ledger/src/eras/conway.rs
+++ b/crates/dugite-ledger/src/eras/conway.rs
@@ -666,6 +666,13 @@ impl EraRules for ConwayRules {
             .pending_retirements
             .retain(|_, epoch| *epoch > new_epoch);
 
+        // MIR rule (Haskell EPOCH ordering: SNAP → POOLREAP → MIR → NEWPP).
+        // Conway has no MIR certs so the pending maps stay empty and this
+        // is a no-op; included only so a Babbage-loaded snapshot with
+        // pending MIR is drained on the first Conway-era boundary.  See
+        // issue #631.
+        crate::state::certificates::apply_pending_mir(certs, epochs);
+
         // === Step 3: DRep pulser completion ===
         // The DRep distribution (voting power) is computed live within
         // ratify_proposals_impl, matching Haskell's pulser completion that
@@ -1600,6 +1607,10 @@ fn make_empty_cert_sub() -> CertSubState {
             stake_map: HashMap::new(),
         },
         script_stake_credentials: HashSet::new(),
+        pending_mir_reserves: std::collections::HashMap::new(),
+        pending_mir_treasury: std::collections::HashMap::new(),
+        pending_mir_delta_reserves: 0,
+        pending_mir_delta_treasury: 0,
     }
 }
 
@@ -1707,6 +1718,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
 

--- a/crates/dugite-ledger/src/eras/dijkstra.rs
+++ b/crates/dugite-ledger/src/eras/dijkstra.rs
@@ -813,6 +813,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
     fn make_gov_sub() -> GovSubState {
@@ -1431,6 +1435,10 @@ mod tests {
                     stake_map: HashMap::new(),
                 },
                 script_stake_credentials: HashSet::new(),
+                pending_mir_reserves: std::collections::HashMap::new(),
+                pending_mir_treasury: std::collections::HashMap::new(),
+                pending_mir_delta_reserves: 0,
+                pending_mir_delta_treasury: 0,
             };
             // Reach back into the parent `tests` module for fixture helpers.
             let mut gov = super::make_gov_sub();
@@ -1733,6 +1741,10 @@ mod tests {
                     stake_map: HashMap::new(),
                 },
                 script_stake_credentials: HashSet::new(),
+                pending_mir_reserves: std::collections::HashMap::new(),
+                pending_mir_treasury: std::collections::HashMap::new(),
+                pending_mir_delta_reserves: 0,
+                pending_mir_delta_treasury: 0,
             };
             let mut epochs = EpochSubState {
                 snapshots: crate::state::EpochSnapshots::default(),
@@ -1947,6 +1959,10 @@ mod tests {
                         stake_map: HashMap::new(),
                     },
                     script_stake_credentials: HashSet::new(),
+                    pending_mir_reserves: std::collections::HashMap::new(),
+                    pending_mir_treasury: std::collections::HashMap::new(),
+                    pending_mir_delta_reserves: 0,
+                    pending_mir_delta_treasury: 0,
                 };
                 let gov = super::make_gov_sub();
                 let epochs = EpochSubState {
@@ -2342,6 +2358,10 @@ mod tests {
                         stake_map: HashMap::new(),
                     },
                     script_stake_credentials: HashSet::new(),
+                    pending_mir_reserves: std::collections::HashMap::new(),
+                    pending_mir_treasury: std::collections::HashMap::new(),
+                    pending_mir_delta_reserves: 0,
+                    pending_mir_delta_treasury: 0,
                 };
                 let gov = super::make_gov_sub();
                 let epochs = EpochSubState {
@@ -2721,6 +2741,10 @@ mod tests {
                             stake_map: HashMap::new(),
                         },
                         script_stake_credentials: HashSet::new(),
+                        pending_mir_reserves: std::collections::HashMap::new(),
+                        pending_mir_treasury: std::collections::HashMap::new(),
+                        pending_mir_delta_reserves: 0,
+                        pending_mir_delta_treasury: 0,
                     },
                     GovSubState {
                         governance: Arc::new(crate::state::GovernanceState::default()),

--- a/crates/dugite-ledger/src/eras/shelley.rs
+++ b/crates/dugite-ledger/src/eras/shelley.rs
@@ -482,6 +482,12 @@ impl EraRules for ShelleyRules {
             .pending_retirements
             .retain(|_, epoch| *epoch > new_epoch);
 
+        // MIR rule (Haskell EPOCH ordering: SNAP → POOLREAP → MIR → NEWPP).
+        // Drain pending `dsIRewards` map + pot-transfer accumulators into
+        // reward_accounts + reserves/treasury per
+        // `Cardano.Ledger.Shelley.Rules.Mir.applyMIR`.  See issue #631.
+        crate::state::certificates::apply_pending_mir(certs, epochs);
+
         // Capture prevPParams BEFORE PPUP updates.
         //
         // Post-Babbage (PV >= 7) `d` is conceptually 0 (no overlay slots —
@@ -1010,6 +1016,10 @@ mod tests {
                 stake_map: HashMap::new(),
             },
             script_stake_credentials: HashSet::new(),
+            pending_mir_reserves: std::collections::HashMap::new(),
+            pending_mir_treasury: std::collections::HashMap::new(),
+            pending_mir_delta_reserves: 0,
+            pending_mir_delta_treasury: 0,
         }
     }
 

--- a/crates/dugite-ledger/src/state/certificates.rs
+++ b/crates/dugite-ledger/src/state/certificates.rs
@@ -29,6 +29,89 @@ pub(crate) fn is_conway_only_certificate(cert: &Certificate) -> bool {
     )
 }
 
+/// Drain the pending MIR (`dsIRewards`) map and apply it to reward
+/// accounts and pots per Haskell `Cardano.Ledger.Shelley.Rules.Mir.applyMIR`.
+///
+/// Called at every epoch boundary AFTER SNAP/POOLREAP and BEFORE NEWPP
+/// (matching the Haskell EPOCH STS sequence).  In Conway+ MIR certs
+/// are no longer reachable, so the pending maps stay empty and the
+/// function is a no-op.
+///
+/// Per Haskell:
+/// 1. For each (cred, delta) in `dsIRewards.irwdSrcReserves` /
+///    `dsIRewards.irwdSrcTreasury`: credit `reward_accounts[cred] += delta`,
+///    debit the source pot for the sum of all deltas (positive deltas
+///    debit the pot, negative deltas refund into it).
+/// 2. For each `deltaReserves` / `deltaTreasury` accumulator: move the
+///    coin between pots.
+/// 3. Empty all pending maps and zero the accumulators.
+pub(crate) fn apply_pending_mir(
+    certs: &mut super::substates::CertSubState,
+    epochs: &mut super::substates::EpochSubState,
+) {
+    // ── 1. Per-credential MIR distributions ─────────────────────────
+    for (src, pending) in [
+        ("reserves", std::mem::take(&mut certs.pending_mir_reserves)),
+        ("treasury", std::mem::take(&mut certs.pending_mir_treasury)),
+    ] {
+        if pending.is_empty() {
+            continue;
+        }
+        let mut net_pot_debit: i128 = 0;
+        for (cred, delta) in pending {
+            let entry = Arc::make_mut(&mut certs.reward_accounts)
+                .entry(cred)
+                .or_insert(Lovelace(0));
+            let new_balance = entry.0 as i128 + delta;
+            if new_balance < 0 {
+                panic!(
+                    "MIR: credential {} underflows reward balance ({} + {} < 0) — invariant broken",
+                    cred.to_hex(),
+                    entry.0,
+                    delta,
+                );
+            }
+            entry.0 = new_balance as u64;
+            net_pot_debit += delta;
+        }
+        match src {
+            "reserves" => {
+                epochs.reserves.0 = (epochs.reserves.0 as i128 - net_pot_debit)
+                    .try_into()
+                    .expect("MIR reserves debit underflows reserves — invariant broken");
+            }
+            "treasury" => {
+                epochs.treasury.0 = (epochs.treasury.0 as i128 - net_pot_debit)
+                    .try_into()
+                    .expect("MIR treasury debit underflows treasury — invariant broken");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // ── 2. Pot-to-pot transfers ─────────────────────────────────────
+    let dr = std::mem::take(&mut certs.pending_mir_delta_reserves);
+    let dt = std::mem::take(&mut certs.pending_mir_delta_treasury);
+    if dr != 0 {
+        // reserves -> treasury
+        epochs.reserves.0 = (epochs.reserves.0 as i128 - dr)
+            .try_into()
+            .expect("MIR deltaReserves underflows reserves — invariant broken");
+        epochs.treasury.0 = (epochs.treasury.0 as i128 + dr)
+            .try_into()
+            .expect("MIR deltaReserves overflows treasury u64");
+    }
+    if dt != 0 {
+        // treasury -> reserves
+        epochs.treasury.0 = (epochs.treasury.0 as i128 - dt)
+            .try_into()
+            .expect("MIR deltaTreasury underflows treasury — invariant broken");
+        epochs.reserves.0 = (epochs.reserves.0 as i128 + dt)
+            .try_into()
+            .expect("MIR deltaTreasury overflows reserves u64");
+    }
+}
+
 impl LedgerState {
     /// Process a certificate with pointer tracking for Pointer address resolution.
     ///
@@ -521,74 +604,47 @@ impl LedgerState {
                 );
             }
             Certificate::MoveInstantaneousRewards { source, target } => {
-                // MIR: transfer funds between reserves/treasury or distribute to stake credentials
+                // Per Haskell `Cardano.Ledger.Shelley.Rules.Mir.applyMIRCert`
+                // MIR certs do NOT credit reward_accounts or move pots during
+                // LEDGER STS — they accumulate into the `InstantaneousRewards`
+                // (`dsIRewards`) pending-delta map on `DState`. The actual
+                // application happens at the next epoch boundary via the
+                // MIR sub-rule of EPOCH.  See issue #631.
                 match target {
                     MIRTarget::StakeCredentials(creds) => {
-                        let mut total_distributed: u64 = 0;
+                        let pending = match source {
+                            MIRSource::Reserves => &mut self.certs.pending_mir_reserves,
+                            MIRSource::Treasury => &mut self.certs.pending_mir_treasury,
+                        };
                         for (cred, amount) in creds {
                             let key = credential_to_hash(cred);
-                            let entry = Arc::make_mut(&mut self.certs.reward_accounts)
-                                .entry(key)
-                                .or_insert(Lovelace(0));
-                            if *amount >= 0 {
-                                let amt = *amount as u64;
-                                entry.0 = entry.0.saturating_add(amt);
-                                total_distributed = total_distributed.saturating_add(amt);
-                            } else {
-                                entry.0 = entry.0.saturating_sub(amount.unsigned_abs());
-                            }
+                            let entry = pending.entry(key).or_insert(0i128);
+                            *entry += *amount as i128;
                             debug!(
-                                "MIR: distributed {} lovelace from {:?} to {}",
+                                "MIR: pending {} lovelace from {:?} to {}",
                                 amount,
                                 source,
                                 key.to_hex()
                             );
                         }
-                        // Debit the source pot for the total positive amount distributed
-                        if total_distributed > 0 {
-                            match source {
-                                MIRSource::Reserves => {
-                                    self.epochs.reserves.0 =
-                                        self.epochs.reserves.0.checked_sub(total_distributed).expect("reserves underflow during MIR/governance refund — ledger invariant broken");
-                                }
-                                MIRSource::Treasury => {
-                                    self.epochs.treasury.0 =
-                                        self.epochs.treasury.0.checked_sub(total_distributed).expect("treasury underflow during MIR/governance refund — ledger invariant broken");
-                                }
-                            }
-                        }
                     }
                     MIRTarget::OtherAccountingPot(coin) => {
-                        // Transfer between reserves and treasury
-                        // Use saturating arithmetic to handle compound MIR operations
-                        // where credential distributions and pot transfers interact
+                        // Pot-to-pot transfer: accumulate the delta, apply at
+                        // epoch boundary.  Per Haskell `dsIRewards . deltaReserves`
+                        // / `deltaTreasury`.
                         match source {
                             MIRSource::Reserves => {
-                                // Move from reserves to treasury, capped at available
-                                let actual = (*coin).min(self.epochs.reserves.0);
-                                self.epochs.reserves.0 =
-                                    self.epochs.reserves.0.checked_sub(actual).expect("reserves underflow during MIR/governance refund — ledger invariant broken");
-                                self.epochs.treasury.0 =
-                                    self.epochs.treasury.0.checked_add(actual).expect(
-                                        "treasury overflow during MIR/governance refund — u64",
-                                    );
+                                self.certs.pending_mir_delta_reserves += *coin as i128;
                                 debug!(
-                                    "MIR: transferred {} lovelace from reserves to treasury",
-                                    actual
+                                    "MIR: pending {} lovelace pot-transfer reserves -> treasury",
+                                    coin
                                 );
                             }
                             MIRSource::Treasury => {
-                                // Move from treasury to reserves, capped at available
-                                let actual = (*coin).min(self.epochs.treasury.0);
-                                self.epochs.treasury.0 =
-                                    self.epochs.treasury.0.checked_sub(actual).expect("treasury underflow during MIR/governance refund — ledger invariant broken");
-                                self.epochs.reserves.0 =
-                                    self.epochs.reserves.0.checked_add(actual).expect(
-                                        "reserves overflow during MIR/governance refund — u64",
-                                    );
+                                self.certs.pending_mir_delta_treasury += *coin as i128;
                                 debug!(
-                                    "MIR: transferred {} lovelace from treasury to reserves",
-                                    actual
+                                    "MIR: pending {} lovelace pot-transfer treasury -> reserves",
+                                    coin
                                 );
                             }
                         }
@@ -1196,70 +1252,30 @@ impl LedgerState {
                 );
             }
             Certificate::MoveInstantaneousRewards { source, target } => {
-                // MIR — no delta changes recorded (pre-Conway, not replayed via deltas).
+                // MIR: accumulate into the pending dsIRewards map per
+                // Haskell `applyMIRCert` (see issue #631).  Drained at the
+                // next epoch boundary by `apply_pending_mir`.  Pre-Conway
+                // only — Conway removes MIR certs entirely.
                 match target {
                     MIRTarget::StakeCredentials(creds) => {
-                        let mut total_distributed: u64 = 0;
+                        let pending = match source {
+                            MIRSource::Reserves => &mut self.certs.pending_mir_reserves,
+                            MIRSource::Treasury => &mut self.certs.pending_mir_treasury,
+                        };
                         for (cred, amount) in creds {
                             let key = credential_to_hash(cred);
-                            let entry = Arc::make_mut(&mut self.certs.reward_accounts)
-                                .entry(key)
-                                .or_insert(Lovelace(0));
-                            if *amount >= 0 {
-                                let amt = *amount as u64;
-                                entry.0 = entry.0.saturating_add(amt);
-                                total_distributed = total_distributed.saturating_add(amt);
-                            } else {
-                                entry.0 = entry.0.saturating_sub(amount.unsigned_abs());
-                            }
-                            debug!(
-                                "MIR: distributed {} lovelace from {:?} to {}",
-                                amount,
-                                source,
-                                key.to_hex()
-                            );
-                        }
-                        if total_distributed > 0 {
-                            match source {
-                                MIRSource::Reserves => {
-                                    self.epochs.reserves.0 =
-                                        self.epochs.reserves.0.checked_sub(total_distributed).expect("reserves underflow during MIR/governance refund — ledger invariant broken");
-                                }
-                                MIRSource::Treasury => {
-                                    self.epochs.treasury.0 =
-                                        self.epochs.treasury.0.checked_sub(total_distributed).expect("treasury underflow during MIR/governance refund — ledger invariant broken");
-                                }
-                            }
+                            let entry = pending.entry(key).or_insert(0i128);
+                            *entry += *amount as i128;
                         }
                     }
-                    MIRTarget::OtherAccountingPot(coin) => {
-                        match source {
-                            MIRSource::Reserves => {
-                                let actual = (*coin).min(self.epochs.reserves.0);
-                                self.epochs.reserves.0 = self.epochs.reserves.0.checked_sub(actual).expect("reserves underflow during MIR/governance refund — ledger invariant broken");
-                                self.epochs.treasury.0 =
-                                    self.epochs.treasury.0.checked_add(actual).expect(
-                                        "treasury overflow during MIR/governance refund — u64",
-                                    );
-                                debug!(
-                                    "MIR: transferred {} lovelace from reserves to treasury",
-                                    actual
-                                );
-                            }
-                            MIRSource::Treasury => {
-                                let actual = (*coin).min(self.epochs.treasury.0);
-                                self.epochs.treasury.0 = self.epochs.treasury.0.checked_sub(actual).expect("treasury underflow during MIR/governance refund — ledger invariant broken");
-                                self.epochs.reserves.0 =
-                                    self.epochs.reserves.0.checked_add(actual).expect(
-                                        "reserves overflow during MIR/governance refund — u64",
-                                    );
-                                debug!(
-                                    "MIR: transferred {} lovelace from treasury to reserves",
-                                    actual
-                                );
-                            }
+                    MIRTarget::OtherAccountingPot(coin) => match source {
+                        MIRSource::Reserves => {
+                            self.certs.pending_mir_delta_reserves += *coin as i128;
                         }
-                    }
+                        MIRSource::Treasury => {
+                            self.certs.pending_mir_delta_treasury += *coin as i128;
+                        }
+                    },
                 }
             }
         }
@@ -2227,6 +2243,7 @@ mod tests {
             source: MIRSource::Reserves,
             target: MIRTarget::StakeCredentials(vec![(cred, amount)]),
         });
+        super::apply_pending_mir(&mut state.certs, &mut state.epochs);
 
         let balance = state
             .certs
@@ -2266,6 +2283,7 @@ mod tests {
             source: MIRSource::Treasury,
             target: MIRTarget::StakeCredentials(vec![(cred, amount)]),
         });
+        super::apply_pending_mir(&mut state.certs, &mut state.epochs);
 
         let balance = state
             .certs
@@ -2300,6 +2318,7 @@ mod tests {
             source: MIRSource::Reserves,
             target: MIRTarget::OtherAccountingPot(3_000_000_000),
         });
+        super::apply_pending_mir(&mut state.certs, &mut state.epochs);
 
         assert_eq!(
             state.epochs.reserves.0, 7_000_000_000,
@@ -2327,6 +2346,7 @@ mod tests {
             source: MIRSource::Treasury,
             target: MIRTarget::OtherAccountingPot(2_000_000_000),
         });
+        super::apply_pending_mir(&mut state.certs, &mut state.epochs);
 
         assert_eq!(
             state.epochs.treasury.0, 6_000_000_000,
@@ -2350,19 +2370,21 @@ mod tests {
         state.epochs.reserves.0 = 1_000_000;
         state.epochs.treasury.0 = 0;
 
-        // Try to move 5B from a 1M reserve — should be capped at 1M.
+        // Try to move 5B from a 1M reserve.  Per Haskell `applyMIR` the
+        // pot debit is unconditional — a value that exceeds the source pot
+        // would have already been rejected upstream by `validateMIRCert`
+        // (`InsufficientForInstantaneousRewards`), so reaching apply with
+        // an over-source coin is an invariant violation and panics.
         state.process_certificate(&Certificate::MoveInstantaneousRewards {
             source: MIRSource::Reserves,
             target: MIRTarget::OtherAccountingPot(5_000_000_000),
         });
-
-        assert_eq!(
-            state.epochs.reserves.0, 0,
-            "Reserves capped: can't go below 0"
-        );
-        assert_eq!(
-            state.epochs.treasury.0, 1_000_000,
-            "Only actual reserves transferred to treasury"
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            super::apply_pending_mir(&mut state.certs, &mut state.epochs)
+        }));
+        assert!(
+            result.is_err(),
+            "apply_pending_mir must panic on a delta that exceeds the source pot"
         );
     }
 

--- a/crates/dugite-ledger/src/state/epoch.rs
+++ b/crates/dugite-ledger/src/state/epoch.rs
@@ -457,6 +457,14 @@ impl LedgerState {
             .pending_retirements
             .retain(|_, epoch| *epoch > new_epoch);
 
+        // MIR rule (Haskell EPOCH ordering: SNAP → POOLREAP → MIR → NEWPP).
+        // Drain the pending `dsIRewards` map and pot-transfer accumulators
+        // into reward_accounts + reserves/treasury per
+        // `Cardano.Ledger.Shelley.Rules.Mir.applyMIR`.  Pre-Conway only —
+        // Conway never produces MIR certs so the pending maps stay empty
+        // and this is a no-op.  See issue #631.
+        super::certificates::apply_pending_mir(&mut self.certs, &mut self.epochs);
+
         // Capture prevPParams BEFORE PPUP updates curPP, matching Haskell's
         // NEWPP rule: prevPParams = old curPParams (before this boundary's PPUP).
         // The RUPD at the NEXT boundary will use prev_protocol_params for ALL

--- a/crates/dugite-ledger/src/state/mod.rs
+++ b/crates/dugite-ledger/src/state/mod.rs
@@ -1,5 +1,5 @@
 mod apply;
-mod certificates;
+pub(crate) mod certificates;
 mod epoch;
 #[cfg(feature = "epoch-state-debug")]
 pub mod epoch_state_debug;
@@ -607,6 +607,10 @@ impl LedgerState {
                 pointer_map: HashMap::new(),
                 stake_distribution: StakeDistributionState::default(),
                 script_stake_credentials: std::collections::HashSet::new(),
+                pending_mir_reserves: std::collections::HashMap::new(),
+                pending_mir_treasury: std::collections::HashMap::new(),
+                pending_mir_delta_reserves: 0,
+                pending_mir_delta_treasury: 0,
             },
             gov: GovSubState {
                 governance: Arc::new(GovernanceState::default()),
@@ -939,6 +943,10 @@ impl LedgerState {
                 pointer_map: HashMap::new(), // Conway era: pointers excluded
                 stake_distribution: StakeDistributionState { stake_map },
                 script_stake_credentials,
+                pending_mir_reserves: HashMap::new(),
+                pending_mir_treasury: HashMap::new(),
+                pending_mir_delta_reserves: 0,
+                pending_mir_delta_treasury: 0,
             },
             gov: GovSubState {
                 governance: Arc::new(gov),

--- a/crates/dugite-ledger/src/state/snapshot.rs
+++ b/crates/dugite-ledger/src/state/snapshot.rs
@@ -135,7 +135,7 @@ impl LedgerState {
     /// dugite is pre-1.0 and makes no snapshot back-compat guarantee:
     /// there is no migration shim and no `serde(default)` fallbacks on
     /// fields added after launch.
-    pub(crate) const SNAPSHOT_VERSION: u8 = 17;
+    pub(crate) const SNAPSHOT_VERSION: u8 = 18;
 
     /// Save ledger state snapshot to disk using bincode serialization.
     ///

--- a/crates/dugite-ledger/src/state/snapshot_format.rs
+++ b/crates/dugite-ledger/src/state/snapshot_format.rs
@@ -141,6 +141,20 @@ pub struct LedgerStateSnapshot {
     pub total_stake_key_deposits: u64,
     /// Script-type stake credentials.
     pub script_stake_credentials: std::collections::HashSet<Hash32>,
+    /// Pending MIR reserves-sourced reward deltas (Haskell
+    /// `dsIRewards . irwdSrcReserves`; see issue #631).
+    pub pending_mir_reserves: HashMap<Hash32, i128>,
+    /// Pending MIR treasury-sourced reward deltas (Haskell
+    /// `dsIRewards . irwdSrcTreasury`).
+    pub pending_mir_treasury: HashMap<Hash32, i128>,
+    /// Pending pot-to-pot accumulator: reserves drained at the next epoch
+    /// boundary and routed to treasury (Haskell
+    /// `dsIRewards . deltaReserves`).
+    pub pending_mir_delta_reserves: i128,
+    /// Pending pot-to-pot accumulator: treasury drained at the next epoch
+    /// boundary and routed to reserves (Haskell
+    /// `dsIRewards . deltaTreasury`).
+    pub pending_mir_delta_treasury: i128,
     /// Per-block UTxO diffs for the last k blocks.
     #[serde(skip)]
     pub diff_seq: DiffSeq,
@@ -177,6 +191,10 @@ impl From<&super::LedgerState> for LedgerStateSnapshot {
             pointer_map: s.certs.pointer_map.clone(),
             stake_distribution: s.certs.stake_distribution.clone(),
             script_stake_credentials: s.certs.script_stake_credentials.clone(),
+            pending_mir_reserves: s.certs.pending_mir_reserves.clone(),
+            pending_mir_treasury: s.certs.pending_mir_treasury.clone(),
+            pending_mir_delta_reserves: s.certs.pending_mir_delta_reserves,
+            pending_mir_delta_treasury: s.certs.pending_mir_delta_treasury,
             // Gov sub-state
             governance: Arc::clone(&s.gov.governance),
             // Consensus sub-state
@@ -249,6 +267,10 @@ impl From<LedgerStateSnapshot> for super::LedgerState {
                 pointer_map: s.pointer_map,
                 stake_distribution: s.stake_distribution,
                 script_stake_credentials: s.script_stake_credentials,
+                pending_mir_reserves: s.pending_mir_reserves,
+                pending_mir_treasury: s.pending_mir_treasury,
+                pending_mir_delta_reserves: s.pending_mir_delta_reserves,
+                pending_mir_delta_treasury: s.pending_mir_delta_treasury,
             },
             gov: GovSubState {
                 governance: s.governance,

--- a/crates/dugite-ledger/src/state/substates.rs
+++ b/crates/dugite-ledger/src/state/substates.rs
@@ -50,6 +50,24 @@ pub struct CertSubState {
     pub pointer_map: HashMap<dugite_primitives::credentials::Pointer, Hash32>,
     pub stake_distribution: StakeDistributionState,
     pub script_stake_credentials: HashSet<Hash32>,
+    /// Pending MIR per-credential reward deltas sourced from the reserves
+    /// pot (Haskell `dsIRewards . irwdSrcReserves` — half of
+    /// `InstantaneousRewards`).  Accumulated by MIR-cert apply during
+    /// LEDGER STS and drained at the next epoch boundary by `applyMIR`;
+    /// never credited directly to `reward_accounts` while a tx is
+    /// processing.  Pre-Conway only; Conway removes MIR certs entirely.
+    pub pending_mir_reserves: HashMap<Hash32, i128>,
+    /// Pending MIR per-credential reward deltas sourced from the treasury
+    /// pot (Haskell `dsIRewards . irwdSrcTreasury`).
+    pub pending_mir_treasury: HashMap<Hash32, i128>,
+    /// Pending pot-to-pot transfer accumulator (Haskell
+    /// `dsIRewards . deltaReserves`): reserves drained at the next epoch
+    /// boundary and routed to treasury.
+    pub pending_mir_delta_reserves: i128,
+    /// Pending pot-to-pot transfer accumulator (Haskell
+    /// `dsIRewards . deltaTreasury`): treasury drained at the next epoch
+    /// boundary and routed to reserves.
+    pub pending_mir_delta_treasury: i128,
 }
 
 /// Governance state: proposals, votes, DReps, committee.

--- a/crates/dugite-ledger/src/state/tests.rs
+++ b/crates/dugite-ledger/src/state/tests.rs
@@ -4123,6 +4123,7 @@ fn test_mir_stake_credential_distribution() {
         source: MIRSource::Reserves,
         target: MIRTarget::StakeCredentials(vec![(cred.clone(), 1_000_000)]),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
     assert_eq!(
         state.certs.reward_accounts.get(&key),
         Some(&Lovelace(1_000_000))
@@ -4142,6 +4143,7 @@ fn test_mir_pot_transfer() {
         source: MIRSource::Reserves,
         target: MIRTarget::OtherAccountingPot(2_000_000),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
     assert_eq!(state.epochs.reserves, Lovelace(8_000_000));
     assert_eq!(state.epochs.treasury, Lovelace(7_000_000));
 
@@ -4150,6 +4152,7 @@ fn test_mir_pot_transfer() {
         source: MIRSource::Treasury,
         target: MIRTarget::OtherAccountingPot(3_000_000),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
     assert_eq!(state.epochs.reserves, Lovelace(11_000_000));
     assert_eq!(state.epochs.treasury, Lovelace(4_000_000));
 }
@@ -4915,6 +4918,7 @@ fn test_mir_stake_credentials_debits_reserves() {
             (cred2.clone(), 2_000_000),
         ]),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
 
     assert_eq!(state.certs.reward_accounts[&key1], Lovelace(3_000_000));
     assert_eq!(state.certs.reward_accounts[&key2], Lovelace(2_000_000));
@@ -4938,6 +4942,7 @@ fn test_mir_stake_credentials_debits_treasury() {
         source: MIRSource::Treasury,
         target: MIRTarget::StakeCredentials(vec![(cred.clone(), 7_000_000)]),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
 
     assert_eq!(state.certs.reward_accounts[&key], Lovelace(7_000_000));
     // Treasury should be debited
@@ -4946,9 +4951,11 @@ fn test_mir_stake_credentials_debits_treasury() {
 
 #[test]
 fn test_mir_compound_credential_and_pot_transfer() {
-    // Issue #16: When both credential distribution AND OtherAccountingPot transfer
-    // happen from the same source pot, the sequential operations must use saturating
-    // arithmetic to avoid underflow/overflow if the first operation depletes the pot.
+    // Per Haskell `applyMIR` MIR application is unconditional: any cert
+    // whose delta would underflow the source pot must have been rejected
+    // upstream by `validateMIRCert` (`InsufficientForInstantaneousRewards`).
+    // After issue #631 the apply path panics on such a scenario instead of
+    // silently capping at the available balance.
     let mut state = LedgerState::new(ProtocolParameters::mainnet_defaults());
     state.epochs.reserves = Lovelace(10_000_000);
     state.epochs.treasury = Lovelace(5_000_000);
@@ -4957,29 +4964,33 @@ fn test_mir_compound_credential_and_pot_transfer() {
     let key = credential_to_hash(&cred);
     state.process_certificate(&Certificate::StakeRegistration(cred.clone()));
 
-    // Step 1: MIR distributes 8M from reserves to credential (leaves 2M in reserves)
+    // 8M from reserves to credential, drained at the next epoch boundary.
     state.process_certificate(&Certificate::MoveInstantaneousRewards {
         source: MIRSource::Reserves,
         target: MIRTarget::StakeCredentials(vec![(cred.clone(), 8_000_000)]),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
     assert_eq!(state.epochs.reserves, Lovelace(2_000_000));
     assert_eq!(state.certs.reward_accounts[&key], Lovelace(8_000_000));
 
-    // Step 2: MIR pot transfer tries to move 5M from reserves to treasury,
-    // but only 2M remain. Should cap at available (2M), not panic/underflow.
+    // Now a 5M pot transfer with only 2M reserves: invalid per Haskell.
     state.process_certificate(&Certificate::MoveInstantaneousRewards {
         source: MIRSource::Reserves,
         target: MIRTarget::OtherAccountingPot(5_000_000),
     });
-    // Reserves fully drained (capped at 2M available)
-    assert_eq!(state.epochs.reserves, Lovelace(0));
-    // Treasury receives only the 2M that was actually available
-    assert_eq!(state.epochs.treasury, Lovelace(7_000_000));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs)
+    }));
+    assert!(
+        result.is_err(),
+        "apply_pending_mir must panic when delta exceeds source pot"
+    );
 }
 
 #[test]
 fn test_mir_pot_transfer_exceeds_source_treasury() {
-    // Symmetric test: treasury pot transfer exceeding available balance
+    // Symmetric case for treasury → reserves pot transfer that exceeds
+    // available balance.
     let mut state = LedgerState::new(ProtocolParameters::mainnet_defaults());
     state.epochs.reserves = Lovelace(20_000_000);
     state.epochs.treasury = Lovelace(3_000_000);
@@ -4987,36 +4998,45 @@ fn test_mir_pot_transfer_exceeds_source_treasury() {
     let cred = Credential::VerificationKey(Hash28::from_bytes([0xff; 28]));
     state.process_certificate(&Certificate::StakeRegistration(cred.clone()));
 
-    // Distribute 2M from treasury to credential (leaves 1M)
     state.process_certificate(&Certificate::MoveInstantaneousRewards {
         source: MIRSource::Treasury,
         target: MIRTarget::StakeCredentials(vec![(cred.clone(), 2_000_000)]),
     });
+    crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs);
     assert_eq!(state.epochs.treasury, Lovelace(1_000_000));
 
-    // Try to transfer 10M from treasury to reserves, but only 1M available
     state.process_certificate(&Certificate::MoveInstantaneousRewards {
         source: MIRSource::Treasury,
         target: MIRTarget::OtherAccountingPot(10_000_000),
     });
-    assert_eq!(state.epochs.treasury, Lovelace(0));
-    assert_eq!(state.epochs.reserves, Lovelace(21_000_000));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs)
+    }));
+    assert!(
+        result.is_err(),
+        "apply_pending_mir must panic when treasury delta exceeds source pot"
+    );
 }
 
 #[test]
 fn test_mir_pot_transfer_zero_source() {
-    // Edge case: pot transfer when source is already zero
+    // Edge case: a pot transfer from an already-empty source pot is an
+    // invariant violation per Haskell and panics on apply.
     let mut state = LedgerState::new(ProtocolParameters::mainnet_defaults());
     state.epochs.reserves = Lovelace(0);
     state.epochs.treasury = Lovelace(5_000_000);
 
-    // Should be a no-op, not panic
     state.process_certificate(&Certificate::MoveInstantaneousRewards {
         source: MIRSource::Reserves,
         target: MIRTarget::OtherAccountingPot(1_000_000),
     });
-    assert_eq!(state.epochs.reserves, Lovelace(0));
-    assert_eq!(state.epochs.treasury, Lovelace(5_000_000));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::state::certificates::apply_pending_mir(&mut state.certs, &mut state.epochs)
+    }));
+    assert!(
+        result.is_err(),
+        "apply_pending_mir must panic on pot transfer from empty source"
+    );
 }
 
 #[test]

--- a/crates/dugite-ledger/tests/snapshot_stability.rs
+++ b/crates/dugite-ledger/tests/snapshot_stability.rs
@@ -56,11 +56,12 @@ fn snapshot_format_hash_stability() {
     // This hash was computed from the current LedgerStateSnapshot layout.
     // If this changes, existing snapshot files become unreadable.
     //
-    // Last update: SNAPSHOT_VERSION 16 → 17 (issue #629) — `prev_d`
-    // changed from `f64` (8 bytes) to `Rational { numerator: u64,
-    // denominator: u64 }` (16 bytes), shifting every byte after the
-    // `prev_protocol_params` block in the bincode stream.
-    const EXPECTED_HASH: &str = "cd02b0b4d223ea934b0595440a400169c88a947b0f8a84d5832291db18711af4";
+    // Last update: SNAPSHOT_VERSION 17 → 18 (issue #631) — `CertSubState`
+    // gained four pending-MIR fields (`pending_mir_reserves`,
+    // `pending_mir_treasury`, `pending_mir_delta_reserves`,
+    // `pending_mir_delta_treasury`) so MIR-cert effects accumulate per
+    // Haskell `dsIRewards` and drain at the next epoch boundary.
+    const EXPECTED_HASH: &str = "ced0d4b9701568bd4697d2caeaf7971018638bda0c88b84e61ad89415820c575";
 
     if EXPECTED_HASH == "COMPUTE_ON_FIRST_RUN" {
         panic!(


### PR DESCRIPTION
## Summary

Replaces the immediate-credit MIR semantics with Haskell's pending-delta map (`dsIRewards`) drained at the next epoch boundary per `Cardano.Ledger.Shelley.Rules.Mir.applyMIRCert`.

- `CertSubState` gains four pending fields: `pending_mir_reserves`, `pending_mir_treasury`, `pending_mir_delta_reserves`, `pending_mir_delta_treasury`.
- MIR cert handlers accumulate into the pending maps instead of mutating `reward_accounts` / pots during LEDGER STS.
- New free fn `state::certificates::apply_pending_mir` drains the pending maps with checked arithmetic — panics on negative balance or pot underflow (matches Haskell `unsafeNonNegativeCoin`).
- Wired into the boundary handlers in `state/epoch.rs`, `eras/shelley.rs`, and `eras/conway.rs` between POOLREAP and NEWPP, matching the Haskell EPOCH STS sequence (SNAP → POOLREAP → MIR → NEWPP).
- Snapshot v17 → v18 to reflect the new fields' presence in the bincode layout.
- Tests that previously asserted dugite's silent saturating-cap behaviour for over-pot MIR transfers are rewritten to assert the Haskell-conformant panic — those scenarios would be rejected upstream by `validateMIRCert` and reaching apply with them is an invariant violation.

MIR is pre-Conway only (Conway removes MIR certs entirely). Preview/preprod stayed correct at byte level because MIR usage there is sparse and within-epoch — for mainnet from-genesis sync this is required for correct treasury/reserves alignment.

## Test plan

- [x] `cargo nextest run -p dugite-ledger` (1432/1432 pass)
- [x] `just check` (fmt + clippy + build + test + doc-test)
- [ ] CI green
- [ ] Long-horizon preview/preprod sync still byte-exact

Closes #631.