### PR TITLE
chore(storage): drop WAL-compaction log from warn! to debug!

### DIFF
--- a/crates/dugite-storage/src/volatile_db.rs
+++ b/crates/dugite-storage/src/volatile_db.rs
@@ -644,10 +644,11 @@ impl VolatileDB {
         // G4: proactively compact the WAL if it has grown past the size cap.
         // This rewrites the WAL to contain only the current in-memory blocks,
         // dropping finalized entries that survived after flush_to_immutable.
+        // Routine maintenance — logged at `debug!` so it doesn't look alarming.
         if let Some(ref wal) = self.wal {
             match std::fs::metadata(&wal.path) {
                 Ok(meta) if meta.len() > WAL_MAX_SIZE_BYTES => {
-                    warn!(
+                    debug!(
                         wal_bytes = meta.len(),
                         cap_bytes = WAL_MAX_SIZE_BYTES,
                         "WAL size cap exceeded — compacting before next append"


### PR DESCRIPTION
## Summary

The VolatileDB WAL hits its 400 MiB size cap roughly every ~14 min of catch-up sync (one append per block at ~5 blocks/sec × ~10 KB/entry). When that happens, `add_block` proactively rewrites the WAL with just the blocks still in the volatile in-memory store — intentional, self-healing maintenance with no data loss, no chain divergence, no operator action required.

Logging this at `warn!` made fast catch-up sync logs look alarming. Reduce to `debug!`. Operators can re-enable via `RUST_LOG=dugite_storage=debug` when investigating WAL behaviour.

## Test plan

- [x] `cargo nextest run -p dugite-storage` (241/241 pass)
- [ ] CI green