### PR TITLE
test(fuzz): fix body_hash + add in-house UPLC and Byron fuzz targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -57,13 +57,21 @@ jobs:
           # Phase 4 — Plutus / Phase-2
           # NOTE: plutus_script_decode is intentionally OMITTED — upstream uplc
           # and pallas-codec panic on malformed input (see top-doc in that file
-          # and the catch_unwind guard in dugite-ledger/src/plutus.rs).
+          # and the catch_unwind guard in dugite-ledger/src/plutus.rs). The
+          # in-house decoder is covered by dugite_uplc_program_decode below.
           - plutus_data_decode
           - cost_model_eval
           # Audit #544 — CBOR serialization strictness (D2/D3/D9/D10/D15)
           - vkey_witness_sizes
           - plutus_bignum
           - cbor_skip_value_depth
+          # In-house decoders — production code path for phase-2 validation
+          - dugite_uplc_program_decode
+          - dugite_uplc_data_decode
+          # Issue #545 E5 — body-hash round-trip soundness
+          - body_hash
+          # Issue #613 — Byron block-header decode hardening
+          - byron_block_decode
     steps:
       - uses: actions/checkout@v6
 

--- a/crates/dugite-serialization/src/decode/mod.rs
+++ b/crates/dugite-serialization/src/decode/mod.rs
@@ -70,6 +70,12 @@ use dugite_primitives::transaction::{Transaction, TransactionInput, TransactionO
 /// Conway keys 0-33 and Dijkstra keys 34-37 are all handled.
 pub use era_conway::ppu_from_cbor;
 
+/// Decode a Byron main-chain block from its inner CBOR (post envelope strip).
+/// Re-exported so fuzz harnesses and external tooling (Mithril chunk
+/// inspection, era-specific replay) can call the Byron path directly without
+/// constructing a full envelope.
+pub use era_byron::{decode_byron_ebb_block, decode_byron_main_block};
+
 // ---------------------------------------------------------------------------
 // Public API — every block-level decode routes through the in-house decoder
 // ---------------------------------------------------------------------------

--- a/crates/dugite-serialization/src/lib.rs
+++ b/crates/dugite-serialization/src/lib.rs
@@ -18,8 +18,9 @@ pub use decode::cbor_helpers::{
 };
 pub use decode::{
     decode_block, decode_block_minimal, decode_block_minimal_with_byron_epoch_length,
-    decode_block_with_byron_epoch_length, decode_transaction, decode_transaction_input,
-    decode_transaction_output, decode_wrapped_block_header,
+    decode_block_with_byron_epoch_length, decode_byron_ebb_block, decode_byron_main_block,
+    decode_transaction, decode_transaction_input, decode_transaction_output,
+    decode_wrapped_block_header,
 };
 
 // Helper exposed by the existing in-house pipeline; used by mithril chunk-file

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "dugite-primitives",
  "dugite-serialization",
  "dugite-storage",
+ "dugite-uplc",
  "libfuzzer-sys",
  "minicbor 0.25.1",
  "tempfile",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,10 @@ dugite-lsm = { path = "../crates/dugite-lsm" }
 dugite-crypto = { path = "../crates/dugite-crypto" }
 dugite-consensus = { path = "../crates/dugite-consensus" }
 dugite-storage = { path = "../crates/dugite-storage" }
+# In-house UPLC implementation — the decoder/evaluator that runs in production.
+# This is the target the new fuzz_dugite_uplc_* binaries exercise; the upstream
+# aiken `uplc` dep below is kept around for the upstream-bug-surface targets.
+dugite-uplc = { path = "../crates/dugite-uplc" }
 # Direct uplc dep surfaces eval_phase_two_raw, Program::from_cbor/from_flat,
 # uplc::plutus_data, and apply_params_to_script for Plutus Phase-4 fuzz targets.
 uplc = { git = "https://github.com/aiken-lang/aiken.git", rev = "6806d52211fbb469ae13aa0e0290aeb6b9b3e8cf" }
@@ -283,4 +287,29 @@ doc = false
 [[bin]]
 name = "fuzz_tx_metadata_decode"
 path = "fuzz_targets/tx_metadata_decode.rs"
+doc = false
+
+# In-house dugite-uplc Program decoder (production phase-2 script entry).
+# Distinct from fuzz_plutus_script_decode, which exercises the upstream
+# Aiken `uplc` crate — that is NOT the decoder dugite runs in production.
+[[bin]]
+name = "fuzz_dugite_uplc_program_decode"
+path = "fuzz_targets/dugite_uplc_program_decode.rs"
+doc = false
+
+# In-house dugite-uplc Data::from_cbor decoder (datums, redeemers, inline
+# datums). Distinct from fuzz_plutus_data_decode which routes through the
+# upstream Aiken `uplc::plutus_data`.
+[[bin]]
+name = "fuzz_dugite_uplc_data_decode"
+path = "fuzz_targets/dugite_uplc_data_decode.rs"
+doc = false
+
+# Byron-era block decode (issue #613). Wraps fuzzer bytes in a Byron era
+# envelope so mutation exercises decode_byron_main_block /
+# decode_byron_ebb_block specifically — random mutation through decode_block
+# would otherwise converge on the richer Shelley+ tags.
+[[bin]]
+name = "fuzz_byron_block_decode"
+path = "fuzz_targets/byron_block_decode.rs"
 doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -13,12 +13,30 @@ rustup install nightly
 
 ## Available Targets
 
-| Target | Description | Input |
-|--------|-------------|-------|
-| `fuzz_decode_block` | CBOR block deserialization | Raw bytes fed to `decode_block()` |
-| `fuzz_decode_transaction` | CBOR transaction deserialization (all eras) | Raw bytes fed to `decode_transaction()` |
-| `fuzz_mux_segment` | Ouroboros multiplexer segment parsing | Raw bytes fed to `Segment::decode()` |
-| `fuzz_nonce_update` | Evolving nonce blake2b computation | Arbitrary-length bytes simulating VRF output |
+The current target list is the authoritative source — run
+
+```bash
+cargo +nightly fuzz list
+```
+
+to enumerate all fuzz binaries. Highlights:
+
+| Target | Description |
+|--------|-------------|
+| `fuzz_decode_block` | Multi-era CBOR block deserialization |
+| `fuzz_byron_block_decode` | Byron-era block decoder (issue #613) — calls `decode_byron_main_block` / `decode_byron_ebb_block` directly |
+| `fuzz_decode_transaction` | CBOR transaction deserialization (all eras) |
+| `fuzz_dugite_uplc_program_decode` | In-house UPLC `Program::{from_cbor, from_flat}` + flat-encoding round-trip |
+| `fuzz_dugite_uplc_data_decode` | In-house `PlutusData::from_cbor` + CBOR round-trip identity |
+| `fuzz_plutus_data_decode` | Upstream Aiken `uplc::plutus_data` (sanity-check) |
+| `fuzz_plutus_script_decode` | Upstream Aiken `Program::from_cbor` / `from_flat` — **CI-excluded** (upstream panics in `pallas_codec` and `uplc::tx`) |
+| `fuzz_body_hash` | `validate_block_body_hash` round-trip + invariant checks |
+| `fuzz_nonce_update` | Evolving nonce blake2b computation |
+
+> ⚠️ The in-house `fuzz_dugite_uplc_*` targets are the **production** path
+> for phase-2 validation. The upstream `fuzz_plutus_*` targets exercise
+> the Aiken `uplc` crate only and are useful for parity checking, not
+> for catching dugite DoS surface.
 
 ## Running a Target
 

--- a/fuzz/fuzz_targets/body_hash.rs
+++ b/fuzz/fuzz_targets/body_hash.rs
@@ -1,28 +1,46 @@
 //! Fuzz target for block body-hash verification (issue #545 E5).
 //!
-//! `validate_block_body_hash` computes `blake2b_256(body_bytes)` and compares
-//! it against `header.body_hash`. This target verifies:
-//!   1. The check never panics on arbitrary body bytes or header hashes.
-//!   2. When the header hash exactly matches blake2b_256(body), the check passes.
-//!   3. When the header hash does NOT match, the check returns `BodyHashMismatch`
-//!      with consistent fields (header_hash == supplied hash, computed == actual).
-//!   4. `extract_block_body_cbor` never panics on arbitrary raw CBOR.
+//! `validate_block_body_hash(header, raw_block_cbor)` extracts the inner body
+//! components from a wrapped block CBOR (`[era_tag, [header, c_0, ..., c_N]]`)
+//! and computes
+//!
+//!   `bbHash = blake2b_256( blake2b_256(c_0) || ... || blake2b_256(c_N) )`
+//!
+//! before comparing against `header.body_hash`. See
+//! `dugite_consensus::praos::compute_block_body_hash`.
+//!
+//! Invariants this target exercises:
+//!   1. Neither `validate_block_body_hash` nor `extract_block_body_cbor` /
+//!      `extract_block_body_components` may panic on arbitrary input.
+//!   2. When the header is populated with the *correctly computed* hash
+//!      (`compute_block_body_hash(components)`), `validate_block_body_hash`
+//!      must return `Ok` — round-trip soundness.
+//!   3. When the header hash is supplied by the fuzzer (and statistically
+//!      will not match), the function must return `Ok`, `BodyExtractionFailed`,
+//!      or `BodyHashMismatch` with self-consistent fields. No other error
+//!      variant is permitted from this path.
 //!
 //! Byte layout:
-//!   [0..32]  = header.body_hash bytes (what the header claims)
+//!   [0..32]  = header.body_hash bytes (used iff the "matching hash" mode is
+//!              not selected, see control byte).
 //!   [32]     = control byte:
-//!                bit 0: if set, overwrite header hash with blake2b_256(body) → expect Ok
-//!                bit 1: if set, pass the raw block wrapper bytes through extract_block_body_cbor
-//!   [33..]   = body bytes (the block body CBOR, passed to validate_block_body_hash)
+//!                bit 0 set : populate header.body_hash with the correct hash
+//!                            computed from the extracted components (round-
+//!                            trip mode). Falls back to the fuzzer-supplied
+//!                            bytes when extraction fails.
+//!                bit 1 set : additionally run `extract_block_body_cbor` for
+//!                            panic coverage.
+//!   [33..]   = candidate raw block CBOR.
 //!
 //! Run with: cargo +nightly fuzz run fuzz_body_hash -- -max_total_time=300
 
 #![no_main]
 
-use dugite_consensus::praos::{validate_block_body_hash, ConsensusError};
+use dugite_consensus::praos::{compute_block_body_hash, validate_block_body_hash, ConsensusError};
 use dugite_primitives::block::{BlockHeader, OperationalCert, ProtocolVersion, VrfOutput};
 use dugite_primitives::hash::Hash32;
 use dugite_primitives::time::{BlockNo, SlotNo};
+use dugite_serialization::{extract_block_body_cbor, extract_block_body_components};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -30,25 +48,27 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
 
-    // Parse header body_hash from first 32 bytes.
-    let hash_bytes: [u8; 32] = data[0..32].try_into().unwrap();
+    let supplied_hash_bytes: [u8; 32] = data[0..32].try_into().unwrap();
     let control = data[32];
     let body_bytes = &data[33..];
 
-    let make_match = (control & 1) != 0;
+    let round_trip = (control & 1) != 0;
     let test_extract = (control & 2) != 0;
 
-    // Exercise extract_block_body_cbor on raw bytes — must never panic.
     if test_extract {
-        let _ = dugite_serialization::extract_block_body_cbor(body_bytes);
+        let _ = extract_block_body_cbor(body_bytes);
     }
 
-    // Determine the claimed body_hash in the header.
-    let claimed_hash = if make_match {
-        // Compute the correct hash so validate_block_body_hash must return Ok.
-        dugite_primitives::hash::blake2b_256(body_bytes)
-    } else {
-        Hash32::from_bytes(hash_bytes)
+    // Try the actual extraction once so we know whether `round_trip` mode
+    // can construct a hash that the validator will accept.
+    let extracted = extract_block_body_components(body_bytes);
+    let supplied_hash = Hash32::from_bytes(supplied_hash_bytes);
+    let claimed_hash = match (round_trip, &extracted) {
+        (true, Some(components)) => compute_block_body_hash(components),
+        // Round-trip requested but no extractable components: fall through
+        // to the fuzzer-supplied hash; the validator will return
+        // BodyExtractionFailed, which is a legal outcome.
+        _ => supplied_hash,
     };
 
     let header = BlockHeader {
@@ -78,34 +98,52 @@ fuzz_target!(|data: &[u8]| {
         prev_nonce: None,
     };
 
-    // validate_block_body_hash must never panic.
     let result = validate_block_body_hash(&header, body_bytes);
 
-    if make_match {
-        // Hash was constructed to match → must succeed.
-        assert!(
-            result.is_ok(),
-            "validate_block_body_hash must return Ok when hashes match: {result:?}"
-        );
-    } else {
-        // Hash may or may not match depending on body_bytes content.
-        // Either outcome is valid, but the error shape must be consistent.
-        if let Err(ConsensusError::BodyHashMismatch {
-            header_hash,
-            computed_hash,
-        }) = result
-        {
-            // The header_hash in the error must equal what we put in the header.
+    let extracted_ok = extracted.is_some();
+    match (&result, round_trip, extracted_ok) {
+        // Sound outcomes.
+        (Ok(()), _, _) => {
+            // If we entered round-trip mode with a successful extraction, Ok
+            // is mandatory; if we're here that holds. If round_trip=false and
+            // Ok fires, the fuzzer guessed the right hash — fine.
+        }
+        (Err(ConsensusError::BodyExtractionFailed), _, false) => {
+            // Extraction reported failure; the validator must report the same.
+        }
+        (Err(ConsensusError::BodyExtractionFailed), _, true) => panic!(
+            "validate_block_body_hash returned BodyExtractionFailed but \
+             extract_block_body_components succeeded on the same input — \
+             extractors must agree"
+        ),
+        (
+            Err(ConsensusError::BodyHashMismatch {
+                header_hash,
+                computed_hash,
+            }),
+            false,
+            true,
+        ) => {
             assert_eq!(
-                header_hash, claimed_hash,
+                *header_hash, claimed_hash,
                 "BodyHashMismatch.header_hash must equal header.body_hash"
             );
-            // The computed hash must NOT equal the header hash (that's why it failed).
             assert_ne!(
-                header_hash, computed_hash,
+                *header_hash, *computed_hash,
                 "BodyHashMismatch.computed_hash must differ from header_hash"
             );
         }
-        // Ok(()) is also valid if hash_bytes happen to be blake2b_256(body_bytes).
+        (Err(ConsensusError::BodyHashMismatch { .. }), true, true) => panic!(
+            "round_trip mode + successful extraction must yield Ok, got \
+             BodyHashMismatch: {result:?}"
+        ),
+        (Err(ConsensusError::BodyHashMismatch { .. }), _, false) => panic!(
+            "BodyHashMismatch fired but extraction returned None — \
+             validator should have returned BodyExtractionFailed instead"
+        ),
+        (Err(other), _, _) => panic!(
+            "validate_block_body_hash may only return Ok, BodyExtractionFailed, \
+             or BodyHashMismatch; got: {other:?}"
+        ),
     }
 });

--- a/fuzz/fuzz_targets/byron_block_decode.rs
+++ b/fuzz/fuzz_targets/byron_block_decode.rs
@@ -1,0 +1,46 @@
+//! Fuzz target for the Byron-era block decoders (issue #613).
+//!
+//! `decode_block` covers all eras but under random mutation the fuzzer
+//! converges on Shelley+ era tags because they have richer downstream
+//! structure. Byron has been comparatively under-fuzzed; the current focus
+//! issue #613 is hardening the Byron block-header decode path.
+//!
+//! Calls the Byron-specific inner decoders directly via the re-exports in
+//! `dugite_serialization::decode_byron_main_block` /
+//! `decode_byron_ebb_block`. This bypasses the era envelope so every byte
+//! the fuzzer mutates is fed straight into the Byron decoder — maximum
+//! coverage density.
+//!
+//! Byte layout:
+//!   [0]      control byte
+//!              bit 0 set → main block (decode_byron_main_block)
+//!              bit 0 clear → EBB block (decode_byron_ebb_block)
+//!   [1..9]   little-endian u64 byron_epoch_length, clamped to [1, 2^20]
+//!            to avoid useless overflow inside slot arithmetic
+//!   [9..]    inner Byron CBOR — fed verbatim into the Byron decoder
+//!
+//! Property: the Byron decoders must never panic, abort, or hit an integer
+//! overflow on arbitrary input. They may only return Err.
+//!
+//! Run with:
+//!   cargo +nightly fuzz run fuzz_byron_block_decode -- -max_total_time=300
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 10 {
+        return;
+    }
+    let control = data[0];
+    let epoch_len_raw = u64::from_le_bytes(data[1..9].try_into().unwrap());
+    let byron_epoch_length = (epoch_len_raw & 0x000F_FFFF).max(1);
+    let inner = &data[9..];
+
+    if (control & 1) != 0 {
+        let _ = dugite_serialization::decode_byron_main_block(inner, byron_epoch_length);
+    } else {
+        let _ = dugite_serialization::decode_byron_ebb_block(inner, byron_epoch_length);
+    }
+});

--- a/fuzz/fuzz_targets/dugite_uplc_data_decode.rs
+++ b/fuzz/fuzz_targets/dugite_uplc_data_decode.rs
@@ -1,0 +1,44 @@
+//! Fuzz target for the **in-house** dugite-uplc `Data::from_cbor` decoder.
+//!
+//! `dugite_uplc::Data::from_cbor` is the production decoder used by
+//! phase-2 script validation to materialise datums, redeemers, and inline
+//! UTxO datums. Defensive invariants the decoder documents:
+//!   - depth cap (`DATA_MAX_DEPTH`)
+//!   - 64-byte chunk cap on definite-length byte / bignum chunks
+//!   - clamped `Vec::with_capacity`
+//!   - rejection of trailing bytes
+//!
+//! Any panic, OOM, or successful decode that fails to re-encode round-trip
+//! is a real DoS / consensus-divergence finding. `Data` round-trip via
+//! `to_cbor()` followed by `from_cbor()` must be the identity on every
+//! decodable input (this is required for byte-exact datum hashing).
+//!
+//! Run with:
+//!   cargo +nightly fuzz run fuzz_dugite_uplc_data_decode -- -max_total_time=300
+
+#![no_main]
+
+use dugite_uplc::Data;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(decoded) = Data::from_cbor(data) else {
+        return;
+    };
+
+    let re_encoded = match decoded.to_cbor() {
+        Ok(b) => b,
+        Err(e) => panic!("Data::to_cbor failed on a decoded value: {e:?}"),
+    };
+
+    match Data::from_cbor(&re_encoded) {
+        Ok(rt) => assert_eq!(
+            decoded, rt,
+            "Data::from_cbor ∘ to_cbor must be the identity"
+        ),
+        Err(e) => panic!(
+            "decoded Data failed to round-trip through to_cbor → from_cbor: \
+             {e:?}"
+        ),
+    }
+});

--- a/fuzz/fuzz_targets/dugite_uplc_program_decode.rs
+++ b/fuzz/fuzz_targets/dugite_uplc_program_decode.rs
@@ -1,0 +1,67 @@
+//! Fuzz target for the **in-house** dugite-uplc program decoder.
+//!
+//! `dugite_uplc::Program::{from_cbor, from_flat}` is the production decoder
+//! used by phase-2 script validation in dugite-ledger; the previously-existing
+//! `fuzz_plutus_script_decode` only exercises the upstream Aiken `uplc` crate,
+//! which is **not** the implementation that runs in production. Any panic or
+//! out-of-bounds read in this target is a real DoS finding.
+//!
+//! Defensive properties checked here:
+//!   1. Neither `from_cbor` nor `from_flat` may panic on arbitrary input.
+//!   2. If decoding succeeds, the resulting program must round-trip via
+//!      `to_flat()` and re-decode to a structurally identical program. This
+//!      guards against decoder/encoder asymmetry that has historically been
+//!      a source of subtle script-hash divergences.
+//!
+//! Byte layout:
+//!   [0]    mode select:
+//!            bit 0 clear → exercise `Program::from_cbor`
+//!            bit 0 set   → exercise `Program::from_flat`
+//!   [1..]  payload bytes.
+//!
+//! Run with:
+//!   cargo +nightly fuzz run fuzz_dugite_uplc_program_decode -- -max_total_time=300
+
+#![no_main]
+
+use dugite_uplc::Program;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+    let mode = data[0] & 1;
+    let payload = &data[1..];
+
+    let decoded = if mode == 0 {
+        Program::from_cbor(payload)
+    } else {
+        Program::from_flat(payload)
+    };
+
+    let Ok(program) = decoded else {
+        return;
+    };
+
+    // Round-trip via flat encoding.
+    let re_encoded = match program.to_flat() {
+        Ok(b) => b,
+        // Encoder failures on a valid program are themselves a finding.
+        Err(e) => panic!("Program::to_flat failed on decoded program: {e:?}"),
+    };
+    match Program::from_flat(&re_encoded) {
+        Ok(round_trip) => assert_eq!(
+            program,
+            round_trip,
+            "Program::from_flat ∘ to_flat must be the identity \
+             (mode={mode}, len={len})",
+            len = payload.len()
+        ),
+        Err(e) => panic!(
+            "decoded program failed to re-decode after to_flat (mode={mode}, \
+             len={len}): {e:?}",
+            len = payload.len()
+        ),
+    }
+});


### PR DESCRIPTION
## Summary

Smoke-running all existing fuzz targets surfaced two failures:

- **`fuzz_body_hash`** was wired wrong: it computed `blake2b_256(body_bytes)` and asserted `Ok`, but `validate_block_body_hash` runs `extract_block_body_components` first and computes a structured bbHash (`blake2b_256( concat(blake2b_256(c_i)) )`), so the round-trip assertion was vacuous. The target was never in CI either, which is why this latent bug wasn't caught earlier.
- **`fuzz_plutus_script_decode`** crashes in `pallas_codec::flat::Decoder::word` — already documented as a known upstream issue and explicitly CI-excluded.

### Fixes
- Rewrite `fuzz_body_hash` to compute the actual round-trip hash via `compute_block_body_hash(extracted_components)` when in `round_trip` mode, and fall back to `BodyExtractionFailed` when extraction returns `None`. Adds invariant: validator and component extractor must agree on extractability.
- Wire `fuzz_body_hash` into `.github/workflows/fuzz.yml`.

### New fuzz targets
- **`fuzz_dugite_uplc_program_decode`** — in-house `Program::{from_cbor, from_flat}` + flat-encoding round-trip identity. The production phase-2 decoder; the existing `fuzz_plutus_script_decode` only covered the upstream Aiken decoder.
- **`fuzz_dugite_uplc_data_decode`** — in-house `Data::from_cbor` + CBOR round-trip identity (required for byte-exact datum hashing).
- **`fuzz_byron_block_decode`** (issue #613) — calls `decode_byron_main_block` / `decode_byron_ebb_block` directly. Random mutation through the generic `decode_block` envelope converges on richer Shelley+ tags and starves Byron coverage; direct invocation gives ~18× higher new-edge density (290 vs 16 new units in equivalent time).

### Side change
Re-exported `decode_byron_{main,ebb}_block` from `dugite_serialization` (previously `pub(crate)`) so the fuzz harness — and external tooling like Mithril chunk inspection — can call the Byron path directly.

### Status
- Before: **48 / 50** targets pass smoke run
- After: **52 / 53** targets pass smoke run (single remaining failure is the documented CI-excluded upstream-bug surface)
- `cargo nextest run -p dugite-serialization` → 1105 / 1105 pass
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo +nightly fmt` clean on changed files

## Test plan
- [x] Build all 53 fuzz targets (`cargo +nightly fuzz build`)
- [x] 10s smoke of every target (`fuzz_plutus_script_decode` excluded — upstream)
- [x] Extended 60s runs on `fuzz_body_hash`, `fuzz_byron_block_decode`, `fuzz_dugite_uplc_program_decode`, `fuzz_dugite_uplc_data_decode` — clean
- [x] `dugite-serialization` test suite green after re-exports
- [ ] CI fuzz workflow runs (nightly schedule + workflow_dispatch)