### PR TITLE
docs: fix stale content across 6 pages; fix mithril test env-var race

### DIFF
--- a/crates/dugite-node/src/mithril.rs
+++ b/crates/dugite-node/src/mithril.rs
@@ -2764,6 +2764,10 @@ mod tests {
     use super::*;
     use ed25519_dalek::Signer;
 
+    // Env vars are process-global and `cargo test` runs tests in threads.
+    // Serialise all tests that call `set_var` / `remove_var` through this lock.
+    static MITHRIL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_aggregator_url_mainnet() {
         assert_eq!(
@@ -4097,11 +4101,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("snapshot.tar.zst");
 
+        // Serialise env-var writes: cargo test runs tests in threads.
+        let _env_lock = MITHRIL_ENV_LOCK.lock().unwrap();
         // Force parallelism = 4 for a deterministic test.
         std::env::set_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM", "4");
         let result =
             download_snapshot(&client, &format!("http://{addr}/snap"), &dest, SIZE as u64).await;
         std::env::remove_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM");
+        drop(_env_lock);
         result.expect("parallel download should succeed");
 
         // Verify the assembled file.
@@ -4425,12 +4432,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("snapshot.tar.zst");
 
+        let _env_lock = MITHRIL_ENV_LOCK.lock().unwrap();
         // Force parallelism = 4 for a deterministic test.
         std::env::set_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM", "4");
         std::env::remove_var("DUGITE_MITHRIL_FORCE_SEQUENTIAL");
         let result =
             download_snapshot(&client, &format!("http://{addr}/snap"), &dest, SIZE as u64).await;
         std::env::remove_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM");
+        drop(_env_lock);
         result.expect("range-probe parallel download should succeed");
 
         // Output must match the source byte-for-byte.
@@ -4513,10 +4522,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("snapshot.tar.zst");
 
+        let _env_lock = MITHRIL_ENV_LOCK.lock().unwrap();
         std::env::set_var("DUGITE_MITHRIL_FORCE_SEQUENTIAL", "1");
         let result =
             download_snapshot(&client, &format!("http://{addr}/snap"), &dest, SIZE as u64).await;
         std::env::remove_var("DUGITE_MITHRIL_FORCE_SEQUENTIAL");
+        drop(_env_lock);
         result.expect("force-sequential download should succeed");
 
         let got = std::fs::read(&dest).unwrap();

--- a/crates/dugite-node/src/mithril.rs
+++ b/crates/dugite-node/src/mithril.rs
@@ -2765,8 +2765,14 @@ mod tests {
     use ed25519_dalek::Signer;
 
     // Env vars are process-global and `cargo test` runs tests in threads.
-    // Serialise all tests that call `set_var` / `remove_var` through this lock.
-    static MITHRIL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Serialise all tests that call `set_var`/`remove_var` through this lock.
+    // Uses tokio::sync::Mutex so the guard can be held across `.await` without
+    // triggering clippy::await_holding_lock.
+    static MITHRIL_ENV_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> =
+        std::sync::OnceLock::new();
+    fn env_lock() -> &'static tokio::sync::Mutex<()> {
+        MITHRIL_ENV_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
 
     #[test]
     fn test_aggregator_url_mainnet() {
@@ -4102,13 +4108,12 @@ mod tests {
         let dest = dir.path().join("snapshot.tar.zst");
 
         // Serialise env-var writes: cargo test runs tests in threads.
-        let _env_lock = MITHRIL_ENV_LOCK.lock().unwrap();
+        let _env_lock = env_lock().lock().await;
         // Force parallelism = 4 for a deterministic test.
         std::env::set_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM", "4");
         let result =
             download_snapshot(&client, &format!("http://{addr}/snap"), &dest, SIZE as u64).await;
         std::env::remove_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM");
-        drop(_env_lock);
         result.expect("parallel download should succeed");
 
         // Verify the assembled file.
@@ -4432,14 +4437,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("snapshot.tar.zst");
 
-        let _env_lock = MITHRIL_ENV_LOCK.lock().unwrap();
+        let _env_lock = env_lock().lock().await;
         // Force parallelism = 4 for a deterministic test.
         std::env::set_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM", "4");
         std::env::remove_var("DUGITE_MITHRIL_FORCE_SEQUENTIAL");
         let result =
             download_snapshot(&client, &format!("http://{addr}/snap"), &dest, SIZE as u64).await;
         std::env::remove_var("DUGITE_MITHRIL_DOWNLOAD_PARALLELISM");
-        drop(_env_lock);
         result.expect("range-probe parallel download should succeed");
 
         // Output must match the source byte-for-byte.
@@ -4522,12 +4526,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("snapshot.tar.zst");
 
-        let _env_lock = MITHRIL_ENV_LOCK.lock().unwrap();
+        let _env_lock = env_lock().lock().await;
         std::env::set_var("DUGITE_MITHRIL_FORCE_SEQUENTIAL", "1");
         let result =
             download_snapshot(&client, &format!("http://{addr}/snap"), &dest, SIZE as u64).await;
         std::env::remove_var("DUGITE_MITHRIL_FORCE_SEQUENTIAL");
-        drop(_env_lock);
         result.expect("force-sequential download should succeed");
 
         let got = std::fs::read(&dest).unwrap();

--- a/docs/src/architecture/ledger.md
+++ b/docs/src/architecture/ledger.md
@@ -37,7 +37,7 @@ flowchart TD
     ET --> TXS
     TXS --> P1[Phase-1 Validation<br/>Structural + witness checks]
     P1 --> P2{Plutus scripts?}
-    P2 -->|Yes| EVAL[Phase-2 Evaluation<br/>uplc CEK machine]
+    P2 -->|Yes| EVAL[Phase-2 Evaluation<br/>dugite-uplc CEK machine]
     P2 -->|No| APPLY[Apply UTxO changes]
     EVAL --> APPLY
     APPLY --> CERT[Process certificates]
@@ -78,7 +78,7 @@ For transactions containing Plutus scripts (V1/V2/V3):
 1. **Script data hash** — Matches the hash of redeemers + datums + cost models
 2. **Collateral** — Sufficient collateral provided (150% of estimated fees in Conway)
 3. **Execution units** — Each redeemer's CPU and memory within budget
-4. **Script evaluation** — Each script is executed via the uplc CEK machine with the appropriate cost model
+4. **Script evaluation** — Each script is executed via the dugite-uplc CEK machine with the appropriate cost model
 5. **Block budget** — Total execution units across all transactions do not exceed block limits
 
 Scripts are evaluated in parallel using rayon when the `parallel-verification` feature is enabled (default).

--- a/docs/src/architecture/networking.md
+++ b/docs/src/architecture/networking.md
@@ -314,7 +314,7 @@ The governor maintains six independent target counts (matching cardano-node defa
 | Target | Default | Description |
 |--------|---------|-------------|
 | `TargetNumberOfKnownPeers` | 85 | Total peers in the peer table (cold + warm + hot) |
-| `TargetNumberOfEstablishedPeers` | 40 | Warm + hot peers (TCP connected) |
+| `TargetNumberOfEstablishedPeers` | 30 | Warm + hot peers (TCP connected) |
 | `TargetNumberOfActivePeers` | 15 | Hot peers (fully syncing) |
 | `TargetNumberOfKnownBigLedgerPeers` | 15 | Known big ledger peers |
 | `TargetNumberOfEstablishedBigLedgerPeers` | 10 | Established big ledger peers |

--- a/docs/src/architecture/p2p-governor.md
+++ b/docs/src/architecture/p2p-governor.md
@@ -84,7 +84,7 @@ The governor maintains six independent target counts:
 
 | Target | Default |
 |---|---|
-| Known peers | 100 |
+| Known peers | 85 |
 | Established peers | 40 |
 | Active peers | 15 |
 | Known big-ledger peers | 15 |

--- a/docs/src/architecture/p2p-governor.md
+++ b/docs/src/architecture/p2p-governor.md
@@ -43,7 +43,7 @@ The policy layer. Runs on a 30-second `tokio::interval` in `dugite-node`.
 | Established (warm+hot) target enforcement | Maintains established peer count |
 | Surplus reduction | Demote/disconnect lowest reputation, local-root protected |
 | Churn mechanism | 20% target reduction cycle at configurable intervals |
-| Default targets | active=15, established=40, known=85 (matching cardano-node) |
+| Default targets | active=15, established=30, known=85 (matching cardano-node) |
 
 ---
 
@@ -85,7 +85,7 @@ The governor maintains six independent target counts:
 | Target | Default |
 |---|---|
 | Known peers | 85 |
-| Established peers | 40 |
+| Established peers | 30 |
 | Active peers | 15 |
 | Known big-ledger peers | 15 |
 | Established big-ledger peers | 10 |

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Dugite can be installed from pre-built binaries, container images, or built from source.
+Dugite can be installed from pre-built binaries or built from source.
 
 ## Pre-built Binaries
 
@@ -10,8 +10,9 @@ Download the latest release from [GitHub Releases](https://github.com/michaeljfa
 |----------|-------------|----------|
 | Linux | x86_64 | `dugite-x86_64-linux.tar.gz` |
 | Linux | aarch64 | `dugite-aarch64-linux.tar.gz` |
-| macOS | x86_64 (Intel) | `dugite-x86_64-macos.tar.gz` |
 | macOS | Apple Silicon | `dugite-aarch64-macos.tar.gz` |
+
+> **Note:** macOS x86_64 (Intel) binaries are not published — GitHub's macOS runners are aarch64-only. Intel Mac users should [build from source](#building-from-source).
 
 ```bash
 # Example: download and extract for Linux x86_64
@@ -29,26 +30,9 @@ sha256sum -c SHA256SUMS.txt
 
 ## Container Image
 
-Multi-architecture container images (amd64 and arm64) are published to GitHub Container Registry:
+> **Coming soon:** Container images (ghcr.io/michaeljfazio/dugite) are not yet published. Track progress in [issue #507](https://github.com/michaeljfazio/dugite/issues/507). For now, use [pre-built binaries](#pre-built-binaries) or [build from source](#building-from-source).
 
-```bash
-docker pull ghcr.io/michaeljfazio/dugite:latest
-```
-
-The image uses a [distroless](https://github.com/GoogleContainerTools/distroless) base (`gcr.io/distroless/cc-debian12:nonroot`) for minimal attack surface — no shell, no package manager, runs as nonroot (UID 65532).
-
-Run the node:
-
-```bash
-docker run -d \
-  --name dugite \
-  -p 3001:3001 \
-  -p 12798:12798 \
-  -v dugite-data:/opt/dugite/db \
-  ghcr.io/michaeljfazio/dugite:latest
-```
-
-See [Kubernetes Deployment](./running/kubernetes.md) for production container deployments.
+See [Kubernetes Deployment](./running/kubernetes.md) for production container deployments once images are available.
 
 ## Building from Source
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -25,7 +25,7 @@ The Cardano ecosystem benefits from client diversity. Running multiple independe
 - **Multi-era support** — Byron, Shelley, Allegra, Mary, Alonzo, Babbage, and Conway eras.
 - **Conway governance (CIP-1694)** — DRep registration, voting, proposals, constitutional committee, treasury withdrawals.
 - **Pipelined multi-peer sync** — Header collection from a primary peer with parallel block fetching from multiple peers.
-- **Plutus script execution** — Plutus V1/V2/V3 evaluation via the uplc CEK machine.
+- **Plutus script execution** — Plutus V1/V2/V3 evaluation via the in-house `dugite-uplc` CEK machine (fully conformant, all test vectors pass).
 - **Node-to-Node (N2N) protocol** — Full Ouroboros mini-protocol suite: ChainSync, BlockFetch, TxSubmission2, KeepAlive, PeerSharing.
 - **Node-to-Client (N2C) protocol** — Unix domain socket server with LocalChainSync, LocalStateQuery, LocalTxSubmission, and LocalTxMonitor.
 - **cardano-cli compatible CLI** — Key generation, transaction building, signing, submission, queries, and governance commands.

--- a/docs/src/running/topology.md
+++ b/docs/src/running/topology.md
@@ -186,6 +186,14 @@ A relay node that maintains a connection to your block producer:
 }
 ```
 
+## DNS SRV Resolution
+
+When a hostname is specified in any `accessPoints` entry, Dugite queries DNS for SRV records at `_cardano._tcp.<host>` before falling back to A/AAAA lookup — matching the behaviour of the Haskell cardano-node. SRV records carry port, priority, and weight fields (RFC 2782); Dugite honours priority ordering and performs a weighted shuffle within equal-priority groups.
+
+If no SRV records exist (NXDOMAIN or empty answer), Dugite falls back to a direct A/AAAA lookup using the port specified in the topology entry.
+
+IPv4 and IPv6 addresses are both accepted; Dugite resolves A and AAAA records concurrently.
+
 ## SIGHUP Topology Reload
 
 Dugite supports live topology reloading. Send a `SIGHUP` signal to the running node process, and it will re-read the topology file and update the peer manager with the new configuration:


### PR DESCRIPTION
## Summary

- **installation.md** [WRONG] — removed non-existent macOS x86_64 binary (CI uses aarch64-only macOS runners); marked container image as coming soon (#507, not yet published)
- **introduction.md** [VAGUE] — named dugite-uplc explicitly, noted full conformance
- **architecture/networking.md** [STALE] — TargetNumberOfEstablishedPeers 40→30 (matches config.json)
- **architecture/p2p-governor.md** [STALE] — same established-peers fix
- **running/topology.md** [MISSING] — added DNS SRV resolution section (_cardano._tcp.<host>, RFC 2782; implemented in peer/discovery.rs but undocumented)
- **mithril.rs** — fix flaky test_download_snapshot_parallel_ranged and two other env-var tests: wrap set_var/remove_var in static MITHRIL_ENV_LOCK to prevent cargo test thread races

## Previously fixed (earlier commits on this branch)

- architecture/overview.md: 14-crate → 15-crate
- cli/dugite-node.md: add --consensus-mode flag
- running/networks.md: PV11 requirement for preview
- reference/troubleshooting.md: handshake version by network
- reference/benchmarks.md: note build log predates pallas/aiken removal
- architecture/p2p-governor.md: default known-peers 100→85

## Test plan

- [ ] CI green
- [ ] cargo nextest run -p dugite-node passes
- [ ] cargo test -p dugite-node -- mithril::tests passes (no race under threaded runner)