### PR TITLE
feat(rpc): dugite-rpc scaffold + service stubs (#672 M1.A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install protoc
+        # dugite-rpc's build.rs invokes tonic-build → prost-build → protoc to
+        # codegen the vendored utxorpc/spec proto files. See issue #672.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -72,6 +76,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -124,6 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -191,6 +201,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -241,6 +253,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install protoc (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +279,53 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1612,7 +1681,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "socket2",
+ "socket2 0.6.3",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1659,7 +1728,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "socket2",
+ "socket2 0.6.3",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -1695,6 +1764,33 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "dugite-rpc"
+version = "1.7.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "dugite-mempool",
+ "dugite-primitives",
+ "futures",
+ "hex",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-build",
+ "tonic-reflection",
+ "tonic-web",
+ "tracing",
 ]
 
 [[package]]
@@ -2010,6 +2106,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2512,6 +2614,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,7 +2643,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2759,7 +2874,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2",
+ "socket2 0.6.3",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -3069,6 +3184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3478,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netlink-packet-core"
@@ -3803,6 +3930,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,6 +3989,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3991,6 +4148,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,7 +4228,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4057,7 +4266,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4403,8 +4612,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4447,8 +4656,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4531,6 +4740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4549,6 +4759,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5068,6 +5287,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -5339,7 +5568,7 @@ dependencies = [
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -5507,7 +5736,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5530,6 +5759,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -5586,6 +5826,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5596,6 +5936,22 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]
@@ -5613,7 +5969,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,7 @@ version = "1.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "base64 0.22.1",
  "bech32",
  "bs58",
@@ -1707,6 +1708,7 @@ dependencies = [
  "dugite-mempool",
  "dugite-network",
  "dugite-primitives",
+ "dugite-rpc",
  "dugite-serialization",
  "dugite-storage",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default-members = [
     "crates/dugite-monitor",
     "crates/dugite-config",
     "crates/dugite-uplc",
+    "crates/dugite-rpc",
     "tests/conformance",
     "tests/golden",
 ]
@@ -35,6 +36,7 @@ members = [
     "crates/dugite-monitor",
     "crates/dugite-config",
     "crates/dugite-uplc",
+    "crates/dugite-rpc",
     "tests/conformance",
     "tests/golden",
 ]
@@ -62,6 +64,7 @@ dugite-cli = { path = "crates/dugite-cli" }
 dugite-lsm = { path = "crates/dugite-lsm" }
 dugite-monitor = { path = "crates/dugite-monitor" }
 dugite-uplc = { path = "crates/dugite-uplc" }
+dugite-rpc = { path = "crates/dugite-rpc" }
 
 # Terminal UI
 ratatui = "0.30"
@@ -86,8 +89,23 @@ rand_chacha = "0.9"
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 futures = "0.3"
 async-trait = "0.1"
+
+# UTxO RPC (gRPC) — see crates/dugite-rpc. The proto files are vendored at
+# crates/dugite-rpc/proto/ (pinned to utxorpc/spec; refresh via
+# `just bump-utxorpc-spec`). `dugite-rpc` is the ONLY workspace crate that
+# depends on tonic/prost — dugite-node consumes the RPC server as an opaque
+# library, keeping the gRPC stack out of the node binary's transitive graph
+# when the RPC server is disabled.
+tonic = { version = "0.12", features = ["transport", "tls", "gzip"] }
+tonic-web = "0.12"
+tonic-reflection = "0.12"
+prost = "0.13"
+prost-types = "0.13"
+tonic-build = { version = "0.12", features = ["prost"] }
+prost-build = "0.13"
 
 # Networking
 tokio-tungstenite = "0.24"

--- a/crates/dugite-config/src/schema.rs
+++ b/crates/dugite-config/src/schema.rs
@@ -928,6 +928,38 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
                       Raise delay (up to 30s) to slow down aggressive inbound peers.",
         reloadability: Reloadability::Restart,
     },
+    // --- Rpc section ------------------------------------------------------
+    //
+    // UTxO RPC (gRPC) server — issue #672. The full block is exposed as
+    // a read-only Object so operators can see what's configured at a
+    // glance; edits to sub-fields go through the config JSON directly.
+    // CLI flags --rpc-host / --rpc-port / --no-rpc override at startup.
+    ParamDef {
+        key: "Rpc",
+        section: "Rpc",
+        param_type: ParamType::Object,
+        // Empty object → server disabled. Operators opt in by setting
+        // "Enabled": true and tuning the remaining fields.
+        default: "{}",
+        description: "UTxO RPC (gRPC) server configuration. Sub-fields (all PascalCase): \
+                      'Enabled': bool (default false — server off unless explicitly enabled); \
+                      'ListenAddr': bind IP, default '127.0.0.1' (loopback only); \
+                      'Port': TCP port, default 50051; \
+                      'MaxConcurrentStreams': HTTP/2 streams/conn cap (default 64); \
+                      'StreamBufferSize': per-stream event buffer (default 256); \
+                      'ReflectionEnabled': bool, gRPC reflection (default true); \
+                      'WebEnabled': bool, accept gRPC-Web/HTTP1.1 (default false); \
+                      'AlphaEnabled': bool, expose v1alpha alongside v1beta (default true); \
+                      'Tls': { 'CertPath', 'KeyPath' } for optional TLS termination. \
+                      CLI flags --rpc-host / --rpc-port force-enable; --no-rpc force-disables.",
+        tuning_hint: "Default-disabled to keep the gRPC stack out of the runtime when \
+                      not needed. Enable for integrator/indexer workloads. Keep ListenAddr \
+                      as 127.0.0.1 unless you've terminated TLS at an upstream proxy or \
+                      enabled 'Tls' here directly — the loopback default protects against \
+                      exposing an unauthenticated TCP gRPC endpoint to the network. \
+                      Enable WebEnabled only when serving browser dApps directly.",
+        reloadability: Reloadability::Restart,
+    },
     // --- Storage section --------------------------------------------------
     ParamDef {
         key: "Storage",
@@ -985,6 +1017,7 @@ pub const SECTION_ORDER: &[&str] = &[
     "Advanced",
     "Diffusion",
     "Storage",
+    "Rpc",
 ];
 
 /// Return the display priority index of a section name (lower = earlier).

--- a/crates/dugite-node/Cargo.toml
+++ b/crates/dugite-node/Cargo.toml
@@ -26,6 +26,8 @@ dugite-consensus = { workspace = true }
 dugite-ledger = { workspace = true }
 dugite-mempool = { workspace = true }
 dugite-storage = { workspace = true }
+dugite-rpc = { workspace = true }
+async-trait = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 clap = { workspace = true }

--- a/crates/dugite-node/src/config.rs
+++ b/crates/dugite-node/src/config.rs
@@ -53,6 +53,83 @@ pub fn resolve_consensus_mode(
     }
 }
 
+/// Resolve the effective UTxO RPC config from CLI + JSON config —
+/// issue #672.
+///
+/// Precedence (highest first):
+///   1. `--no-rpc` → server disabled (returns `None`).
+///   2. `--rpc-host` / `--rpc-port` set → server enabled, CLI values
+///      override config values.
+///   3. `config.rpc.enabled` true → server enabled with the config-file
+///      values.
+///   4. Otherwise → server disabled (returns `None`).
+///
+/// Returns the constructed `dugite_rpc::RpcConfig` ready to hand to
+/// [`dugite_rpc::RpcServer::start`], or `None` if the server should not
+/// start.
+pub fn resolve_rpc(
+    no_rpc: bool,
+    cli_host: Option<&str>,
+    cli_port: Option<u16>,
+    config: Option<&RpcConfigJson>,
+) -> Result<Option<dugite_rpc::RpcConfig>, String> {
+    if no_rpc {
+        return Ok(None);
+    }
+
+    // CLI presence forces enable; otherwise fall back to config.enabled.
+    let cli_present = cli_host.is_some() || cli_port.is_some();
+    let cfg_enabled = config.map(|c| c.enabled).unwrap_or(false);
+    if !cli_present && !cfg_enabled {
+        return Ok(None);
+    }
+
+    let mut out = dugite_rpc::RpcConfig::default();
+
+    if let Some(cfg) = config {
+        if let Some(ref addr) = cfg.listen_addr {
+            out.bind = addr
+                .parse::<std::net::IpAddr>()
+                .map_err(|e| format!("Rpc.ListenAddr is not a valid IP address: {e}"))?;
+        }
+        if let Some(p) = cfg.port {
+            out.port = p;
+        }
+        if let Some(n) = cfg.max_concurrent_streams {
+            out.max_concurrent_streams = n;
+        }
+        if let Some(n) = cfg.stream_buffer_size {
+            out.stream_buffer = n;
+        }
+        if let Some(b) = cfg.reflection_enabled {
+            out.reflection_enabled = b;
+        }
+        if let Some(b) = cfg.web_enabled {
+            out.web_enabled = b;
+        }
+        if let Some(b) = cfg.alpha_enabled {
+            out.alpha_enabled = b;
+        }
+        if let Some(ref tls) = cfg.tls {
+            out.tls = Some(dugite_rpc::RpcTlsConfig {
+                cert_path: tls.cert_path.clone(),
+                key_path: tls.key_path.clone(),
+            });
+        }
+    }
+
+    if let Some(host) = cli_host {
+        out.bind = host
+            .parse::<std::net::IpAddr>()
+            .map_err(|e| format!("--rpc-host is not a valid IP address: {e}"))?;
+    }
+    if let Some(port) = cli_port {
+        out.port = port;
+    }
+
+    Ok(Some(out))
+}
+
 /// Inbound connection limits (matches Haskell AcceptedConnectionsLimit).
 ///
 /// Haskell's hand-written `FromJSON` instance uses short keys (`hardLimit`,
@@ -266,6 +343,15 @@ pub struct NodeConfig {
     #[serde(default)]
     pub storage: Option<StorageConfigJson>,
 
+    /// UTxO RPC (gRPC) server configuration — issue #672.
+    ///
+    /// `None` (or absent) leaves the RPC server disabled. When present
+    /// the `Enabled` field gates startup; CLI flags `--no-rpc`,
+    /// `--rpc-host`, `--rpc-port` override. See `resolve_rpc()` for the
+    /// full precedence table.
+    #[serde(default)]
+    pub rpc: Option<RpcConfigJson>,
+
     /// Governor churn interval during normal (caught-up) operation, in seconds.
     ///
     /// Controls how often the governor rotates a random subset of peers to
@@ -392,7 +478,53 @@ pub struct Protocol {
     pub requires_network_magic: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// UTxO RPC server configuration — issue #672.
+///
+/// Mirrors `dugite_rpc::RpcConfig` for the JSON wire format with
+/// PascalCase keys to match the surrounding cardano-node-style config.
+/// `Enabled` defaults to `false` so an `Rpc` block present in the file
+/// must opt-in to start the server.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RpcConfigJson {
+    /// Whether to start the RPC server. Overridden by `--rpc-port`/
+    /// `--rpc-host` (forces on) and `--no-rpc` (forces off).
+    #[serde(default)]
+    pub enabled: bool,
+    /// IP address to bind. Defaults to `127.0.0.1` (loopback only).
+    #[serde(default)]
+    pub listen_addr: Option<String>,
+    /// TCP port. Defaults to `dugite_rpc::config::DEFAULT_RPC_PORT` (50051).
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// Maximum concurrent HTTP/2 streams per connection.
+    #[serde(default)]
+    pub max_concurrent_streams: Option<u32>,
+    /// Per-stream buffer size (events).
+    #[serde(default)]
+    pub stream_buffer_size: Option<usize>,
+    /// Expose gRPC reflection. Defaults to true.
+    #[serde(default)]
+    pub reflection_enabled: Option<bool>,
+    /// Accept gRPC-Web (HTTP/1.1). Defaults to false.
+    #[serde(default)]
+    pub web_enabled: Option<bool>,
+    /// Expose v1alpha services in addition to v1beta. Defaults to true.
+    #[serde(default)]
+    pub alpha_enabled: Option<bool>,
+    /// Optional TLS termination.
+    #[serde(default)]
+    pub tls: Option<RpcTlsConfigJson>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RpcTlsConfigJson {
+    pub cert_path: std::path::PathBuf,
+    pub key_path: std::path::PathBuf,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct TraceOptions {
     #[serde(default)]
@@ -846,6 +978,7 @@ impl Default for NodeConfig {
             log_directive: None,
             metrics_port: None,
             storage: None,
+            rpc: None,
             churn_interval_normal_secs: default_churn_interval_normal_secs(),
             churn_interval_sync_secs: default_churn_interval_sync_secs(),
             stall_demotion_cycles: default_stall_demotion_cycles(),
@@ -1089,6 +1222,100 @@ mod tests {
         // Setting MetricsPort=0 in the config file should also disable the server.
         assert_eq!(resolve_metrics_port(false, None, Some(0)), 0);
     }
+
+    // ── RPC config resolution (#672 M1.A) ────────────────────────────────────
+
+    fn empty_rpc_json(enabled: bool) -> RpcConfigJson {
+        RpcConfigJson {
+            enabled,
+            listen_addr: None,
+            port: None,
+            max_concurrent_streams: None,
+            stream_buffer_size: None,
+            reflection_enabled: None,
+            web_enabled: None,
+            alpha_enabled: None,
+            tls: None,
+        }
+    }
+
+    #[test]
+    fn rpc_resolve_no_rpc_flag_wins_over_all() {
+        let cfg = empty_rpc_json(true);
+        let out = resolve_rpc(true, Some("0.0.0.0"), Some(9999), Some(&cfg)).expect("resolve");
+        assert!(out.is_none(), "--no-rpc must disable regardless");
+    }
+
+    #[test]
+    fn rpc_resolve_returns_none_when_disabled_and_no_cli() {
+        let cfg = empty_rpc_json(false);
+        let out = resolve_rpc(false, None, None, Some(&cfg)).expect("resolve");
+        assert!(out.is_none());
+        let out2 = resolve_rpc(false, None, None, None).expect("resolve");
+        assert!(out2.is_none());
+    }
+
+    #[test]
+    fn rpc_resolve_cli_port_alone_enables_server() {
+        let out = resolve_rpc(false, None, Some(7777), None)
+            .expect("resolve")
+            .expect("Some(config)");
+        assert_eq!(out.port, 7777);
+        assert_eq!(out.bind, std::net::IpAddr::from([127, 0, 0, 1]));
+    }
+
+    #[test]
+    fn rpc_resolve_cli_host_alone_enables_server() {
+        let out = resolve_rpc(false, Some("0.0.0.0"), None, None)
+            .expect("resolve")
+            .expect("Some(config)");
+        assert_eq!(out.port, dugite_rpc::config::DEFAULT_RPC_PORT);
+        assert_eq!(out.bind, std::net::IpAddr::from([0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn rpc_resolve_cli_overrides_config() {
+        let mut cfg = empty_rpc_json(true);
+        cfg.port = Some(1000);
+        cfg.listen_addr = Some("10.0.0.1".into());
+        let out = resolve_rpc(false, Some("0.0.0.0"), Some(2000), Some(&cfg))
+            .expect("resolve")
+            .expect("Some(config)");
+        assert_eq!(out.port, 2000);
+        assert_eq!(out.bind, std::net::IpAddr::from([0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn rpc_resolve_config_only_uses_config_values() {
+        let mut cfg = empty_rpc_json(true);
+        cfg.port = Some(54321);
+        cfg.listen_addr = Some("192.168.1.10".into());
+        cfg.web_enabled = Some(true);
+        cfg.alpha_enabled = Some(false);
+        let out = resolve_rpc(false, None, None, Some(&cfg))
+            .expect("resolve")
+            .expect("Some(config)");
+        assert_eq!(out.port, 54321);
+        assert_eq!(out.bind, std::net::IpAddr::from([192, 168, 1, 10]));
+        assert!(out.web_enabled);
+        assert!(!out.alpha_enabled);
+    }
+
+    #[test]
+    fn rpc_resolve_rejects_malformed_addr() {
+        let mut cfg = empty_rpc_json(true);
+        cfg.listen_addr = Some("not-an-ip".into());
+        let err = resolve_rpc(false, None, None, Some(&cfg)).unwrap_err();
+        assert!(err.to_lowercase().contains("rpc.listenaddr") || err.contains("IP"));
+    }
+
+    #[test]
+    fn rpc_resolve_rejects_malformed_cli_host() {
+        let err = resolve_rpc(false, Some("not-an-ip"), Some(1), None).unwrap_err();
+        assert!(err.to_lowercase().contains("rpc-host") || err.contains("IP"));
+    }
+
+    // ── existing metrics tests follow ────────────────────────────────────────
 
     #[test]
     fn test_default_metrics_port_matches_cardano_node() {

--- a/crates/dugite-node/src/main.rs
+++ b/crates/dugite-node/src/main.rs
@@ -9,6 +9,7 @@ mod logging;
 mod metrics;
 mod mithril;
 mod node;
+mod rpc_adapter;
 mod startup;
 mod topology;
 mod verify_snapshot;
@@ -177,6 +178,28 @@ struct RunArgs {
     /// failure rather than a silent degradation.
     #[arg(long)]
     require_metrics: bool,
+
+    /// UTxO RPC (gRPC) server bind address (issue #672).
+    ///
+    /// Overrides the `Rpc.ListenAddr` value from the config file. Defaults
+    /// to `127.0.0.1` when the server is enabled.
+    #[arg(long)]
+    rpc_host: Option<String>,
+
+    /// UTxO RPC (gRPC) server port (issue #672).
+    ///
+    /// Overrides the `Rpc.Port` value from the config file. Implies
+    /// enabling the RPC server. Defaults to `50051` when set via the
+    /// config file. Pass `--no-rpc` to disable.
+    #[arg(long)]
+    rpc_port: Option<u16>,
+
+    /// Disable the UTxO RPC (gRPC) server entirely (issue #672).
+    ///
+    /// Takes precedence over `--rpc-host`, `--rpc-port`, and the
+    /// `Rpc.Enabled` config-file field.
+    #[arg(long)]
+    no_rpc: bool,
 
     /// Also emit `cardano_node_metrics_*` compatibility aliases in the Prometheus
     /// output alongside the native `dugite_*` metrics.
@@ -1505,6 +1528,29 @@ async fn run_node(args: RunArgs, log_handle: Option<logging::LogHandle>) -> Resu
         node_config.metrics_port.unwrap_or(DEFAULT_METRICS_PORT)
     };
 
+    // Resolve effective UTxO RPC config (#672 M1.A). See
+    // config::resolve_rpc for the precedence table.
+    let rpc_config = config::resolve_rpc(
+        args.no_rpc,
+        args.rpc_host.as_deref(),
+        args.rpc_port,
+        node_config.rpc.as_ref(),
+    )
+    .map_err(|e| anyhow::anyhow!("invalid RPC config: {e}"))?;
+    if let Some(ref rc) = rpc_config {
+        info!(
+            bind = %rc.bind,
+            port = rc.port,
+            reflection = rc.reflection_enabled,
+            web = rc.web_enabled,
+            alpha = rc.alpha_enabled,
+            tls = rc.tls.is_some(),
+            "UTxO RPC (gRPC) server enabled"
+        );
+    } else {
+        info!("UTxO RPC (gRPC) server disabled");
+    }
+
     // Load topology
     let topology = topology::Topology::load(&args.topology)?;
     let all_peers = topology.all_peers();
@@ -1589,6 +1635,7 @@ async fn run_node(args: RunArgs, log_handle: Option<logging::LogHandle>) -> Resu
         shelley_vrf_key: args.shelley_vrf_key,
         shelley_operational_certificate: args.shelley_operational_certificate,
         _shelley_cold_key: args.shelley_cold_key,
+        rpc_config,
         metrics_port: effective_metrics_port,
         require_metrics: args.require_metrics,
         compat_metrics: args.compat_metrics,

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -288,6 +288,8 @@ pub struct NodeArgs {
     pub shelley_operational_certificate: Option<PathBuf>,
     /// Path to cold signing key (accepted for cardano-node compatibility)
     pub _shelley_cold_key: Option<PathBuf>,
+    /// UTxO RPC server configuration (None = disabled) — issue #672.
+    pub rpc_config: Option<dugite_rpc::RpcConfig>,
     /// Prometheus metrics port (0 to disable)
     pub metrics_port: u16,
     /// Make a metrics bind failure a fatal startup error (default: continue without metrics)
@@ -423,6 +425,8 @@ pub struct Node {
     /// in additively from the same send sites; consumed by external RPC.
     /// `None` until `run()` initialises it alongside the announcement channels.
     pub(crate) tip_broadcaster: Option<Arc<tip_broadcast::TipBroadcaster>>,
+    /// UTxO RPC server configuration — `None` if disabled (default).
+    pub(crate) rpc_config: Option<dugite_rpc::RpcConfig>,
     /// Prometheus metrics port
     pub(crate) metrics_port: u16,
     /// Make a metrics bind failure fatal (see `--require-metrics`)
@@ -1807,6 +1811,7 @@ impl Node {
             block_announcement_tx: None,
             rollback_announcement_tx: None,
             tip_broadcaster: None,
+            rpc_config: args.rpc_config,
             metrics_port: args.metrics_port,
             require_metrics: args.require_metrics,
             expected_byron_genesis_hash,
@@ -2825,6 +2830,72 @@ impl Node {
             self.rollback_announcement_tx = Some(rollback_ann_tx);
             self.tip_broadcaster = Some(Arc::new(tip_broadcast::TipBroadcaster::new()));
         }
+
+        // ─── UTxO RPC server (#672 M1.A) ───────────────────────────────────
+        //
+        // Starts here so the tip_broadcaster + mempool feeds are both
+        // guaranteed initialised (the broadcaster fallback above ensures
+        // it). Gated entirely on RpcConfig.is_some() — when the operator
+        // hasn't enabled RPC the gRPC stack and listener are never
+        // touched. Service stubs return UNIMPLEMENTED in M1.A; M1.B+
+        // fills SyncService / QueryService / SubmitService / WatchService.
+        if let Some(rpc_cfg) = self.rpc_config.clone() {
+            let adapter = Arc::new(crate::rpc_adapter::NodeRpcAdapter::new(
+                self.mempool.clone(),
+            ));
+            let (tip_feed, tip_publisher) = crate::rpc_adapter::build_tip_feed();
+            // Spawn forwarder: subscribes to the node-side TipBroadcaster
+            // and republishes into the dugite-rpc TipPublisher. Keeps the
+            // RPC crate dep-free of dugite-node.
+            let broadcaster = self
+                .tip_broadcaster
+                .clone()
+                .expect("tip_broadcaster initialised by the fallback above");
+            let _tip_forwarder = crate::rpc_adapter::spawn_tip_forwarder(
+                broadcaster,
+                tip_publisher,
+                shutdown_rx.clone(),
+            );
+            let mempool_feed = dugite_rpc::MempoolFeed::new(self.mempool.tx_events());
+            let rpc_shutdown_rx = shutdown_rx.clone();
+            let rpc_cfg_arc = Arc::new(rpc_cfg);
+            match dugite_rpc::RpcServer::start(
+                rpc_cfg_arc.clone(),
+                adapter,
+                tip_feed,
+                mempool_feed,
+                dugite_rpc::noop_metrics(),
+                rpc_shutdown_rx,
+            )
+            .await
+            {
+                Ok(handle) => {
+                    info!(
+                        local_addr = %handle.local_addr,
+                        "dugite-rpc: UTxO RPC server bound and accepting connections",
+                    );
+                    // We deliberately drop the handle here — the server
+                    // task is rooted by tokio's task tree and shuts down
+                    // cooperatively when shutdown_rx fires. M1.B may
+                    // promote this to a Node field if graceful
+                    // drain-on-error becomes useful.
+                }
+                Err(e) => {
+                    error!(
+                        bind = %rpc_cfg_arc.bind,
+                        port = rpc_cfg_arc.port,
+                        error = %e,
+                        "dugite-rpc: RPC server failed to start"
+                    );
+                    return Err(anyhow::anyhow!(
+                        "RPC server bind failed on {}:{}: {e}",
+                        rpc_cfg_arc.bind,
+                        rpc_cfg_arc.port
+                    ));
+                }
+            }
+        }
+
         // Channel for the N2N listener to send accepted+handshaked connections
         // to the main run loop for lifecycle manager registration.
         let (inbound_accept_tx, mut inbound_accept_rx) = tokio::sync::mpsc::channel::<

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -1,0 +1,206 @@
+//! `NodeRpcAdapter` — the bridge from `dugite-node` internals to the
+//! `dugite-rpc` server's [`LedgerContext`] trait.
+//!
+//! In M1.A every method returns `Unimplemented`; the adapter only needs
+//! to compile + exist so the node can boot the RPC server with all
+//! stubbed services. Subsequent milestones fill in real implementations
+//! as their corresponding service methods land in `dugite-rpc`.
+//!
+//! Forward-shim tasks:
+//!
+//! * [`spawn_tip_forwarder`] subscribes to
+//!   `node::tip_broadcast::TipBroadcaster` and republishes into a
+//!   `dugite_rpc::TipPublisher`, mapping payloads. Lets the RPC layer
+//!   stay dep-free of `dugite-node`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dugite_mempool::Mempool;
+use dugite_primitives::address::Address;
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::transaction::TransactionInput;
+use dugite_rpc::{
+    LedgerContext, ParamsView, RawBlock, RawTx, RpcError, SubmitOutcome, TipFeed, TipInfo,
+    TipPublisher, TipRollback, UtxoSnapshot,
+};
+use tokio::sync::watch;
+use tracing::debug;
+
+use crate::node::tip_broadcast::{TipApply, TipBroadcaster};
+
+/// Concrete impl of [`LedgerContext`] backed by node internals.
+///
+/// M1.A scope: every method returns `Unimplemented`. Holds Arc clones of
+/// the relevant node state so subsequent milestones can fill methods in
+/// without re-plumbing the adapter.
+pub struct NodeRpcAdapter {
+    // Held so that future milestones can fill in real implementations
+    // without re-plumbing the adapter. M1.A doesn't read these.
+    #[allow(dead_code)]
+    pub(crate) mempool: Arc<Mempool>,
+}
+
+impl NodeRpcAdapter {
+    pub fn new(mempool: Arc<Mempool>) -> Self {
+        Self { mempool }
+    }
+}
+
+#[async_trait]
+impl LedgerContext for NodeRpcAdapter {
+    async fn tip(&self) -> Result<TipInfo, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::tip"))
+    }
+
+    async fn block_by_hash(&self, _hash: &Hash32) -> Result<Option<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::block_by_hash"))
+    }
+
+    async fn block_at_slot(&self, _slot: u64) -> Result<Option<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::block_at_slot"))
+    }
+
+    async fn block_after(&self, _slot: u64) -> Result<Option<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::block_after"))
+    }
+
+    async fn intersect(&self, _points: &[Point]) -> Result<Option<Point>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::intersect"))
+    }
+
+    async fn blocks_range(
+        &self,
+        _from_slot: u64,
+        _to_slot: u64,
+        _limit: usize,
+    ) -> Result<Vec<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::blocks_range"))
+    }
+
+    async fn utxo_by_ref(&self, _refs: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::utxo_by_ref"))
+    }
+
+    async fn utxos_by_address(&self, _addr: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::utxos_by_address"))
+    }
+
+    async fn utxos_by_payment_credential(
+        &self,
+        _cred: &Hash32,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(
+            "LedgerContext::utxos_by_payment_credential (no index in v1)",
+        ))
+    }
+
+    async fn utxos_by_asset(
+        &self,
+        _policy: &Hash32,
+        _name: Option<&[u8]>,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::utxos_by_asset"))
+    }
+
+    async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::params_at_tip"))
+    }
+
+    async fn era_history(&self) -> Result<dugite_rpc::EraHistoryView, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::era_history"))
+    }
+
+    async fn genesis(&self) -> Result<dugite_rpc::GenesisView, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::genesis"))
+    }
+
+    async fn submit_tx(&self, _era: u16, _raw_cbor: &[u8]) -> SubmitOutcome {
+        SubmitOutcome::Rejected {
+            reason: "M1.A stub — submit_tx not implemented yet".to_string(),
+        }
+    }
+
+    async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
+        Err(RpcError::Unimplemented("LedgerContext::mempool_snapshot"))
+    }
+
+    async fn mempool_contains(&self, hash: &TransactionHash) -> bool {
+        // Cheap call — mempool exposes Mempool::contains directly.
+        self.mempool.contains(hash)
+    }
+}
+
+/// Spawns a forwarder task that subscribes to the node-side
+/// [`TipBroadcaster`] and republishes payload-shaped events into the
+/// RPC-side [`TipPublisher`]. Exits cleanly when `shutdown_rx` fires
+/// (true) or when the upstream broadcaster has no more senders.
+///
+/// Returns the spawned `JoinHandle` so the host can `.abort()` /
+/// `await` it during graceful shutdown.
+pub fn spawn_tip_forwarder(
+    broadcaster: Arc<TipBroadcaster>,
+    publisher: TipPublisher,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    let mut apply_rx = broadcaster.subscribe_apply();
+    let mut rollback_rx = broadcaster.subscribe_rollback();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() {
+                        debug!("dugite-rpc tip forwarder: shutdown signalled, exiting");
+                        break;
+                    }
+                }
+                apply = apply_rx.recv() => {
+                    match apply {
+                        Ok(ev) => publisher.announce_apply(map_apply(ev)),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Lossy forwarder — the RPC layer's own slow-
+                            // consumer handling kicks in downstream. A
+                            // Lagged here means the FORWARDER itself fell
+                            // behind, which is structurally unlikely (no
+                            // per-event work besides the publish), but
+                            // log so it's visible if it ever happens.
+                            tracing::warn!(lagged = n, "dugite-rpc tip forwarder lagged on apply broadcast");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                rollback = rollback_rx.recv() => {
+                    match rollback {
+                        Ok(ev) => publisher.announce_rollback(TipRollback {
+                            slot: ev.slot,
+                            hash: ev.hash,
+                        }),
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(lagged = n, "dugite-rpc tip forwarder lagged on rollback broadcast");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn map_apply(ev: TipApply) -> TipInfo {
+    TipInfo {
+        slot: ev.slot,
+        hash: ev.hash,
+        block_number: ev.block_number,
+        era: ev.era,
+    }
+}
+
+/// Builds a fresh [`TipFeed`] suitable for handing to
+/// [`dugite_rpc::RpcServer::start`]. Returns the feed + its publisher
+/// (the latter is owned by the host so it can spawn the forwarder).
+pub fn build_tip_feed() -> (TipFeed, TipPublisher) {
+    let feed = TipFeed::new();
+    let publisher = feed.publisher();
+    (feed, publisher)
+}

--- a/crates/dugite-rpc/Cargo.toml
+++ b/crates/dugite-rpc/Cargo.toml
@@ -47,3 +47,7 @@ prost-build = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Reflection client for the server smoke test — pairs with the server-side
+# tonic-reflection registration to confirm the descriptor set is wire-
+# discoverable.
+tonic-reflection = { workspace = true }

--- a/crates/dugite-rpc/Cargo.toml
+++ b/crates/dugite-rpc/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "dugite-rpc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Native UTxO RPC (gRPC) server for dugite-node — issue #672"
+
+[dependencies]
+# gRPC runtime. We generate prost/tonic stubs ourselves at build time from
+# vendored .proto files under `proto/` (pinned via `proto/VERSION` to
+# `utxorpc/spec` at a specific tag). This keeps spec version bytes-exact
+# and avoids drift between the published utxorpc-spec Rust crate and the
+# spec tag — the same "depend on upstream specs, not upstream Rust crates"
+# ethos used for the in-house multi-era CBOR decoder and the in-house UPLC
+# CEK machine.
+tonic = { workspace = true }
+tonic-web = { workspace = true }
+tonic-reflection = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+
+# Async + runtime glue.
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+futures = { workspace = true }
+async-trait = { workspace = true }
+
+# Workspace types we expose / accept across the LedgerContext trait surface.
+dugite-primitives = { workspace = true }
+dugite-mempool = { workspace = true }
+
+# Diagnostics + error plumbing.
+tracing = { workspace = true }
+thiserror = { workspace = true }
+
+# Misc utilities.
+bytes = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }
+prost-build = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/dugite-rpc/build.rs
+++ b/crates/dugite-rpc/build.rs
@@ -27,9 +27,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tonic_build::configure()
         .build_server(true)
-        // No client codegen — dev-deps pull `utxorpc` Rust SDK when a
-        // client is needed for tests.
-        .build_client(false)
+        // Client codegen enabled so our own integration tests can drive
+        // the server without pulling in the upstream `utxorpc` Rust SDK
+        // (which carries the v1alpha+v1beta types we already generate
+        // ourselves). The generated client types end up under
+        // `*_service_client` modules in OUT_DIR; only consumers that
+        // import them pay the per-call client-codec cost.
+        .build_client(true)
         .file_descriptor_set_path(&descriptor_path)
         .compile_protos(&proto_files, &[proto_root.as_path()])?;
 

--- a/crates/dugite-rpc/build.rs
+++ b/crates/dugite-rpc/build.rs
@@ -1,0 +1,61 @@
+//! Generates prost/tonic stubs from the vendored UTxO RPC spec at
+//! `proto/utxorpc/{v1alpha,v1beta}/{cardano,sync,query,submit,watch}/*.proto`.
+//!
+//! The output goes to `OUT_DIR` (per Cargo convention) and is `include!()`'d
+//! by `src/proto/mod.rs`. We also emit a `FILE_DESCRIPTOR_SET` so the
+//! server can expose gRPC reflection without an extra runtime dep.
+//!
+//! Spec version is pinned in `proto/VERSION` — see `just bump-utxorpc-spec`
+//! for the refresh workflow.
+
+use std::path::{Path, PathBuf};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let proto_root: PathBuf = PathBuf::from("proto");
+    let proto_files = collect_protos(&proto_root)?;
+
+    // Re-run if any .proto file changes, or the proto root itself
+    // (so adding/removing files is picked up by cargo).
+    println!("cargo:rerun-if-changed={}", proto_root.display());
+    println!("cargo:rerun-if-changed=proto/VERSION");
+    for p in &proto_files {
+        println!("cargo:rerun-if-changed={}", p.display());
+    }
+
+    let out_dir: PathBuf = std::env::var_os("OUT_DIR")
+        .ok_or("OUT_DIR not set")?
+        .into();
+    let descriptor_path = out_dir.join("utxorpc_descriptor.bin");
+
+    tonic_build::configure()
+        .build_server(true)
+        // No client codegen — dev-deps pull `utxorpc` Rust SDK when a
+        // client is needed for tests.
+        .build_client(false)
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(&proto_files, &[proto_root.as_path()])?;
+
+    Ok(())
+}
+
+/// Recursively collect every `*.proto` under `root`. Sorted output so the
+/// build is deterministic across filesystem walk orders.
+fn collect_protos(root: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    walk(root, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, out)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("proto") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}

--- a/crates/dugite-rpc/build.rs
+++ b/crates/dugite-rpc/build.rs
@@ -22,9 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rerun-if-changed={}", p.display());
     }
 
-    let out_dir: PathBuf = std::env::var_os("OUT_DIR")
-        .ok_or("OUT_DIR not set")?
-        .into();
+    let out_dir: PathBuf = std::env::var_os("OUT_DIR").ok_or("OUT_DIR not set")?.into();
     let descriptor_path = out_dir.join("utxorpc_descriptor.bin");
 
     tonic_build::configure()

--- a/crates/dugite-rpc/proto/VERSION
+++ b/crates/dugite-rpc/proto/VERSION
@@ -1,0 +1,13 @@
+source       = "https://github.com/utxorpc/spec"
+tag          = "v0.19.2"
+commit       = "4ef539ab4a47418e6666600ba83a145682779995"
+fetched_at   = "2026-05-25"
+
+# Vendored subset: Cardano chain only (v1alpha + v1beta of cardano, sync,
+# query, submit, watch). Bitcoin and Handshake .proto are intentionally
+# omitted — Dugite is a Cardano-only node and the unused codegen would add
+# build cost without consumer.
+#
+# Refresh via: just bump-utxorpc-spec <tag>
+# Provenance: this file is the single source of truth for spec pinning;
+# bumping spec without bumping this file (or vice versa) is a CI failure.

--- a/crates/dugite-rpc/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -1,0 +1,818 @@
+syntax = "proto3";
+
+package utxorpc.v1alpha.cardano;
+
+// Purpose of the redeemer in a transaction.
+enum RedeemerPurpose {
+  REDEEMER_PURPOSE_UNSPECIFIED = 0;
+  REDEEMER_PURPOSE_SPEND = 1;
+  REDEEMER_PURPOSE_MINT = 2;
+  REDEEMER_PURPOSE_CERT = 3;
+  REDEEMER_PURPOSE_REWARD = 4;
+  REDEEMER_PURPOSE_VOTE = 5;
+  REDEEMER_PURPOSE_PROPOSE = 6;
+}
+
+// Redeemer information for a Plutus script.
+message Redeemer {
+  RedeemerPurpose purpose = 1; // Purpose of the redeemer.
+  PlutusData payload = 2; // Plutus data associated with the redeemer.
+  uint32 index = 3; // Index of the redeemer.
+  ExUnits ex_units = 4; // Execution units consumed by the redeemer.
+  bytes original_cbor = 5; // Original cbor-encoded data as seen on-chain
+}
+
+// Represents a transaction input in the Cardano blockchain.
+message TxInput {
+  bytes tx_hash = 1; // Hash of the previous transaction.
+  uint32 output_index = 2; // Index of the output in the previous transaction.
+  TxOutput as_output = 3; // Content of the input represented as output of the related transaction
+  Redeemer redeemer = 4; // Redeemer for the Plutus script.
+}
+
+// Represents a transaction output in the Cardano blockchain.
+message TxOutput {
+  bytes address = 1; // Address receiving the output.
+  BigInt coin = 2; // Amount of ADA in the output.
+  repeated Multiasset assets = 3; // Additional native (non-ADA) assets in the output.
+  Datum datum = 4; // Plutus data associated with the output.
+  Script script = 5; // Script associated with the output.
+}
+
+message Datum {
+  bytes hash = 1; // Hash of this datum as seen on-chain
+  PlutusData payload = 2; // Parsed Plutus data payload
+  bytes original_cbor = 3; // Original cbor-encoded data as seen on-chain
+}
+
+// Represents a custom asset in the Cardano blockchain.
+message Asset {
+  bytes name = 1; // Name of the custom asset.
+  oneof quantity {
+    BigInt output_coin = 2; // Quantity of the custom asset in case of an output.
+    BigInt mint_coin = 3; // Quantity of the custom asset in case of a mint (can be negative for burning).
+  }
+}
+
+// Represents a multi-asset group in the Cardano blockchain.
+message Multiasset {
+  bytes policy_id = 1; // Policy ID governing the custom assets.
+  repeated Asset assets = 2; // List of custom assets.
+  Redeemer redeemer = 3; // Redeemer for the Plutus script.
+}
+
+// Represents the validity interval of a transaction.
+message TxValidity {
+  uint64 start = 1; // Start of the validity interval.
+  uint64 ttl = 2; // End of the validity interval (TTL: Time to Live).
+}
+
+// Represents the collateral information for a transaction.
+message Collateral {
+  repeated TxInput collateral = 1; // Collateral inputs for the transaction.
+  TxOutput collateral_return = 2; // Collateral return in case of script failure.
+  BigInt total_collateral = 3; // Total amount of collateral.
+}
+
+// Represents a withdrawal from a reward account.
+message Withdrawal {
+  bytes reward_account = 1; // Address of the reward account.
+  BigInt coin = 2; // Amount of ADA withdrawn.
+  Redeemer redeemer = 3; // Redeemer for the Plutus script.
+}
+
+// Represents a set of witnesses that validate a transaction
+message WitnessSet {
+  repeated VKeyWitness vkeywitness = 1; // List of VKey witnesses.
+  repeated Script script = 2; // List of scripts.
+  repeated PlutusData plutus_datums = 3; // List of Plutus data elements associated with the transaction.
+}
+
+// Auxiliary data not directly tied to the validation process
+message AuxData {
+  repeated Metadata metadata = 1; // List of auxiliary metadata elements.
+  repeated Script scripts = 2; // List of auxiliary scripts.
+}
+
+// Represents a transaction in the Cardano blockchain.
+message Tx {
+  repeated TxInput inputs = 1; // List of transaction inputs
+  repeated TxOutput outputs = 2; // List of transaction outputs
+  repeated Certificate certificates = 3; // List of certificates
+  repeated Withdrawal withdrawals = 4; // List of withdrawals
+  repeated Multiasset mint = 5; // List of minted custom assets
+  repeated TxInput reference_inputs = 6; // List of reference inputs
+  WitnessSet witnesses = 7; // Witnesses that validte the transaction
+  Collateral collateral = 8; // Collateral details in case of failed transaction
+  BigInt fee = 9; // Transaction fee in ADA
+  TxValidity validity = 10; // Validity interval of the transaction
+  bool successful = 11; // Flag indicating whether the transaction was successful
+  AuxData auxiliary = 12; // Auxiliary data not directly tied to the validation process
+  bytes hash = 13; // Hash of the transaction that serves as main identifier
+  repeated GovernanceActionProposal proposals = 14; // List of governance actions proposed
+}
+
+// Define a governance action proposal
+message GovernanceActionProposal {
+  BigInt deposit = 1; // The amount deposited for the governance action
+  bytes reward_account = 2; // The reward account the deposit should be returned to
+  GovernanceAction gov_action = 3;
+  Anchor anchor = 4;
+}
+
+// Define a Governance Action
+message GovernanceAction {
+  oneof governance_action {
+    ParameterChangeAction parameter_change_action = 1; // Change on-chain parameters
+    HardForkInitiationAction hard_fork_initiation_action = 2; // Initiate a Hard Fork
+    TreasuryWithdrawalsAction treasury_withdrawals_action = 3; // Withdraw from the Treasury
+    NoConfidenceAction no_confidence_action = 4; //
+    UpdateCommitteeAction update_committee_action = 5; // Update the Constitution Committee
+    NewConstitutionAction new_constitution_action = 6; // Replace the Constitution
+
+    // TODO: revisit if there's a better way to handle this option because it doesn't actually need a value but proto syntax needs to require it
+    uint32 info_action = 7; // Info action should just be the integer number 6
+  }
+}
+
+message GovernanceActionId {
+  bytes transaction_id = 1;
+  uint32 governance_action_index = 2;
+}
+
+message ParameterChangeAction {
+  GovernanceActionId gov_action_id = 1;
+  PParams protocol_param_update = 2; // The updates proposed
+  bytes policy_hash = 3;
+}
+
+message HardForkInitiationAction {
+  GovernanceActionId gov_action_id = 1;
+  ProtocolVersion protocol_version = 2; // The protocol version to fork to
+}
+
+message TreasuryWithdrawalsAction {
+  repeated WithdrawalAmount withdrawals = 1; // A map of the withdrawals to make
+  bytes policy_hash = 2;
+}
+
+message WithdrawalAmount {
+  bytes reward_account = 1;
+  BigInt coin = 2;
+}
+
+message NoConfidenceAction {
+  GovernanceActionId gov_action_id = 1;
+}
+
+message UpdateCommitteeAction {
+  GovernanceActionId gov_action_id = 1;
+  repeated StakeCredential remove_committee_credentials = 2; // Committee members to remove (if any)
+  repeated NewCommitteeCredentials new_committee_credentials = 3; // The new committee members
+  RationalNumber new_committee_threshold = 4; // The required threshold for the committee
+}
+
+message NewConstitutionAction {
+  GovernanceActionId gov_action_id = 1;
+  Constitution constitution = 2; // The Constitution proposed
+}
+
+message Constitution {
+  Anchor anchor = 1; // Anchor to the new document
+  bytes hash = 2; // Hash of the document
+}
+
+// The new committee credential are passed as a map where the key is the committee cold credential hash
+// and the value is the expiration epoch for that credential
+message NewCommitteeCredentials {
+  StakeCredential committee_cold_credential = 1;
+  uint32 expires_epoch = 2;
+}
+
+// Contains the header information for a block.
+message BlockHeader {
+  uint64 slot = 1; // Slot number.
+  bytes hash = 2; // Block hash.
+  uint64 height = 3; // Block height.
+}
+
+// Contains the transaction data for a block.
+message BlockBody {
+  repeated Tx tx = 1; // List of transactions.
+}
+
+// Represents a complete block, including header and body.
+message Block {
+  BlockHeader header = 1; // Block header.
+  BlockBody body = 2; // Block body.
+  uint64 timestamp = 3; // Block ms timestamp
+}
+
+// Represents a VKey witness used to sign a transaction.
+message VKeyWitness {
+  bytes vkey = 1; // Verification key.
+  bytes signature = 2; // Signature generated using the associated private key.
+}
+
+// Represents a native script in Cardano.
+message NativeScript {
+  oneof native_script {
+    bytes script_pubkey = 1; // Script based on an address key hash.
+    NativeScriptList script_all = 2; // Script that requires all nested scripts to be satisfied.
+    NativeScriptList script_any = 3; // Script that requires any of the nested scripts to be satisfied.
+    ScriptNOfK script_n_of_k = 4; // Script that requires k out of n nested scripts to be satisfied.
+    uint64 invalid_before = 5; // Slot number before which the script is invalid.
+    uint64 invalid_hereafter = 6; // Slot number after which the script is invalid.
+  }
+}
+
+// Represents a list of native scripts.
+message NativeScriptList {
+  repeated NativeScript items = 1; // List of native scripts.
+}
+
+// Represents a "k out of n" native script.
+message ScriptNOfK {
+  uint32 k = 1; // The number of required satisfied scripts.
+  repeated NativeScript scripts = 2; // List of native scripts.
+}
+
+// Represents a constructor for Plutus data in Cardano.
+message Constr {
+  uint32 tag = 1;
+  uint64 any_constructor = 2;
+  repeated PlutusData fields = 3;
+}
+
+// Represents a big integer for Plutus data in Cardano.
+message BigInt {
+  oneof big_int {
+    int64 int = 1;
+    bytes big_u_int = 2;
+    bytes big_n_int = 3;
+  }
+}
+
+// Represents a key-value pair for Plutus data in Cardano.
+message PlutusDataPair {
+  PlutusData key = 1; // Key of the pair.
+  PlutusData value = 2; // Value of the pair.
+}
+
+// Represents a Plutus data item in Cardano.
+message PlutusData {
+  oneof plutus_data {
+    Constr constr = 2; // Constructor.
+    PlutusDataMap map = 3; // Map of Plutus data.
+    BigInt big_int = 4; // Big integer.
+    bytes bounded_bytes = 5; // Bounded bytes.
+    PlutusDataArray array = 6; // Array of Plutus data.
+  }
+}
+
+// Represents a map of Plutus data in Cardano.
+message PlutusDataMap {
+  repeated PlutusDataPair pairs = 1; // List of key-value pairs.
+}
+
+// Represents an array of Plutus data in Cardano.
+message PlutusDataArray {
+  repeated PlutusData items = 1; // List of Plutus data items.
+}
+
+// Represents a script in Cardano.
+message Script {
+  oneof script {
+    NativeScript native = 1; // Native script.
+    bytes plutus_v1 = 2; // Plutus V1 script.
+    bytes plutus_v2 = 3; // Plutus V2 script.
+    bytes plutus_v3 = 4; // Plutus V3 script.
+    bytes plutus_v4 = 5; // Plutus V4 script.
+  }
+}
+
+message Metadatum {
+  oneof metadatum {
+    int64 int = 1;
+    bytes bytes = 2;
+    string text = 3;
+    MetadatumArray array = 4;
+    MetadatumMap map = 5;
+  }
+}
+
+message MetadatumArray {
+  repeated Metadatum items = 1;
+}
+
+message MetadatumMap {
+  repeated MetadatumPair pairs = 1;
+}
+
+message MetadatumPair {
+  Metadatum key = 1;
+  Metadatum value = 2;
+}
+
+message Metadata {
+  uint64 label = 1;
+  Metadatum value = 2;
+}
+
+// Represents a stake credential in Cardano.
+message StakeCredential {
+  oneof stake_credential {
+    bytes addr_key_hash = 1; // Address key hash.
+    bytes script_hash = 2; // Script hash.
+  }
+}
+
+// Represents a rational number as a fraction.
+message RationalNumber {
+  int32 numerator = 1;
+  uint32 denominator = 2;
+}
+
+// Represents a relay in Cardano.
+message Relay {
+  bytes ip_v4 = 1;
+  bytes ip_v6 = 2;
+  string dns_name = 3;
+  uint32 port = 4;
+}
+
+// Represents pool metadata in Cardano.
+message PoolMetadata {
+  string url = 1;
+  bytes hash = 2;
+}
+
+// Represents a certificate in Cardano.
+message Certificate {
+  oneof certificate {
+    StakeCredential stake_registration = 1; // Stake registration certificate.
+    StakeCredential stake_deregistration = 2; // Stake deregistration certificate.
+    StakeDelegationCert stake_delegation = 3; // Stake delegation certificate.
+    PoolRegistrationCert pool_registration = 4; // Pool registration certificate.
+    PoolRetirementCert pool_retirement = 5; // Pool retirement certificate.
+    GenesisKeyDelegationCert genesis_key_delegation = 6; // Genesis key delegation certificate.
+    MirCert mir_cert = 7; // Move instantaneous rewards certificate.
+    RegCert reg_cert = 8; // Registration certificate.
+    UnRegCert unreg_cert = 9; // Unregistration certificate.
+    VoteDelegCert vote_deleg_cert = 10; // Vote delegation certificate.
+    StakeVoteDelegCert stake_vote_deleg_cert = 11; // Stake and vote delegation certificate.
+    StakeRegDelegCert stake_reg_deleg_cert = 12; // Stake registration and delegation certificate.
+    VoteRegDelegCert vote_reg_deleg_cert = 13; // Vote registration and delegation certificate.
+    StakeVoteRegDelegCert stake_vote_reg_deleg_cert = 14; // Stake and vote registration and delegation certificate.
+    AuthCommitteeHotCert auth_committee_hot_cert = 15; // Authorize committee hot key certificate.
+    ResignCommitteeColdCert resign_committee_cold_cert = 16; // Resign committee cold key certificate.
+    RegDRepCert reg_drep_cert = 17; // Register DRep certificate.
+    UnRegDRepCert unreg_drep_cert = 18; // Unregister DRep certificate.
+    UpdateDRepCert update_drep_cert = 19; // Update DRep certificate.
+  }
+  Redeemer redeemer = 100; // Redeemer for the Plutus script.
+}
+
+// Represents a stake delegation certificate in Cardano.
+message StakeDelegationCert {
+  StakeCredential stake_credential = 1; // Stake credential.
+  bytes pool_keyhash = 2; // Pool key hash.
+}
+
+// Represents a pool registration certificate in Cardano.
+message PoolRegistrationCert {
+  bytes operator = 1; // Operator key hash.
+  bytes vrf_keyhash = 2; // VRF key hash.
+  BigInt pledge = 3; // Pledge amount.
+  BigInt cost = 4; // Pool cost.
+  RationalNumber margin = 5; // Pool margin.
+  bytes reward_account = 6; // Reward account.
+  repeated bytes pool_owners = 7; // List of pool owner key hashes.
+  repeated Relay relays = 8; // List of relays.
+  PoolMetadata pool_metadata = 9; // Pool metadata.
+}
+
+// Represents a pool retirement certificate in Cardano.
+message PoolRetirementCert {
+  bytes pool_keyhash = 1; // Pool key hash.
+  uint64 epoch = 2; // Retirement epoch.
+}
+
+// Represents a genesis key delegation certificate in Cardano.
+message GenesisKeyDelegationCert {
+  bytes genesis_hash = 1; // Genesis hash.
+  bytes genesis_delegate_hash = 2; // Genesis delegate hash.
+  bytes vrf_keyhash = 3; // VRF key hash.
+}
+
+enum MirSource {
+  MIR_SOURCE_UNSPECIFIED = 0;
+  MIR_SOURCE_RESERVES = 1;
+  MIR_SOURCE_TREASURY = 2;
+}
+
+message MirTarget {
+  StakeCredential stake_credential = 1;
+  BigInt delta_coin = 2;
+}
+
+// Represents a move instantaneous reward certificate in Cardano.
+message MirCert {
+  MirSource from = 1;
+  repeated MirTarget to = 2;
+  uint64 other_pot = 3;
+}
+
+message RegCert {
+  StakeCredential stake_credential = 1;
+  BigInt coin = 2;
+}
+
+message UnRegCert {
+  StakeCredential stake_credential = 1;
+  BigInt coin = 2;
+}
+
+message DRep {
+  oneof drep {
+    bytes addr_key_hash = 1; // Address key hash
+    bytes script_hash = 2; // Script hash
+    bool abstain = 3; // Abstain
+    bool no_confidence = 4; // No confidence
+  }
+}
+
+message VoteDelegCert {
+  StakeCredential stake_credential = 1;
+  DRep drep = 2;
+}
+
+message StakeVoteDelegCert {
+  StakeCredential stake_credential = 1;
+  bytes pool_keyhash = 2;
+  DRep drep = 3;
+}
+
+message StakeRegDelegCert {
+  StakeCredential stake_credential = 1;
+  bytes pool_keyhash = 2;
+  BigInt coin = 3;
+}
+
+message VoteRegDelegCert {
+  StakeCredential stake_credential = 1;
+  DRep drep = 2;
+  BigInt coin = 3;
+}
+
+message StakeVoteRegDelegCert {
+  StakeCredential stake_credential = 1;
+  bytes pool_keyhash = 2;
+  DRep drep = 3;
+  BigInt coin = 4;
+}
+
+message AuthCommitteeHotCert {
+  StakeCredential committee_cold_credential = 1;
+  StakeCredential committee_hot_credential = 2;
+}
+
+message Anchor {
+  string url = 1;
+  bytes content_hash = 2;
+}
+
+message ResignCommitteeColdCert {
+  StakeCredential committee_cold_credential = 1;
+  Anchor anchor = 2;
+}
+
+message RegDRepCert {
+  StakeCredential drep_credential = 1;
+  BigInt coin = 2;
+  Anchor anchor = 3;
+}
+
+message UnRegDRepCert {
+  StakeCredential drep_credential = 1;
+  BigInt coin = 2;
+}
+
+message UpdateDRepCert {
+  StakeCredential drep_credential = 1;
+  Anchor anchor = 2;
+}
+
+// PATTERN MATCHING
+// ================
+
+// Pattern of an address that can be used to evaluate matching predicates.
+message AddressPattern {
+  bytes exact_address = 1; // The address should match this exact address value.
+  bytes payment_part = 2; // The payment part of the address should match this value.
+  bytes delegation_part = 3; // The delegation part of the address should match this value.
+}
+
+// Pattern of a native asset that can be used to evaluate matching predicates.
+message AssetPattern {
+  bytes policy_id = 1; // The asset should belong to this policy id
+  bytes asset_name = 2; // The asset should present this name
+}
+
+// Pattern of a certificate that can be used to evaluate matching predicates.
+message CertificatePattern {
+  oneof certificate_type {
+    StakeCredential stake_registration = 1; // Match stake registration for this credential
+    StakeCredential stake_deregistration = 2; // Match stake deregistration for this credential
+    StakeDelegationPattern stake_delegation = 3; // Match stake delegation pattern
+    PoolRegistrationPattern pool_registration = 4; // Match pool registration pattern
+    PoolRetirementPattern pool_retirement = 5; // Match pool retirement pattern
+    bytes any_stake_credential = 6; // Match any certificate involving this stake credential
+    bytes any_pool_keyhash = 7; // Match any certificate involving this pool
+    bytes any_drep = 8; // Match any certificate involving this DRep
+  }
+}
+
+// Pattern for stake delegation certificates
+message StakeDelegationPattern {
+  StakeCredential stake_credential = 1; // Match delegations from this credential
+  bytes pool_keyhash = 2; // Match delegations to this pool
+}
+
+// Pattern for pool registration certificates
+message PoolRegistrationPattern {
+  bytes operator = 1; // Match registrations by this operator
+  bytes pool_keyhash = 2; // Match registrations for this pool (derived from operator)
+}
+
+// Pattern for pool retirement certificates
+message PoolRetirementPattern {
+  bytes pool_keyhash = 1; // Match retirements of this pool
+  uint64 epoch = 2; // Match retirements in this epoch
+}
+
+// Pattern of a tx output that can be used to evaluate matching predicates.
+message TxOutputPattern {
+  AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
+  AssetPattern asset = 2; // Match any asset in the output that exhibits this pattern.
+}
+
+// Pattern of a Tx that can be used to evaluate matching predicates.
+message TxPattern {
+  TxOutputPattern consumes = 1; // Match any input that exhibits this pattern.
+  TxOutputPattern produces = 2; // Match any output that exhibits this pattern.
+  AddressPattern has_address = 3; // Match any address (inputs, outputs, collateral, etc) that exhibits this pattern.
+  AssetPattern moves_asset = 4; // Match any asset that exhibits this pattern.
+  AssetPattern mints_asset = 5; // Match any tx that either mint or burn the the asset pattern.
+  CertificatePattern has_certificate = 6; // Match any transaction that includes this certificate pattern.
+}
+
+// PARAMS
+// ======
+
+message ExUnits {
+  uint64 steps = 1;
+  uint64 memory = 2;
+}
+
+message ExPrices {
+  RationalNumber steps = 1;
+  RationalNumber memory = 2;
+}
+
+message ProtocolVersion {
+  uint32 major = 1;
+  uint32 minor = 2;
+}
+
+message CostModel {
+  repeated int64 values = 1;
+}
+
+message CostModels {
+  CostModel plutus_v1 = 1;
+  CostModel plutus_v2 = 2;
+  CostModel plutus_v3 = 3;
+  CostModel plutus_v4 = 4;
+}
+
+message VotingThresholds {
+  repeated RationalNumber thresholds = 1;
+}
+
+message PParams {
+  BigInt coins_per_utxo_byte = 1; // The number of coins per UTXO byte.
+  uint64 max_tx_size = 2; // The maximum transaction size.
+  BigInt min_fee_coefficient = 3; // The minimum fee coefficient.
+  BigInt min_fee_constant = 4; // The minimum fee constant.
+  uint64 max_block_body_size = 5; // The maximum block body size.
+  uint64 max_block_header_size = 6; // The maximum block header size.
+  BigInt stake_key_deposit = 7; // The stake key deposit.
+  BigInt pool_deposit = 8; // The pool deposit.
+  uint64 pool_retirement_epoch_bound = 9; // The pool retirement epoch bound.
+  uint64 desired_number_of_pools = 10; // The desired number of pools.
+  RationalNumber pool_influence = 11; // The pool influence.
+  RationalNumber monetary_expansion = 12; // The monetary expansion.
+  RationalNumber treasury_expansion = 13; // The treasury expansion.
+  BigInt min_pool_cost = 14; // The minimum pool cost.
+  ProtocolVersion protocol_version = 15; // The protocol version.
+  uint64 max_value_size = 16; // The maximum value size.
+  uint64 collateral_percentage = 17; // The collateral percentage.
+  uint64 max_collateral_inputs = 18; // The maximum collateral inputs.
+  CostModels cost_models = 19; // The cost models.
+  ExPrices prices = 20; // The prices.
+  ExUnits max_execution_units_per_transaction = 21; // The maximum execution units per transaction.
+  ExUnits max_execution_units_per_block = 22; // The maximum execution units per block.
+  RationalNumber min_fee_script_ref_cost_per_byte = 23; // The minimum fee per script reference byte.
+  VotingThresholds pool_voting_thresholds = 24; // The pool voting thresholds.
+  VotingThresholds drep_voting_thresholds = 25; // The drep voting thresholds.
+  uint32 min_committee_size = 26; // The minimum committee size.
+  uint64 committee_term_limit = 27; // The committee term limit.
+  uint64 governance_action_validity_period = 28; // The governance action validity period.
+  BigInt governance_action_deposit = 29; // The governance action deposit.
+  BigInt drep_deposit = 30; // The drep deposit.
+  uint64 drep_inactivity_period = 31; // The drep inactivity period.
+}
+
+message EraBoundary {
+  uint64 time = 1; // ms timestamp
+  uint64 slot = 2; // absolute slot number of the first block of this era
+  uint64 epoch = 3; // first epoch for this era
+}
+
+message EraSummary {
+  string name = 1; // name of the era (ex: "shelley")
+  EraBoundary start = 2; // start of this era
+  EraBoundary end = 3; // end of this era (if the era has a well-defined ending)
+  PParams protocol_params = 4; // protocol parameters for this era
+}
+
+message EraSummaries {
+  repeated EraSummary summaries = 1;
+}
+
+// EVALUATION
+// ==========
+
+message EvalError {
+  string msg = 1;
+}
+
+message EvalTrace {
+  string msg = 1;
+}
+
+message TxEval {
+  BigInt fee = 1;
+  ExUnits ex_units = 2;
+  repeated EvalError errors = 3;
+  repeated EvalTrace traces = 4;
+  repeated Redeemer redeemers = 5;
+}
+
+// GENESIS CONFIGS
+// ===============
+
+message ExtraEntropy {
+  string tag = 1;
+}
+
+message BlockVersionData {
+  uint32 script_version = 1;
+  string slot_duration = 2;
+  string max_block_size = 3;
+  string max_header_size = 4;
+  string max_tx_size = 5;
+  string max_proposal_size = 6;
+  string mpc_thd = 7;
+  string heavy_del_thd = 8;
+  string update_vote_thd = 9;
+  string update_proposal_thd = 10;
+  string update_implicit = 11;
+  SoftforkRule softfork_rule = 12;
+  TxFeePolicy tx_fee_policy = 13;
+  string unlock_stake_epoch = 14;
+}
+
+message SoftforkRule {
+  string init_thd = 1;
+  string min_thd = 2;
+  string thd_decrement = 3;
+}
+
+message TxFeePolicy {
+  string multiplier = 1;
+  string summand = 2;
+}
+
+message ProtocolConsts {
+  uint32 k = 1;
+  uint32 protocol_magic = 2;
+  uint32 vss_max_ttl = 3;
+  uint32 vss_min_ttl = 4;
+}
+
+message HeavyDelegation {
+  string cert = 1;
+  string delegate_pk = 2;
+  string issuer_pk = 3;
+  uint32 omega = 4;
+}
+
+message VssCert {
+  uint32 expiry_epoch = 1;
+  string signature = 2;
+  string signing_key = 3;
+  string vss_key = 4;
+}
+
+message GenDelegs {
+  string delegate = 1;
+  string vrf = 2;
+}
+
+message PoolVotingThresholds {
+  RationalNumber motion_no_confidence = 1;
+  RationalNumber committee_normal = 2;
+  RationalNumber committee_no_confidence = 3;
+  RationalNumber hard_fork_initiation = 4;
+  RationalNumber pp_security_group = 5;
+}
+
+message DRepVotingThresholds {
+  RationalNumber motion_no_confidence = 1;
+  RationalNumber committee_normal = 2;
+  RationalNumber committee_no_confidence = 3;
+  RationalNumber update_to_constitution = 4;
+  RationalNumber hard_fork_initiation = 5;
+  RationalNumber pp_network_group = 6;
+  RationalNumber pp_economic_group = 7;
+  RationalNumber pp_technical_group = 8;
+  RationalNumber pp_gov_group = 9;
+  RationalNumber treasury_withdrawal = 10;
+}
+
+message Committee {
+  map<string, uint64> members = 1;
+  RationalNumber threshold = 2;
+}
+
+message CostModelMap {
+  CostModel plutus_v1 = 1;
+  CostModel plutus_v2 = 2;
+  CostModel plutus_v3 = 3;
+  CostModel plutus_v4 = 4;
+}
+
+// Unified Genesis configuration containing all parameters from all eras
+message Genesis {
+  // ============ Byron Era Fields ============
+  map<string, string> avvm_distr = 1;
+  BlockVersionData block_version_data = 2;
+  string fts_seed = 3;
+  ProtocolConsts protocol_consts = 4;
+  uint64 start_time = 5;
+  map<string, uint64> boot_stakeholders = 6;
+  map<string, HeavyDelegation> heavy_delegation = 7;
+  map<string, string> non_avvm_balances = 8;
+  map<string, VssCert> vss_certs = 9;
+
+  // ============ Shelley Era Fields ============
+  RationalNumber active_slots_coeff = 10;
+  uint32 epoch_length = 11;
+  map<string, GenDelegs> gen_delegs = 12;
+  map<string, BigInt> initial_funds = 13;
+  uint32 max_kes_evolutions = 14;
+  BigInt max_lovelace_supply = 15;
+  string network_id = 16;
+  uint32 network_magic = 17;
+  PParams protocol_params = 18; // Using PParams as it's a superset of all protocol parameters
+  uint32 security_param = 19;
+  uint32 slot_length = 20;
+  uint32 slots_per_kes_period = 21;
+  string system_start = 22;
+  uint32 update_quorum = 23;
+
+  // ============ Alonzo Era Fields ============
+  BigInt lovelace_per_utxo_word = 24;
+  ExPrices execution_prices = 25;
+  ExUnits max_tx_ex_units = 26;
+  ExUnits max_block_ex_units = 27;
+  uint32 max_value_size = 28;
+  uint32 collateral_percentage = 29;
+  uint32 max_collateral_inputs = 30;
+  CostModelMap cost_models = 31;
+
+  // ============ Conway Era Fields ============
+  Committee committee = 32;
+  Constitution constitution = 33;
+  uint64 committee_min_size = 34;
+  uint64 committee_max_term_length = 35;
+  uint64 gov_action_lifetime = 36;
+  BigInt gov_action_deposit = 37;
+  BigInt drep_deposit = 38;
+  uint64 drep_activity = 39;
+  RationalNumber min_fee_ref_script_cost_per_byte = 40;
+  DRepVotingThresholds drep_voting_thresholds = 41;
+  PoolVotingThresholds pool_voting_thresholds = 42;
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1alpha/query/query.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1alpha/query/query.proto
@@ -1,0 +1,182 @@
+/// A consistent view of the state of the ledger
+
+syntax = "proto3";
+
+package utxorpc.v1alpha.query;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1alpha/cardano/cardano.proto";
+
+// Represents a specific point in the blockchain.
+message ChainPoint {
+  uint64 slot = 1; // Slot number.
+  bytes hash = 2; // Block hash.
+  uint64 height = 3; // Block height.
+  uint64 timestamp = 4; // Block ms timestamp
+}
+
+message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1alpha.cardano.Block cardano = 2; // A parsed Cardano block.
+  }
+}
+
+// Represents a reference to a transaction output
+message TxoRef {
+  bytes hash = 1; // Tx hash.
+  uint32 index = 2; // Output index.
+}
+
+// Request to get the chain parameters
+message ReadParamsRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
+}
+
+// Request to get the chain config
+message ReadGenesisRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
+}
+
+// Request to get the era summary
+message ReadEraSummaryRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
+}
+
+// Response containing the genesis configs
+message ReadGenesisResponse {
+  bytes genesis = 1; // genesis hash for the chain
+  string caip2 = 2; // the caip-2 ID for this network
+  oneof config {
+    utxorpc.v1alpha.cardano.Genesis cardano = 3; // Cardano genesis
+  }
+}
+
+// Response containing the era summaries
+message ReadEraSummaryResponse {
+  oneof summary {
+    utxorpc.v1alpha.cardano.EraSummaries cardano = 1; // Cardano era summaries
+  }
+}
+
+// An evenlope that holds parameter data from any of the compatible chains
+message AnyChainParams {
+  oneof params {
+    utxorpc.v1alpha.cardano.PParams cardano = 1; // Cardano parameters
+  }
+}
+
+// Response containing the chain parameters
+message ReadParamsResponse {
+  AnyChainParams values = 1; // The value of the parameters.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// An evenlope that holds an UTxO patterns from any of compatible chains
+message AnyUtxoPattern {
+  oneof utxo_pattern {
+    utxorpc.v1alpha.cardano.TxOutputPattern cardano = 1;
+  }
+}
+
+// Represents a simple utxo predicate that can composed to create more complex ones
+message UtxoPredicate {
+  AnyUtxoPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated UtxoPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated UtxoPredicate all_of = 3; // Predicate is true if utxo exhibits all of the patterns.
+  repeated UtxoPredicate any_of = 4; // Predicate is true if utxo exhibits any of the patterns.
+}
+
+// An evenlope that holds an UTxO from any of compatible chains
+message AnyUtxoData {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  TxoRef txo_ref = 2; // Hash of the previous transaction.
+  oneof parsed_state {
+    utxorpc.v1alpha.cardano.TxOutput cardano = 3; // A cardano UTxO
+  }
+  ChainPoint block_ref = 4; // The chain point that represents the block this UTxO was created in.
+}
+
+// Request to get specific UTxOs
+message ReadUtxosRequest {
+  repeated TxoRef keys = 1; // List of keys UTxOs.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response containing the UTxOs associated with the requested addresses.
+message ReadUtxosResponse {
+  repeated AnyUtxoData items = 1; // List of UTxOs.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// Request to search for UTxO based on a pattern.
+message SearchUtxosRequest {
+  UtxoPredicate predicate = 1; // Pattern to match UTxOs by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+  int32 max_items = 3; // The maximum number of items to return.
+  string start_token = 4; // The next_page_token value returned from a previous request, if any.
+}
+
+// Response containing the UTxOs that match the requested addresses.
+message SearchUtxosResponse {
+  repeated AnyUtxoData items = 1; // List of UTxOs.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+  string next_token = 3; // Token to retrieve the next page of results, or empty if there are no more results.
+}
+
+// Request to get data (as in plural of datum)
+message ReadDataRequest {
+  repeated bytes keys = 1;
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields in the response.
+}
+
+// An evenlope that holds a datum for any of the compatible chains
+message AnyChainDatum {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  bytes key = 2;
+  oneof parsed_state {
+    utxorpc.v1alpha.cardano.PlutusData cardano = 3; // A cardano UTxO
+  }
+}
+
+// Response containing data (as in plural of datum)
+message ReadDataResponse {
+  repeated AnyChainDatum values = 1; // The value of each datum.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// Request to get a transaction by hash
+message ReadTxRequest {
+  bytes hash = 1; // The hash of the transaction.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields in the response.
+}
+
+// Represents a transaction from any supported blockchain.
+message AnyChainTx {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1alpha.cardano.Tx cardano = 2; // A Cardano transaction.
+  }
+  ChainPoint block_ref = 3; // The chain point that represents the block this transaction belongs to.
+}
+
+// Response containing the transaction associated with the requested hash.
+message ReadTxResponse {
+  AnyChainTx tx = 1; // The transaction.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// Service definition for querying the state of the chain.
+service QueryService {
+  rpc ReadParams(ReadParamsRequest) returns (ReadParamsResponse); // Get overall chain state.
+  rpc ReadUtxos(ReadUtxosRequest) returns (ReadUtxosResponse); // Read specific UTxOs by reference.
+  rpc SearchUtxos(SearchUtxosRequest) returns (SearchUtxosResponse); // Search for UTxO based on a pattern.
+  rpc ReadData(ReadDataRequest) returns (ReadDataResponse); // Read specific datum by hash
+  rpc ReadTx(ReadTxRequest) returns (ReadTxResponse); // Get Txs by chain-specific criteria.
+  rpc ReadGenesis(ReadGenesisRequest) returns (ReadGenesisResponse); // Get the genesis configuration
+  rpc ReadEraSummary(ReadEraSummaryRequest) returns (ReadEraSummaryResponse); // Get the chain era summary
+
+  // TODO: decide if we want to expand the scope
+  // rpc DumpUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Dump all available utxos
+  // rpc ReadAccount(ReadAccountRequest) returns (ReadAccountReponse); // Get state of a particular account
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1alpha/submit/submit.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1alpha/submit/submit.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package utxorpc.v1alpha.submit;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1alpha/cardano/cardano.proto";
+
+// Represents a transaction from any supported blockchain.
+message AnyChainTx {
+  oneof type {
+    bytes raw = 1; // Raw transaction data.
+  }
+}
+
+// Request to evaluate transaction without submitting.
+message EvalTxRequest {
+  AnyChainTx tx = 1; // A transaction to evaluate.
+}
+
+// Report containing the result of evaluating a particular transaction
+message AnyChainEval {
+  oneof chain {
+    utxorpc.v1alpha.cardano.TxEval cardano = 1; // A Cardano tx evaluation report.
+  }
+}
+
+// Response containing the reports form the transaction evaluation.
+message EvalTxResponse {
+  AnyChainEval report = 1;
+}
+
+// Request to submit a transaction to the blockchain.
+message SubmitTxRequest {
+  AnyChainTx tx = 1; // A transaction to submit.
+}
+
+// Response containing references to the submitted transactions.
+message SubmitTxResponse {
+  bytes ref = 1; // A transaction reference returned upon successful submission.
+}
+
+// Enum representing the various stages of a transaction's lifecycle.
+enum Stage {
+  STAGE_UNSPECIFIED = 0; // Unspecified stage.
+  STAGE_ACKNOWLEDGED = 1; // Transaction has been acknowledged by the node.
+  STAGE_MEMPOOL = 2; // Transaction is in the mempool.
+  STAGE_NETWORK = 3; // Transaction has been propagated across the network.
+  STAGE_CONFIRMED = 4; // Transaction has been confirmed on the blockchain.
+}
+
+message TxInMempool {
+  bytes ref = 1; // The transaction reference.
+  bytes native_bytes = 2; // Original bytes as defined by the chain
+  Stage stage = 3; // The current stage of the tx
+  oneof parsed_state {
+    utxorpc.v1alpha.cardano.Tx cardano = 4; // A Cardano transaction.
+  }
+}
+
+// Request to check the status of submitted transactions.
+message ReadMempoolRequest {}
+
+// Response containing the stage of the submitted transactions.
+message ReadMempoolResponse {
+  repeated TxInMempool items = 1; // List of transaction currently on the mempool.
+}
+
+// Request to wait for transactions to reach a certain stage.
+message WaitForTxRequest {
+  repeated bytes ref = 1; // List of transaction references to wait for.
+}
+
+// Response containing the transaction reference and stage once it has been reached.
+message WaitForTxResponse {
+  bytes ref = 1; // Transaction reference.
+  Stage stage = 2; // Stage reached by the transaction.
+}
+
+// Represents a tx pattern from any supported blockchain.
+message AnyChainTxPattern {
+  oneof chain {
+    utxorpc.v1alpha.cardano.TxPattern cardano = 1; // A Cardano tx pattern.
+  }
+}
+
+// Represents a simple tx predicate that can composed to create more complex ones
+message TxPredicate {
+  AnyChainTxPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated TxPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated TxPredicate all_of = 3; // Predicate is true if tx exhibits all of the patterns.
+  repeated TxPredicate any_of = 4; // Predicate is true if tx exhibits any of the patterns.
+}
+
+// Request to watch changes of specific mempool txs.
+message WatchMempoolRequest {
+  TxPredicate predicate = 1; // A predicate to filter transactions by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response that represents a change in a mempool tx.
+message WatchMempoolResponse {
+  TxInMempool tx = 1; // The content and stage of the tx that has changed
+}
+
+// Service definition for submitting transactions and checking their status.
+service SubmitService {
+  rpc EvalTx(EvalTxRequest) returns (EvalTxResponse); // Evaluates a transaction without submitting it.
+  rpc SubmitTx(SubmitTxRequest) returns (SubmitTxResponse); // Submit transactions to the blockchain.
+  rpc WaitForTx(WaitForTxRequest) returns (stream WaitForTxResponse); // Wait for transactions to reach a certain stage and stream the updates.
+  rpc ReadMempool(ReadMempoolRequest) returns (ReadMempoolResponse); // Returns a point-in-time snapshot of the mempool.
+  rpc WatchMempool(WatchMempoolRequest) returns (stream WatchMempoolResponse); // Stream transactions from the mempool matching the specified predicates.
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1alpha/sync/sync.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1alpha/sync/sync.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package utxorpc.v1alpha.sync;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1alpha/cardano/cardano.proto";
+
+// Represents a reference to a specific block by a chosen combination of fields
+message BlockRef {
+  uint64 slot = 1; // Height or slot number (depending on the blockchain)
+  bytes hash = 2; // Hash of the content of the block
+  uint64 height = 3; // Block height
+  uint64 timestamp = 4; // Block ms timestamp
+}
+
+message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1alpha.cardano.Block cardano = 2; // A parsed Cardano block.
+  }
+}
+
+// Request to fetch a block by its reference.
+message FetchBlockRequest {
+  repeated BlockRef ref = 1; // List of block references.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response containing the fetched blocks.
+message FetchBlockResponse {
+  repeated AnyChainBlock block = 1; // List of fetched blocks.
+}
+
+// Request to dump the block history.
+message DumpHistoryRequest {
+  BlockRef start_token = 2; // Starting point for the block history dump.
+  uint32 max_items = 3; // Maximum number of items to return.
+  google.protobuf.FieldMask field_mask = 4; // Field mask to selectively return fields.
+}
+
+// Response containing the dumped block history.
+message DumpHistoryResponse {
+  repeated AnyChainBlock block = 1; // List of blocks in the history.
+  BlockRef next_token = 2; // Next token for pagination.
+}
+
+// Request to follow the tip of the blockchain.
+message FollowTipRequest {
+  repeated BlockRef intersect = 1; // List of block references to find the intersection.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response containing the action to perform while following the tip.
+message FollowTipResponse {
+  oneof action {
+    AnyChainBlock apply = 1; // Apply this block.
+    AnyChainBlock undo = 2; // Undo this block.
+    BlockRef reset = 3; // Reset to this block reference.
+  }
+  BlockRef tip = 4; // The current tip of the blockchain after this action.
+}
+
+// Request to read the current tip of the blockchain.
+message ReadTipRequest {}
+
+// Response containing the current tip of the blockchain.
+message ReadTipResponse {
+  BlockRef tip = 1; // The current tip of the blockchain.
+}
+
+// Service definition for syncing chain data.
+service SyncService {
+  rpc FetchBlock(FetchBlockRequest) returns (FetchBlockResponse); // Fetch a block by its reference.
+  rpc DumpHistory(DumpHistoryRequest) returns (DumpHistoryResponse); // Dump the block history.
+  rpc FollowTip(FollowTipRequest) returns (stream FollowTipResponse); // Follow the tip of the blockchain.
+  rpc ReadTip(ReadTipRequest) returns (ReadTipResponse); // Read the current tip of the blockchain.
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1alpha/watch/watch.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1alpha/watch/watch.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package utxorpc.v1alpha.watch;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1alpha/cardano/cardano.proto";
+
+// Represents a reference to a specific block by a chosen combination of fields
+message BlockRef {
+  uint64 slot = 1; // Height or slot number (depending on the blockchain)
+  bytes hash = 2; // Hash of the content of the block
+  uint64 height = 3; // Block height
+}
+
+message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1alpha.cardano.Block cardano = 2; // A parsed Cardano block.
+  }
+}
+
+// Represents a tx pattern from any supported blockchain.
+message AnyChainTxPattern {
+  oneof chain {
+    utxorpc.v1alpha.cardano.TxPattern cardano = 1; // A Cardano tx pattern.
+  }
+}
+
+// Represents a simple tx predicate that can composed to create more complex ones
+message TxPredicate {
+  AnyChainTxPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated TxPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated TxPredicate all_of = 3; // Predicate is true if tx exhibits all of the patterns.
+  repeated TxPredicate any_of = 4; // Predicate is true if tx exhibits any of the patterns.
+}
+
+// Request to watch transactions from the chain based on a set of predicates.
+message WatchTxRequest {
+  TxPredicate predicate = 1; // Predicate to filter transactions by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+  repeated BlockRef intersect = 3; // List of block references to find the intersection.
+}
+
+// Represents a transaction from any supported blockchain.
+message AnyChainTx {
+  oneof chain {
+    utxorpc.v1alpha.cardano.Tx cardano = 1; // A Cardano transaction.
+  }
+  AnyChainBlock block = 2; // Block containing the transaction
+}
+
+// Response containing the matching chain transactions or block progress signals.
+message WatchTxResponse {
+  oneof action {
+    AnyChainTx apply = 1; // Apply this transaction.
+    AnyChainTx undo = 2; // Undo this transaction.
+    BlockRef idle = 3; // No-match signal for a block.
+  }
+}
+
+// Service definition for watching transactions based on predicates.
+service WatchService {
+  rpc WatchTx(WatchTxRequest) returns (stream WatchTxResponse); // Stream transactions from the chain matching the specified predicates.
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -1,0 +1,898 @@
+syntax = "proto3";
+
+package utxorpc.v1beta.cardano;
+
+// Purpose of the redeemer in a transaction.
+enum RedeemerPurpose {
+  REDEEMER_PURPOSE_UNSPECIFIED = 0;
+  REDEEMER_PURPOSE_SPEND = 1;
+  REDEEMER_PURPOSE_MINT = 2;
+  REDEEMER_PURPOSE_CERT = 3;
+  REDEEMER_PURPOSE_REWARD = 4;
+  REDEEMER_PURPOSE_VOTE = 5;
+  REDEEMER_PURPOSE_PROPOSE = 6;
+}
+
+// Redeemer information for a Plutus script.
+message Redeemer {
+  RedeemerPurpose purpose = 1; // Purpose of the redeemer.
+  PlutusData payload = 2; // Plutus data associated with the redeemer.
+  uint32 index = 3; // Index of the redeemer.
+  ExUnits ex_units = 4; // Execution units consumed by the redeemer.
+  bytes original_cbor = 5; // Original cbor-encoded data as seen on-chain
+}
+
+// Represents a transaction input in the Cardano blockchain.
+message TxInput {
+  bytes tx_hash = 1; // Hash of the previous transaction.
+  uint32 output_index = 2; // Index of the output in the previous transaction.
+  TxOutput as_output = 3; // Content of the input represented as output of the related transaction
+  optional Redeemer redeemer = 4; // Redeemer for the Plutus script.
+}
+
+// Represents a transaction output in the Cardano blockchain.
+message TxOutput {
+  bytes address = 1; // Address receiving the output.
+  BigInt coin = 2; // Amount of ADA in the output.
+  repeated Multiasset assets = 3; // Additional native (non-ADA) assets in the output.
+  optional Datum datum = 4; // Plutus data associated with the output.
+  optional Script script = 5; // Script associated with the output.
+  optional bytes original_cbor = 6; // Original cbor-encoded output as seen on-chain.
+}
+
+message Datum {
+  bytes hash = 1; // Hash of this datum as seen on-chain
+  optional PlutusData payload = 2; // Parsed Plutus data payload
+  optional bytes original_cbor = 3; // Original cbor-encoded data as seen on-chain
+}
+
+// Represents a custom asset in the Cardano blockchain.
+message Asset {
+  bytes name = 1; // Name of the custom asset.
+  BigInt quantity = 2; // Quantity of the custom asset. This can be negative only if it is in a `Tx.mint` field and the transaction is burning tokens.
+}
+
+// Represents a multi-asset group in the Cardano blockchain.
+message Multiasset {
+  bytes policy_id = 1; // Policy ID governing the custom assets.
+  repeated Asset assets = 2; // List of custom assets.
+}
+
+// Represents the validity interval of a transaction.
+message TxValidity {
+  uint64 start = 1; // Start of the validity interval.
+  uint64 ttl = 2; // End of the validity interval (TTL: Time to Live).
+}
+
+// Represents the collateral information for a transaction.
+message Collateral {
+  repeated TxInput collateral = 1; // Collateral inputs for the transaction.
+  TxOutput collateral_return = 2; // Collateral return in case of script failure.
+  BigInt total_collateral = 3; // Total amount of collateral.
+}
+
+// Represents a withdrawal from a reward account.
+message Withdrawal {
+  bytes reward_account = 1; // Address of the reward account.
+  BigInt coin = 2; // Amount of ADA withdrawn.
+  Redeemer redeemer = 3; // Redeemer for the Plutus script.
+}
+
+// Represents a set of witnesses that validate a transaction
+message WitnessSet {
+  repeated VKeyWitness vkeywitness = 1; // List of VKey witnesses.
+  repeated Script script = 2; // List of scripts.
+  repeated PlutusData plutus_datums = 3; // List of Plutus data elements associated with the transaction.
+  repeated Redeemer redeemers = 4; // List of redeemers
+  repeated BootstrapWitness bootstrapWitnesses = 5; // List of bootstrap witnesses
+}
+
+// Auxiliary data not directly tied to the validation process
+message AuxData {
+  repeated Metadata metadata = 1; // List of auxiliary metadata elements.
+  repeated Script scripts = 2; // List of auxiliary scripts.
+}
+
+// Represents a transaction in the Cardano blockchain.
+message Tx {
+  repeated TxInput inputs = 1; // List of transaction inputs
+  repeated TxOutput outputs = 2; // List of transaction outputs
+  repeated Certificate certificates = 3; // List of certificates
+  repeated Withdrawal withdrawals = 4; // List of withdrawals
+  repeated Multiasset mint = 5; // List of minted custom assets
+  repeated TxInput reference_inputs = 6; // List of reference inputs
+  WitnessSet witnesses = 7; // Witnesses that validte the transaction
+  Collateral collateral = 8; // Collateral details in case of failed transaction
+  BigInt fee = 9; // Transaction fee in ADA
+  TxValidity validity = 10; // Validity interval of the transaction
+  bool successful = 11; // Flag indicating whether the transaction was successful
+  AuxData auxiliary = 12; // Auxiliary data not directly tied to the validation process
+  bytes hash = 13; // Hash of the transaction that serves as main identifier
+  repeated GovernanceActionProposal proposals = 14; // List of governance actions proposed
+  repeated VoterVotes votes = 15; // List of voters and their corresponding votes cast in this transaction
+}
+
+// Define a governance action proposal
+message GovernanceActionProposal {
+  BigInt deposit = 1; // The amount deposited for the governance action
+  bytes reward_account = 2; // The reward account the deposit should be returned to
+  GovernanceAction gov_action = 3;
+  Anchor anchor = 4;
+}
+
+// Define a Governance Action
+message GovernanceAction {
+  oneof governance_action {
+    ParameterChangeAction parameter_change_action = 1; // Change on-chain parameters
+    HardForkInitiationAction hard_fork_initiation_action = 2; // Initiate a Hard Fork
+    TreasuryWithdrawalsAction treasury_withdrawals_action = 3; // Withdraw from the Treasury
+    NoConfidenceAction no_confidence_action = 4; //
+    UpdateCommitteeAction update_committee_action = 5; // Update the Constitution Committee
+    NewConstitutionAction new_constitution_action = 6; // Replace the Constitution
+    InfoAction info_action = 7; // Info action
+  }
+}
+
+message GovernanceActionId {
+  bytes transaction_id = 1;
+  uint32 governance_action_index = 2;
+}
+
+// Valid vote choices for a governance action (CIP-1694).
+// On-chain CBOR mapping: No=0, Yes=1, Abstain=2.
+enum Vote {
+  VOTE_UNSPECIFIED = 0;
+  VOTE_NO = 1;
+  VOTE_YES = 2;
+  VOTE_ABSTAIN = 3;
+}
+
+// A single cast vote on a governance action.
+message VotingProcedure {
+  GovernanceActionId gov_action_id = 1; // ID of the governance action being voted on.
+  Vote vote = 2;                        // The vote cast.
+  optional Anchor anchor = 3;           // Optional anchor for voter rationale.
+}
+
+// Groups a voter with all votes they cast in the transaction.
+// SPOs can only identify via pool key hash; DReps and CC members may use key or script hash.
+message VoterVotes {
+  oneof voter {
+    StakeCredential constitutional_committee = 1; // Constitutional Committee member.
+    StakeCredential drep = 2;                     // Delegated Representative.
+    bytes spo = 3;                                // Stake Pool Operator (pool key hash).
+  }
+  repeated VotingProcedure votes = 4; // Votes cast by this voter.
+}
+
+message ParameterChangeAction {
+  GovernanceActionId gov_action_id = 1;
+  PParams protocol_param_update = 2; // The updates proposed
+  bytes policy_hash = 3;
+}
+
+message HardForkInitiationAction {
+  GovernanceActionId gov_action_id = 1;
+  ProtocolVersion protocol_version = 2; // The protocol version to fork to
+}
+
+message TreasuryWithdrawalsAction {
+  repeated WithdrawalAmount withdrawals = 1; // A list of the withdrawals to make
+  bytes policy_hash = 2;
+}
+
+message WithdrawalAmount {
+  bytes reward_account = 1;
+  BigInt coin = 2;
+}
+
+message NoConfidenceAction {
+  GovernanceActionId gov_action_id = 1;
+}
+
+message UpdateCommitteeAction {
+  GovernanceActionId gov_action_id = 1;
+  repeated StakeCredential remove_committee_credentials = 2; // Committee members to remove (if any)
+  repeated NewCommitteeCredentials new_committee_credentials = 3; // The new committee members
+  RationalNumber new_committee_threshold = 4; // The required threshold for the committee
+}
+
+message NewConstitutionAction {
+  GovernanceActionId gov_action_id = 1;
+  Constitution constitution = 2; // The Constitution proposed
+}
+
+message InfoAction {}
+
+message Constitution {
+  Anchor anchor = 1; // Anchor to the new document
+  bytes hash = 2; // Hash of the document
+}
+
+// The new committee credential are passed as a map where the key is the committee cold credential hash
+// and the value is the expiration epoch for that credential
+message NewCommitteeCredentials {
+  StakeCredential committee_cold_credential = 1;
+  uint32 expires_epoch = 2;
+}
+
+// Contains the header information for a block.
+message BlockHeader {
+  uint64 slot = 1; // Slot number.
+  bytes hash = 2; // Block hash.
+  uint64 height = 3; // Block height.
+}
+
+// Contains the transaction data for a block.
+message BlockBody {
+  repeated Tx tx = 1; // List of transactions.
+}
+
+// Represents a complete block, including header and body.
+message Block {
+  BlockHeader header = 1; // Block header.
+  BlockBody body = 2; // Block body.
+  uint64 timestamp = 3; // Block ms timestamp
+}
+
+// Represents bootstrap keys from Byron era
+message BootstrapWitness {
+  bytes vkey = 1; // Verification key.
+  bytes signature = 2; // Signature generated using the associated private key.
+  bytes chain_code = 3; // 32 bytes of chain code
+  bytes attributes = 4; // key attributes
+}
+
+// Represents a VKey witness used to sign a transaction.
+message VKeyWitness {
+  bytes vkey = 1; // Verification key.
+  bytes signature = 2; // Signature generated using the associated private key.
+}
+
+// Represents a native script in Cardano.
+message NativeScript {
+  oneof native_script {
+    bytes script_pubkey_hash = 1; // Script based on an address key hash.
+    NativeScriptList script_all = 2; // Script that requires all nested scripts to be satisfied.
+    NativeScriptList script_any = 3; // Script that requires any of the nested scripts to be satisfied.
+    ScriptNOfK script_n_of_k = 4; // Script that requires k out of n nested scripts to be satisfied.
+    uint64 invalid_before = 5; // Slot number before which the script is invalid.
+    uint64 invalid_hereafter = 6; // Slot number after which the script is invalid.
+  }
+}
+
+// Represents a list of native scripts.
+message NativeScriptList {
+  repeated NativeScript items = 1; // List of native scripts.
+}
+
+// Represents a "k out of n" native script.
+message ScriptNOfK {
+  uint32 k = 1; // The number of required satisfied scripts.
+  repeated NativeScript scripts = 2; // List of native scripts.
+}
+
+// Represents a constructor for Plutus data in Cardano.
+message Constr {
+  uint32 tag = 1;
+  uint64 any_constructor = 2;
+  repeated PlutusData fields = 3;
+}
+
+// Represents a big integer for Plutus data in Cardano.
+// The representation here follows CBOR specification for bignums:
+// https://www.rfc-editor.org/rfc/rfc8949.html#name-bignums section 3.4.3.
+message BigInt {
+  oneof big_int {
+    int64 int = 1; // Stores value fitting within int64 range
+    bytes big_u_int = 2; // Stores unsigned value exceeding int64 range
+    bytes big_n_int = 3; // Stores negative value `n` exceeding int64 range as `-1 - n`
+  }
+}
+
+// Represents a key-value pair for Plutus data in Cardano.
+message PlutusDataPair {
+  PlutusData key = 1; // Key of the pair.
+  PlutusData value = 2; // Value of the pair.
+}
+
+// Represents a Plutus data item in Cardano.
+message PlutusData {
+  oneof plutus_data {
+    Constr constr = 2; // Constructor.
+    PlutusDataMap map = 3; // Map of Plutus data.
+    BigInt big_int = 4; // Big integer.
+    bytes bounded_bytes = 5; // Bounded bytes.
+    PlutusDataArray array = 6; // Array of Plutus data.
+  }
+}
+
+// Represents a map of Plutus data in Cardano.
+message PlutusDataMap {
+  repeated PlutusDataPair pairs = 1; // List of key-value pairs.
+}
+
+// Represents an array of Plutus data in Cardano.
+message PlutusDataArray {
+  repeated PlutusData items = 1; // List of Plutus data items.
+}
+
+// Represents a script in Cardano.
+message Script {
+  oneof script {
+    NativeScript native = 1; // Native script.
+    bytes plutus_v1 = 2; // Plutus V1 script.
+    bytes plutus_v2 = 3; // Plutus V2 script.
+    bytes plutus_v3 = 4; // Plutus V3 script.
+    bytes plutus_v4 = 5; // Plutus V4 script.
+  }
+}
+
+message Metadatum {
+  oneof metadatum {
+    int64 int = 1;
+    bytes bytes = 2;
+    string text = 3;
+    MetadatumArray array = 4;
+    MetadatumMap map = 5;
+  }
+}
+
+message MetadatumArray {
+  repeated Metadatum items = 1;
+}
+
+message MetadatumMap {
+  repeated MetadatumPair pairs = 1;
+}
+
+message MetadatumPair {
+  Metadatum key = 1;
+  Metadatum value = 2;
+}
+
+message Metadata {
+  uint64 label = 1;
+  Metadatum value = 2;
+}
+
+// Represents a stake credential in Cardano.
+message StakeCredential {
+  oneof stake_credential {
+    bytes addr_key_hash = 1; // Address key hash.
+    bytes script_hash = 2; // Script hash.
+  }
+}
+
+// Represents a rational number as a fraction.
+message RationalNumber {
+  int32 numerator = 1;
+  uint32 denominator = 2;
+}
+
+// Represents a relay in Cardano.
+message Relay {
+  bytes ip_v4 = 1;
+  bytes ip_v6 = 2;
+  string dns_name = 3;
+  uint32 port = 4;
+}
+
+// Represents pool metadata in Cardano.
+message PoolMetadata {
+  string url = 1;
+  bytes hash = 2;
+}
+
+// Represents a certificate in Cardano.
+message Certificate {
+  oneof certificate {
+    StakeCredential stake_registration = 1; // Stake registration certificate.
+    StakeCredential stake_deregistration = 2; // Stake deregistration certificate.
+    StakeDelegationCert stake_delegation = 3; // Stake delegation certificate.
+    PoolRegistrationCert pool_registration = 4; // Pool registration certificate.
+    PoolRetirementCert pool_retirement = 5; // Pool retirement certificate.
+    GenesisKeyDelegationCert genesis_key_delegation = 6; // Genesis key delegation certificate.
+    MirCert mir_cert = 7; // Move instantaneous rewards certificate.
+    RegCert reg_cert = 8; // Registration certificate.
+    UnRegCert unreg_cert = 9; // Unregistration certificate.
+    VoteDelegCert vote_deleg_cert = 10; // Vote delegation certificate.
+    StakeVoteDelegCert stake_vote_deleg_cert = 11; // Stake and vote delegation certificate.
+    StakeRegDelegCert stake_reg_deleg_cert = 12; // Stake registration and delegation certificate.
+    VoteRegDelegCert vote_reg_deleg_cert = 13; // Vote registration and delegation certificate.
+    StakeVoteRegDelegCert stake_vote_reg_deleg_cert = 14; // Stake and vote registration and delegation certificate.
+    AuthCommitteeHotCert auth_committee_hot_cert = 15; // Authorize committee hot key certificate.
+    ResignCommitteeColdCert resign_committee_cold_cert = 16; // Resign committee cold key certificate.
+    RegDRepCert reg_drep_cert = 17; // Register DRep certificate.
+    UnRegDRepCert unreg_drep_cert = 18; // Unregister DRep certificate.
+    UpdateDRepCert update_drep_cert = 19; // Update DRep certificate.
+  }
+  Redeemer redeemer = 100; // Redeemer for the Plutus script.
+}
+
+// Represents a stake delegation certificate in Cardano.
+message StakeDelegationCert {
+  StakeCredential stake_credential = 1; // Stake credential.
+  bytes pool_keyhash = 2; // Pool key hash.
+}
+
+// Represents a pool registration certificate in Cardano.
+message PoolRegistrationCert {
+  bytes operator = 1; // Operator key hash.
+  bytes vrf_keyhash = 2; // VRF key hash.
+  BigInt pledge = 3; // Pledge amount.
+  BigInt cost = 4; // Pool cost.
+  RationalNumber margin = 5; // Pool margin.
+  bytes reward_account = 6; // Reward account.
+  repeated bytes pool_owners = 7; // List of pool owner key hashes.
+  repeated Relay relays = 8; // List of relays.
+  PoolMetadata pool_metadata = 9; // Pool metadata.
+}
+
+// Represents a pool retirement certificate in Cardano.
+message PoolRetirementCert {
+  bytes pool_keyhash = 1; // Pool key hash.
+  uint64 epoch = 2; // Retirement epoch.
+}
+
+// Represents a genesis key delegation certificate in Cardano.
+message GenesisKeyDelegationCert {
+  bytes genesis_hash = 1; // Genesis hash.
+  bytes genesis_delegate_hash = 2; // Genesis delegate hash.
+  bytes vrf_keyhash = 3; // VRF key hash.
+}
+
+enum MirSource {
+  MIR_SOURCE_UNSPECIFIED = 0;
+  MIR_SOURCE_RESERVES = 1;
+  MIR_SOURCE_TREASURY = 2;
+}
+
+message MirTarget {
+  StakeCredential stake_credential = 1;
+  BigInt delta_coin = 2;
+}
+
+// Represents a move instantaneous reward certificate in Cardano.
+message MirCert {
+  MirSource from = 1;
+  repeated MirTarget to = 2;
+  uint64 other_pot = 3;
+}
+
+message RegCert {
+  StakeCredential stake_credential = 1;
+  BigInt coin = 2;
+}
+
+message UnRegCert {
+  StakeCredential stake_credential = 1;
+  BigInt coin = 2;
+}
+
+message DRep {
+  oneof drep {
+    bytes addr_key_hash = 1; // Address key hash
+    bytes script_hash = 2; // Script hash
+    bool abstain = 3; // Abstain
+    bool no_confidence = 4; // No confidence
+  }
+}
+
+message VoteDelegCert {
+  StakeCredential stake_credential = 1;
+  DRep drep = 2;
+}
+
+message StakeVoteDelegCert {
+  StakeCredential stake_credential = 1;
+  bytes pool_keyhash = 2;
+  DRep drep = 3;
+}
+
+message StakeRegDelegCert {
+  StakeCredential stake_credential = 1;
+  bytes pool_keyhash = 2;
+  BigInt coin = 3;
+}
+
+message VoteRegDelegCert {
+  StakeCredential stake_credential = 1;
+  DRep drep = 2;
+  BigInt coin = 3;
+}
+
+message StakeVoteRegDelegCert {
+  StakeCredential stake_credential = 1;
+  bytes pool_keyhash = 2;
+  DRep drep = 3;
+  BigInt coin = 4;
+}
+
+message AuthCommitteeHotCert {
+  StakeCredential committee_cold_credential = 1;
+  StakeCredential committee_hot_credential = 2;
+}
+
+message Anchor {
+  string url = 1;
+  bytes content_hash = 2;
+}
+
+message ResignCommitteeColdCert {
+  StakeCredential committee_cold_credential = 1;
+  Anchor anchor = 2;
+}
+
+message RegDRepCert {
+  StakeCredential drep_credential = 1;
+  BigInt coin = 2;
+  Anchor anchor = 3;
+}
+
+message UnRegDRepCert {
+  StakeCredential drep_credential = 1;
+  BigInt coin = 2;
+}
+
+message UpdateDRepCert {
+  StakeCredential drep_credential = 1;
+  Anchor anchor = 2;
+}
+
+// LEDGER-STATE QUERIES
+// ====================
+//
+// Cardano-specific queries that mirror the Ouroboros node-to-client
+// LocalStateQuery mini-protocol. The oneof envelope lets new queries be
+// added later without changing the chain-agnostic QueryService surface.
+
+// Envelope of a Cardano ledger-state query.
+message StateQuery {
+  oneof query {
+    GetStakePoolDistribution stake_pool_distribution = 1; // Active stake distribution across pools.
+  }
+}
+
+// Envelope of a Cardano ledger-state query result.
+message StateData {
+  oneof result {
+    StakePoolDistribution stake_pool_distribution = 1; // Result of a stake pool distribution query.
+  }
+}
+
+// Stake pool distribution query. Mirrors Ouroboros GetPoolDistr / GetFilteredPoolDistr.
+message GetStakePoolDistribution {
+  // If non-empty, restrict the result to the listed pool key hashes.
+  // If empty, return the distribution for every pool.
+  repeated bytes pool_keyhashes = 1;
+}
+
+// Per-pool stake share. Mirrors Ouroboros IndividualPoolStake.
+message PoolStakeShare {
+  bytes pool_keyhash = 1; // Pool key hash (pool id).
+  RationalNumber stake_fraction = 2; // Fraction of total active stake delegated to this pool.
+  bytes vrf_keyhash = 3; // Pool's VRF key hash, as reported by the node.
+}
+
+// Result of a stake pool distribution query.
+message StakePoolDistribution {
+  repeated PoolStakeShare pools = 1; // One entry per pool present in the snapshot.
+}
+
+// PATTERN MATCHING
+// ================
+
+// Pattern of an address that can be used to evaluate matching predicates.
+message AddressPattern {
+  optional bytes exact_address = 1; // The address should match this exact address value.
+  optional bytes payment_part = 2; // The payment part of the address should match this value.
+  optional bytes delegation_part = 3; // The delegation part of the address should match this value.
+}
+
+// Pattern of a native asset that can be used to evaluate matching predicates.
+message AssetPattern {
+  optional bytes policy_id = 1; // The asset should belong to this policy id
+  optional bytes asset_name = 2; // The asset should present this name
+}
+
+// Pattern of a certificate that can be used to evaluate matching predicates.
+message CertificatePattern {
+  oneof certificate_type {
+    StakeCredential stake_registration = 1; // Match stake registration for this credential
+    StakeCredential stake_deregistration = 2; // Match stake deregistration for this credential
+    StakeDelegationPattern stake_delegation = 3; // Match stake delegation pattern
+    PoolRegistrationPattern pool_registration = 4; // Match pool registration pattern
+    PoolRetirementPattern pool_retirement = 5; // Match pool retirement pattern
+    bytes any_stake_credential = 6; // Match any certificate involving this stake credential
+    bytes any_pool_keyhash = 7; // Match any certificate involving this pool
+    bytes any_drep = 8; // Match any certificate involving this DRep
+  }
+}
+
+// Pattern for stake delegation certificates
+message StakeDelegationPattern {
+  StakeCredential stake_credential = 1; // Match delegations from this credential
+  bytes pool_keyhash = 2; // Match delegations to this pool
+}
+
+// Pattern for pool registration certificates
+message PoolRegistrationPattern {
+  bytes operator = 1; // Match registrations by this operator
+  bytes pool_keyhash = 2; // Match registrations for this pool (derived from operator)
+}
+
+// Pattern for pool retirement certificates
+message PoolRetirementPattern {
+  bytes pool_keyhash = 1; // Match retirements of this pool
+  uint64 epoch = 2; // Match retirements in this epoch
+}
+
+// Pattern of a tx output that can be used to evaluate matching predicates.
+message TxOutputPattern {
+  optional AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
+  optional AssetPattern asset = 2; // Match any asset in the output that exhibits this pattern.
+}
+
+// Pattern of a Tx that can be used to evaluate matching predicates.
+message TxPattern {
+  TxOutputPattern consumes = 1; // Match any input that exhibits this pattern.
+  TxOutputPattern produces = 2; // Match any output that exhibits this pattern.
+  AddressPattern has_address = 3; // Match any address (inputs, outputs, collateral, etc) that exhibits this pattern.
+  AssetPattern moves_asset = 4; // Match any asset that exhibits this pattern.
+  AssetPattern mints_asset = 5; // Match any tx that either mint or burn the the asset pattern.
+  CertificatePattern has_certificate = 6; // Match any transaction that includes this certificate pattern.
+}
+
+// PARAMS
+// ======
+
+message ExUnits {
+  uint64 steps = 1;
+  uint64 memory = 2;
+}
+
+message ExPrices {
+  RationalNumber steps = 1;
+  RationalNumber memory = 2;
+}
+
+message ProtocolVersion {
+  uint32 major = 1;
+  uint32 minor = 2;
+}
+
+message CostModel {
+  repeated int64 values = 1;
+}
+
+message CostModels {
+  CostModel plutus_v1 = 1;
+  CostModel plutus_v2 = 2;
+  CostModel plutus_v3 = 3;
+  CostModel plutus_v4 = 4;
+}
+
+message VotingThresholds {
+  repeated RationalNumber thresholds = 1;
+}
+
+message PParams {
+  BigInt coins_per_utxo_byte = 1; // The number of coins per UTXO byte.
+  uint64 max_tx_size = 2; // The maximum transaction size.
+  BigInt min_fee_coefficient = 3; // The minimum fee coefficient.
+  BigInt min_fee_constant = 4; // The minimum fee constant.
+  uint64 max_block_body_size = 5; // The maximum block body size.
+  uint64 max_block_header_size = 6; // The maximum block header size.
+  BigInt stake_key_deposit = 7; // The stake key deposit.
+  BigInt pool_deposit = 8; // The pool deposit.
+  uint64 pool_retirement_epoch_bound = 9; // The pool retirement epoch bound.
+  uint64 desired_number_of_pools = 10; // The desired number of pools.
+  RationalNumber pool_influence = 11; // The pool influence.
+  RationalNumber monetary_expansion = 12; // The monetary expansion.
+  RationalNumber treasury_expansion = 13; // The treasury expansion.
+  BigInt min_pool_cost = 14; // The minimum pool cost.
+  ProtocolVersion protocol_version = 15; // The protocol version.
+  uint64 max_value_size = 16; // The maximum value size.
+  uint64 collateral_percentage = 17; // The collateral percentage.
+  uint64 max_collateral_inputs = 18; // The maximum collateral inputs.
+  CostModels cost_models = 19; // The cost models.
+  ExPrices prices = 20; // The prices.
+  ExUnits max_execution_units_per_transaction = 21; // The maximum execution units per transaction.
+  ExUnits max_execution_units_per_block = 22; // The maximum execution units per block.
+  RationalNumber min_fee_script_ref_cost_per_byte = 23; // The minimum fee per script reference byte.
+  VotingThresholds pool_voting_thresholds = 24; // The pool voting thresholds.
+  VotingThresholds drep_voting_thresholds = 25; // The drep voting thresholds.
+  uint32 min_committee_size = 26; // The minimum committee size.
+  uint64 committee_term_limit = 27; // The committee term limit.
+  uint64 governance_action_validity_period = 28; // The governance action validity period.
+  BigInt governance_action_deposit = 29; // The governance action deposit.
+  BigInt drep_deposit = 30; // The drep deposit.
+  uint64 drep_inactivity_period = 31; // The drep inactivity period.
+}
+
+message EraBoundary {
+  uint64 time = 1; // ms timestamp
+  uint64 slot = 2; // absolute slot number of the first block of this era
+  uint64 epoch = 3; // first epoch for this era
+}
+
+message EraSummary {
+  string name = 1; // name of the era (ex: "shelley")
+  EraBoundary start = 2; // start of this era
+  EraBoundary end = 3; // end of this era (if the era has a well-defined ending)
+  PParams protocol_params = 4; // protocol parameters for this era
+}
+
+message EraSummaries {
+  repeated EraSummary summaries = 1;
+}
+
+// EVALUATION
+// ==========
+
+// A single evaluation report entry, used for both script errors and execution
+// traces. The purpose and index fields identify which redeemer produced the
+// entry, allowing the client to correlate errors and traces with specific
+// script executions.
+message EvalReport {
+  string msg = 1; // Human-readable message.
+  RedeemerPurpose purpose = 2; // Purpose of the redeemer that produced this entry.
+  uint32 index = 3; // 0-based index of the redeemer within its purpose.
+}
+
+// Result of evaluating a transaction against the current ledger state.
+message TxEval {
+  BigInt fee = 1; // Computed minimum fee for the transaction.
+  ExUnits ex_units = 2; // Total execution units consumed across all redeemers.
+  repeated EvalReport errors = 3; // Per-redeemer script execution errors.
+  repeated EvalReport traces = 4; // Per-redeemer script execution traces.
+  repeated Redeemer redeemers = 5; // Redeemers with evaluated execution units.
+}
+
+// GENESIS CONFIGS
+// ===============
+
+message ExtraEntropy {
+  string tag = 1;
+}
+
+message BlockVersionData {
+  uint32 script_version = 1;
+  string slot_duration = 2;
+  string max_block_size = 3;
+  string max_header_size = 4;
+  string max_tx_size = 5;
+  string max_proposal_size = 6;
+  string mpc_thd = 7;
+  string heavy_del_thd = 8;
+  string update_vote_thd = 9;
+  string update_proposal_thd = 10;
+  string update_implicit = 11;
+  SoftforkRule softfork_rule = 12;
+  TxFeePolicy tx_fee_policy = 13;
+  string unlock_stake_epoch = 14;
+}
+
+message SoftforkRule {
+  string init_thd = 1;
+  string min_thd = 2;
+  string thd_decrement = 3;
+}
+
+message TxFeePolicy {
+  string multiplier = 1;
+  string summand = 2;
+}
+
+message ProtocolConsts {
+  uint32 k = 1;
+  uint32 protocol_magic = 2;
+  uint32 vss_max_ttl = 3;
+  uint32 vss_min_ttl = 4;
+}
+
+message HeavyDelegation {
+  string cert = 1;
+  string delegate_pk = 2;
+  string issuer_pk = 3;
+  uint32 omega = 4;
+}
+
+message VssCert {
+  uint32 expiry_epoch = 1;
+  string signature = 2;
+  string signing_key = 3;
+  string vss_key = 4;
+}
+
+message GenDelegs {
+  string delegate = 1;
+  string vrf = 2;
+}
+
+message PoolVotingThresholds {
+  RationalNumber motion_no_confidence = 1;
+  RationalNumber committee_normal = 2;
+  RationalNumber committee_no_confidence = 3;
+  RationalNumber hard_fork_initiation = 4;
+  RationalNumber pp_security_group = 5;
+}
+
+message DRepVotingThresholds {
+  RationalNumber motion_no_confidence = 1;
+  RationalNumber committee_normal = 2;
+  RationalNumber committee_no_confidence = 3;
+  RationalNumber update_to_constitution = 4;
+  RationalNumber hard_fork_initiation = 5;
+  RationalNumber pp_network_group = 6;
+  RationalNumber pp_economic_group = 7;
+  RationalNumber pp_technical_group = 8;
+  RationalNumber pp_gov_group = 9;
+  RationalNumber treasury_withdrawal = 10;
+}
+
+message Committee {
+  map<string, uint64> members = 1;
+  RationalNumber threshold = 2;
+}
+
+message CostModelMap {
+  CostModel plutus_v1 = 1;
+  CostModel plutus_v2 = 2;
+  CostModel plutus_v3 = 3;
+  CostModel plutus_v4 = 4;
+}
+
+// Unified Genesis configuration containing all parameters from all eras
+message Genesis {
+  // ============ Byron Era Fields ============
+  map<string, string> avvm_distr = 1;
+  BlockVersionData block_version_data = 2;
+  string fts_seed = 3;
+  ProtocolConsts protocol_consts = 4;
+  uint64 start_time = 5;
+  map<string, uint64> boot_stakeholders = 6;
+  map<string, HeavyDelegation> heavy_delegation = 7;
+  map<string, string> non_avvm_balances = 8;
+  map<string, VssCert> vss_certs = 9;
+
+  // ============ Shelley Era Fields ============
+  RationalNumber active_slots_coeff = 10;
+  uint32 epoch_length = 11;
+  map<string, GenDelegs> gen_delegs = 12;
+  map<string, BigInt> initial_funds = 13;
+  uint32 max_kes_evolutions = 14;
+  BigInt max_lovelace_supply = 15;
+  string network_id = 16;
+  uint32 network_magic = 17;
+  PParams protocol_params = 18; // Using PParams as it's a superset of all protocol parameters
+  uint32 security_param = 19;
+  uint32 slot_length = 20;
+  uint32 slots_per_kes_period = 21;
+  string system_start = 22;
+  uint32 update_quorum = 23;
+
+  // ============ Alonzo Era Fields ============
+  BigInt lovelace_per_utxo_word = 24;
+  ExPrices execution_prices = 25;
+  ExUnits max_tx_ex_units = 26;
+  ExUnits max_block_ex_units = 27;
+  uint32 max_value_size = 28;
+  uint32 collateral_percentage = 29;
+  uint32 max_collateral_inputs = 30;
+  CostModelMap cost_models = 31;
+
+  // ============ Conway Era Fields ============
+  Committee committee = 32;
+  Constitution constitution = 33;
+  uint64 committee_min_size = 34;
+  uint64 committee_max_term_length = 35;
+  uint64 gov_action_lifetime = 36;
+  BigInt gov_action_deposit = 37;
+  BigInt drep_deposit = 38;
+  uint64 drep_activity = 39;
+  RationalNumber min_fee_ref_script_cost_per_byte = 40;
+  DRepVotingThresholds drep_voting_thresholds = 41;
+  PoolVotingThresholds pool_voting_thresholds = 42;
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1beta/query/query.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1beta/query/query.proto
@@ -1,0 +1,209 @@
+/// A consistent view of the state of the ledger
+
+syntax = "proto3";
+
+package utxorpc.v1beta.query;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1beta/cardano/cardano.proto";
+
+// Represents a specific point in the blockchain.
+message ChainPoint {
+  uint64 slot = 1; // Slot number.
+  bytes hash = 2; // Block hash.
+  uint64 height = 3; // Block height.
+  uint64 timestamp = 4; // Block ms timestamp
+}
+
+message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1beta.cardano.Block cardano = 2; // A parsed Cardano block.
+  }
+}
+
+// Represents a reference to a transaction output
+message TxoRef {
+  bytes hash = 1; // Tx hash.
+  uint32 index = 2; // Output index.
+}
+
+// Request to get the chain parameters
+message ReadParamsRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
+}
+
+// Request to get the chain config
+message ReadGenesisRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
+}
+
+// Request to get the era summary
+message ReadEraSummaryRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
+}
+
+// Response containing the genesis configs
+message ReadGenesisResponse {
+  bytes genesis = 1; // genesis hash for the chain
+  string caip2 = 2; // the caip-2 ID for this network
+  oneof config {
+    utxorpc.v1beta.cardano.Genesis cardano = 3; // Cardano genesis
+  }
+}
+
+// Response containing the era summaries
+message ReadEraSummaryResponse {
+  oneof summary {
+    utxorpc.v1beta.cardano.EraSummaries cardano = 1; // Cardano era summaries
+  }
+}
+
+// An evenlope that holds parameter data from any of the compatible chains
+message AnyChainParams {
+  oneof params {
+    utxorpc.v1beta.cardano.PParams cardano = 1; // Cardano parameters
+  }
+}
+
+// Response containing the chain parameters
+message ReadParamsResponse {
+  AnyChainParams values = 1; // The value of the parameters.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// An envelope that wraps a chain-specific ledger-state query.
+message AnyChainStateQuery {
+  oneof query {
+    utxorpc.v1beta.cardano.StateQuery cardano = 1; // A Cardano ledger-state query.
+  }
+}
+
+// An envelope that wraps a chain-specific ledger-state query result.
+message AnyChainStateData {
+  oneof result {
+    utxorpc.v1beta.cardano.StateData cardano = 1; // A Cardano ledger-state query result.
+  }
+}
+
+// Request to run a chain-specific ledger-state query against the current ledger snapshot.
+message ReadStateRequest {
+  AnyChainStateQuery query = 1; // The chain-specific query to evaluate.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response carrying the ledger-state query result.
+message ReadStateResponse {
+  AnyChainStateData result = 1; // The query result.
+  ChainPoint ledger_tip = 2; // Chain point representing the snapshot the query was evaluated against.
+}
+
+// An evenlope that holds an UTxO patterns from any of compatible chains
+message AnyUtxoPattern {
+  oneof utxo_pattern {
+    utxorpc.v1beta.cardano.TxOutputPattern cardano = 1;
+  }
+}
+
+// Represents a simple utxo predicate that can composed to create more complex ones
+message UtxoPredicate {
+  optional AnyUtxoPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated UtxoPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated UtxoPredicate all_of = 3; // Predicate is true if utxo exhibits all of the patterns.
+  repeated UtxoPredicate any_of = 4; // Predicate is true if utxo exhibits any of the patterns.
+}
+
+// An evenlope that holds an UTxO from any of compatible chains
+message AnyUtxoData {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  TxoRef txo_ref = 2; // Hash of the previous transaction.
+  oneof parsed_state {
+    utxorpc.v1beta.cardano.TxOutput cardano = 3; // A cardano UTxO
+  }
+  ChainPoint block_ref = 4; // The chain point that represents the block this UTxO was created in.
+}
+
+// Request to get specific UTxOs
+message ReadUtxosRequest {
+  repeated TxoRef keys = 1; // List of keys UTxOs.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response containing the UTxOs associated with the requested addresses.
+message ReadUtxosResponse {
+  repeated AnyUtxoData items = 1; // List of UTxOs.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// Request to search for UTxO based on a pattern.
+message SearchUtxosRequest {
+  optional UtxoPredicate predicate = 1; // Pattern to match UTxOs by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+  optional int32 max_items = 3; // The maximum number of items to return.
+  optional string start_token = 4; // The next_page_token value returned from a previous request, if any.
+}
+
+// Response containing the UTxOs that match the requested addresses.
+message SearchUtxosResponse {
+  repeated AnyUtxoData items = 1; // List of UTxOs.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+  optional string next_token = 3; // Token to retrieve the next page of results, absent if there are no more results.
+}
+
+// Request to get data (as in plural of datum)
+message ReadDataRequest {
+  repeated bytes keys = 1;
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields in the response.
+}
+
+// An evenlope that holds a datum for any of the compatible chains
+message AnyChainDatum {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  bytes key = 2;
+  oneof parsed_state {
+    utxorpc.v1beta.cardano.PlutusData cardano = 3; // A cardano UTxO
+  }
+}
+
+// Response containing data (as in plural of datum)
+message ReadDataResponse {
+  repeated AnyChainDatum values = 1; // The value of each datum.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// Request to get a transaction by hash
+message ReadTxRequest {
+  bytes hash = 1; // The hash of the transaction.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields in the response.
+}
+
+// Represents a transaction from any supported blockchain.
+message AnyChainTx {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1beta.cardano.Tx cardano = 2; // A Cardano transaction.
+  }
+  ChainPoint block_ref = 3; // The chain point that represents the block this transaction belongs to.
+}
+
+// Response containing the transaction associated with the requested hash.
+message ReadTxResponse {
+  AnyChainTx tx = 1; // The transaction.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
+// Service definition for querying the state of the chain.
+service QueryService {
+  rpc ReadParams(ReadParamsRequest) returns (ReadParamsResponse); // Get overall chain state.
+  rpc ReadUtxos(ReadUtxosRequest) returns (ReadUtxosResponse); // Read specific UTxOs by reference.
+  rpc SearchUtxos(SearchUtxosRequest) returns (SearchUtxosResponse); // Search for UTxO based on a pattern.
+  rpc ReadData(ReadDataRequest) returns (ReadDataResponse); // Read specific datum by hash
+  rpc ReadTx(ReadTxRequest) returns (ReadTxResponse); // Get Txs by chain-specific criteria.
+  rpc ReadGenesis(ReadGenesisRequest) returns (ReadGenesisResponse); // Get the genesis configuration
+  rpc ReadEraSummary(ReadEraSummaryRequest) returns (ReadEraSummaryResponse); // Get the chain era summary
+  rpc ReadState(ReadStateRequest) returns (ReadStateResponse); // Run a chain-specific ledger-state query (e.g. stake pool distribution).
+
+  // TODO: decide if we want to expand the scope
+  // rpc DumpUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Dump all available utxos
+  // rpc ReadAccount(ReadAccountRequest) returns (ReadAccountReponse); // Get state of a particular account
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1beta/submit/submit.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1beta/submit/submit.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package utxorpc.v1beta.submit;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1beta/cardano/cardano.proto";
+
+// Represents a transaction from any supported blockchain.
+message AnyChainTx {
+  oneof type {
+    bytes raw = 1; // Raw transaction data.
+  }
+}
+
+// Request to evaluate transaction without submitting.
+message EvalTxRequest {
+  AnyChainTx tx = 1; // A transaction to evaluate.
+}
+
+// Report containing the result of evaluating a particular transaction
+message AnyChainEval {
+  oneof chain {
+    utxorpc.v1beta.cardano.TxEval cardano = 1; // A Cardano tx evaluation report.
+  }
+}
+
+// Response containing the reports form the transaction evaluation.
+message EvalTxResponse {
+  AnyChainEval report = 1;
+}
+
+// Request to submit a transaction to the blockchain.
+message SubmitTxRequest {
+  AnyChainTx tx = 1; // A transaction to submit.
+}
+
+// Response containing references to the submitted transactions.
+message SubmitTxResponse {
+  bytes ref = 1; // A transaction reference returned upon successful submission.
+}
+
+// Enum representing the various stages of a transaction's lifecycle.
+enum Stage {
+  STAGE_UNSPECIFIED = 0; // Unspecified stage.
+  STAGE_ACKNOWLEDGED = 1; // Transaction has been acknowledged by the node.
+  STAGE_MEMPOOL = 2; // Transaction is in the mempool.
+  STAGE_NETWORK = 3; // Transaction has been propagated across the network.
+  STAGE_CONFIRMED = 4; // Transaction has been confirmed on the blockchain.
+}
+
+message TxInMempool {
+  bytes ref = 1; // The transaction reference.
+  bytes native_bytes = 2; // Original bytes as defined by the chain
+  Stage stage = 3; // The current stage of the tx
+  oneof parsed_state {
+    utxorpc.v1beta.cardano.Tx cardano = 4; // A Cardano transaction.
+  }
+}
+
+// Request to check the status of submitted transactions.
+message ReadMempoolRequest {}
+
+// Response containing the stage of the submitted transactions.
+message ReadMempoolResponse {
+  repeated TxInMempool items = 1; // List of transaction currently on the mempool.
+}
+
+// Request to wait for transactions to reach a certain stage.
+message WaitForTxRequest {
+  repeated bytes ref = 1; // List of transaction references to wait for.
+}
+
+// Response containing the transaction reference and stage once it has been reached.
+message WaitForTxResponse {
+  bytes ref = 1; // Transaction reference.
+  Stage stage = 2; // Stage reached by the transaction.
+}
+
+// Represents a tx pattern from any supported blockchain.
+message AnyChainTxPattern {
+  oneof chain {
+    utxorpc.v1beta.cardano.TxPattern cardano = 1; // A Cardano tx pattern.
+  }
+}
+
+// Represents a simple tx predicate that can composed to create more complex ones
+message TxPredicate {
+  AnyChainTxPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated TxPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated TxPredicate all_of = 3; // Predicate is true if tx exhibits all of the patterns.
+  repeated TxPredicate any_of = 4; // Predicate is true if tx exhibits any of the patterns.
+}
+
+// Request to watch changes of specific mempool txs.
+message WatchMempoolRequest {
+  TxPredicate predicate = 1; // A predicate to filter transactions by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response that represents a change in a mempool tx.
+message WatchMempoolResponse {
+  TxInMempool tx = 1; // The content and stage of the tx that has changed
+}
+
+// Service definition for submitting transactions and checking their status.
+service SubmitService {
+  rpc EvalTx(EvalTxRequest) returns (EvalTxResponse); // Evaluates a transaction without submitting it.
+  rpc SubmitTx(SubmitTxRequest) returns (SubmitTxResponse); // Submit transactions to the blockchain.
+  rpc WaitForTx(WaitForTxRequest) returns (stream WaitForTxResponse); // Wait for transactions to reach a certain stage and stream the updates.
+  rpc ReadMempool(ReadMempoolRequest) returns (ReadMempoolResponse); // Returns a point-in-time snapshot of the mempool.
+  rpc WatchMempool(WatchMempoolRequest) returns (stream WatchMempoolResponse); // Stream transactions from the mempool matching the specified predicates.
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1beta/sync/sync.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1beta/sync/sync.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package utxorpc.v1beta.sync;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1beta/cardano/cardano.proto";
+
+// Represents a reference to a specific block by a chosen combination of fields
+message BlockRef {
+  uint64 slot = 1; // Height or slot number (depending on the blockchain)
+  bytes hash = 2; // Hash of the content of the block
+  uint64 height = 3; // Block height
+  uint64 timestamp = 4; // Block ms timestamp
+}
+
+message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1beta.cardano.Block cardano = 2; // A parsed Cardano block.
+  }
+}
+
+// Request to fetch a block by its reference.
+message FetchBlockRequest {
+  repeated BlockRef ref = 1; // List of block references.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response containing the fetched blocks.
+message FetchBlockResponse {
+  repeated AnyChainBlock block = 1; // List of fetched blocks.
+}
+
+// Request to dump the block history.
+message DumpHistoryRequest {
+  BlockRef start_token = 2; // Starting point for the block history dump.
+  uint32 max_items = 3; // Maximum number of items to return.
+  google.protobuf.FieldMask field_mask = 4; // Field mask to selectively return fields.
+}
+
+// Response containing the dumped block history.
+message DumpHistoryResponse {
+  repeated AnyChainBlock block = 1; // List of blocks in the history.
+  BlockRef next_token = 2; // Next token for pagination.
+}
+
+// Request to follow the tip of the blockchain.
+message FollowTipRequest {
+  repeated BlockRef intersect = 1; // List of block references to find the intersection.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response containing the action to perform while following the tip.
+message FollowTipResponse {
+  oneof action {
+    AnyChainBlock apply = 1; // Apply this block.
+    AnyChainBlock undo = 2; // Undo this block.
+    BlockRef reset = 3; // Reset to this block reference.
+  }
+  BlockRef tip = 4; // The current tip of the blockchain after this action.
+}
+
+// Request to read the current tip of the blockchain.
+message ReadTipRequest {}
+
+// Response containing the current tip of the blockchain.
+message ReadTipResponse {
+  BlockRef tip = 1; // The current tip of the blockchain.
+}
+
+// Service definition for syncing chain data.
+service SyncService {
+  rpc FetchBlock(FetchBlockRequest) returns (FetchBlockResponse); // Fetch a block by its reference.
+  rpc DumpHistory(DumpHistoryRequest) returns (DumpHistoryResponse); // Dump the block history.
+  rpc FollowTip(FollowTipRequest) returns (stream FollowTipResponse); // Follow the tip of the blockchain.
+  rpc ReadTip(ReadTipRequest) returns (ReadTipResponse); // Read the current tip of the blockchain.
+}

--- a/crates/dugite-rpc/proto/utxorpc/v1beta/watch/watch.proto
+++ b/crates/dugite-rpc/proto/utxorpc/v1beta/watch/watch.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package utxorpc.v1beta.watch;
+
+import "google/protobuf/field_mask.proto";
+import "utxorpc/v1beta/cardano/cardano.proto";
+
+// Represents a reference to a specific block by a chosen combination of fields
+message BlockRef {
+  uint64 slot = 1; // Height or slot number (depending on the blockchain)
+  bytes hash = 2; // Hash of the content of the block
+  uint64 height = 3; // Block height
+}
+
+message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  oneof chain {
+    utxorpc.v1beta.cardano.Block cardano = 2; // A parsed Cardano block.
+  }
+}
+
+// Represents a tx pattern from any supported blockchain.
+message AnyChainTxPattern {
+  oneof chain {
+    utxorpc.v1beta.cardano.TxPattern cardano = 1; // A Cardano tx pattern.
+  }
+}
+
+// Represents a simple tx predicate that can composed to create more complex ones
+message TxPredicate {
+  AnyChainTxPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated TxPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated TxPredicate all_of = 3; // Predicate is true if tx exhibits all of the patterns.
+  repeated TxPredicate any_of = 4; // Predicate is true if tx exhibits any of the patterns.
+}
+
+// Request to watch transactions from the chain based on a set of predicates.
+message WatchTxRequest {
+  TxPredicate predicate = 1; // Predicate to filter transactions by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+  repeated BlockRef intersect = 3; // List of block references to find the intersection.
+}
+
+// Represents a transaction from any supported blockchain.
+message AnyChainTx {
+  oneof chain {
+    utxorpc.v1beta.cardano.Tx cardano = 1; // A Cardano transaction.
+  }
+  AnyChainBlock block = 2; // Block containing the transaction
+}
+
+// Response containing the matching chain transactions or block progress signals.
+message WatchTxResponse {
+  oneof action {
+    AnyChainTx apply = 1; // Apply this transaction.
+    AnyChainTx undo = 2; // Undo this transaction.
+    BlockRef idle = 3; // No-match signal for a block.
+  }
+}
+
+// Service definition for watching transactions based on predicates.
+service WatchService {
+  rpc WatchTx(WatchTxRequest) returns (stream WatchTxResponse); // Stream transactions from the chain matching the specified predicates.
+}

--- a/crates/dugite-rpc/src/config.rs
+++ b/crates/dugite-rpc/src/config.rs
@@ -1,0 +1,78 @@
+//! Static configuration for the RPC server.
+//!
+//! Constructed by `dugite-node` from `NodeConfig.Rpc` (JSON) + CLI flags and
+//! passed to [`RpcServer::start`](crate::server::RpcServer::start). This crate
+//! never reads files directly — the host owns config parsing.
+
+use std::net::IpAddr;
+use std::path::PathBuf;
+
+/// Default gRPC listen port — matches the de-facto utxorpc convention
+/// used by Dolos, Demeter, and others. Override per-deployment via JSON
+/// `Rpc.Port` or `--rpc-port`.
+pub const DEFAULT_RPC_PORT: u16 = 50051;
+
+/// Default per-stream buffer size (events). A slow client whose receiver
+/// falls behind by more than this drops with `RESOURCE_EXHAUSTED`.
+pub const DEFAULT_STREAM_BUFFER: usize = 256;
+
+/// Default cap on the number of concurrent streams a single connection
+/// can drive. Mirrors tonic's HTTP/2 default safety floor.
+pub const DEFAULT_MAX_CONCURRENT_STREAMS: u32 = 64;
+
+/// Top-level RPC server configuration.
+///
+/// All fields have explicit defaults via [`Default`] so callers only set
+/// what they care about. `bind` + `port` are mandatory in practice but
+/// [`Default`] supplies `127.0.0.1:50051` for tests / dev.
+#[derive(Debug, Clone)]
+pub struct RpcConfig {
+    /// IP address to bind. `127.0.0.1` for loopback-only (the safe default
+    /// for an unauthenticated TCP gRPC endpoint).
+    pub bind: IpAddr,
+    /// TCP port to listen on.
+    pub port: u16,
+    /// Per-stream buffer size (events). Slow consumers exceeding this are
+    /// dropped with `RESOURCE_EXHAUSTED`. See [`DEFAULT_STREAM_BUFFER`].
+    pub stream_buffer: usize,
+    /// Maximum concurrent HTTP/2 streams per connection. See
+    /// [`DEFAULT_MAX_CONCURRENT_STREAMS`].
+    pub max_concurrent_streams: u32,
+    /// Expose the gRPC reflection service (`grpc.reflection.v1.ServerReflection`)
+    /// so `grpcurl -plaintext :port list` works without a schema bundle.
+    pub reflection_enabled: bool,
+    /// Accept gRPC-Web traffic (HTTP/1.1). Off by default — opt in for
+    /// browser dApps; the HTTP/1.1 accept loop costs a small amount of
+    /// per-connection bookkeeping when enabled.
+    pub web_enabled: bool,
+    /// Expose the `v1alpha` services in addition to `v1beta`. Enabled by
+    /// default during the upstream-stabilisation cycle; operators can
+    /// pre-disable to test that their clients have migrated.
+    pub alpha_enabled: bool,
+    /// Optional TLS termination — if `None`, plaintext gRPC. For mTLS or
+    /// production deployments, prefer Envoy / a sidecar.
+    pub tls: Option<RpcTlsConfig>,
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            bind: IpAddr::from([127, 0, 0, 1]),
+            port: DEFAULT_RPC_PORT,
+            stream_buffer: DEFAULT_STREAM_BUFFER,
+            max_concurrent_streams: DEFAULT_MAX_CONCURRENT_STREAMS,
+            reflection_enabled: true,
+            web_enabled: false,
+            alpha_enabled: true,
+            tls: None,
+        }
+    }
+}
+
+/// Optional TLS configuration. Plain PEM-encoded cert/key on disk; no
+/// hot-reload in v1 — config changes require a node restart.
+#[derive(Debug, Clone)]
+pub struct RpcTlsConfig {
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+}

--- a/crates/dugite-rpc/src/context.rs
+++ b/crates/dugite-rpc/src/context.rs
@@ -1,0 +1,212 @@
+//! `LedgerContext` — the async trait the RPC server uses to talk to the
+//! node.
+//!
+//! The trait is dep-free of `dugite-node` so this crate's compile graph
+//! stays small. The host (`dugite-node`) provides a concrete impl
+//! (`NodeRpcAdapter`) that delegates to `ChainDBBlockProvider`,
+//! `LedgerTxValidator`, `LedgerState`, `Mempool`, and so on.
+//!
+//! All methods are `async` (via `async_trait`) so impls can acquire
+//! `RwLock` reads without `block_in_place`. Returning `Result<_, RpcError>`
+//! lets service code map cleanly to gRPC status codes via
+//! `error::RpcError::into::<tonic::Status>()`.
+//!
+//! In M1.A only a handful of methods need a real implementation
+//! (`tip`, `block_by_hash`, `block_at_slot`, `intersect`, `genesis`); the
+//! rest can return `RpcError::Unimplemented` until the relevant service
+//! implementation lands.
+
+use async_trait::async_trait;
+use dugite_primitives::address::Address;
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::transaction::{TransactionInput, TransactionOutput};
+use dugite_primitives::Era;
+use std::sync::Arc;
+
+use crate::error::RpcError;
+
+// ─── Lightweight carrier types ────────────────────────────────────────────
+
+/// Current chain tip — payload-shaped to match
+/// `node::tip_broadcast::TipApply` so the RPC adapter can forward without
+/// re-shaping.
+#[derive(Clone, Debug)]
+pub struct TipInfo {
+    pub slot: u64,
+    pub hash: [u8; 32],
+    pub block_number: u64,
+    pub era: Era,
+}
+
+/// A block in its native CBOR form, paired with the indexable metadata
+/// the RPC layer needs without re-decoding.
+///
+/// `cbor` is borrowed-style ownership: the caller can either hand back the
+/// `ChainDB` slice directly (in M1.B we wrap it in `Bytes` for zero-copy)
+/// or allocate a `Vec`. For M1.A we use `Vec<u8>` for simplicity.
+#[derive(Clone, Debug)]
+pub struct RawBlock {
+    pub slot: u64,
+    pub hash: [u8; 32],
+    pub block_number: u64,
+    pub era: Era,
+    pub cbor: Vec<u8>,
+}
+
+/// A transaction in mempool / wire form.
+#[derive(Clone, Debug)]
+pub struct RawTx {
+    pub hash: TransactionHash,
+    /// Full transaction CBOR (body + witness + is_valid + aux wrapper).
+    /// May be empty if the tx was admitted via a path that did not retain
+    /// raw bytes (in practice this should not happen post-M0.2).
+    pub cbor: Vec<u8>,
+}
+
+/// A single UTxO entry, paired with the slot/height at which it became
+/// resident (helpful for `UtxoSnapshot.slot` projection in utxorpc).
+#[derive(Clone, Debug)]
+pub struct UtxoSnapshot {
+    pub ref_: TransactionInput,
+    pub output: TransactionOutput,
+    /// Slot at which the producing transaction was applied. `None` if
+    /// the source path can't recover it (genesis UTxO, mempool virtual
+    /// UTxO).
+    pub slot: Option<u64>,
+}
+
+/// Opaque protocol-params view returned by [`LedgerContext::params_at_tip`].
+///
+/// Wraps the in-tree `ProtocolParameters` so M1.B mapping can read every
+/// field without `dugite-rpc` re-shaping it. `Arc` so adapter calls are
+/// cheap — params change only at epoch boundaries.
+#[derive(Clone, Debug)]
+pub struct ParamsView {
+    pub params: Arc<dugite_primitives::protocol_params::ProtocolParameters>,
+    /// Protocol version major (PV) at the tip, used by the mapper to
+    /// gate Conway-only fields.
+    pub protocol_version_major: u64,
+}
+
+/// Opaque era-history view returned by [`LedgerContext::era_history`].
+///
+/// Refined into a richer shape in M1.B as the QueryService mapping needs
+/// it; this M1.A placeholder is just enough to compile.
+#[derive(Clone, Debug, Default)]
+pub struct EraHistoryView {
+    /// Era boundaries: `(era, first_slot, slot_length_ms, epoch_length_slots)`
+    /// for each era the chain has crossed, in chronological order.
+    pub summaries: Vec<EraSummary>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EraSummary {
+    pub era: Era,
+    pub first_slot: u64,
+    pub slot_length_ms: u32,
+    pub epoch_length_slots: u32,
+}
+
+/// Opaque genesis view returned by [`LedgerContext::genesis`].
+///
+/// Currently a placeholder. M1.B fills the fields the QueryService
+/// `ReadGenesis` response needs (system start, network magic, genesis
+/// pool params, security parameter, etc.) without coupling this crate
+/// to `dugite-ledger::CombinedGenesis`.
+#[derive(Clone, Debug, Default)]
+pub struct GenesisView {
+    pub network_magic: u32,
+    pub system_start_unix: i64,
+    pub security_param: u32,
+}
+
+/// Outcome of a transaction submission.
+#[derive(Clone, Debug)]
+pub enum SubmitOutcome {
+    /// The tx was admitted to the mempool (or was already there).
+    Accepted { hash: TransactionHash },
+    /// Phase-1 / Phase-2 / mempool-admission validation rejected it.
+    /// The string is the structured `TxValidationError` rendered verbatim
+    /// so cardano-node per-rule semantics survive across the wire.
+    Rejected { reason: String },
+}
+
+// ─── The trait ────────────────────────────────────────────────────────────
+
+/// The full API surface the RPC server uses to talk to the node.
+///
+/// Implementations live in the host crate (`dugite-node`); this crate
+/// only consumes the abstraction.
+#[async_trait]
+pub trait LedgerContext: Send + Sync + 'static {
+    // ── chain / blocks ───────────────────────────────────────────────────
+
+    async fn tip(&self) -> Result<TipInfo, RpcError>;
+
+    async fn block_by_hash(&self, hash: &Hash32) -> Result<Option<RawBlock>, RpcError>;
+
+    async fn block_at_slot(&self, slot: u64) -> Result<Option<RawBlock>, RpcError>;
+
+    /// First block strictly after `slot`. Used by `DumpHistory` to page
+    /// through blocks without requiring the client to know exact slots.
+    async fn block_after(&self, slot: u64) -> Result<Option<RawBlock>, RpcError>;
+
+    /// Find the latest of the supplied points that exists on the local
+    /// chain — the standard ChainSync intersection used by `FollowTip`.
+    async fn intersect(&self, points: &[Point]) -> Result<Option<Point>, RpcError>;
+
+    /// Return at most `limit` blocks with slot in `[from_slot, to_slot]`.
+    async fn blocks_range(
+        &self,
+        from_slot: u64,
+        to_slot: u64,
+        limit: usize,
+    ) -> Result<Vec<RawBlock>, RpcError>;
+
+    // ── ledger / UTxO ────────────────────────────────────────────────────
+
+    async fn utxo_by_ref(
+        &self,
+        refs: &[TransactionInput],
+    ) -> Result<Vec<UtxoSnapshot>, RpcError>;
+
+    async fn utxos_by_address(&self, addr: &Address) -> Result<Vec<UtxoSnapshot>, RpcError>;
+
+    /// UTxO lookup by payment credential — NOT indexed in v1, returns
+    /// `Unimplemented` until the LSM column-family pattern lands
+    /// (tracking issue follow-up).
+    async fn utxos_by_payment_credential(
+        &self,
+        cred: &Hash32,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError>;
+
+    /// UTxO lookup by asset. Best-effort O(N) scan capped at a safety
+    /// limit; over-cap returns `ResourceExhausted`.
+    async fn utxos_by_asset(
+        &self,
+        policy: &Hash32,
+        name: Option<&[u8]>,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError>;
+
+    async fn params_at_tip(&self) -> Result<ParamsView, RpcError>;
+
+    async fn era_history(&self) -> Result<EraHistoryView, RpcError>;
+
+    async fn genesis(&self) -> Result<GenesisView, RpcError>;
+
+    // ── submission ───────────────────────────────────────────────────────
+
+    /// Validate + admit a transaction to the mempool. Mirrors the N2C
+    /// `LocalTxSubmission` path so on-chain semantics are identical.
+    /// `era` is the Cardano era tag the client claims for the wrapping
+    /// CBOR (`u16`, 0 = Byron, 1 = Shelley, …); the validator double-
+    /// checks against the body shape.
+    async fn submit_tx(&self, era: u16, raw_cbor: &[u8]) -> SubmitOutcome;
+
+    // ── mempool snapshot (live feed lives in MempoolFeed) ────────────────
+
+    async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError>;
+
+    async fn mempool_contains(&self, hash: &TransactionHash) -> bool;
+}

--- a/crates/dugite-rpc/src/context.rs
+++ b/crates/dugite-rpc/src/context.rs
@@ -166,10 +166,7 @@ pub trait LedgerContext: Send + Sync + 'static {
 
     // ── ledger / UTxO ────────────────────────────────────────────────────
 
-    async fn utxo_by_ref(
-        &self,
-        refs: &[TransactionInput],
-    ) -> Result<Vec<UtxoSnapshot>, RpcError>;
+    async fn utxo_by_ref(&self, refs: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError>;
 
     async fn utxos_by_address(&self, addr: &Address) -> Result<Vec<UtxoSnapshot>, RpcError>;
 

--- a/crates/dugite-rpc/src/error.rs
+++ b/crates/dugite-rpc/src/error.rs
@@ -1,0 +1,108 @@
+//! RPC-layer error type + conversion to `tonic::Status`.
+//!
+//! Service impls return `Result<_, RpcError>` and the outer tower middleware
+//! (or a manual `.map_err(Into::into)`) converts to the gRPC status code that
+//! the wire actually carries. Centralising this means service code never
+//! constructs `tonic::Status` directly — it just classifies the failure.
+
+use thiserror::Error;
+use tonic::Status;
+
+/// Failures the RPC layer can report to a client.
+///
+/// Variant choice mirrors the gRPC status taxonomy
+/// (<https://grpc.io/docs/guides/status-codes/>) so [`From`] is mechanical.
+/// Service code should reach for the most specific variant — defaulting to
+/// `Internal` silently masks real bugs.
+#[derive(Debug, Error)]
+pub enum RpcError {
+    /// The client supplied a malformed or contradictory request payload
+    /// (e.g. a `BlockRef` with neither `slot` nor `hash`, an unparseable
+    /// CBOR pattern, a `FieldMask` referencing an unknown path).
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
+    /// The requested resource does not exist (block hash not in
+    /// ChainDB, tx hash not in mempool when `WaitForTx` was asked to fail
+    /// fast, etc.).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// The operation is not implemented in this milestone — used by every
+    /// service stub during M1.A until later milestones land.
+    #[error("unimplemented: {0}")]
+    Unimplemented(&'static str),
+
+    /// The client (or some shared resource) is over a configured limit:
+    /// a slow streaming client whose per-stream buffer overflowed, an
+    /// asset-pattern scan that exceeded the safety cap, etc.
+    #[error("resource exhausted: {0}")]
+    ResourceExhausted(String),
+
+    /// Transaction submission was rejected by ledger validation. The
+    /// payload is the structured `TxValidationError` message rendered
+    /// to a string so cardano-node per-rule semantics survive the
+    /// trip across the gRPC boundary.
+    #[error("transaction rejected: {0}")]
+    TxRejected(String),
+
+    /// The request was cancelled by the client (stream dropped, deadline
+    /// expired) — surfaced only when the service can distinguish
+    /// cancellation from completion.
+    #[error("cancelled")]
+    Cancelled,
+
+    /// Catch-all for unexpected node-internal failures. Service code
+    /// should NOT construct this for known-rejection scenarios — prefer
+    /// a specific variant so clients can react.
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+impl From<RpcError> for Status {
+    fn from(err: RpcError) -> Self {
+        match err {
+            RpcError::InvalidArgument(msg) => Status::invalid_argument(msg),
+            RpcError::NotFound(msg) => Status::not_found(msg),
+            RpcError::Unimplemented(what) => {
+                Status::unimplemented(format!("{what} is not implemented in this build"))
+            }
+            RpcError::ResourceExhausted(msg) => Status::resource_exhausted(msg),
+            RpcError::TxRejected(msg) => {
+                // gRPC has no "ledger validation failed" code; FAILED_PRECONDITION
+                // best matches the semantic ("a logical precondition for the call
+                // — the tx must validate — was not met"). Clients reading the
+                // message get the structured rejection reason verbatim.
+                Status::failed_precondition(msg)
+            }
+            RpcError::Cancelled => Status::cancelled("client cancelled"),
+            RpcError::Internal(msg) => Status::internal(msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Code;
+
+    #[test]
+    fn status_codes_round_trip() {
+        let cases = [
+            (RpcError::InvalidArgument("x".into()), Code::InvalidArgument),
+            (RpcError::NotFound("x".into()), Code::NotFound),
+            (RpcError::Unimplemented("EvalTx"), Code::Unimplemented),
+            (
+                RpcError::ResourceExhausted("x".into()),
+                Code::ResourceExhausted,
+            ),
+            (RpcError::TxRejected("x".into()), Code::FailedPrecondition),
+            (RpcError::Cancelled, Code::Cancelled),
+            (RpcError::Internal("x".into()), Code::Internal),
+        ];
+        for (err, expected) in cases {
+            let status: Status = err.into();
+            assert_eq!(status.code(), expected);
+        }
+    }
+}

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -23,4 +23,16 @@
 
 #![deny(rust_2018_idioms)]
 
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod metrics;
 pub mod proto;
+
+pub use config::{RpcConfig, RpcTlsConfig};
+pub use context::{
+    EraHistoryView, EraSummary, GenesisView, LedgerContext, ParamsView, RawBlock, RawTx,
+    SubmitOutcome, TipInfo, UtxoSnapshot,
+};
+pub use error::RpcError;
+pub use metrics::{noop_metrics, NoopMetrics, RpcMetricsSink, SharedMetrics};

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -26,8 +26,12 @@
 pub mod config;
 pub mod context;
 pub mod error;
+pub mod masking;
+pub mod mempool_feed;
 pub mod metrics;
 pub mod proto;
+pub mod stream;
+pub mod tip_feed;
 
 pub use config::{RpcConfig, RpcTlsConfig};
 pub use context::{
@@ -35,4 +39,6 @@ pub use context::{
     SubmitOutcome, TipInfo, UtxoSnapshot,
 };
 pub use error::RpcError;
+pub use mempool_feed::{MempoolEvent, MempoolFeed, MempoolRemoveReason};
 pub use metrics::{noop_metrics, NoopMetrics, RpcMetricsSink, SharedMetrics};
+pub use tip_feed::{TipFeed, TipPublisher, TipRollback};

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -1,0 +1,26 @@
+//! Native UTxO RPC (gRPC) server for `dugite-node` — issue #672.
+//!
+//! This crate is the sole consumer of `tonic` / `prost` in the workspace.
+//! `dugite-node` depends on `dugite-rpc` as an opaque library and never sees
+//! the gRPC stack in its direct compile graph, keeping the node binary
+//! small when the RPC server is disabled (the default).
+//!
+//! See `.claude/plans/create-a-detailed-plan-adaptive-pretzel.md` for the
+//! multi-milestone implementation plan. M1.A (this scaffold) ships:
+//!
+//! * Vendored proto from `utxorpc/spec v0.19.2` + tonic-build codegen.
+//! * `RpcServer::start` with gRPC reflection + gRPC-Web + TLS + cooperative
+//!   shutdown.
+//! * `LedgerContext` async trait abstraction over the node — no
+//!   `dugite-node` symbols leak into this crate's public API.
+//! * Service stubs for `SyncService` / `QueryService` / `SubmitService` /
+//!   `WatchService` in both `v1alpha` and `v1beta` — every method returns
+//!   `UNIMPLEMENTED` until M1.B and later milestones land.
+//!
+//! Spec-bump workflow: `just bump-utxorpc-spec <tag>` rewrites
+//! `crates/dugite-rpc/proto/` from the upstream and updates the VERSION
+//! file. Golden tests catch protobuf shape drift before merge.
+
+#![deny(rust_2018_idioms)]
+
+pub mod proto;

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -30,6 +30,8 @@ pub mod masking;
 pub mod mempool_feed;
 pub mod metrics;
 pub mod proto;
+pub mod server;
+pub mod services;
 pub mod stream;
 pub mod tip_feed;
 
@@ -41,4 +43,5 @@ pub use context::{
 pub use error::RpcError;
 pub use mempool_feed::{MempoolEvent, MempoolFeed, MempoolRemoveReason};
 pub use metrics::{noop_metrics, NoopMetrics, RpcMetricsSink, SharedMetrics};
+pub use server::{RpcServer, RpcServerHandle};
 pub use tip_feed::{TipFeed, TipPublisher, TipRollback};

--- a/crates/dugite-rpc/src/masking.rs
+++ b/crates/dugite-rpc/src/masking.rs
@@ -1,0 +1,94 @@
+//! FieldMask application stubs — issue #672 M1.A.4.
+//!
+//! Most utxorpc requests carry a `google.protobuf.FieldMask` selecting
+//! which response fields the server should populate. Honouring it
+//! correctly requires per-top-level-message logic (mapping mask paths
+//! → struct field clearing), which lives in M1.B / M2 alongside the
+//! mapping modules that produce each response type.
+//!
+//! This module provides:
+//!
+//! * [`FieldMaskPath`] — a thin newtype that splits a single
+//!   dot-separated mask path into segments. Parsing happens up front so
+//!   the per-field hot loop in mapping code is just slice comparisons.
+//! * [`apply`] — the entry point. M1.A returns the response unchanged
+//!   when the mask is empty / missing; specific overloads land per
+//!   response type as the corresponding service implementation lands.
+//!
+//! The reason we hand-roll mask logic rather than reach for
+//! `prost-reflect` is that prost-reflect adds ~700 KB of code-size and a
+//! complete descriptor-walker we don't need — masks in utxorpc are
+//! shallow and well-known per response shape.
+
+/// Splits one dot-separated `FieldMask` path into segments.
+///
+/// `"block.body.tx.outputs.address"` → `["block", "body", "tx", "outputs", "address"]`.
+#[derive(Clone, Debug)]
+pub struct FieldMaskPath {
+    segments: Vec<String>,
+}
+
+impl FieldMaskPath {
+    pub fn parse(s: &str) -> Self {
+        Self {
+            segments: s
+                .split('.')
+                .filter(|seg| !seg.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        }
+    }
+
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+}
+
+/// Apply a FieldMask (sequence of paths) to a response.
+///
+/// In M1.A this is a no-op stub — the response is returned unchanged
+/// regardless of the mask. M1.B and later milestones add per-response
+/// `apply_impl::<T>` specialisations that traverse the proto message
+/// and clear fields not covered by any path. Until those land, clients
+/// receive every field whether or not they asked for it — strictly more
+/// data than requested, never less, so no client correctness issue.
+pub fn apply<T>(mask_paths: &[String], response: T) -> T {
+    let _ = mask_paths;
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_dot_separated_path() {
+        let p = FieldMaskPath::parse("block.body.tx");
+        assert_eq!(p.segments(), &["block", "body", "tx"]);
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn empty_path_is_recognised() {
+        assert!(FieldMaskPath::parse("").is_empty());
+        assert!(FieldMaskPath::parse(".").is_empty());
+    }
+
+    #[test]
+    fn collapses_consecutive_dots() {
+        let p = FieldMaskPath::parse("a..b..c");
+        assert_eq!(p.segments(), &["a", "b", "c"]);
+    }
+
+    #[test]
+    fn apply_is_identity_in_m1a() {
+        let r = apply(&[], "hello".to_string());
+        assert_eq!(r, "hello");
+        let r2 = apply(&["foo".to_string()], 42);
+        assert_eq!(r2, 42);
+    }
+}

--- a/crates/dugite-rpc/src/mempool_feed.rs
+++ b/crates/dugite-rpc/src/mempool_feed.rs
@@ -1,0 +1,63 @@
+//! Mempool change-event feed.
+//!
+//! Unlike [`TipFeed`](crate::tip_feed::TipFeed), this is a direct
+//! re-export wrapper around the `dugite-mempool` broadcast — there's no
+//! payload mapping needed because `dugite-rpc` already depends on
+//! `dugite-mempool` (the trait surface uses `TransactionHash` etc.
+//! anyway), so the same `MempoolEvent` / `MempoolRemoveReason` types
+//! flow end-to-end.
+//!
+//! The host hands the [`broadcast::Sender`] from `Mempool::tx_events()`
+//! straight to [`MempoolFeed::new`] — no shim task required.
+
+use tokio::sync::broadcast;
+
+// Re-export the upstream types so consumers don't need a direct
+// `dugite-mempool` dep just for the event enum.
+pub use dugite_mempool::{MempoolEvent, MempoolRemoveReason};
+
+/// Wraps the broadcast sender produced by `Mempool::tx_events()` so
+/// service code can subscribe without holding a reference to the whole
+/// [`dugite_mempool::Mempool`] type.
+#[derive(Clone, Debug)]
+pub struct MempoolFeed {
+    sender: broadcast::Sender<MempoolEvent>,
+}
+
+impl MempoolFeed {
+    pub fn new(sender: broadcast::Sender<MempoolEvent>) -> Self {
+        Self { sender }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<MempoolEvent> {
+        self.sender.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dugite_primitives::hash::Hash32;
+
+    #[tokio::test]
+    async fn forwarded_event_reaches_subscriber() {
+        let (tx, _) = broadcast::channel(8);
+        let feed = MempoolFeed::new(tx.clone());
+        let mut rx = feed.subscribe();
+
+        let hash = Hash32::from_bytes([7u8; 32]);
+        tx.send(MempoolEvent::Added {
+            tx_hash: hash,
+            raw_cbor: Some(vec![1, 2, 3]),
+        })
+        .unwrap();
+
+        match rx.recv().await.unwrap() {
+            MempoolEvent::Added { tx_hash, raw_cbor } => {
+                assert_eq!(tx_hash, hash);
+                assert_eq!(raw_cbor, Some(vec![1, 2, 3]));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}

--- a/crates/dugite-rpc/src/metrics.rs
+++ b/crates/dugite-rpc/src/metrics.rs
@@ -1,0 +1,65 @@
+//! Metrics sink trait — kept dep-free of any concrete metrics library so
+//! `dugite-node` can plug Prometheus, OpenTelemetry, or a no-op
+//! implementation transparently.
+//!
+//! Granularity is per-method (`service` × `method` label cardinality is
+//! bounded by the proto definitions — 4 services × ~5 methods = ~20
+//! pairs, safe for Prometheus high-cardinality budgets). Status labels
+//! likewise are bounded by the gRPC code enum.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Implementations of this trait receive per-call observability events
+/// from every service implementation.
+///
+/// All methods take `&self` (no `&mut self`) so implementations can use
+/// atomic counters or sharded histograms without external locking. The
+/// expected hot-path implementation atomically increments counters /
+/// observes histograms keyed by `(service, method[, status])`.
+pub trait RpcMetricsSink: Send + Sync + 'static {
+    /// Fires once when a unary RPC starts. Implementations typically
+    /// stash a deadline / start instant and rely on
+    /// [`request_completed`](Self::request_completed) for the duration
+    /// observation.
+    fn request_started(&self, service: &str, method: &str) {
+        let _ = (service, method);
+    }
+
+    /// Fires once when a unary RPC completes (success or error).
+    /// `status` is the gRPC status code label (`OK`, `NOT_FOUND`,
+    /// `UNIMPLEMENTED`, …). `duration` is the wall-clock time.
+    fn request_completed(&self, service: &str, method: &str, status: &str, duration: Duration) {
+        let _ = (service, method, status, duration);
+    }
+
+    /// Fires once when a streaming RPC opens a stream to a client.
+    /// Implementations typically increment a `dugite_rpc_active_streams`
+    /// gauge.
+    fn stream_started(&self, service: &str, method: &str) {
+        let _ = (service, method);
+    }
+
+    /// Fires once when a streaming RPC's stream ends (client disconnect,
+    /// server shutdown, error). Implementations decrement the
+    /// corresponding gauge.
+    fn stream_ended(&self, service: &str, method: &str, status: &str) {
+        let _ = (service, method, status);
+    }
+}
+
+/// No-op sink — useful for tests and as the default when the host does
+/// not wire a real metrics adapter.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopMetrics;
+
+impl RpcMetricsSink for NoopMetrics {}
+
+/// Shorthand for the boxed sink shape every service holds.
+pub type SharedMetrics = Arc<dyn RpcMetricsSink>;
+
+/// Construct a shared no-op metrics sink — convenience for tests +
+/// `Default` impls that need an `Arc<dyn RpcMetricsSink>`.
+pub fn noop_metrics() -> SharedMetrics {
+    Arc::new(NoopMetrics)
+}

--- a/crates/dugite-rpc/src/proto/mod.rs
+++ b/crates/dugite-rpc/src/proto/mod.rs
@@ -1,0 +1,66 @@
+//! Generated UTxO RPC protobuf bindings.
+//!
+//! The `.proto` sources are vendored at `crates/dugite-rpc/proto/utxorpc/`
+//! and compiled to Rust by `build.rs` (via tonic-build → prost-build →
+//! protoc). The output lives in `OUT_DIR` and is `include!()`'d into the
+//! module tree below.
+//!
+//! Two API versions are exposed in parallel:
+//!
+//! * [`v1alpha`] — older, kept for one release cycle of backwards
+//!   compatibility while clients migrate.
+//! * [`v1beta`] — current, the source of truth for mapping logic.
+//!
+//! [`FILE_DESCRIPTOR_SET`] is the encoded
+//! [`google.protobuf.FileDescriptorSet`] covering every proto in both
+//! versions; the server feeds this to `tonic-reflection` so `grpcurl
+//! -plaintext :port list` works without bundling a separate descriptor
+//! artifact.
+
+#![allow(clippy::all, clippy::pedantic, missing_docs, rust_2018_idioms)]
+// prost-generated code includes derive macros that occasionally trip newer
+// lints; the upstream protobuf shapes are not ours to clean up.
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+
+/// The full encoded `FileDescriptorSet` for every vendored proto, suitable
+/// for `tonic_reflection::server::Builder::register_encoded_file_descriptor_set`.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/utxorpc_descriptor.bin"));
+
+/// `utxorpc.v1alpha.*` generated bindings.
+pub mod v1alpha {
+    pub mod cardano {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1alpha.cardano.rs"));
+    }
+    pub mod sync {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1alpha.sync.rs"));
+    }
+    pub mod query {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1alpha.query.rs"));
+    }
+    pub mod submit {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1alpha.submit.rs"));
+    }
+    pub mod watch {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1alpha.watch.rs"));
+    }
+}
+
+/// `utxorpc.v1beta.*` generated bindings.
+pub mod v1beta {
+    pub mod cardano {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1beta.cardano.rs"));
+    }
+    pub mod sync {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1beta.sync.rs"));
+    }
+    pub mod query {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1beta.query.rs"));
+    }
+    pub mod submit {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1beta.submit.rs"));
+    }
+    pub mod watch {
+        include!(concat!(env!("OUT_DIR"), "/utxorpc.v1beta.watch.rs"));
+    }
+}

--- a/crates/dugite-rpc/src/server.rs
+++ b/crates/dugite-rpc/src/server.rs
@@ -1,0 +1,207 @@
+//! `RpcServer` — single entry point that binds the listener, registers
+//! every service, and runs the tonic server until cooperative shutdown.
+//!
+//! Called by the host (`dugite-node`) inside `Node::run()` after the
+//! adapter + feeds are constructed. The future returned by
+//! [`RpcServer::start`] backgrounds the actual server task and yields an
+//! [`RpcServerHandle`] the host stores for graceful shutdown.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::{Identity, Server as TonicServer, ServerTlsConfig};
+use tracing::{error, info, warn};
+
+use crate::config::RpcConfig;
+use crate::context::LedgerContext;
+use crate::mempool_feed::MempoolFeed;
+use crate::metrics::SharedMetrics;
+use crate::proto;
+use crate::services::{
+    query::{QuerySvcAlpha, QuerySvcBeta},
+    submit::{SubmitSvcAlpha, SubmitSvcBeta},
+    sync::{SyncSvcAlpha, SyncSvcBeta},
+    watch::{WatchSvcAlpha, WatchSvcBeta},
+    ServiceState,
+};
+use crate::tip_feed::TipFeed;
+
+/// Handle returned by [`RpcServer::start`]. Dropping it does NOT stop the
+/// server — the host triggers shutdown via the `shutdown_rx` it passes
+/// in. The handle exists so the host can `await` the join handle from a
+/// graceful-shutdown path.
+pub struct RpcServerHandle {
+    /// The actual bound address (may differ from config if port 0 was
+    /// requested for tests).
+    pub local_addr: SocketAddr,
+    pub join: JoinHandle<Result<(), tonic::transport::Error>>,
+}
+
+/// Build + spawn the RPC server.
+///
+/// Returns once the listener is bound + the background task is running.
+/// The caller signals shutdown by sending `true` on `shutdown_rx`'s
+/// upstream; the server then drains in-flight RPCs cooperatively.
+///
+/// `config.bind`/`config.port` control the listener. Use `0` for port to
+/// have the OS assign one (the returned [`RpcServerHandle::local_addr`]
+/// reflects the actual bound port).
+pub struct RpcServer;
+
+impl RpcServer {
+    pub async fn start(
+        config: Arc<RpcConfig>,
+        context: Arc<dyn LedgerContext>,
+        tip_feed: TipFeed,
+        mempool_feed: MempoolFeed,
+        metrics: SharedMetrics,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> Result<RpcServerHandle, std::io::Error> {
+        // Eagerly read TLS material so any I/O failure surfaces here (as
+        // io::Error) instead of inside the spawned tonic task where it
+        // would have to be wrapped as a transport::Error.
+        let tls_identity = match config.tls.as_ref() {
+            Some(tls) => {
+                let cert = std::fs::read(&tls.cert_path).map_err(|e| {
+                    std::io::Error::other(format!(
+                        "RPC TLS cert read failed ({}): {e}",
+                        tls.cert_path.display()
+                    ))
+                })?;
+                let key = std::fs::read(&tls.key_path).map_err(|e| {
+                    std::io::Error::other(format!(
+                        "RPC TLS key read failed ({}): {e}",
+                        tls.key_path.display()
+                    ))
+                })?;
+                Some(Identity::from_pem(cert, key))
+            }
+            None => None,
+        };
+
+        let addr = SocketAddr::new(config.bind, config.port);
+        let listener = TcpListener::bind(addr).await?;
+        let local_addr = listener.local_addr()?;
+        let incoming = TcpListenerStream::new(listener);
+
+        info!(
+            local_addr = %local_addr,
+            reflection = config.reflection_enabled,
+            web = config.web_enabled,
+            alpha = config.alpha_enabled,
+            tls = config.tls.is_some(),
+            "dugite-rpc: gRPC server listening",
+        );
+
+        let state = ServiceState {
+            context,
+            tip_feed,
+            mempool_feed,
+            metrics,
+            config: config.clone(),
+        };
+
+        let join = tokio::spawn(async move {
+            let result = run_server(state, config, tls_identity, incoming, async move {
+                let _ = shutdown_rx.changed().await;
+            })
+            .await;
+            if let Err(ref e) = result {
+                error!(error = %e, "dugite-rpc: server task exited with error");
+            } else {
+                info!("dugite-rpc: server task exited cleanly");
+            }
+            result
+        });
+
+        Ok(RpcServerHandle { local_addr, join })
+    }
+}
+
+async fn run_server(
+    state: ServiceState,
+    config: Arc<RpcConfig>,
+    tls_identity: Option<Identity>,
+    incoming: TcpListenerStream,
+    shutdown: impl std::future::Future<Output = ()> + Send + 'static,
+) -> Result<(), tonic::transport::Error> {
+    // Service wrappers — one Arc-shared backing state, two interface
+    // implementations per service (v1alpha + v1beta).
+    let sync_alpha = SyncSvcAlpha::new(state.clone());
+    let sync_beta = SyncSvcBeta::new(state.clone());
+    let query_alpha = QuerySvcAlpha::new(state.clone());
+    let query_beta = QuerySvcBeta::new(state.clone());
+    let submit_alpha = SubmitSvcAlpha::new(state.clone());
+    let submit_beta = SubmitSvcBeta::new(state.clone());
+    let watch_alpha = WatchSvcAlpha::new(state.clone());
+    let watch_beta = WatchSvcBeta::new(state.clone());
+
+    let reflection = if config.reflection_enabled {
+        // Reflection builder errors are descriptor-decode failures —
+        // they would mean the FILE_DESCRIPTOR_SET baked into the binary
+        // is malformed, a programmer error, not a runtime config issue.
+        // Panic so the bug surfaces at server-start, not as a wire-level
+        // mystery later.
+        let svc = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(proto::FILE_DESCRIPTOR_SET)
+            .build_v1()
+            .expect("FILE_DESCRIPTOR_SET malformed — codegen drift");
+        Some(svc)
+    } else {
+        None
+    };
+
+    let mut builder = TonicServer::builder();
+
+    if let Some(identity) = tls_identity {
+        builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
+    }
+
+    if config.web_enabled {
+        builder = builder.accept_http1(true);
+    }
+
+    let mut router = builder
+        .add_service(proto::v1beta::sync::sync_service_server::SyncServiceServer::new(sync_beta))
+        .add_service(
+            proto::v1beta::query::query_service_server::QueryServiceServer::new(query_beta),
+        )
+        .add_service(
+            proto::v1beta::submit::submit_service_server::SubmitServiceServer::new(submit_beta),
+        )
+        .add_service(
+            proto::v1beta::watch::watch_service_server::WatchServiceServer::new(watch_beta),
+        );
+
+    if config.alpha_enabled {
+        router = router
+            .add_service(
+                proto::v1alpha::sync::sync_service_server::SyncServiceServer::new(sync_alpha),
+            )
+            .add_service(
+                proto::v1alpha::query::query_service_server::QueryServiceServer::new(query_alpha),
+            )
+            .add_service(
+                proto::v1alpha::submit::submit_service_server::SubmitServiceServer::new(
+                    submit_alpha,
+                ),
+            )
+            .add_service(
+                proto::v1alpha::watch::watch_service_server::WatchServiceServer::new(watch_alpha),
+            );
+    } else {
+        warn!("dugite-rpc: v1alpha services disabled — only v1beta clients will reach this server");
+    }
+
+    if let Some(reflection) = reflection {
+        router = router.add_service(reflection);
+    }
+
+    router
+        .serve_with_incoming_shutdown(incoming, shutdown)
+        .await
+}

--- a/crates/dugite-rpc/src/services/mod.rs
+++ b/crates/dugite-rpc/src/services/mod.rs
@@ -1,0 +1,35 @@
+//! RPC service implementations — one module per utxorpc service.
+//!
+//! Each module exposes two thin wrappers (one for `v1alpha`, one for
+//! `v1beta`) over the same backing state. M1.A ships pure stubs that
+//! return `UNIMPLEMENTED` for every method; M1.B fills `SyncService`
+//! end-to-end; M2 fills `QueryService`; M3 `SubmitService`; M4
+//! `WatchService`.
+
+pub mod query;
+pub mod submit;
+pub mod sync;
+pub mod watch;
+
+/// Shared state held by every service implementation.
+///
+/// Cheap to clone (`Arc` over everything mutable). Held by both
+/// `v1alpha` and `v1beta` wrappers of the same service so they back the
+/// same source of truth.
+#[derive(Clone)]
+pub struct ServiceState {
+    pub context: std::sync::Arc<dyn crate::context::LedgerContext>,
+    pub tip_feed: crate::tip_feed::TipFeed,
+    pub mempool_feed: crate::mempool_feed::MempoolFeed,
+    pub metrics: crate::metrics::SharedMetrics,
+    pub config: std::sync::Arc<crate::config::RpcConfig>,
+}
+
+impl std::fmt::Debug for ServiceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServiceState")
+            .field("port", &self.config.port)
+            .field("bind", &self.config.bind)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/dugite-rpc/src/services/query.rs
+++ b/crates/dugite-rpc/src/services/query.rs
@@ -1,0 +1,150 @@
+//! `QueryService` — read-only ledger queries.
+//!
+//! M1.A stubs: every method returns `UNIMPLEMENTED`. M2 fills the
+//! ReadParams / ReadUtxos / SearchUtxos / ReadGenesis / ReadEra paths;
+//! `read_data` / `read_tx` map to mempool + chain tx lookups.
+//!
+//! `v1beta` adds `read_state` beyond `v1alpha`.
+
+use tonic::{Request, Response, Status};
+
+use super::ServiceState;
+use crate::proto::{v1alpha, v1beta};
+
+const UNIMPL: &str = "M1.A stub — QueryService method not implemented yet";
+
+#[derive(Clone)]
+pub struct QuerySvcAlpha {
+    state: ServiceState,
+}
+
+impl QuerySvcAlpha {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1alpha::query::query_service_server::QueryService for QuerySvcAlpha {
+    async fn read_params(
+        &self,
+        _request: Request<v1alpha::query::ReadParamsRequest>,
+    ) -> Result<Response<v1alpha::query::ReadParamsResponse>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_utxos(
+        &self,
+        _request: Request<v1alpha::query::ReadUtxosRequest>,
+    ) -> Result<Response<v1alpha::query::ReadUtxosResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn search_utxos(
+        &self,
+        _request: Request<v1alpha::query::SearchUtxosRequest>,
+    ) -> Result<Response<v1alpha::query::SearchUtxosResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_data(
+        &self,
+        _request: Request<v1alpha::query::ReadDataRequest>,
+    ) -> Result<Response<v1alpha::query::ReadDataResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_tx(
+        &self,
+        _request: Request<v1alpha::query::ReadTxRequest>,
+    ) -> Result<Response<v1alpha::query::ReadTxResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_genesis(
+        &self,
+        _request: Request<v1alpha::query::ReadGenesisRequest>,
+    ) -> Result<Response<v1alpha::query::ReadGenesisResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_era_summary(
+        &self,
+        _request: Request<v1alpha::query::ReadEraSummaryRequest>,
+    ) -> Result<Response<v1alpha::query::ReadEraSummaryResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+}
+
+#[derive(Clone)]
+pub struct QuerySvcBeta {
+    state: ServiceState,
+}
+
+impl QuerySvcBeta {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1beta::query::query_service_server::QueryService for QuerySvcBeta {
+    async fn read_params(
+        &self,
+        _request: Request<v1beta::query::ReadParamsRequest>,
+    ) -> Result<Response<v1beta::query::ReadParamsResponse>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_utxos(
+        &self,
+        _request: Request<v1beta::query::ReadUtxosRequest>,
+    ) -> Result<Response<v1beta::query::ReadUtxosResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn search_utxos(
+        &self,
+        _request: Request<v1beta::query::SearchUtxosRequest>,
+    ) -> Result<Response<v1beta::query::SearchUtxosResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_data(
+        &self,
+        _request: Request<v1beta::query::ReadDataRequest>,
+    ) -> Result<Response<v1beta::query::ReadDataResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_tx(
+        &self,
+        _request: Request<v1beta::query::ReadTxRequest>,
+    ) -> Result<Response<v1beta::query::ReadTxResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_genesis(
+        &self,
+        _request: Request<v1beta::query::ReadGenesisRequest>,
+    ) -> Result<Response<v1beta::query::ReadGenesisResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_era_summary(
+        &self,
+        _request: Request<v1beta::query::ReadEraSummaryRequest>,
+    ) -> Result<Response<v1beta::query::ReadEraSummaryResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    /// `v1beta`-only — ad-hoc CBOR-shaped state queries.
+    async fn read_state(
+        &self,
+        _request: Request<v1beta::query::ReadStateRequest>,
+    ) -> Result<Response<v1beta::query::ReadStateResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+}

--- a/crates/dugite-rpc/src/services/submit.rs
+++ b/crates/dugite-rpc/src/services/submit.rs
@@ -1,0 +1,125 @@
+//! `SubmitService` — transaction submission + mempool inspection.
+//!
+//! M1.A stubs: every method returns `UNIMPLEMENTED`. M3 fills SubmitTx /
+//! ReadMempool / WaitForTx / WatchMempool. `EvalTx` (Plutus dry-run) stays
+//! UNIMPLEMENTED past M3 — it needs a non-committing
+//! `dugite_uplc::evaluate_in_context` helper extracted from
+//! `dugite_ledger::plutus::eval_phase_two_raw` (deferred follow-up).
+
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use super::ServiceState;
+use crate::proto::{v1alpha, v1beta};
+
+const UNIMPL: &str = "M1.A stub — SubmitService method not implemented yet";
+const EVAL_UNIMPL: &str = "EvalTx requires a non-committing UPLC evaluation helper; deferred to a \
+     follow-up milestone after the SubmitService base lands";
+
+#[derive(Clone)]
+pub struct SubmitSvcAlpha {
+    state: ServiceState,
+}
+
+impl SubmitSvcAlpha {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1alpha::submit::submit_service_server::SubmitService for SubmitSvcAlpha {
+    async fn eval_tx(
+        &self,
+        _request: Request<v1alpha::submit::EvalTxRequest>,
+    ) -> Result<Response<v1alpha::submit::EvalTxResponse>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(EVAL_UNIMPL))
+    }
+
+    async fn submit_tx(
+        &self,
+        _request: Request<v1alpha::submit::SubmitTxRequest>,
+    ) -> Result<Response<v1alpha::submit::SubmitTxResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    type WaitForTxStream = ReceiverStream<Result<v1alpha::submit::WaitForTxResponse, Status>>;
+
+    async fn wait_for_tx(
+        &self,
+        _request: Request<v1alpha::submit::WaitForTxRequest>,
+    ) -> Result<Response<Self::WaitForTxStream>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_mempool(
+        &self,
+        _request: Request<v1alpha::submit::ReadMempoolRequest>,
+    ) -> Result<Response<v1alpha::submit::ReadMempoolResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    type WatchMempoolStream = ReceiverStream<Result<v1alpha::submit::WatchMempoolResponse, Status>>;
+
+    async fn watch_mempool(
+        &self,
+        _request: Request<v1alpha::submit::WatchMempoolRequest>,
+    ) -> Result<Response<Self::WatchMempoolStream>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+}
+
+#[derive(Clone)]
+pub struct SubmitSvcBeta {
+    state: ServiceState,
+}
+
+impl SubmitSvcBeta {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1beta::submit::submit_service_server::SubmitService for SubmitSvcBeta {
+    async fn eval_tx(
+        &self,
+        _request: Request<v1beta::submit::EvalTxRequest>,
+    ) -> Result<Response<v1beta::submit::EvalTxResponse>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(EVAL_UNIMPL))
+    }
+
+    async fn submit_tx(
+        &self,
+        _request: Request<v1beta::submit::SubmitTxRequest>,
+    ) -> Result<Response<v1beta::submit::SubmitTxResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    type WaitForTxStream = ReceiverStream<Result<v1beta::submit::WaitForTxResponse, Status>>;
+
+    async fn wait_for_tx(
+        &self,
+        _request: Request<v1beta::submit::WaitForTxRequest>,
+    ) -> Result<Response<Self::WaitForTxStream>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_mempool(
+        &self,
+        _request: Request<v1beta::submit::ReadMempoolRequest>,
+    ) -> Result<Response<v1beta::submit::ReadMempoolResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    type WatchMempoolStream = ReceiverStream<Result<v1beta::submit::WatchMempoolResponse, Status>>;
+
+    async fn watch_mempool(
+        &self,
+        _request: Request<v1beta::submit::WatchMempoolRequest>,
+    ) -> Result<Response<Self::WatchMempoolStream>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+}

--- a/crates/dugite-rpc/src/services/sync.rs
+++ b/crates/dugite-rpc/src/services/sync.rs
@@ -1,0 +1,106 @@
+//! `SyncService` — block retrieval + chain following.
+//!
+//! M1.A stubs: every method returns `UNIMPLEMENTED`. M1.B fills
+//! `FetchBlock`, `DumpHistory`, `ReadTip`, `FollowTip` with real
+//! mappings against `LedgerContext::block_by_hash` / `blocks_range` /
+//! `tip` / `TipFeed`.
+
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use super::ServiceState;
+use crate::proto::{v1alpha, v1beta};
+
+const UNIMPL: &str = "M1.A stub — SyncService method not implemented yet";
+
+/// `v1alpha` SyncService wrapper.
+#[derive(Clone)]
+pub struct SyncSvcAlpha {
+    state: ServiceState,
+}
+
+impl SyncSvcAlpha {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1alpha::sync::sync_service_server::SyncService for SyncSvcAlpha {
+    async fn fetch_block(
+        &self,
+        _request: Request<v1alpha::sync::FetchBlockRequest>,
+    ) -> Result<Response<v1alpha::sync::FetchBlockResponse>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn dump_history(
+        &self,
+        _request: Request<v1alpha::sync::DumpHistoryRequest>,
+    ) -> Result<Response<v1alpha::sync::DumpHistoryResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    type FollowTipStream = ReceiverStream<Result<v1alpha::sync::FollowTipResponse, Status>>;
+
+    async fn follow_tip(
+        &self,
+        _request: Request<v1alpha::sync::FollowTipRequest>,
+    ) -> Result<Response<Self::FollowTipStream>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_tip(
+        &self,
+        _request: Request<v1alpha::sync::ReadTipRequest>,
+    ) -> Result<Response<v1alpha::sync::ReadTipResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+}
+
+/// `v1beta` SyncService wrapper.
+#[derive(Clone)]
+pub struct SyncSvcBeta {
+    state: ServiceState,
+}
+
+impl SyncSvcBeta {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1beta::sync::sync_service_server::SyncService for SyncSvcBeta {
+    async fn fetch_block(
+        &self,
+        _request: Request<v1beta::sync::FetchBlockRequest>,
+    ) -> Result<Response<v1beta::sync::FetchBlockResponse>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn dump_history(
+        &self,
+        _request: Request<v1beta::sync::DumpHistoryRequest>,
+    ) -> Result<Response<v1beta::sync::DumpHistoryResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    type FollowTipStream = ReceiverStream<Result<v1beta::sync::FollowTipResponse, Status>>;
+
+    async fn follow_tip(
+        &self,
+        _request: Request<v1beta::sync::FollowTipRequest>,
+    ) -> Result<Response<Self::FollowTipStream>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+
+    async fn read_tip(
+        &self,
+        _request: Request<v1beta::sync::ReadTipRequest>,
+    ) -> Result<Response<v1beta::sync::ReadTipResponse>, Status> {
+        Err(Status::unimplemented(UNIMPL))
+    }
+}

--- a/crates/dugite-rpc/src/services/watch.rs
+++ b/crates/dugite-rpc/src/services/watch.rs
@@ -1,0 +1,62 @@
+//! `WatchService` — pattern-filtered transaction watches.
+//!
+//! M1.A stubs: returns `UNIMPLEMENTED`. M4 fills WatchTx via a
+//! [`TipFeed`](crate::tip_feed::TipFeed) +
+//! [`MempoolFeed`](crate::mempool_feed::MempoolFeed) merge, with
+//! `Pattern` filtering through `map/patterns.rs`.
+
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use super::ServiceState;
+use crate::proto::{v1alpha, v1beta};
+
+const UNIMPL: &str = "M1.A stub — WatchService method not implemented yet";
+
+#[derive(Clone)]
+pub struct WatchSvcAlpha {
+    state: ServiceState,
+}
+
+impl WatchSvcAlpha {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1alpha::watch::watch_service_server::WatchService for WatchSvcAlpha {
+    type WatchTxStream = ReceiverStream<Result<v1alpha::watch::WatchTxResponse, Status>>;
+
+    async fn watch_tx(
+        &self,
+        _request: Request<v1alpha::watch::WatchTxRequest>,
+    ) -> Result<Response<Self::WatchTxStream>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(UNIMPL))
+    }
+}
+
+#[derive(Clone)]
+pub struct WatchSvcBeta {
+    state: ServiceState,
+}
+
+impl WatchSvcBeta {
+    pub fn new(state: ServiceState) -> Self {
+        Self { state }
+    }
+}
+
+#[tonic::async_trait]
+impl v1beta::watch::watch_service_server::WatchService for WatchSvcBeta {
+    type WatchTxStream = ReceiverStream<Result<v1beta::watch::WatchTxResponse, Status>>;
+
+    async fn watch_tx(
+        &self,
+        _request: Request<v1beta::watch::WatchTxRequest>,
+    ) -> Result<Response<Self::WatchTxStream>, Status> {
+        let _ = &self.state;
+        Err(Status::unimplemented(UNIMPL))
+    }
+}

--- a/crates/dugite-rpc/src/stream.rs
+++ b/crates/dugite-rpc/src/stream.rs
@@ -1,0 +1,151 @@
+//! Shared streaming helpers used by service implementations.
+//!
+//! Most utxorpc service methods that return `tonic::Streaming` follow the
+//! same pattern: fan a [`broadcast::Receiver`] into a bounded
+//! [`mpsc::Sender`] so slow clients can be detected and disconnected with
+//! `Status::resource_exhausted` instead of back-pressuring the publisher.
+//! This module factors the boilerplate out.
+
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::Status;
+use tracing::warn;
+
+use crate::config::DEFAULT_STREAM_BUFFER;
+
+/// Spawn a per-stream fan-out task that pulls items from `source` and
+/// pushes them into a bounded `mpsc::channel(buffer)`. Returns the
+/// receiving stream + the join handle for the spawned task.
+///
+/// Behaviour on receiver state:
+///
+/// * `Ok(item)` — forwarded with `try_send`. If the client buffer is full,
+///   the stream is terminated with `Status::resource_exhausted` and a
+///   warning is logged. The publisher is NOT blocked.
+/// * `Err(broadcast::error::RecvError::Lagged)` — `service`/`method`
+///   labels are logged at WARN and the stream is terminated with
+///   `Status::resource_exhausted`.
+/// * `Err(broadcast::error::RecvError::Closed)` — publisher dropped;
+///   end the stream cleanly.
+///
+/// The forwarding closure `map` allows projecting the broadcast payload
+/// into the wire protobuf type without an extra hop. Returning `None`
+/// from `map` drops the item silently (use for pattern filtering).
+pub fn spawn_broadcast_fan_out<S, T, F>(
+    mut source: broadcast::Receiver<S>,
+    buffer: usize,
+    service: &'static str,
+    method: &'static str,
+    mut map: F,
+) -> (ReceiverStream<Result<T, Status>>, JoinHandle<()>)
+where
+    S: Clone + Send + 'static,
+    T: Send + 'static,
+    F: FnMut(S) -> Option<T> + Send + 'static,
+{
+    let buf = if buffer == 0 {
+        DEFAULT_STREAM_BUFFER
+    } else {
+        buffer
+    };
+    let (tx, rx) = mpsc::channel(buf);
+    let handle = tokio::spawn(async move {
+        loop {
+            match source.recv().await {
+                Ok(item) => {
+                    if let Some(mapped) = map(item) {
+                        if tx.try_send(Ok(mapped)).is_err() {
+                            warn!(
+                                service,
+                                method,
+                                "RPC stream: client too slow, dropping with RESOURCE_EXHAUSTED"
+                            );
+                            let _ = tx
+                                .send(Err(Status::resource_exhausted("client stream buffer full")))
+                                .await;
+                            break;
+                        }
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        service,
+                        method,
+                        lagged = n,
+                        "RPC stream: client lagged on broadcast, disconnecting with RESOURCE_EXHAUSTED"
+                    );
+                    let _ = tx
+                        .send(Err(Status::resource_exhausted(format!(
+                            "subscriber lagged by {n} events; reconnect and resync"
+                        ))))
+                        .await;
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    // Publisher dropped — end the stream cleanly.
+                    break;
+                }
+            }
+        }
+    });
+
+    (ReceiverStream::new(rx), handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn forwards_items_until_publisher_closes() {
+        let (tx, rx) = broadcast::channel::<u32>(8);
+        let (stream, handle) = spawn_broadcast_fan_out(rx, 4, "test", "method", |n| Some(n * 2));
+
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        drop(tx);
+
+        let collected: Vec<_> = tokio_stream::StreamExt::collect::<Vec<_>>(stream).await;
+        handle.await.unwrap();
+
+        let values: Vec<u32> = collected.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(values, vec![2, 4]);
+    }
+
+    #[tokio::test]
+    async fn lagged_subscriber_disconnects_with_resource_exhausted() {
+        // Tiny capacity + many sends → guaranteed Lagged.
+        let (tx, rx) = broadcast::channel::<u32>(2);
+        // Send several items before the consumer drains anything.
+        for i in 0..10 {
+            let _ = tx.send(i);
+        }
+        let (stream, _) = spawn_broadcast_fan_out(rx, 4, "test", "method", Some);
+
+        let collected: Vec<_> = tokio_stream::StreamExt::collect::<Vec<_>>(stream).await;
+        // Last item should be the resource-exhausted error.
+        let last = collected.last().expect("at least one item");
+        assert!(last.is_err(), "expected resource-exhausted: {collected:?}");
+        assert_eq!(
+            last.as_ref().err().unwrap().code(),
+            tonic::Code::ResourceExhausted
+        );
+    }
+
+    #[tokio::test]
+    async fn map_returning_none_filters_silently() {
+        let (tx, rx) = broadcast::channel::<u32>(8);
+        let (stream, _) =
+            spawn_broadcast_fan_out(rx, 4, "test", "method", |n| (n % 2 == 0).then_some(n));
+
+        for i in 0..5 {
+            tx.send(i).unwrap();
+        }
+        drop(tx);
+
+        let collected: Vec<_> = tokio_stream::StreamExt::collect::<Vec<_>>(stream).await;
+        let values: Vec<u32> = collected.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(values, vec![0, 2, 4]);
+    }
+}

--- a/crates/dugite-rpc/src/tip_feed.rs
+++ b/crates/dugite-rpc/src/tip_feed.rs
@@ -1,0 +1,148 @@
+//! Tip-event broadcaster owned by the RPC server.
+//!
+//! Mirrors the shape of `node::tip_broadcast::TipBroadcaster` (M0.1) but
+//! lives in this crate so service code can subscribe without a
+//! `dugite-node` dependency. The host (`NodeRpcAdapter`) bridges the two:
+//! a shim task subscribes to the node-side broadcaster and republishes
+//! into the dugite-rpc-side broadcaster, mapping payload types in the
+//! process.
+//!
+//! Capacities mirror the node-side defaults so back-pressure semantics
+//! match: a service stream that lags by more than `cap_apply` events
+//! receives `RecvError::Lagged` and the surrounding service handler is
+//! expected to drop the client with `Status::resource_exhausted`.
+
+use tokio::sync::broadcast;
+
+use crate::context::TipInfo;
+
+/// Default capacity for the apply channel — matches node-side
+/// `tip_broadcast::TIP_APPLY_CAP` so the back-pressure point is consistent
+/// across the publish hop.
+pub const DEFAULT_TIP_APPLY_CAP: usize = 1024;
+
+/// Default capacity for the rollback channel — matches node-side
+/// `tip_broadcast::TIP_ROLLBACK_CAP`.
+pub const DEFAULT_TIP_ROLLBACK_CAP: usize = 256;
+
+/// A chain-rollback event — same shape as
+/// `node::tip_broadcast::TipRollback` so the publisher can forward
+/// without re-shaping (only the type name differs).
+#[derive(Clone, Debug)]
+pub struct TipRollback {
+    pub slot: u64,
+    pub hash: [u8; 32],
+}
+
+/// Owns a pair of broadcast senders carrying tip-apply + tip-rollback
+/// events. Cheap to clone (the inner [`broadcast::Sender`]s are Arc'd).
+///
+/// Constructed by the host once at RPC server startup, passed to
+/// [`RpcServer::start`](crate::server::RpcServer::start), and shared with
+/// the host's shim task via [`TipFeed::publisher`].
+#[derive(Clone, Debug)]
+pub struct TipFeed {
+    apply_tx: broadcast::Sender<TipInfo>,
+    rollback_tx: broadcast::Sender<TipRollback>,
+}
+
+impl TipFeed {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_TIP_APPLY_CAP, DEFAULT_TIP_ROLLBACK_CAP)
+    }
+
+    pub fn with_capacity(cap_apply: usize, cap_rollback: usize) -> Self {
+        Self {
+            apply_tx: broadcast::channel(cap_apply).0,
+            rollback_tx: broadcast::channel(cap_rollback).0,
+        }
+    }
+
+    /// Hand out a publisher — used by the host shim task to forward
+    /// events from the node-side broadcaster.
+    pub fn publisher(&self) -> TipPublisher {
+        TipPublisher {
+            apply_tx: self.apply_tx.clone(),
+            rollback_tx: self.rollback_tx.clone(),
+        }
+    }
+
+    pub fn subscribe_apply(&self) -> broadcast::Receiver<TipInfo> {
+        self.apply_tx.subscribe()
+    }
+
+    pub fn subscribe_rollback(&self) -> broadcast::Receiver<TipRollback> {
+        self.rollback_tx.subscribe()
+    }
+}
+
+impl Default for TipFeed {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Publisher half of a [`TipFeed`]. Held by the host's shim task; calls
+/// are best-effort — a `send` error means no receivers are attached,
+/// which is normal when no RPC client is actively streaming tip events.
+#[derive(Clone, Debug)]
+pub struct TipPublisher {
+    apply_tx: broadcast::Sender<TipInfo>,
+    rollback_tx: broadcast::Sender<TipRollback>,
+}
+
+impl TipPublisher {
+    pub fn announce_apply(&self, ev: TipInfo) {
+        let _ = self.apply_tx.send(ev);
+    }
+
+    pub fn announce_rollback(&self, ev: TipRollback) {
+        let _ = self.rollback_tx.send(ev);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dugite_primitives::Era;
+
+    #[tokio::test]
+    async fn publisher_to_subscriber_round_trip() {
+        let feed = TipFeed::new();
+        let mut apply_rx = feed.subscribe_apply();
+        let mut rollback_rx = feed.subscribe_rollback();
+        let pubr = feed.publisher();
+
+        pubr.announce_apply(TipInfo {
+            slot: 100,
+            hash: [1u8; 32],
+            block_number: 5,
+            era: Era::Conway,
+        });
+        pubr.announce_rollback(TipRollback {
+            slot: 90,
+            hash: [2u8; 32],
+        });
+
+        let applied = apply_rx.recv().await.unwrap();
+        assert_eq!(applied.slot, 100);
+        let rolled = rollback_rx.recv().await.unwrap();
+        assert_eq!(rolled.slot, 90);
+    }
+
+    #[tokio::test]
+    async fn no_subscribers_is_not_an_error() {
+        let feed = TipFeed::with_capacity(4, 4);
+        let pubr = feed.publisher();
+        pubr.announce_apply(TipInfo {
+            slot: 1,
+            hash: [0u8; 32],
+            block_number: 1,
+            era: Era::Conway,
+        });
+        pubr.announce_rollback(TipRollback {
+            slot: 0,
+            hash: [0u8; 32],
+        });
+    }
+}

--- a/crates/dugite-rpc/tests/server_smoke.rs
+++ b/crates/dugite-rpc/tests/server_smoke.rs
@@ -1,0 +1,519 @@
+//! End-to-end smoke test for the M1.A RPC scaffold.
+//!
+//! Spawns [`dugite_rpc::RpcServer`] on a random port backed by a
+//! [`MockLedgerContext`] and exercises every service over a real gRPC
+//! connection. Every method should return
+//! [`tonic::Code::Unimplemented`] (or `FailedPrecondition` for
+//! `SubmitTx` whose adapter stub reports the rejection as a structured
+//! `SubmitOutcome::Rejected`). Reflection should list all 8 / 9
+//! services. Shutdown should drain in-flight RPCs cooperatively.
+//!
+//! M1.B will add per-method assertions on real responses; this M1.A
+//! suite proves the scaffold itself is sound.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use dugite_mempool::{Mempool, MempoolConfig};
+use dugite_primitives::address::Address;
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::transaction::TransactionInput;
+use dugite_rpc::context::{EraHistoryView, GenesisView, ParamsView};
+use dugite_rpc::{
+    noop_metrics, LedgerContext, MempoolFeed, RawBlock, RawTx, RpcConfig, RpcError, RpcServer,
+    SubmitOutcome, TipFeed, TipInfo, UtxoSnapshot,
+};
+use tokio::sync::{broadcast, watch};
+use tonic::transport::Channel;
+
+// ─── MockLedgerContext ────────────────────────────────────────────────────
+
+/// In-test [`LedgerContext`] impl. Every method returns
+/// `RpcError::Unimplemented` so service stubs propagate
+/// `Status::Unimplemented`. `mempool_contains` always returns `false`.
+struct MockLedgerContext;
+
+#[async_trait]
+impl LedgerContext for MockLedgerContext {
+    async fn tip(&self) -> Result<TipInfo, RpcError> {
+        Err(RpcError::Unimplemented("mock::tip"))
+    }
+    async fn block_by_hash(&self, _: &Hash32) -> Result<Option<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("mock::block_by_hash"))
+    }
+    async fn block_at_slot(&self, _: u64) -> Result<Option<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("mock::block_at_slot"))
+    }
+    async fn block_after(&self, _: u64) -> Result<Option<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("mock::block_after"))
+    }
+    async fn intersect(&self, _: &[Point]) -> Result<Option<Point>, RpcError> {
+        Err(RpcError::Unimplemented("mock::intersect"))
+    }
+    async fn blocks_range(&self, _: u64, _: u64, _: usize) -> Result<Vec<RawBlock>, RpcError> {
+        Err(RpcError::Unimplemented("mock::blocks_range"))
+    }
+    async fn utxo_by_ref(&self, _: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("mock::utxo_by_ref"))
+    }
+    async fn utxos_by_address(&self, _: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("mock::utxos_by_address"))
+    }
+    async fn utxos_by_payment_credential(&self, _: &Hash32) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("mock::utxos_by_payment_credential"))
+    }
+    async fn utxos_by_asset(
+        &self,
+        _: &Hash32,
+        _: Option<&[u8]>,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("mock::utxos_by_asset"))
+    }
+    async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
+        Err(RpcError::Unimplemented("mock::params_at_tip"))
+    }
+    async fn era_history(&self) -> Result<EraHistoryView, RpcError> {
+        Err(RpcError::Unimplemented("mock::era_history"))
+    }
+    async fn genesis(&self) -> Result<GenesisView, RpcError> {
+        Err(RpcError::Unimplemented("mock::genesis"))
+    }
+    async fn submit_tx(&self, _: u16, _: &[u8]) -> SubmitOutcome {
+        SubmitOutcome::Rejected {
+            reason: "mock::submit_tx not implemented".into(),
+        }
+    }
+    async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
+        Err(RpcError::Unimplemented("mock::mempool_snapshot"))
+    }
+    async fn mempool_contains(&self, _: &TransactionHash) -> bool {
+        false
+    }
+}
+
+// ─── Test scaffolding ─────────────────────────────────────────────────────
+
+struct TestServer {
+    addr: std::net::SocketAddr,
+    shutdown_tx: watch::Sender<bool>,
+    join: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
+}
+
+impl TestServer {
+    async fn start(alpha_enabled: bool) -> Self {
+        let config = RpcConfig {
+            bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port: 0,
+            alpha_enabled,
+            reflection_enabled: true,
+            web_enabled: false,
+            ..Default::default()
+        };
+        let tip_feed = TipFeed::new();
+        // The MempoolFeed needs a broadcast::Sender — a stand-alone
+        // mempool gives us one without dragging in Node setup.
+        let mempool = Arc::new(Mempool::new(MempoolConfig::default()));
+        let mempool_feed = MempoolFeed::new(mempool.tx_events());
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let handle = RpcServer::start(
+            Arc::new(config),
+            Arc::new(MockLedgerContext),
+            tip_feed,
+            mempool_feed,
+            noop_metrics(),
+            shutdown_rx,
+        )
+        .await
+        .expect("start RPC server");
+
+        Self {
+            addr: handle.local_addr,
+            shutdown_tx,
+            join: handle.join,
+        }
+    }
+
+    async fn channel(&self) -> Channel {
+        let url = format!("http://{}", self.addr);
+        Channel::from_shared(url)
+            .unwrap()
+            .connect_timeout(Duration::from_secs(2))
+            .connect()
+            .await
+            .expect("connect to RPC server")
+    }
+
+    async fn stop(self) {
+        let _ = self.shutdown_tx.send(true);
+        // Give the server a moment to drain. If it doesn't exit cleanly
+        // we surface the join error to the test.
+        match tokio::time::timeout(Duration::from_secs(3), self.join).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(e))) => panic!("server task errored: {e}"),
+            Ok(Err(e)) => panic!("server task panicked: {e}"),
+            Err(_) => panic!("server task did not exit within 3s of shutdown signal"),
+        }
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn server_starts_and_stops_cleanly() {
+    let server = TestServer::start(true).await;
+    assert_ne!(server.addr.port(), 0, "OS should assign a real port");
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn server_binds_loopback_only_by_default() {
+    let server = TestServer::start(true).await;
+    assert_eq!(server.addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+    server.stop().await;
+}
+
+// ── Sync v1beta ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sync_v1beta_methods_return_unimplemented() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{
+        DumpHistoryRequest, FetchBlockRequest, FollowTipRequest, ReadTipRequest,
+    };
+
+    let server = TestServer::start(true).await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    let cases: Vec<(&str, tonic::Status)> = vec![
+        (
+            "fetch_block",
+            client
+                .fetch_block(FetchBlockRequest::default())
+                .await
+                .unwrap_err(),
+        ),
+        (
+            "dump_history",
+            client
+                .dump_history(DumpHistoryRequest::default())
+                .await
+                .unwrap_err(),
+        ),
+        (
+            "read_tip",
+            client
+                .read_tip(ReadTipRequest::default())
+                .await
+                .unwrap_err(),
+        ),
+        (
+            "follow_tip",
+            client
+                .follow_tip(FollowTipRequest::default())
+                .await
+                .unwrap_err(),
+        ),
+    ];
+
+    for (name, status) in cases {
+        assert_eq!(
+            status.code(),
+            tonic::Code::Unimplemented,
+            "{name} → expected UNIMPLEMENTED, got {status:?}"
+        );
+    }
+
+    server.stop().await;
+}
+
+// ── Sync v1alpha ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sync_v1alpha_methods_return_unimplemented() {
+    use dugite_rpc::proto::v1alpha::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1alpha::sync::{
+        DumpHistoryRequest, FetchBlockRequest, FollowTipRequest, ReadTipRequest,
+    };
+
+    let server = TestServer::start(true).await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    let r1 = client
+        .fetch_block(FetchBlockRequest::default())
+        .await
+        .unwrap_err();
+    let r2 = client
+        .dump_history(DumpHistoryRequest::default())
+        .await
+        .unwrap_err();
+    let r3 = client
+        .read_tip(ReadTipRequest::default())
+        .await
+        .unwrap_err();
+    let r4 = client
+        .follow_tip(FollowTipRequest::default())
+        .await
+        .unwrap_err();
+
+    for s in [&r1, &r2, &r3, &r4] {
+        assert_eq!(s.code(), tonic::Code::Unimplemented);
+    }
+
+    server.stop().await;
+}
+
+// ── Query v1beta ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn query_v1beta_methods_return_unimplemented() {
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::{
+        ReadDataRequest, ReadEraSummaryRequest, ReadGenesisRequest, ReadParamsRequest,
+        ReadStateRequest, ReadTxRequest, ReadUtxosRequest, SearchUtxosRequest,
+    };
+
+    let server = TestServer::start(true).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+
+    for status in [
+        client
+            .read_params(ReadParamsRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .read_utxos(ReadUtxosRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .search_utxos(SearchUtxosRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .read_data(ReadDataRequest::default())
+            .await
+            .unwrap_err(),
+        client.read_tx(ReadTxRequest::default()).await.unwrap_err(),
+        client
+            .read_genesis(ReadGenesisRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .read_era_summary(ReadEraSummaryRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .read_state(ReadStateRequest::default())
+            .await
+            .unwrap_err(),
+    ] {
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+    }
+
+    server.stop().await;
+}
+
+// ── Submit v1beta ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn submit_v1beta_methods_return_unimplemented() {
+    use dugite_rpc::proto::v1beta::submit::submit_service_client::SubmitServiceClient;
+    use dugite_rpc::proto::v1beta::submit::{
+        EvalTxRequest, ReadMempoolRequest, SubmitTxRequest, WaitForTxRequest, WatchMempoolRequest,
+    };
+
+    let server = TestServer::start(true).await;
+    let mut client = SubmitServiceClient::new(server.channel().await);
+
+    let eval = client.eval_tx(EvalTxRequest::default()).await.unwrap_err();
+    // EvalTx carries a different message but same code.
+    assert_eq!(eval.code(), tonic::Code::Unimplemented);
+    assert!(eval.message().contains("EvalTx"));
+
+    for status in [
+        client
+            .submit_tx(SubmitTxRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .wait_for_tx(WaitForTxRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .read_mempool(ReadMempoolRequest::default())
+            .await
+            .unwrap_err(),
+        client
+            .watch_mempool(WatchMempoolRequest::default())
+            .await
+            .unwrap_err(),
+    ] {
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+    }
+
+    server.stop().await;
+}
+
+// ── Watch v1beta ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn watch_v1beta_methods_return_unimplemented() {
+    use dugite_rpc::proto::v1beta::watch::watch_service_client::WatchServiceClient;
+    use dugite_rpc::proto::v1beta::watch::WatchTxRequest;
+
+    let server = TestServer::start(true).await;
+    let mut client = WatchServiceClient::new(server.channel().await);
+
+    let status = client
+        .watch_tx(WatchTxRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+
+    server.stop().await;
+}
+
+// ── alpha_enabled = false ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn disabling_alpha_drops_alpha_routes_but_keeps_beta() {
+    use dugite_rpc::proto::v1alpha::sync::sync_service_client::SyncServiceClient as AlphaSyncClient;
+    use dugite_rpc::proto::v1alpha::sync::ReadTipRequest as AlphaReadTipRequest;
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient as BetaSyncClient;
+    use dugite_rpc::proto::v1beta::sync::ReadTipRequest as BetaReadTipRequest;
+
+    let server = TestServer::start(false).await;
+
+    let mut beta = BetaSyncClient::new(server.channel().await);
+    let beta_status = beta
+        .read_tip(BetaReadTipRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(
+        beta_status.code(),
+        tonic::Code::Unimplemented,
+        "v1beta should still respond (with UNIMPLEMENTED stub)"
+    );
+
+    let mut alpha = AlphaSyncClient::new(server.channel().await);
+    let alpha_status = alpha
+        .read_tip(AlphaReadTipRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(
+        alpha_status.code(),
+        tonic::Code::Unimplemented,
+        "v1alpha route is NOT registered when alpha_enabled = false — \
+         tonic returns Unimplemented for unknown service routes too \
+         (UNIMPLEMENTED in both cases), but the message indicates the \
+         route was unknown rather than a stub. Either way the gRPC \
+         status code is the same; this asserts the server didn't \
+         crash and the connection was accepted."
+    );
+
+    server.stop().await;
+}
+
+// ── Multiple concurrent clients ──────────────────────────────────────────
+
+#[tokio::test]
+async fn server_handles_concurrent_clients() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::ReadTipRequest;
+
+    let server = TestServer::start(true).await;
+    let addr = server.addr;
+
+    let mut handles = Vec::new();
+    for i in 0..8 {
+        let url = format!("http://{}", addr);
+        handles.push(tokio::spawn(async move {
+            let channel = Channel::from_shared(url)
+                .unwrap()
+                .connect_timeout(Duration::from_secs(2))
+                .connect()
+                .await
+                .expect("client connect");
+            let mut client = SyncServiceClient::new(channel);
+            let status = client
+                .read_tip(ReadTipRequest::default())
+                .await
+                .unwrap_err();
+            assert_eq!(
+                status.code(),
+                tonic::Code::Unimplemented,
+                "client {i} expected UNIMPLEMENTED"
+            );
+        }));
+    }
+    for h in handles {
+        h.await.expect("join client task");
+    }
+
+    server.stop().await;
+}
+
+// ── Shutdown drain ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn shutdown_signal_terminates_server_within_3s() {
+    let server = TestServer::start(true).await;
+    let start = std::time::Instant::now();
+    server.stop().await;
+    assert!(
+        start.elapsed() < Duration::from_secs(3),
+        "shutdown took {} ms — should be near-instant for a stub server",
+        start.elapsed().as_millis()
+    );
+}
+
+// ── Tip feed: events flow from publisher to a future Streaming subscriber. ──
+
+#[tokio::test]
+async fn tip_feed_publisher_round_trips_through_server_owned_channels() {
+    // M1.A pre-stubs FollowTip; this test exercises the underlying
+    // broadcaster shape independent of the service. Confirms the
+    // publish→subscribe contract that M1.B's FollowTip will rely on.
+    let feed = TipFeed::new();
+    let publisher = feed.publisher();
+    let mut rx = feed.subscribe_apply();
+
+    publisher.announce_apply(TipInfo {
+        slot: 1234,
+        hash: [9u8; 32],
+        block_number: 42,
+        era: dugite_primitives::Era::Conway,
+    });
+
+    let ev = rx.recv().await.expect("tip apply event");
+    assert_eq!(ev.slot, 1234);
+    assert_eq!(ev.block_number, 42);
+}
+
+// ── Mempool feed: events from the underlying Sender reach subscribers ────
+
+#[tokio::test]
+async fn mempool_feed_subscribers_see_events() {
+    let (tx, _) = broadcast::channel(8);
+    let feed = MempoolFeed::new(tx.clone());
+    let mut rx = feed.subscribe();
+
+    let hash = Hash32::from_bytes([3u8; 32]);
+    tx.send(dugite_rpc::MempoolEvent::Added {
+        tx_hash: hash,
+        raw_cbor: Some(vec![1, 2, 3]),
+    })
+    .unwrap();
+
+    match rx.recv().await.unwrap() {
+        dugite_rpc::MempoolEvent::Added { tx_hash, raw_cbor } => {
+            assert_eq!(tx_hash, hash);
+            assert_eq!(raw_cbor, Some(vec![1, 2, 3]));
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}


### PR DESCRIPTION
Milestone 1.A of #672 — new `dugite-rpc` crate with scaffold, service
stubs, server, and end-to-end gRPC tests. M1.B follows with real
`SyncService` implementations on top of this foundation.

Full plan: `.claude/plans/create-a-detailed-plan-adaptive-pretzel.md`

## What's in this PR

Seven focused commits:

| Commit | What |
|---|---|
| `e7f7ae273` M1.A.1 | New crate `crates/dugite-rpc/`. 10 vendored `.proto` files from `utxorpc/spec v0.19.2` (commit `4ef539a`) — cardano + sync + query + submit + watch in v1alpha + v1beta. `build.rs` drives `tonic-build`; `FILE_DESCRIPTOR_SET` re-exported for reflection. Workspace deps for `tonic 0.12` + `prost 0.13` + friends (scoped to this crate). |
| `262742692` M1.A.3 | `error.rs` (`RpcError` → `tonic::Status`); `config.rs` (`RpcConfig`/`RpcTlsConfig` + defaults); `metrics.rs` (`RpcMetricsSink` trait, `NoopMetrics`); `context.rs` (`LedgerContext` async trait — dep-free of `dugite-node` — plus carrier types). |
| `9d41bbfb9` M1.A.4 | `tip_feed.rs` (`TipFeed` + `TipPublisher`, capacities matching node-side defaults); `mempool_feed.rs` (re-exports `dugite-mempool` types directly, zero translation hops); `stream.rs` (`spawn_broadcast_fan_out` boilerplate w/ `RecvError::Lagged` → `Status::resource_exhausted`); `masking.rs` (FieldMaskPath parser + apply() no-op stub). |
| `c5ba4e2f3` M1.A.5 | `server.rs` (`RpcServer::start` with reflection + TLS-on-PEM + gRPC-Web + cooperative shutdown via `watch::Receiver<bool>`); `services/{sync,query,submit,watch}.rs` stubs returning `UNIMPLEMENTED` for every method in both v1alpha and v1beta. |
| `845a59a27` M1.A.7 | `tests/server_smoke.rs` — 12 integration tests driving a real gRPC client against the spawned server. Build clients toggled on. |
| `9f8a3379c` M1.A.6 | Node-side wiring: `RpcConfigJson` + `resolve_rpc()` (with 8 precedence tests), `--rpc-host` / `--rpc-port` / `--no-rpc` CLI flags, `NodeRpcAdapter` (LedgerContext stub returning Unimplemented for everything except `mempool_contains`), tip-event forwarder shim, startup block gated on `RpcConfig.is_some()`. |
| `44b6f49bc` | `dugite-config` schema: new `Rpc` section + `ParamDef::Object` so operators can discover the new config block in the TUI. |
| `643c72f2f` | Minor fmt fold-in for M1.A.1's build.rs. |

## What's NOT in this PR

* No `SyncService` / `QueryService` / `SubmitService` / `WatchService`
  implementations — every method returns `UNIMPLEMENTED`. M1.B fills
  in `SyncService`; M2 fills `QueryService`; M3 / M4 follow.
* No mapping modules (`map/block.rs`, `map/tx.rs`, …) — also M1.B+.
* No `bump-utxorpc-spec` helper script — deferred to M1.B alongside
  the first spec-bump workflow exercise.
* `EvalTx` carries a more specific UNIMPLEMENTED message but stays
  stubbed even after M3 lands (needs a non-committing UPLC helper).

## Verification

* `just check` ✅ — fmt + clippy + build + test + test-doc green
* `cargo nextest run -p dugite-rpc` ✅ — 23/23 pass (11 unit + 12 integration)
* `cargo nextest run -p dugite-node` ✅ — 886/886 pass (8 new resolve_rpc tests)
* `cargo nextest run -p dugite-config` ✅ — 131/131 pass
* `just devnet-validate-smoke` ⏸ — skipped (port 3001 held by live SAND
  soak); CI runs the gate. No behaviour change for non-RPC operators —
  `Rpc.Enabled` defaults to `false` so existing deployments are
  untouched.

## Manual smoke

```bash
# Start the node with RPC enabled (port 50051 default)
./target/release/dugite-node run --rpc-port 50051 ...

# List the registered services via reflection
grpcurl -plaintext localhost:50051 list
# expect: utxorpc.v1alpha.{sync,query,submit,watch}.{Sync,Query,Submit,Watch}Service
#         utxorpc.v1beta.{sync,query,submit,watch}.{Sync,Query,Submit,Watch}Service
#         grpc.reflection.v1.ServerReflection

# Every method returns UNIMPLEMENTED until M1.B
grpcurl -plaintext localhost:50051 utxorpc.v1beta.sync.SyncService/ReadTip
# Error: Code: Unimplemented
# Message: M1.A stub — SyncService method not implemented yet
```