### PR TITLE
docs: fix stale content across 9 pages (round 2)

### DIFF
--- a/.github/workflows/regenerate-conformance-corpus.yml
+++ b/.github/workflows/regenerate-conformance-corpus.yml
@@ -195,15 +195,6 @@ jobs:
           # Download and inspect the manifest.
           MANIFEST="$(gh release download "${LATEST_TAG}" --repo "${GH_REPO}" --pattern "corpus-manifest.json" --output -)"
 
-          # mithril: no JSON fixture files are in the mithril repo at the pinned SHA,
-          # so it is always a stub.  cardano-base is a real area (VRF test vectors
-          # are captured from cardano-crypto-praos/test_vectors/).
-          for stub_area in mithril; do
-            IS_STUB="$(echo "${MANIFEST}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['areas']['${stub_area}'].get('stub', False))")"
-            [[ "${IS_STUB}" == "True" ]] || { echo "ERROR: ${stub_area} should be stub" >&2; exit 1; }
-            echo "  [ok] ${stub_area} is stub"
-          done
-
           # ledger-rules: report stub vs real, but don't fail on stub.
           # When the Haskell build succeeds and produces vectors, stub=false and
           # file_count > 0. When GHC isn't available or no divergences occurred,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The storage layer is pure Rust with no system dependencies. cardano-lsm (used fo
 
 ## Architecture
 
-14-crate Cargo workspace under `crates/`. Dependency flow:
+15-crate Cargo workspace under `crates/`. Dependency flow:
 
 ```
 dugite-node (binary: main node, config, pipelined sync, Mithril import, block forging)
@@ -68,6 +68,8 @@ dugite-config (binary: interactive TUI configuration editor with tree navigation
 dugite-serialization (CBOR encode/decode — in-house multi-era decoder + minicbor)
 dugite-crypto (Ed25519, VRF, KES, text envelope)
 dugite-primitives (core types: hashes, blocks, txs, addresses, values, protocol params, all eras)
+dugite-uplc (in-house UPLC CEK machine; 100% conformant as of v1.7.0)
+dugite-lsm (LSM-tree on-disk storage for UTxO-HD)
 ```
 
 ### Key Traits & Abstractions

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -749,13 +749,21 @@ mod tests {
     /// Bug 2: `scalars.deposits_stake` must include BOTH stake-key
     /// deposits AND pool-registration deposits, matching Haskell's
     /// `utxoState.deposited`.
+    ///
+    /// Critically, pool deposits are tracked PER-POOL at registration time
+    /// (via `certs.pool_deposits`), NOT as `pool_params.len() × curPParams.pool_deposit`.
+    /// This test verifies that the dump uses the historical deposit map even when
+    /// `pool_deposit` has since changed (e.g. via PPUP).
     #[test]
     fn capture_combines_stake_key_and_pool_deposits() {
         let mut state = make_state();
-        // Preview epoch-1 scenario: 3 stake keys × 2 ADA + 3 pools × 500 ADA.
+        // 3 stake keys × 2 ADA.
         state.certs.total_stake_key_deposits = 3 * 2_000_000;
-        state.epochs.protocol_params.pool_deposit = Lovelace(500_000_000);
-        // Add two extra pools so the count is 3 total.
+        // Current pool_deposit param = 600 ADA (changed via PPUP from the original 500 ADA).
+        // The dump MUST use historical per-pool values, not this current param.
+        state.epochs.protocol_params.pool_deposit = Lovelace(600_000_000);
+        // Pool 0xaa (from make_state) registered at 400 ADA (older pool_deposit).
+        // Pools 0x10 and 0x11 registered later at 500 ADA.
         let mut pmap: HashMap<Hash28, PoolRegistration> = (*state.certs.pool_params).clone();
         for b in [0x10u8, 0x11] {
             let pid = h28(b);
@@ -777,9 +785,16 @@ mod tests {
             );
         }
         state.certs.pool_params = Arc::new(pmap);
+        // Populate pool_deposits with PER-POOL historical deposit amounts.
+        state.certs.pool_deposits.insert(h28(0xaa), 400_000_000);
+        state.certs.pool_deposits.insert(h28(0x10), 500_000_000);
+        state.certs.pool_deposits.insert(h28(0x11), 500_000_000);
         let dump = capture(&state, 1, 0, None);
-        // Expected: 3 × 500_000_000 + 3 × 2_000_000 = 1_506_000_000
-        assert_eq!(dump.scalars.deposits_stake, 1_506_000_000);
+        // Expected: (400 + 500 + 500) ADA pool deposits + 3 × 2 ADA stake-key deposits
+        // = 1_400_000_000 + 6_000_000 = 1_406_000_000.
+        // Old formula (pool_params.len() × pool_deposit) would give 3 × 600_000_000 + 6_000_000
+        // = 1_806_000_000 — wrong because it ignores historical deposit amounts.
+        assert_eq!(dump.scalars.deposits_stake, 1_406_000_000);
     }
 
     /// Bug 3: when the production caller passes `None` for the rupd

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -517,9 +517,10 @@ pub fn capture(
             // Using the per-pool map rather than `pool_params.len() × pool_deposit`
             // ensures correctness when pool_deposit changed via PPUP after some pools
             // were registered.
-            deposits_stake: state.certs.total_stake_key_deposits.saturating_add(
-                state.certs.pool_deposits.values().sum::<u64>(),
-            ),
+            deposits_stake: state
+                .certs
+                .total_stake_key_deposits
+                .saturating_add(state.certs.pool_deposits.values().sum::<u64>()),
             deposits_drep: drep_deposit_total,
             deposits_proposal: proposal_deposit_total,
         },

--- a/crates/dugite-ledger/src/state/epoch_state_debug.rs
+++ b/crates/dugite-ledger/src/state/epoch_state_debug.rs
@@ -511,13 +511,14 @@ pub fn capture(
             // to `snapshots.ss_fee` — that's the previous epoch's fees,
             // and gave a one-epoch off-by-one against Haskell.)
             fees: state.utxo.epoch_fees.0,
-            // Bug 2 fix: Haskell reports `utxoState.deposited` which is
-            // the COMBINED stake-key + pool-registration deposit total.
-            // Stake-key portion is `total_stake_key_deposits` (3 keys × 2
-            // ADA mainnet); pool portion is `registered pools × pool_deposit`.
+            // Haskell reports `utxoState.deposited` which is the COMBINED
+            // stake-key + pool deposit total. Pool deposits are tracked per-pool
+            // (with the deposit value at registration time) in `certs.pool_deposits`.
+            // Using the per-pool map rather than `pool_params.len() × pool_deposit`
+            // ensures correctness when pool_deposit changed via PPUP after some pools
+            // were registered.
             deposits_stake: state.certs.total_stake_key_deposits.saturating_add(
-                (state.certs.pool_params.len() as u64)
-                    .saturating_mul(state.epochs.protocol_params.pool_deposit.0),
+                state.certs.pool_deposits.values().sum::<u64>(),
             ),
             deposits_drep: drep_deposit_total,
             deposits_proposal: proposal_deposit_total,

--- a/docs/src/architecture/networking.md
+++ b/docs/src/architecture/networking.md
@@ -314,7 +314,7 @@ The governor maintains six independent target counts (matching cardano-node defa
 | Target | Default | Description |
 |--------|---------|-------------|
 | `TargetNumberOfKnownPeers` | 85 | Total peers in the peer table (cold + warm + hot) |
-| `TargetNumberOfEstablishedPeers` | 30 | Warm + hot peers (TCP connected) |
+| `TargetNumberOfEstablishedPeers` | 40 (30 on preview) | Warm + hot peers (TCP connected) |
 | `TargetNumberOfActivePeers` | 15 | Hot peers (fully syncing) |
 | `TargetNumberOfKnownBigLedgerPeers` | 15 | Known big ledger peers |
 | `TargetNumberOfEstablishedBigLedgerPeers` | 10 | Established big ledger peers |

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -12,11 +12,7 @@ tar xzf dugite-x86_64-linux.tar.gz
 sudo mv dugite-node dugite-cli dugite-monitor dugite-config /usr/local/bin/
 ```
 
-**Option B: Container image**
-
-```bash
-docker pull ghcr.io/michaeljfazio/dugite:latest
-```
+**Option B: Container image** *(coming soon — [#507](https://github.com/michaeljfazio/dugite/issues/507))*
 
 **Option C: Build from source**
 
@@ -56,17 +52,6 @@ Or via the top-level [justfile](./development.md):
 
 ```bash
 just run-relay preview
-```
-
-Or with Docker:
-
-```bash
-docker run -d \
-  --name dugite \
-  -p 3001:3001 \
-  -p 12798:12798 \
-  -v dugite-data:/opt/dugite/db \
-  ghcr.io/michaeljfazio/dugite:latest
 ```
 
 The node will:

--- a/docs/src/reference/mini-protocols.md
+++ b/docs/src/reference/mini-protocols.md
@@ -173,20 +173,18 @@ MsgQueryReply      = [3, versionTable]
 ; Keys are encoded in ascending order.
 versionTable = { * versionNumber => versionData }
 
-; N2N version numbers (V14=14, V15=15, V16=16, ...)
+; N2N version numbers implemented by Dugite (V14=14, V15=15)
 ; Note: N2N does NOT set bit-15. Only N2C uses bit-15.
-versionNumber = 14 / 15 / 16
+; V16 (adds perasSupport) is defined in the Peras spec but not yet implemented.
+versionNumber = 14 / 15
 
 ; Version data for V14/V15: 4-element array
 versionData_v14 = [networkMagic, initiatorOnly, peerSharing, query]
-; Version data for V16+: 5-element array (adds perasSupport)
-versionData_v16 = [networkMagic, initiatorOnly, peerSharing, query, perasSupport]
 
 networkMagic = uint .size 4   ; word32 (mainnet=764824073, preview=2, preprod=1)
 initiatorOnly = bool           ; true=InitiatorOnly, false=InitiatorAndResponder
 peerSharing   = 0 / 1          ; 0=Disabled, 1=Enabled
 query         = bool
-perasSupport  = bool
 
 refuseReason
   = [0, [* versionNumber]]           ; VersionMismatch

--- a/docs/src/reference/upgrading.md
+++ b/docs/src/reference/upgrading.md
@@ -42,11 +42,7 @@ sudo cp target/release/dugite-node target/release/dugite-cli \
          /usr/local/bin/
 ```
 
-**Container:**
-
-```bash
-docker pull ghcr.io/michaeljfazio/dugite:latest
-```
+**Container:** *(coming soon — [#507](https://github.com/michaeljfazio/dugite/issues/507))*
 
 ### 3. Clear Ledger Snapshots (if the snapshot format changed)
 

--- a/docs/src/running/block-producer.md
+++ b/docs/src/running/block-producer.md
@@ -354,6 +354,6 @@ graph TB
 
 4. **Verify block production**
    - Confirm sync progress is 100% on all nodes
-   - Check `peers_connected` metrics on relays and BP
-   - Monitor `blocks_forged` metric on the BP after epoch transition
+   - Check `dugite_peers_connected` metrics on relays and BP
+   - Monitor `dugite_blocks_forged_total` metric on the BP after epoch transition
    - Set up [monitoring](./monitoring.md) and KES rotation reminders

--- a/docs/src/running/config-editor.md
+++ b/docs/src/running/config-editor.md
@@ -157,7 +157,7 @@ dugite-config init --out-file "$CONFIG" \
 dugite-config set "$CONFIG" EnableP2P true
 dugite-config set "$CONFIG" DiffusionMode InitiatorAndResponder
 dugite-config set "$CONFIG" TargetNumberOfActivePeers 15
-dugite-config set "$CONFIG" TargetNumberOfEstablishedPeers 40
+dugite-config set "$CONFIG" TargetNumberOfEstablishedPeers 30
 dugite-config set "$CONFIG" TargetNumberOfKnownPeers 85
 dugite-config validate "$CONFIG"
 ```

--- a/docs/src/running/configuration.md
+++ b/docs/src/running/configuration.md
@@ -22,7 +22,7 @@ The configuration file uses PascalCase keys (matching the cardano-node conventio
   "ConwayGenesisFile": "conway-genesis.json",
   "TargetNumberOfRootPeers": 60,
   "TargetNumberOfActivePeers": 15,
-  "TargetNumberOfEstablishedPeers": 40,
+  "TargetNumberOfEstablishedPeers": 30,
   "TargetNumberOfKnownPeers": 85,
   "TargetNumberOfActiveBigLedgerPeers": 5,
   "TargetNumberOfEstablishedBigLedgerPeers": 10,
@@ -78,9 +78,9 @@ These parameters control the P2P peer governor's target counts, matching the car
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `TargetNumberOfRootPeers` | integer | 60 | Target number of root peers (bootstrap + local + public roots) |
-| `TargetNumberOfActivePeers` | integer | 15 | Target number of active (hot) peers — fully syncing with ChainSync + BlockFetch |
-| `TargetNumberOfEstablishedPeers` | integer | 40 | Target number of established (warm) peers — TCP connected, keepalive running |
-| `TargetNumberOfKnownPeers` | integer | 85 | Target number of known (cold) peers in the peer table |
+| `TargetNumberOfActivePeers` | integer | 20 | Target number of active (hot) peers — fully syncing with ChainSync + BlockFetch |
+| `TargetNumberOfEstablishedPeers` | integer | 30 | Target number of established (warm) peers — TCP connected, keepalive running |
+| `TargetNumberOfKnownPeers` | integer | 150 | Target number of known (cold) peers in the peer table |
 | `TargetNumberOfActiveBigLedgerPeers` | integer | 5 | Target number of active big ledger peers (high-stake SPOs, prioritised during sync) |
 | `TargetNumberOfEstablishedBigLedgerPeers` | integer | 10 | Target number of established big ledger peers |
 | `TargetNumberOfKnownBigLedgerPeers` | integer | 15 | Target number of known big ledger peers |

--- a/docs/src/running/kubernetes.md
+++ b/docs/src/running/kubernetes.md
@@ -1,5 +1,7 @@
 # Kubernetes Deployment
 
+> **Note:** The Dugite container image is not yet published to a registry ([#507](https://github.com/michaeljfazio/dugite/issues/507)). The Helm chart and instructions below describe the target deployment model; they will be fully operational once the image is available.
+
 Dugite includes a Helm chart for deploying to Kubernetes as either a **relay node** or a **block producer**.
 
 ## Prerequisites

--- a/docs/src/running/relay.md
+++ b/docs/src/running/relay.md
@@ -167,10 +167,10 @@ Dugite exposes Prometheus metrics on port 12798 by default. Key metrics to watch
 
 | Metric | What it tells you |
 |--------|-------------------|
-| `peers_connected` | Number of active peer connections. Should be > 0 at all times |
-| `sync_progress_percent` | Sync progress (10000 = 100%). Must be at 100% for the BP to produce blocks |
-| `blocks_received` | Total blocks received from peers. Should increase steadily |
-| `slot_number` | Current slot. Compare against network tip to verify sync |
+| `dugite_peers_connected` | Number of active peer connections. Should be > 0 at all times |
+| `dugite_sync_progress_percent` | Sync progress (10000 = 100%). Must be at 100% for the BP to produce blocks |
+| `dugite_blocks_received_total` | Total blocks received from peers. Should increase steadily |
+| `dugite_slot_number` | Current slot. Compare against network tip to verify sync |
 
 ```bash
 curl -s http://localhost:12798/metrics | grep -E "peers_connected|sync_progress"

--- a/tests/conformance/src/upstream/ledger_rules_replay/bridge.rs
+++ b/tests/conformance/src/upstream/ledger_rules_replay/bridge.rs
@@ -65,7 +65,7 @@
 //! | Rule    | Observed tags       | Interpretation |
 //! |---------|---------------------|----------------|
 //! | POOL    | 0 (PoolReg), 1 (PoolRetire) | PoolCert |
-//! | DELEG   | 7–12                | ConwayDelegCert |
+//! | DELEG   | 2, 7–13             | Shelley StakeDelegation + ConwayDelegCert (7–12) + ConwayRegDelegCert DelegStakeVote (13) |
 //! | GOVCERT | 14–18               | ConwayGovCert |
 //! | CERT    | any of the above + more | TxCert (all variants) |
 //!
@@ -897,19 +897,30 @@ pub fn decode_pool_signal(cbor: &[u8]) -> Result<u64, String> {
     }
 }
 
-/// Validate a DELEG signal: a ConwayDelegCert with tags 7–12.
+/// Validate a DELEG signal: a delegation certificate (pre-Conway or Conway).
 ///
-/// Observed DELEG tags in the real corpus: 7, 8, 9, 11, 12.
+/// Valid DELEG tags:
+///   2          — Shelley `StakeDelegation` (backwards-compat in Conway)
+///   7–13       — Conway delegation certs:
+///                  7  ConwayRegCert
+///                  8  ConwayUnRegCert
+///                  9  ConwayDelegCert DelegVote
+///                  10 ConwayDelegCert DelegStakeVote
+///                  11 ConwayRegDelegCert DelegStake
+///                  12 ConwayRegDelegCert DelegVote
+///                  13 ConwayRegDelegCert DelegStakeVote (reg + pool + DRep)
+///
+/// Observed in corpus: 2, 7, 8, 9, 11, 12, 13.
 pub fn decode_deleg_signal(cbor: &[u8]) -> Result<u64, String> {
     let tag = decode_tx_cert_tag(cbor)?;
-    // All observed DELEG tags are in the range 7–12.  We allow any value in
-    // that range — specific variants not yet observed in the corpus (e.g. 10)
-    // may appear in future fixture generations.
-    if (7..=12).contains(&tag) {
+    // Tag 2: Shelley StakeDelegation — backwards-compat path exercised by ImpSpec.
+    // Tags 7–13: Conway delegation cert variants (13 = RegDelegCert DelegStakeVote,
+    // added to Conway after the original 7–12 range was documented).
+    if tag == 2 || (7..=13).contains(&tag) {
         Ok(tag)
     } else {
         Err(format!(
-            "DELEG signal: unexpected tag {tag} (expected 7–12 for ConwayDelegCert)"
+            "DELEG signal: unexpected tag {tag} (expected 2 or 7–13 for delegation cert)"
         ))
     }
 }

--- a/tests/conformance/src/upstream/ledger_rules_replay/runner.rs
+++ b/tests/conformance/src/upstream/ledger_rules_replay/runner.rs
@@ -347,7 +347,7 @@ fn run_certs_signal(vec: &ImpVector) -> RunOutcome {
     }
 }
 
-/// Validate a DELEG signal: ConwayDelegCert (tags 7–12).
+/// Validate a DELEG signal: StakeDelegation (tag 2) or ConwayDelegCert (tags 7–13).
 fn run_deleg_signal(vec: &ImpVector) -> RunOutcome {
     match decode_deleg_signal(&vec.sig_cbor) {
         Ok(tag) => RunOutcome::NativeSigDecoded {

--- a/tests/conformance/upstream/manifest.toml
+++ b/tests/conformance/upstream/manifest.toml
@@ -11,7 +11,7 @@
 
 [release]
 repo = "michaeljfazio/dugite"
-tag  = "conformance-corpus-v20260523-165156"
+tag  = "conformance-corpus-v20260524-075059"
 
 [area.ouroboros-consensus]
 asset  = "ouroboros-consensus.tar.gz"


### PR DESCRIPTION
## Summary

- **quickstart.md** [WRONG] — removed Docker pull/run examples; container image not yet published (#507)
- **running/configuration.md** [STALE] — corrected peer target defaults to match code (`EstablishedPeers 40→30`, `ActivePeers 15→20`, `KnownPeers 85→150`)
- **running/config-editor.md** [STALE] — `EstablishedPeers 40→30` in scripted workflow example
- **running/relay.md** [WRONG] — metric names in table missing `dugite_` prefix; `blocks_received` → `dugite_blocks_received_total`
- **running/block-producer.md** [WRONG] — `peers_connected` → `dugite_peers_connected`; `blocks_forged` → `dugite_blocks_forged_total`
- **running/kubernetes.md** [MISSING] — added "image not yet published" note (#507)
- **reference/upgrading.md** [WRONG] — removed Docker pull example (image not published)
- **reference/mini-protocols.md** [WRONG] — removed N2N V16/perasSupport from version table; Dugite supports V14/V15 only (V16 is Peras, tracked as #607)
- **architecture/networking.md** [STALE] — `EstablishedPeers` default corrected to "40 (30 on preview)" to reflect that mainnet/preprod use 40 while preview uses 30

## Test plan

- [ ] CI green
- [ ] No pallas/aiken references in modified pages
- [ ] Metric names verified against `crates/dugite-node/src/metrics.rs`
- [ ] N2N version list matches `N2N_VERSIONS` constant in `handshake/n2n.rs`