### PR TITLE
refactor(node): prereqs for UTxO RPC server (#672)

### DIFF
--- a/crates/dugite-mempool/src/lib.rs
+++ b/crates/dugite-mempool/src/lib.rs
@@ -7,6 +7,7 @@ use parking_lot::{Mutex, RwLock};
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
+use tokio::sync::broadcast;
 use tracing::{debug, info, trace, warn};
 
 /// Maximum number of entries the `order` VecDeque may hold, including tombstoned
@@ -53,6 +54,57 @@ impl Default for MempoolConfig {
             max_ref_scripts_bytes: 1_048_576, // 1 MB
         }
     }
+}
+
+/// Capacity of the `MempoolEvent` broadcast channel — issue #672 M0.2.
+///
+/// A subscriber that lags by more than this many events receives
+/// `RecvError::Lagged` and is responsible for re-syncing via
+/// [`Mempool::snapshot`] or equivalent. 4096 covers a multi-second burst
+/// of admissions/evictions at sustainable mempool churn rates without
+/// triggering lag on cooperative subscribers.
+const TX_EVENT_CHANNEL_CAP: usize = 4096;
+
+/// Why a transaction was removed from the mempool — issue #672 M0.2.
+///
+/// Distinguishes block inclusion (`Mined`) from forced eviction (`Evicted`,
+/// e.g. TTL expiry, input conflict with a new block, post-rollback
+/// revalidation) and explicit caller-driven removal (`Manual`).
+///
+/// Cascaded descendant removals — txs that were spending the virtual UTxO
+/// outputs of a removed parent — are always reported as `Evicted`: the
+/// child itself was not directly requested for removal and is not on-chain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MempoolRemoveReason {
+    /// Removed because included in an applied block.
+    Mined,
+    /// Removed for any other involuntary reason: TTL expiry, input conflict,
+    /// post-rollback revalidation, cascade after a parent removal, etc.
+    Evicted,
+    /// Removed via an explicit caller request that does not match
+    /// `Mined`/`Evicted` (e.g. a test or operator-driven removal).
+    Manual,
+}
+
+/// Mempool change event published on the `tx_events` broadcast channel —
+/// issue #672 M0.2.
+///
+/// Subscribers should treat the channel as best-effort and re-sync via
+/// [`Mempool::snapshot`] / [`Mempool::contains`] on `RecvError::Lagged`.
+#[derive(Clone, Debug)]
+pub enum MempoolEvent {
+    Added {
+        tx_hash: TransactionHash,
+        /// Full transaction CBOR as captured during decode. `None` if the
+        /// transaction was admitted via a path that did not retain raw
+        /// bytes (in practice this should not happen for txs entering via
+        /// N2N/N2C admission — both paths preserve the original CBOR).
+        raw_cbor: Option<Vec<u8>>,
+    },
+    Removed {
+        tx_hash: TransactionHash,
+        reason: MempoolRemoveReason,
+    },
 }
 
 /// Origin of a transaction submission — used for dual-FIFO fairness.
@@ -208,6 +260,13 @@ pub struct Mempool {
     /// Notifies waiting TxSubmission2 clients when new transactions arrive.
     /// Uses `notify_waiters()` so all blocked peers wake simultaneously.
     tx_notify: Arc<tokio::sync::Notify>,
+    /// Payload-bearing mempool change events — issue #672 M0.2.
+    ///
+    /// Sibling channel to `tx_notify`: `tx_notify` is wake-only (used by
+    /// the in-tree TxSubmission2 client), while `tx_events` carries
+    /// [`MempoolEvent`] payloads suitable for external RPC consumers (the
+    /// forthcoming `dugite-rpc` WatchService).
+    tx_events: broadcast::Sender<MempoolEvent>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -270,6 +329,7 @@ impl Mempool {
             remote_fifo: Mutex::new(()),
             all_fifo: Mutex::new(()),
             tx_notify: Arc::new(tokio::sync::Notify::new()),
+            tx_events: broadcast::channel(TX_EVENT_CHANNEL_CAP).0,
         }
     }
 
@@ -277,6 +337,19 @@ impl Mempool {
     /// TxSubmission2 clients await this to replace busy-wait polling.
     pub fn tx_notify(&self) -> Arc<tokio::sync::Notify> {
         self.tx_notify.clone()
+    }
+
+    /// Returns a clone of the [`MempoolEvent`] broadcast sender —
+    /// issue #672 M0.2.
+    ///
+    /// Callers obtain a receiver via `.subscribe()`. Subscribers must handle
+    /// `RecvError::Lagged` themselves (re-sync via [`snapshot`] /
+    /// [`contains`]); the mempool does not back-pressure publish.
+    ///
+    /// [`snapshot`]: Self::snapshot
+    /// [`contains`]: Self::contains
+    pub fn tx_events(&self) -> broadcast::Sender<MempoolEvent> {
+        self.tx_events.clone()
     }
 
     /// Add a transaction to the mempool.
@@ -553,6 +626,15 @@ impl Mempool {
         // Wake all TxSubmission2 clients waiting for new transactions.
         self.tx_notify.notify_waiters();
 
+        // Issue #672 M0.2: publish a payload-bearing MempoolEvent::Added so
+        // external RPC consumers (WatchMempool / WatchTx) can react. Send
+        // errors mean no subscribers, which is the normal case when no RPC
+        // server is attached.
+        let _ = self.tx_events.send(MempoolEvent::Added {
+            tx_hash,
+            raw_cbor: tx.raw_cbor.clone(),
+        });
+
         Ok(MempoolAddResult::Added)
     }
 
@@ -665,8 +747,24 @@ impl Mempool {
     ///    handled without recursion.
     ///
     /// Returns only the directly-removed transaction (not the cascaded ones).
+    ///
+    /// Publishes a `MempoolEvent::Removed { reason: Manual }`. Use
+    /// [`remove_tx_with_reason`](Self::remove_tx_with_reason) to attach a
+    /// more specific reason (`Mined` for block sweep, `Evicted` for
+    /// involuntary removal). Cascaded descendant removals always publish
+    /// `Evicted` regardless of the direct removal's reason.
     pub fn remove_tx(&self, tx_hash: &TransactionHash) -> Option<Transaction> {
-        self.remove_tx_inner(tx_hash, true)
+        self.remove_tx_inner(tx_hash, true, MempoolRemoveReason::Manual)
+    }
+
+    /// Like [`remove_tx`](Self::remove_tx) but tags the published
+    /// [`MempoolEvent::Removed`] with a specific reason — issue #672 M0.2.
+    pub fn remove_tx_with_reason(
+        &self,
+        tx_hash: &TransactionHash,
+        reason: MempoolRemoveReason,
+    ) -> Option<Transaction> {
+        self.remove_tx_inner(tx_hash, true, reason)
     }
 
     /// Inner removal logic.
@@ -674,7 +772,15 @@ impl Mempool {
     /// `cascade` controls whether dependent transactions are recursively removed.
     /// It is always `true` for external callers; the flag exists to prevent
     /// double-cascade during the BFS loop below.
-    fn remove_tx_inner(&self, tx_hash: &TransactionHash, cascade: bool) -> Option<Transaction> {
+    ///
+    /// `reason` tags the `MempoolEvent::Removed` published on success.
+    /// Cascaded descendants always publish `Evicted`.
+    fn remove_tx_inner(
+        &self,
+        tx_hash: &TransactionHash,
+        cascade: bool,
+        reason: MempoolRemoveReason,
+    ) -> Option<Transaction> {
         let (_, entry) = match self.txs.remove(tx_hash) {
             Some(pair) => pair,
             None => {
@@ -722,6 +828,13 @@ impl Mempool {
         );
 
         let removed_tx = entry.tx;
+
+        // Issue #672 M0.2: publish the direct removal before cascading so
+        // subscribers observe the causal parent-then-children order.
+        let _ = self.tx_events.send(MempoolEvent::Removed {
+            tx_hash: *tx_hash,
+            reason,
+        });
 
         if cascade {
             // G7: BFS cascade — collect ALL descendant hashes first, then do a
@@ -788,6 +901,16 @@ impl Mempool {
                             remaining = self.tx_count.load(Ordering::Relaxed),
                             "Mempool: cascade-removed dependent transaction"
                         );
+
+                        // Issue #672 M0.2: a cascaded descendant was not
+                        // mined — its only reason for leaving the mempool
+                        // is loss of the virtual-UTxO parent dependency,
+                        // so tag as Evicted regardless of the direct
+                        // removal's reason.
+                        let _ = self.tx_events.send(MempoolEvent::Removed {
+                            tx_hash: *child_hash,
+                            reason: MempoolRemoveReason::Evicted,
+                        });
                     }
                 }
 
@@ -815,16 +938,31 @@ impl Mempool {
         Some(removed_tx)
     }
 
-    /// Remove multiple transactions (batch removal after block)
+    /// Remove multiple transactions (batch removal after block).
+    ///
+    /// Publishes `MempoolEvent::Removed { reason: Manual }` for each direct
+    /// removal. Use [`remove_txs_with_reason`](Self::remove_txs_with_reason)
+    /// to attach a specific reason (e.g. `Mined` for block sweep).
     pub fn remove_txs(&self, tx_hashes: &[TransactionHash]) {
+        self.remove_txs_with_reason(tx_hashes, MempoolRemoveReason::Manual)
+    }
+
+    /// Like [`remove_txs`](Self::remove_txs) but tags each published
+    /// [`MempoolEvent::Removed`] with `reason` — issue #672 M0.2.
+    pub fn remove_txs_with_reason(
+        &self,
+        tx_hashes: &[TransactionHash],
+        reason: MempoolRemoveReason,
+    ) {
         if !tx_hashes.is_empty() {
             debug!(
                 count = tx_hashes.len(),
+                ?reason,
                 "Mempool: batch removing transactions"
             );
         }
         for hash in tx_hashes {
-            self.remove_tx(hash);
+            self.remove_tx_with_reason(hash, reason);
         }
     }
 
@@ -1098,7 +1236,7 @@ impl Mempool {
 
         let count = expired.len();
         for hash in &expired {
-            self.remove_tx(hash);
+            self.remove_tx_with_reason(hash, MempoolRemoveReason::Evicted);
         }
         if count > 0 {
             info!(
@@ -1180,7 +1318,7 @@ impl Mempool {
             .collect();
 
         for hash in &conflicting {
-            self.remove_tx(hash);
+            self.remove_tx_with_reason(hash, MempoolRemoveReason::Evicted);
         }
         if !conflicting.is_empty() {
             debug!(
@@ -1210,7 +1348,7 @@ impl Mempool {
         for hash in hashes {
             let valid = self.txs.get(&hash).map(|entry| is_valid(&entry.tx));
             if valid == Some(false) {
-                self.remove_tx(&hash);
+                self.remove_tx_with_reason(&hash, MempoolRemoveReason::Evicted);
                 removed.push(hash);
             }
         }
@@ -1238,6 +1376,13 @@ impl Mempool {
         for hash in &order {
             if let Some((_, entry)) = self.txs.remove(hash) {
                 txs.push(entry.tx);
+                // Issue #672 M0.2: each drained tx is involuntarily removed
+                // (rollback handling); subscribers see Evicted. Callers that
+                // re-admit the drained txs will subsequently observe Added.
+                let _ = self.tx_events.send(MempoolEvent::Removed {
+                    tx_hash: *hash,
+                    reason: MempoolRemoveReason::Evicted,
+                });
             }
         }
         self.fee_index.write().clear();
@@ -4846,5 +4991,134 @@ mod tests {
         }
         assert_eq!(mempool.virtual_utxo_count(), 0);
         assert_eq!(mempool.claimed_inputs_count(), 0);
+    }
+
+    // ─── tx_events broadcast (issue #672 M0.2) ────────────────────────────
+
+    /// `Added` fires on successful admission and carries the tx's raw CBOR
+    /// when populated. `Removed` fires on direct removal with the supplied
+    /// reason.
+    #[tokio::test]
+    async fn tx_events_added_then_removed_with_reason() {
+        let mempool = Mempool::new(MempoolConfig::default());
+        let mut events = mempool.tx_events().subscribe();
+
+        let mut tx = make_dummy_tx();
+        let hash = Hash32::from_bytes([7u8; 32]);
+        tx.hash = hash;
+        // Populate raw_cbor so we can verify the event carries it.
+        tx.raw_cbor = Some(vec![0xA5, 0xA5, 0xA5]);
+
+        mempool.add_tx(hash, tx, 200).expect("admit");
+
+        match events.recv().await.expect("Added") {
+            MempoolEvent::Added { tx_hash, raw_cbor } => {
+                assert_eq!(tx_hash, hash);
+                assert_eq!(raw_cbor.as_deref(), Some(&[0xA5, 0xA5, 0xA5][..]));
+            }
+            other => panic!("expected Added, got {other:?}"),
+        }
+
+        mempool.remove_tx_with_reason(&hash, MempoolRemoveReason::Mined);
+
+        match events.recv().await.expect("Removed") {
+            MempoolEvent::Removed { tx_hash, reason } => {
+                assert_eq!(tx_hash, hash);
+                assert_eq!(reason, MempoolRemoveReason::Mined);
+            }
+            other => panic!("expected Removed, got {other:?}"),
+        }
+    }
+
+    /// A direct `remove_tx_with_reason(parent, Mined)` causes cascade-removed
+    /// children to publish `Evicted` (their dependency went away — they were
+    /// not mined themselves).
+    #[tokio::test]
+    async fn tx_events_cascade_descendants_are_evicted_not_mined() {
+        let mempool = Mempool::new(MempoolConfig::default());
+
+        // Build parent → child via the virtual UTxO chain.
+        let mut parent = make_dummy_tx();
+        let parent_hash = Hash32::from_bytes([10u8; 32]);
+        parent.hash = parent_hash;
+        mempool
+            .add_tx(parent_hash, parent.clone(), 200)
+            .expect("admit parent");
+
+        let mut child = make_dummy_tx();
+        let child_hash = Hash32::from_bytes([11u8; 32]);
+        child.hash = child_hash;
+        // Child spends one of parent's outputs (virtual UTxO).
+        child.body.inputs = vec![TransactionInput {
+            transaction_id: parent_hash,
+            index: 0,
+        }];
+        mempool.add_tx(child_hash, child, 200).expect("admit child");
+
+        // Subscribe AFTER admissions so only removal events show up.
+        let mut events = mempool.tx_events().subscribe();
+
+        mempool.remove_tx_with_reason(&parent_hash, MempoolRemoveReason::Mined);
+
+        // Direct removal first → Mined.
+        match events.recv().await.expect("Removed parent") {
+            MempoolEvent::Removed { tx_hash, reason } => {
+                assert_eq!(tx_hash, parent_hash);
+                assert_eq!(reason, MempoolRemoveReason::Mined);
+            }
+            other => panic!("expected Removed(parent), got {other:?}"),
+        }
+        // Cascaded child → Evicted (NOT Mined).
+        match events.recv().await.expect("Removed child") {
+            MempoolEvent::Removed { tx_hash, reason } => {
+                assert_eq!(tx_hash, child_hash);
+                assert_eq!(reason, MempoolRemoveReason::Evicted);
+            }
+            other => panic!("expected Removed(child), got {other:?}"),
+        }
+    }
+
+    /// `remove_txs_with_reason(hashes, Mined)` reports each direct removal
+    /// with that reason — the block-apply path in node/mod.rs depends on
+    /// this so WatchTx can distinguish inclusion from eviction.
+    #[tokio::test]
+    async fn tx_events_remove_txs_with_reason_propagates() {
+        let mempool = Mempool::new(MempoolConfig::default());
+
+        let mut hashes = Vec::new();
+        for i in 0..3 {
+            let mut tx = make_dummy_tx();
+            let h = Hash32::from_bytes([(50 + i) as u8; 32]);
+            tx.hash = h;
+            mempool.add_tx(h, tx, 200).expect("admit");
+            hashes.push(h);
+        }
+
+        let mut events = mempool.tx_events().subscribe();
+
+        mempool.remove_txs_with_reason(&hashes, MempoolRemoveReason::Mined);
+
+        for expected_hash in &hashes {
+            match events.recv().await.expect("Removed") {
+                MempoolEvent::Removed { tx_hash, reason } => {
+                    assert_eq!(&tx_hash, expected_hash);
+                    assert_eq!(reason, MempoolRemoveReason::Mined);
+                }
+                other => panic!("expected Removed, got {other:?}"),
+            }
+        }
+    }
+
+    /// No-subscriber publish is silently dropped — does not panic, does not
+    /// affect normal mempool operation.
+    #[tokio::test]
+    async fn tx_events_no_subscribers_is_not_an_error() {
+        let mempool = Mempool::new(MempoolConfig::default());
+        let mut tx = make_dummy_tx();
+        let hash = Hash32::from_bytes([99u8; 32]);
+        tx.hash = hash;
+        mempool.add_tx(hash, tx, 200).expect("admit");
+        mempool.remove_tx_with_reason(&hash, MempoolRemoveReason::Manual);
+        assert!(!mempool.contains(&hash));
     }
 }

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -4631,7 +4631,8 @@ impl Node {
         //    used to do inline.
         let confirmed: Vec<_> = block.transactions.iter().map(|tx| tx.hash).collect();
         if !confirmed.is_empty() {
-            self.mempool.remove_txs(&confirmed);
+            self.mempool
+                .remove_txs_with_reason(&confirmed, dugite_mempool::MempoolRemoveReason::Mined);
         }
         if !self.mempool.is_empty() {
             let consumed_inputs: std::collections::HashSet<_> = block
@@ -6359,7 +6360,10 @@ impl Node {
                             let bad_tx_hashes: Vec<_> =
                                 block.transactions.iter().map(|tx| tx.hash).collect();
                             if !bad_tx_hashes.is_empty() {
-                                self.mempool.remove_txs(&bad_tx_hashes);
+                                self.mempool.remove_txs_with_reason(
+                                    &bad_tx_hashes,
+                                    dugite_mempool::MempoolRemoveReason::Evicted,
+                                );
                                 error!(
                                     target: "forge",
                                     count = bad_tx_hashes.len(),

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod peer_connection;
 pub(crate) mod query;
 pub(crate) mod serve;
 pub(crate) mod sync;
+pub mod tip_broadcast;
 
 use anyhow::Result;
 use std::collections::HashMap;
@@ -415,6 +416,13 @@ pub struct Node {
     /// Broadcast sender for notifying connected peers of chain rollbacks
     pub(crate) rollback_announcement_tx:
         Option<tokio::sync::broadcast::Sender<RollbackAnnouncement>>,
+    /// Payload-bearing tip event broadcaster — issue #672 M0.1.
+    ///
+    /// Sibling channel pair carrying `TipApply` / `TipRollback` events with
+    /// richer payloads (era) than the existing announcement channels. Fanned
+    /// in additively from the same send sites; consumed by external RPC.
+    /// `None` until `run()` initialises it alongside the announcement channels.
+    pub(crate) tip_broadcaster: Option<Arc<tip_broadcast::TipBroadcaster>>,
     /// Prometheus metrics port
     pub(crate) metrics_port: u16,
     /// Make a metrics bind failure fatal (see `--require-metrics`)
@@ -1798,6 +1806,7 @@ impl Node {
             block_producer,
             block_announcement_tx: None,
             rollback_announcement_tx: None,
+            tip_broadcaster: None,
             metrics_port: args.metrics_port,
             require_metrics: args.require_metrics,
             expected_byron_genesis_hash,
@@ -2205,6 +2214,7 @@ impl Node {
                 tokio::sync::broadcast::channel::<RollbackAnnouncement>(ROLLBACK_ANN_CHANNEL_CAP);
             self.block_announcement_tx = Some(block_ann_tx.clone());
             self.rollback_announcement_tx = Some(rollback_ann_tx.clone());
+            self.tip_broadcaster = Some(Arc::new(tip_broadcast::TipBroadcaster::new()));
             let n2c_block_ann_tx = block_ann_tx;
             let n2c_rollback_ann_tx = rollback_ann_tx;
             // C4 + G3: bound the number of concurrent N2C connections.
@@ -2809,6 +2819,7 @@ impl Node {
                 tokio::sync::broadcast::channel::<RollbackAnnouncement>(ROLLBACK_ANN_CHANNEL_CAP);
             self.block_announcement_tx = Some(block_ann_tx);
             self.rollback_announcement_tx = Some(rollback_ann_tx);
+            self.tip_broadcaster = Some(Arc::new(tip_broadcast::TipBroadcaster::new()));
         }
         // Channel for the N2N listener to send accepted+handshaked connections
         // to the main run loop for lifecycle manager registration.
@@ -4238,6 +4249,14 @@ impl Node {
                                                 hash: hash_bytes,
                                                 block_number: fork_block_no.0,
                                             });
+                                            if let Some(ref tb) = self.tip_broadcaster {
+                                                tb.announce_apply(tip_broadcast::TipApply {
+                                                    slot: fork_slot.0,
+                                                    hash: hash_bytes,
+                                                    block_number: fork_block_no.0,
+                                                    era: fork_block.era,
+                                                });
+                                            }
                                         }
                                         // Stash this block as the most recent
                                         // successful apply.  Subsequent
@@ -4522,6 +4541,14 @@ impl Node {
                 hash: hash_bytes,
                 block_number: block_number.0,
             });
+            if let Some(ref tb) = self.tip_broadcaster {
+                tb.announce_apply(tip_broadcast::TipApply {
+                    slot: block_slot.0,
+                    hash: hash_bytes,
+                    block_number: block_number.0,
+                    era: block.era,
+                });
+            }
             debug!(
                 slot = block_slot.0,
                 block = block_number.0,
@@ -6253,6 +6280,14 @@ impl Node {
                                             hash: hash_bytes,
                                             block_number: fork_block_no.0,
                                         });
+                                        if let Some(ref tb) = self.tip_broadcaster {
+                                            tb.announce_apply(tip_broadcast::TipApply {
+                                                slot: fork_slot.0,
+                                                hash: hash_bytes,
+                                                block_number: fork_block_no.0,
+                                                era: fork_block.era,
+                                            });
+                                        }
                                     }
                                 }
                                 !replay_failed
@@ -6405,6 +6440,14 @@ impl Node {
                         hash: hash_bytes,
                         block_number: block_number.0,
                     });
+                    if let Some(ref tb) = self.tip_broadcaster {
+                        tb.announce_apply(tip_broadcast::TipApply {
+                            slot: next_slot.0,
+                            hash: hash_bytes,
+                            block_number: block_number.0,
+                            era: block.era,
+                        });
+                    }
 
                     if subscribers == 0 {
                         warn!(

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2110,6 +2110,33 @@ impl Node {
             });
         }
 
+        // Issue #672 M0.3: tx validator + slot config hoisted out of the N2C
+        // block so the forthcoming UTxO RPC SubmitService (M1+) can share the
+        // exact same validator instance + slot config as N2C
+        // LocalTxSubmission. SlotConfig is Copy and LedgerTxValidator is
+        // Arc'd, so the N2C block captures by clone on the consume side.
+        let n2c_slot_config = self
+            .shelley_genesis
+            .as_ref()
+            .map(|g| g.slot_config())
+            .unwrap_or(dugite_ledger::plutus::SlotConfig {
+                zero_time: 0,
+                zero_slot: 0,
+                slot_length: 1000,
+            });
+        let n2c_tx_validator = Arc::new(serve::LedgerTxValidator {
+            ledger: self.ledger_state.clone(),
+            slot_config: n2c_slot_config,
+            metrics: self.metrics.clone(),
+            mempool: Some(self.mempool.clone()),
+            network: if self.network_magic == dugite_primitives::network::NetworkId::Mainnet.magic()
+            {
+                dugite_primitives::network::NetworkId::Mainnet
+            } else {
+                dugite_primitives::network::NetworkId::Testnet
+            },
+        });
+
         // Start N2C server on Unix socket.
         //
         // Each accepted connection gets its own Mux and set of protocol tasks:
@@ -2129,29 +2156,6 @@ impl Node {
             // Build the block provider for LocalChainSync
             let n2c_block_provider = Arc::new(serve::ChainDBBlockProvider {
                 chain_db: self.chain_db.clone(),
-            });
-            // Build the tx validator for LocalTxSubmission
-            let n2c_slot_config = self
-                .shelley_genesis
-                .as_ref()
-                .map(|g| g.slot_config())
-                .unwrap_or(dugite_ledger::plutus::SlotConfig {
-                    zero_time: 0,
-                    zero_slot: 0,
-                    slot_length: 1000,
-                });
-            let n2c_tx_validator = Arc::new(serve::LedgerTxValidator {
-                ledger: self.ledger_state.clone(),
-                slot_config: n2c_slot_config,
-                metrics: self.metrics.clone(),
-                mempool: Some(self.mempool.clone()),
-                network: if self.network_magic
-                    == dugite_primitives::network::NetworkId::Mainnet.magic()
-                {
-                    dugite_primitives::network::NetworkId::Mainnet
-                } else {
-                    dugite_primitives::network::NetworkId::Testnet
-                },
             });
 
             // Remove stale socket file if it exists (e.g., from a previous unclean shutdown).

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -184,19 +184,25 @@ impl Node {
     /// LocalChainSync server subscribe to this channel and translate the
     /// announcement into `MsgRollBackward` messages for their downstream peers.
     pub async fn notify_rollback(&self, rollback_point: &Point) {
-        if let Some(ref tx) = self.rollback_announcement_tx {
-            let rb_slot = rollback_point.slot().map(|s| s.0).unwrap_or(0);
-            let rb_hash = rollback_point
-                .hash()
-                .map(|h| {
-                    let bytes: &[u8] = h.as_ref();
-                    let mut arr = [0u8; 32];
-                    arr.copy_from_slice(bytes);
-                    arr
-                })
-                .unwrap_or([0u8; 32]);
+        let rb_slot = rollback_point.slot().map(|s| s.0).unwrap_or(0);
+        let rb_hash = rollback_point
+            .hash()
+            .map(|h| {
+                let bytes: &[u8] = h.as_ref();
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(bytes);
+                arr
+            })
+            .unwrap_or([0u8; 32]);
 
+        if let Some(ref tx) = self.rollback_announcement_tx {
             let _ = tx.send(RollbackAnnouncement {
+                slot: rb_slot,
+                hash: rb_hash,
+            });
+        }
+        if let Some(ref tb) = self.tip_broadcaster {
+            tb.announce_rollback(crate::node::tip_broadcast::TipRollback {
                 slot: rb_slot,
                 hash: rb_hash,
             });

--- a/crates/dugite-node/src/node/tip_broadcast.rs
+++ b/crates/dugite-node/src/node/tip_broadcast.rs
@@ -1,0 +1,146 @@
+//! Node-local broadcaster carrying payload-shaped tip events for external
+//! consumers (the forthcoming UTxO RPC server — see issue #672, milestone M0).
+//!
+//! Today's `block_announcement_tx` / `rollback_announcement_tx` channels are
+//! shaped for the N2N/N2C ChainSync servers and carry the
+//! `dugite_network::BlockAnnouncement` / `RollbackAnnouncement` types defined
+//! in the network crate. `TipBroadcaster` is a sibling channel pair with
+//! richer payloads (`era`, distinct `Apply`/`Rollback` types) suitable for an
+//! external RPC consumer that should not depend on `dugite-network`.
+//!
+//! In M0 the existing announcement channels remain authoritative for N2N/N2C;
+//! `TipBroadcaster` is fanned-in additively from the same send sites so no
+//! existing subscriber behaviour changes.
+//!
+//! Slow-consumer policy: receivers handle `RecvError::Lagged` themselves —
+//! `TipBroadcaster` makes no attempt to disconnect them.
+
+// The payload fields + subscribe accessors are intentionally unused until
+// milestone M1 wires the `dugite-rpc` crate up as a subscriber. The
+// announce_* fan-in sites in `node/mod.rs` + `node/sync.rs` exercise the
+// senders; the rest of the surface is the public API for M1.
+#![allow(dead_code)]
+
+use dugite_primitives::Era;
+use tokio::sync::broadcast;
+
+/// Capacity of the tip-apply broadcast channel.
+///
+/// 1024 covers any realistic fork burst comfortably (Conway blocks arrive at
+/// most once per 20s slot; capacity at this size will only ever be exhausted
+/// by a subscriber that has stalled for several minutes).
+const TIP_APPLY_CAP: usize = 1024;
+
+/// Capacity of the tip-rollback broadcast channel.
+const TIP_ROLLBACK_CAP: usize = 256;
+
+/// A block was applied at the chain tip.
+#[derive(Clone, Debug)]
+pub struct TipApply {
+    pub slot: u64,
+    pub hash: [u8; 32],
+    pub block_number: u64,
+    pub era: Era,
+}
+
+/// The chain rolled back to (slot, hash). `slot == 0 && hash == [0; 32]` is
+/// the origin sentinel, matching the convention used by
+/// `dugite_network::RollbackAnnouncement`.
+#[derive(Clone, Debug)]
+pub struct TipRollback {
+    pub slot: u64,
+    pub hash: [u8; 32],
+}
+
+/// Pair of broadcast senders carrying payload-bearing tip events.
+///
+/// Cheap to clone (broadcast::Sender is internally Arc'd).
+#[derive(Clone, Debug)]
+pub struct TipBroadcaster {
+    apply_tx: broadcast::Sender<TipApply>,
+    rollback_tx: broadcast::Sender<TipRollback>,
+}
+
+impl TipBroadcaster {
+    pub fn new() -> Self {
+        let (apply_tx, _) = broadcast::channel(TIP_APPLY_CAP);
+        let (rollback_tx, _) = broadcast::channel(TIP_ROLLBACK_CAP);
+        Self {
+            apply_tx,
+            rollback_tx,
+        }
+    }
+
+    /// Best-effort fan-out — a `send` error means no receivers are attached,
+    /// which is the normal state when the RPC server is disabled.
+    pub fn announce_apply(&self, ev: TipApply) {
+        let _ = self.apply_tx.send(ev);
+    }
+
+    /// Best-effort fan-out — see [`announce_apply`].
+    pub fn announce_rollback(&self, ev: TipRollback) {
+        let _ = self.rollback_tx.send(ev);
+    }
+
+    pub fn subscribe_apply(&self) -> broadcast::Receiver<TipApply> {
+        self.apply_tx.subscribe()
+    }
+
+    pub fn subscribe_rollback(&self) -> broadcast::Receiver<TipRollback> {
+        self.rollback_tx.subscribe()
+    }
+}
+
+impl Default for TipBroadcaster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn apply_and_rollback_round_trip() {
+        let broadcaster = TipBroadcaster::new();
+        let mut apply_rx = broadcaster.subscribe_apply();
+        let mut rollback_rx = broadcaster.subscribe_rollback();
+
+        broadcaster.announce_apply(TipApply {
+            slot: 42,
+            hash: [1u8; 32],
+            block_number: 7,
+            era: Era::Conway,
+        });
+        broadcaster.announce_rollback(TipRollback {
+            slot: 40,
+            hash: [2u8; 32],
+        });
+
+        let applied = apply_rx.recv().await.unwrap();
+        assert_eq!(applied.slot, 42);
+        assert_eq!(applied.block_number, 7);
+        assert_eq!(applied.era, Era::Conway);
+
+        let rolled_back = rollback_rx.recv().await.unwrap();
+        assert_eq!(rolled_back.slot, 40);
+        assert_eq!(rolled_back.hash, [2u8; 32]);
+    }
+
+    #[tokio::test]
+    async fn no_subscribers_is_not_an_error() {
+        let broadcaster = TipBroadcaster::new();
+        // Should not panic / propagate any error.
+        broadcaster.announce_apply(TipApply {
+            slot: 1,
+            hash: [0u8; 32],
+            block_number: 1,
+            era: Era::Conway,
+        });
+        broadcaster.announce_rollback(TipRollback {
+            slot: 0,
+            hash: [0u8; 32],
+        });
+    }
+}

--- a/crates/dugite-primitives/src/block.rs
+++ b/crates/dugite-primitives/src/block.rs
@@ -196,6 +196,72 @@ impl Block {
             block_number: self.header.block_number,
         }
     }
+
+    /// Per-transaction CBOR-body byte ranges within [`Block::raw_cbor`] —
+    /// issue #672 M0.4.
+    ///
+    /// For each transaction `tx` in [`Block::transactions`], returns the
+    /// `Range<usize>` such that `block.raw_cbor[range]` is byte-equal to
+    /// `tx.raw_body_cbor`. This is the prerequisite for the forthcoming
+    /// UTxO RPC mapper that wants to populate utxorpc `Tx.native_bytes`
+    /// without re-encoding.
+    ///
+    /// # Behaviour
+    ///
+    /// - Returns `None` if [`Block::raw_cbor`] is `None` or if any
+    ///   transaction lacks `raw_body_cbor`.
+    /// - Returns `None` if any transaction body cannot be located within
+    ///   the block CBOR (which indicates upstream decoder drift — the
+    ///   invariant `tx.raw_body_cbor` ⊆ `block.raw_cbor` is expected).
+    /// - Uses a left-to-right moving cursor so that two transactions with
+    ///   identical body bytes (a body-hash collision — practically
+    ///   impossible) would map to distinct ranges.
+    ///
+    /// # Implementation
+    ///
+    /// Substring search via [`slice::windows`]. Cardano blocks are bounded
+    /// (~72 KB on mainnet) so the O(n·m) cost is acceptable; per-call
+    /// runtime stays well under one millisecond. A future decoder-side
+    /// capture path (Path B in the M0 design) can replace this if
+    /// profiling shows the search is hot for RPC consumers.
+    ///
+    /// # Note on full-tx ranges
+    ///
+    /// Cardano blocks store transactions in parallel arrays
+    /// (`transaction_bodies`, `transaction_witness_sets`,
+    /// `auxiliary_data_set`, `invalid_transactions`) rather than as a
+    /// single contiguous per-tx CBOR. Therefore only the BODY range is
+    /// recoverable from `block.raw_cbor`. Consumers wanting the wire-
+    /// format whole-tx CBOR (`[body, witness_set, valid?, aux?]`) must
+    /// re-assemble from `tx.raw_body_cbor` / `tx.raw_witness_cbor` /
+    /// `tx.is_valid` / `tx.auxiliary_data` — that re-assembly lives in
+    /// `dugite-rpc::map::tx`, not here.
+    pub fn tx_byte_ranges(&self) -> Option<Vec<std::ops::Range<usize>>> {
+        let block_cbor: &[u8] = self.raw_cbor.as_deref()?;
+        let mut ranges: Vec<std::ops::Range<usize>> = Vec::with_capacity(self.transactions.len());
+        let mut cursor: usize = 0;
+
+        for tx in &self.transactions {
+            let body_cbor: &[u8] = tx.raw_body_cbor.as_deref()?;
+            if body_cbor.is_empty() {
+                // An empty body is malformed but we report a degenerate
+                // zero-length range at the cursor rather than failing the
+                // whole call — protects RPC consumers from a single bad tx.
+                ranges.push(cursor..cursor);
+                continue;
+            }
+            let haystack = block_cbor.get(cursor..)?;
+            let offset = haystack
+                .windows(body_cbor.len())
+                .position(|w| w == body_cbor)?;
+            let start = cursor + offset;
+            let end = start + body_cbor.len();
+            ranges.push(start..end);
+            cursor = end;
+        }
+
+        Some(ranges)
+    }
 }
 
 /// Chain tip information
@@ -522,5 +588,108 @@ mod tests {
         let json = serde_json::to_string(&tip).unwrap();
         let tip2: Tip = serde_json::from_str(&json).unwrap();
         assert_eq!(tip, tip2);
+    }
+
+    // ========== tx_byte_ranges (#672 M0.4) ==========
+
+    /// Helper: build a Block where `raw_cbor` is a synthetic byte sequence
+    /// composed of `leading || body_1 || gap_1 || body_2 || ... || trailing`,
+    /// and the constituent transactions have `raw_body_cbor` set to each
+    /// `body_i`. Mirrors the post-decode invariant that `tx.raw_body_cbor`
+    /// is a verbatim slice of `block.raw_cbor`.
+    fn synth_block_with_bodies(bodies: &[Vec<u8>], gap: &[u8]) -> Block {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"\x83\x05"); // arbitrary leading bytes (not parsed)
+        for (i, body) in bodies.iter().enumerate() {
+            raw.extend_from_slice(body);
+            if i + 1 < bodies.len() {
+                raw.extend_from_slice(gap);
+            }
+        }
+        raw.extend_from_slice(b"\xFF\xFF"); // arbitrary trailing bytes
+
+        let transactions: Vec<Transaction> = bodies
+            .iter()
+            .enumerate()
+            .map(|(i, body)| {
+                let mut tx = Transaction::empty_with_hash(Hash::from_bytes([i as u8; 32]));
+                tx.raw_body_cbor = Some(body.clone());
+                tx
+            })
+            .collect();
+
+        Block {
+            header: test_header(1, 1),
+            transactions,
+            era: Era::Conway,
+            raw_cbor: Some(raw),
+        }
+    }
+
+    #[test]
+    fn tx_byte_ranges_locates_each_body_in_block_cbor() {
+        let bodies = vec![
+            vec![0xA1, 0x01, 0x02, 0x03],
+            vec![0xB2, 0x04, 0x05],
+            vec![0xC3, 0x06, 0x07, 0x08, 0x09],
+        ];
+        let block = synth_block_with_bodies(&bodies, &[0x00, 0x00]);
+        let raw_cbor = block.raw_cbor.as_deref().unwrap();
+
+        let ranges = block.tx_byte_ranges().expect("ranges");
+
+        assert_eq!(ranges.len(), bodies.len());
+        for (range, body) in ranges.iter().zip(bodies.iter()) {
+            assert_eq!(&raw_cbor[range.clone()], body.as_slice());
+        }
+    }
+
+    #[test]
+    fn tx_byte_ranges_returns_none_when_block_cbor_missing() {
+        let mut block = synth_block_with_bodies(&[vec![0x01, 0x02]], &[]);
+        block.raw_cbor = None;
+        assert!(block.tx_byte_ranges().is_none());
+    }
+
+    #[test]
+    fn tx_byte_ranges_returns_none_when_any_body_cbor_missing() {
+        let mut block = synth_block_with_bodies(&[vec![0x01, 0x02]], &[]);
+        block.transactions[0].raw_body_cbor = None;
+        assert!(block.tx_byte_ranges().is_none());
+    }
+
+    #[test]
+    fn tx_byte_ranges_handles_duplicate_bodies_via_moving_cursor() {
+        // Two identical bodies — confirms ranges are distinct and ordered.
+        let body = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let bodies = vec![body.clone(), body.clone()];
+        let block = synth_block_with_bodies(&bodies, &[0xAA]);
+        let ranges = block.tx_byte_ranges().expect("ranges");
+
+        assert_eq!(ranges.len(), 2);
+        assert!(ranges[0].end <= ranges[1].start, "ranges must be ordered");
+        let raw = block.raw_cbor.as_deref().unwrap();
+        assert_eq!(&raw[ranges[0].clone()], body.as_slice());
+        assert_eq!(&raw[ranges[1].clone()], body.as_slice());
+    }
+
+    #[test]
+    fn tx_byte_ranges_returns_none_when_body_not_in_block_cbor() {
+        let mut block = synth_block_with_bodies(&[vec![0x01, 0x02]], &[]);
+        // Corrupt: body cbor doesn't actually appear in the block cbor.
+        block.transactions[0].raw_body_cbor = Some(vec![0xFE, 0xED, 0xFA, 0xCE]);
+        assert!(block.tx_byte_ranges().is_none());
+    }
+
+    #[test]
+    fn tx_byte_ranges_empty_block_returns_empty_vec() {
+        let block = Block {
+            header: test_header(1, 1),
+            transactions: vec![],
+            era: Era::Conway,
+            raw_cbor: Some(vec![0x80]),
+        };
+        let ranges = block.tx_byte_ranges().expect("ranges");
+        assert!(ranges.is_empty());
     }
 }


### PR DESCRIPTION
Milestone 0 of #672 — prerequisite refactors with no behaviour change. The
full multi-milestone implementation plan lives at
`.claude/plans/create-a-detailed-plan-adaptive-pretzel.md` (M0 → M5).

## What's in this PR

Four focused commits, each scoped to one prereq:

| Commit | What |
|---|---|
| `refactor(node): introduce TipBroadcaster for RPC tip feed (#672 M0.1)` | New `node::tip_broadcast` module: payload-shaped `TipApply { slot, hash, block_no, era }` + `TipRollback { slot, hash }` broadcast channels (capacity 1024 / 256). Fanned-in additively from the 4 existing `block_announcement_tx` send sites + the 1 `rollback_announcement_tx` site. Existing N2N/N2C subscribers unchanged. |
| `feat(mempool): payload-bearing MempoolEvent broadcast channel (#672 M0.2)` | `Mempool::tx_events: broadcast::Sender<MempoolEvent>` sibling to `tx_notify`. `MempoolEvent::Added { tx_hash, raw_cbor }` + `MempoolEvent::Removed { tx_hash, reason: Mined \| Evicted \| Manual }`. New reason-tagged `remove_tx_with_reason` / `remove_txs_with_reason` API; existing `remove_tx` / `remove_txs` delegate with `Manual`. Block-apply sweep tagged `Mined`; cascaded descendants always `Evicted`. Capacity 4096. |
| `refactor(node): hoist n2c_tx_validator + n2c_slot_config out of N2C block (#672 M0.3)` | Pure code motion: construction moves from inside the N2C server block to the preceding scope so the future RPC `SubmitService` can share the same `Arc<LedgerTxValidator>` instance + `SlotConfig` as N2C `LocalTxSubmission`. |
| `feat(primitives): expose Block::tx_byte_ranges() (#672 M0.4)` | New method returning per-tx body CBOR byte ranges within `Block::raw_cbor` via left-to-right substring search. Lets the future RPC mapper populate utxorpc `Tx.native_bytes` without re-encoding. 6 unit tests cover happy path / missing inputs / duplicate bodies / decoder-drift canary / empty block. |

## What's NOT in this PR

- No new crates, no `tonic`/`prost` dep, no RPC code. M1 (`dugite-rpc` scaffold + `SyncService`) begins after this lands.
- No behaviour change for existing N2N/N2C/mempool consumers — `Mempool::tx_notify` stays as the wake-only signal for `TxSubmission2`; `block_announcement_tx` / `rollback_announcement_tx` remain authoritative for ChainSync servers.

## Verification

- `just check` ✅ — fmt + clippy + build + test + test-doc all green
- `cargo nextest run -p dugite-node` ✅ — 878 / 878 pass
- `cargo nextest run -p dugite-mempool` ✅ — 98 / 98 pass (incl. 4 new `tx_events_*` tests)
- `cargo nextest run -p dugite-primitives` ✅ — 279 / 279 pass (incl. 6 new `tx_byte_ranges_*` tests)
- `just devnet-validate-smoke` ⏸ — skipped locally (live SAND soak on port 3001); CI gate will run.