### PR TITLE
fix(ledger/conformance): pool deposits exact tracking + corpus v20260524 + DELEG decoder

### DIFF
--- a/.github/workflows/regenerate-conformance-corpus.yml
+++ b/.github/workflows/regenerate-conformance-corpus.yml
@@ -195,15 +195,6 @@ jobs:
           # Download and inspect the manifest.
           MANIFEST="$(gh release download "${LATEST_TAG}" --repo "${GH_REPO}" --pattern "corpus-manifest.json" --output -)"
 
-          # mithril: no JSON fixture files are in the mithril repo at the pinned SHA,
-          # so it is always a stub.  cardano-base is a real area (VRF test vectors
-          # are captured from cardano-crypto-praos/test_vectors/).
-          for stub_area in mithril; do
-            IS_STUB="$(echo "${MANIFEST}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['areas']['${stub_area}'].get('stub', False))")"
-            [[ "${IS_STUB}" == "True" ]] || { echo "ERROR: ${stub_area} should be stub" >&2; exit 1; }
-            echo "  [ok] ${stub_area} is stub"
-          done
-
           # ledger-rules: report stub vs real, but don't fail on stub.
           # When the Haskell build succeeds and produces vectors, stub=false and
           # file_count > 0. When GHC isn't available or no divergences occurred,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The storage layer is pure Rust with no system dependencies. cardano-lsm (used fo
 
 ## Architecture
 
-14-crate Cargo workspace under `crates/`. Dependency flow:
+15-crate Cargo workspace under `crates/`. Dependency flow:
 
 ```
 dugite-node (binary: main node, config, pipelined sync, Mithril import, block forging)
@@ -68,6 +68,8 @@ dugite-config (binary: interactive TUI configuration editor with tree navigation
 dugite-serialization (CBOR encode/decode — in-house multi-era decoder + minicbor)
 dugite-crypto (Ed25519, VRF, KES, text envelope)
 dugite-primitives (core types: hashes, blocks, txs, addresses, values, protocol params, all eras)
+dugite-uplc (in-house UPLC CEK machine; 100% conformant as of v1.7.0)
+dugite-lsm (LSM-tree on-disk storage for UTxO-HD)
 ```
 
 ### Key Traits & Abstractions

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -749,13 +749,21 @@ mod tests {
     /// Bug 2: `scalars.deposits_stake` must include BOTH stake-key
     /// deposits AND pool-registration deposits, matching Haskell's
     /// `utxoState.deposited`.
+    ///
+    /// Critically, pool deposits are tracked PER-POOL at registration time
+    /// (via `certs.pool_deposits`), NOT as `pool_params.len() × curPParams.pool_deposit`.
+    /// This test verifies that the dump uses the historical deposit map even when
+    /// `pool_deposit` has since changed (e.g. via PPUP).
     #[test]
     fn capture_combines_stake_key_and_pool_deposits() {
         let mut state = make_state();
-        // Preview epoch-1 scenario: 3 stake keys × 2 ADA + 3 pools × 500 ADA.
+        // 3 stake keys × 2 ADA.
         state.certs.total_stake_key_deposits = 3 * 2_000_000;
-        state.epochs.protocol_params.pool_deposit = Lovelace(500_000_000);
-        // Add two extra pools so the count is 3 total.
+        // Current pool_deposit param = 600 ADA (changed via PPUP from the original 500 ADA).
+        // The dump MUST use historical per-pool values, not this current param.
+        state.epochs.protocol_params.pool_deposit = Lovelace(600_000_000);
+        // Pool 0xaa (from make_state) registered at 400 ADA (older pool_deposit).
+        // Pools 0x10 and 0x11 registered later at 500 ADA.
         let mut pmap: HashMap<Hash28, PoolRegistration> = (*state.certs.pool_params).clone();
         for b in [0x10u8, 0x11] {
             let pid = h28(b);
@@ -777,9 +785,16 @@ mod tests {
             );
         }
         state.certs.pool_params = Arc::new(pmap);
+        // Populate pool_deposits with PER-POOL historical deposit amounts.
+        state.certs.pool_deposits.insert(h28(0xaa), 400_000_000);
+        state.certs.pool_deposits.insert(h28(0x10), 500_000_000);
+        state.certs.pool_deposits.insert(h28(0x11), 500_000_000);
         let dump = capture(&state, 1, 0, None);
-        // Expected: 3 × 500_000_000 + 3 × 2_000_000 = 1_506_000_000
-        assert_eq!(dump.scalars.deposits_stake, 1_506_000_000);
+        // Expected: (400 + 500 + 500) ADA pool deposits + 3 × 2 ADA stake-key deposits
+        // = 1_400_000_000 + 6_000_000 = 1_406_000_000.
+        // Old formula (pool_params.len() × pool_deposit) would give 3 × 600_000_000 + 6_000_000
+        // = 1_806_000_000 — wrong because it ignores historical deposit amounts.
+        assert_eq!(dump.scalars.deposits_stake, 1_406_000_000);
     }
 
     /// Bug 3: when the production caller passes `None` for the rupd

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -517,9 +517,10 @@ pub fn capture(
             // Using the per-pool map rather than `pool_params.len() × pool_deposit`
             // ensures correctness when pool_deposit changed via PPUP after some pools
             // were registered.
-            deposits_stake: state.certs.total_stake_key_deposits.saturating_add(
-                state.certs.pool_deposits.values().sum::<u64>(),
-            ),
+            deposits_stake: state
+                .certs
+                .total_stake_key_deposits
+                .saturating_add(state.certs.pool_deposits.values().sum::<u64>()),
             deposits_drep: drep_deposit_total,
             deposits_proposal: proposal_deposit_total,
         },

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -511,13 +511,14 @@ pub fn capture(
             // to `snapshots.ss_fee` — that's the previous epoch's fees,
             // and gave a one-epoch off-by-one against Haskell.)
             fees: state.utxo.epoch_fees.0,
-            // Bug 2 fix: Haskell reports `utxoState.deposited` which is
-            // the COMBINED stake-key + pool-registration deposit total.
-            // Stake-key portion is `total_stake_key_deposits` (3 keys × 2
-            // ADA mainnet); pool portion is `registered pools × pool_deposit`.
+            // Haskell reports `utxoState.deposited` which is the COMBINED
+            // stake-key + pool deposit total. Pool deposits are tracked per-pool
+            // (with the deposit value at registration time) in `certs.pool_deposits`.
+            // Using the per-pool map rather than `pool_params.len() × pool_deposit`
+            // ensures correctness when pool_deposit changed via PPUP after some pools
+            // were registered.
             deposits_stake: state.certs.total_stake_key_deposits.saturating_add(
-                (state.certs.pool_params.len() as u64)
-                    .saturating_mul(state.epochs.protocol_params.pool_deposit.0),
+                state.certs.pool_deposits.values().sum::<u64>(),
             ),
             deposits_drep: drep_deposit_total,
             deposits_proposal: proposal_deposit_total,

--- a/tests/conformance/src/upstream/ledger_rules_replay/bridge.rs
+++ b/tests/conformance/src/upstream/ledger_rules_replay/bridge.rs
@@ -65,7 +65,7 @@
 //! | Rule    | Observed tags       | Interpretation |
 //! |---------|---------------------|----------------|
 //! | POOL    | 0 (PoolReg), 1 (PoolRetire) | PoolCert |
-//! | DELEG   | 7–12                | ConwayDelegCert |
+//! | DELEG   | 2, 7–13             | Shelley StakeDelegation + ConwayDelegCert (7–12) + ConwayRegDelegCert DelegStakeVote (13) |
 //! | GOVCERT | 14–18               | ConwayGovCert |
 //! | CERT    | any of the above + more | TxCert (all variants) |
 //!
@@ -897,19 +897,30 @@ pub fn decode_pool_signal(cbor: &[u8]) -> Result<u64, String> {
     }
 }
 
-/// Validate a DELEG signal: a ConwayDelegCert with tags 7–12.
+/// Validate a DELEG signal: a delegation certificate (pre-Conway or Conway).
 ///
-/// Observed DELEG tags in the real corpus: 7, 8, 9, 11, 12.
+/// Valid DELEG tags:
+///   2          — Shelley `StakeDelegation` (backwards-compat in Conway)
+///   7–13       — Conway delegation certs:
+///                  7  ConwayRegCert
+///                  8  ConwayUnRegCert
+///                  9  ConwayDelegCert DelegVote
+///                  10 ConwayDelegCert DelegStakeVote
+///                  11 ConwayRegDelegCert DelegStake
+///                  12 ConwayRegDelegCert DelegVote
+///                  13 ConwayRegDelegCert DelegStakeVote (reg + pool + DRep)
+///
+/// Observed in corpus: 2, 7, 8, 9, 11, 12, 13.
 pub fn decode_deleg_signal(cbor: &[u8]) -> Result<u64, String> {
     let tag = decode_tx_cert_tag(cbor)?;
-    // All observed DELEG tags are in the range 7–12.  We allow any value in
-    // that range — specific variants not yet observed in the corpus (e.g. 10)
-    // may appear in future fixture generations.
-    if (7..=12).contains(&tag) {
+    // Tag 2: Shelley StakeDelegation — backwards-compat path exercised by ImpSpec.
+    // Tags 7–13: Conway delegation cert variants (13 = RegDelegCert DelegStakeVote,
+    // added to Conway after the original 7–12 range was documented).
+    if tag == 2 || (7..=13).contains(&tag) {
         Ok(tag)
     } else {
         Err(format!(
-            "DELEG signal: unexpected tag {tag} (expected 7–12 for ConwayDelegCert)"
+            "DELEG signal: unexpected tag {tag} (expected 2 or 7–13 for delegation cert)"
         ))
     }
 }

--- a/tests/conformance/src/upstream/ledger_rules_replay/runner.rs
+++ b/tests/conformance/src/upstream/ledger_rules_replay/runner.rs
@@ -347,7 +347,7 @@ fn run_certs_signal(vec: &ImpVector) -> RunOutcome {
     }
 }
 
-/// Validate a DELEG signal: ConwayDelegCert (tags 7–12).
+/// Validate a DELEG signal: StakeDelegation (tag 2) or ConwayDelegCert (tags 7–13).
 fn run_deleg_signal(vec: &ImpVector) -> RunOutcome {
     match decode_deleg_signal(&vec.sig_cbor) {
         Ok(tag) => RunOutcome::NativeSigDecoded {

--- a/tests/conformance/upstream/manifest.toml
+++ b/tests/conformance/upstream/manifest.toml
@@ -11,7 +11,7 @@
 
 [release]
 repo = "michaeljfazio/dugite"
-tag  = "conformance-corpus-v20260523-165156"
+tag  = "conformance-corpus-v20260524-075059"
 
 [area.ouroboros-consensus]
 asset  = "ouroboros-consensus.tar.gz"


### PR DESCRIPTION
## Summary

### fix(ledger): per-pool deposit map in epoch-state dump
- `epoch_state_debug::capture` was computing pool deposits as `pool_params.len() × curPParams.pool_deposit` — an approximation that drifts when `pool_deposit` changes via PPUP after some pools are already registered
- Switch to `certs.pool_deposits.values().sum()` (exact per-pool values at registration time)
- Ref: issue #615 deposits_stake sub-item

### chore(conformance): update corpus to v20260524-075059 + fix mithril stub check
- Mithril now has 20 real fixture files (was stub); the verification check was outdated, removed
- New corpus: 277 ouroboros-consensus, 17 cardano-ledger, 14 cardano-node, 3001 plutus, **28,295 ledger-rules** (ImpSpec Haskell), 14 cardano-base, 20 mithril

### fix(conformance): expand DELEG decoder to accept tags 2 and 13
- The new ImpSpec corpus includes DELEG vectors with tag 2 (Shelley `StakeDelegation`, backwards-compat in Conway) and tag 13 (`ConwayRegDelegCert DelegStakeVote` — register + pool + DRep)
- Decoder previously only accepted 7–12; updated to accept `tag == 2 || 7..=13`
- Reference: `cardano-ledger` `ConwayTxCert` CBOR encoding table

### chore: CLAUDE.md crate count 14→15
- Added dugite-uplc and dugite-lsm to the architecture section

## Test plan

- [x] `cargo nextest run -p dugite-ledger` — 1432/1432 pass
- [x] `cargo clippy -p dugite-ledger --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build -p dugite-conformance` — clean
- [ ] CI: build-and-test + upstream conformance (UPLC + golden decode)