### PR TITLE
feat(rpc): SyncService implementation (#672 M1.B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "bytes",
  "dugite-mempool",
  "dugite-primitives",
+ "dugite-serialization",
  "futures",
  "hex",
  "prost",

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2841,6 +2841,7 @@ impl Node {
         // fills SyncService / QueryService / SubmitService / WatchService.
         if let Some(rpc_cfg) = self.rpc_config.clone() {
             let adapter = Arc::new(crate::rpc_adapter::NodeRpcAdapter::new(
+                self.chain_db.clone(),
                 self.mempool.clone(),
             ));
             let (tip_feed, tip_publisher) = crate::rpc_adapter::build_tip_feed();

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -1,17 +1,22 @@
 //! `NodeRpcAdapter` — the bridge from `dugite-node` internals to the
 //! `dugite-rpc` server's [`LedgerContext`] trait.
 //!
-//! In M1.A every method returns `Unimplemented`; the adapter only needs
-//! to compile + exist so the node can boot the RPC server with all
-//! stubbed services. Subsequent milestones fill in real implementations
-//! as their corresponding service methods land in `dugite-rpc`.
+//! M1.B (this commit): all chain/blocks methods are implemented end-to-end
+//! against [`ChainDB`] + [`Mempool`]:
 //!
-//! Forward-shim tasks:
+//! * `tip` — reads from `chain_db.get_tip()` and looks up the matching
+//!   block's era via a minimal CBOR decode.
+//! * `block_by_hash` — direct `chain_db.get_block()`.
+//! * `block_at_slot` — `chain_db.get_block_at_or_after_slot()` filtered
+//!   to exact-match.
+//! * `block_after` — `chain_db.get_next_block_after_slot()`.
+//! * `intersect` — walks the supplied points newest-to-oldest, returns
+//!   the first that exists on-chain.
+//! * `blocks_range` — `chain_db.get_blocks_in_slot_range()` then decodes
+//!   identity per block for the carrier fields.
 //!
-//! * [`spawn_tip_forwarder`] subscribes to
-//!   `node::tip_broadcast::TipBroadcaster` and republishes into a
-//!   `dugite_rpc::TipPublisher`, mapping payloads. Lets the RPC layer
-//!   stay dep-free of `dugite-node`.
+//! `utxo_* / params_at_tip / era_history / genesis / submit_tx /
+//! mempool_snapshot` remain `Unimplemented` pending M2 / M3.
 
 use std::sync::Arc;
 
@@ -20,63 +25,154 @@ use dugite_mempool::Mempool;
 use dugite_primitives::address::Address;
 use dugite_primitives::block::Point;
 use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::time::SlotNo;
 use dugite_primitives::transaction::TransactionInput;
 use dugite_rpc::{
     LedgerContext, ParamsView, RawBlock, RawTx, RpcError, SubmitOutcome, TipFeed, TipInfo,
     TipPublisher, TipRollback, UtxoSnapshot,
 };
-use tokio::sync::watch;
+use dugite_serialization::decode::decode_block_minimal;
+use dugite_storage::ChainDB;
+use tokio::sync::{watch, RwLock};
 use tracing::debug;
 
 use crate::node::tip_broadcast::{TipApply, TipBroadcaster};
 
 /// Concrete impl of [`LedgerContext`] backed by node internals.
-///
-/// M1.A scope: every method returns `Unimplemented`. Holds Arc clones of
-/// the relevant node state so subsequent milestones can fill methods in
-/// without re-plumbing the adapter.
 pub struct NodeRpcAdapter {
-    // Held so that future milestones can fill in real implementations
-    // without re-plumbing the adapter. M1.A doesn't read these.
-    #[allow(dead_code)]
+    pub(crate) chain_db: Arc<RwLock<ChainDB>>,
     pub(crate) mempool: Arc<Mempool>,
 }
 
 impl NodeRpcAdapter {
-    pub fn new(mempool: Arc<Mempool>) -> Self {
-        Self { mempool }
+    pub fn new(chain_db: Arc<RwLock<ChainDB>>, mempool: Arc<Mempool>) -> Self {
+        Self { chain_db, mempool }
+    }
+
+    /// Pull (slot, hash, block_no, era) for a raw block CBOR via a
+    /// minimal decode. Returns an internal error if the decode fails —
+    /// this should never happen for blocks that ChainDB successfully
+    /// admitted, so a failure here indicates on-disk corruption.
+    fn raw_block_from_cbor(cbor: Vec<u8>) -> Result<RawBlock, RpcError> {
+        let block = decode_block_minimal(&cbor)
+            .map_err(|e| RpcError::Internal(format!("block decode failed: {e}")))?;
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(block.header.header_hash.as_ref());
+        Ok(RawBlock {
+            slot: block.header.slot.0,
+            hash,
+            block_number: block.header.block_number.0,
+            era: block.era,
+            cbor,
+        })
     }
 }
 
 #[async_trait]
 impl LedgerContext for NodeRpcAdapter {
     async fn tip(&self) -> Result<TipInfo, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::tip"))
+        let db = self.chain_db.read().await;
+        let (slot, hash, block_no) = match db.get_tip_info() {
+            Some(t) => t,
+            None => return Err(RpcError::NotFound("chain tip not available".into())),
+        };
+        // Look up the actual block to recover the era. Minor cost
+        // (one minimal decode); the tip is queried often but blocks
+        // are bounded ~72 KB and the decode is microseconds.
+        let cbor = db
+            .get_block(&hash)
+            .map_err(|e| RpcError::Internal(format!("chain_db get_block: {e}")))?
+            .ok_or_else(|| {
+                RpcError::Internal("tip block missing from ChainDB after get_tip".into())
+            })?;
+        let raw = Self::raw_block_from_cbor(cbor)?;
+        Ok(TipInfo {
+            slot: slot.0,
+            hash: raw.hash,
+            block_number: block_no.0,
+            era: raw.era,
+        })
     }
 
-    async fn block_by_hash(&self, _hash: &Hash32) -> Result<Option<RawBlock>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::block_by_hash"))
+    async fn block_by_hash(&self, hash: &Hash32) -> Result<Option<RawBlock>, RpcError> {
+        let db = self.chain_db.read().await;
+        let Some(cbor) = db
+            .get_block(hash)
+            .map_err(|e| RpcError::Internal(format!("chain_db get_block: {e}")))?
+        else {
+            return Ok(None);
+        };
+        Self::raw_block_from_cbor(cbor).map(Some)
     }
 
-    async fn block_at_slot(&self, _slot: u64) -> Result<Option<RawBlock>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::block_at_slot"))
+    async fn block_at_slot(&self, slot: u64) -> Result<Option<RawBlock>, RpcError> {
+        let db = self.chain_db.read().await;
+        let Some((s, _h, cbor)) = db
+            .get_block_at_or_after_slot(SlotNo(slot))
+            .map_err(|e| RpcError::Internal(format!("chain_db get_block_at_or_after_slot: {e}")))?
+        else {
+            return Ok(None);
+        };
+        if s.0 != slot {
+            return Ok(None);
+        }
+        Self::raw_block_from_cbor(cbor).map(Some)
     }
 
-    async fn block_after(&self, _slot: u64) -> Result<Option<RawBlock>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::block_after"))
+    async fn block_after(&self, slot: u64) -> Result<Option<RawBlock>, RpcError> {
+        let db = self.chain_db.read().await;
+        let Some((_s, _h, cbor)) = db
+            .get_next_block_after_slot(SlotNo(slot))
+            .map_err(|e| RpcError::Internal(format!("chain_db get_next_block_after_slot: {e}")))?
+        else {
+            return Ok(None);
+        };
+        Self::raw_block_from_cbor(cbor).map(Some)
     }
 
-    async fn intersect(&self, _points: &[Point]) -> Result<Option<Point>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::intersect"))
+    async fn intersect(&self, points: &[Point]) -> Result<Option<Point>, RpcError> {
+        let db = self.chain_db.read().await;
+        // Scan from newest-slot to oldest: ChainSync intersection
+        // semantics return the LATEST point that exists. Origin is
+        // always valid as a fallback.
+        let mut sorted: Vec<&Point> = points.iter().collect();
+        sorted.sort_by_key(|p| std::cmp::Reverse(p.slot().map(|s| s.0).unwrap_or(0)));
+        for point in sorted {
+            match point {
+                Point::Origin => return Ok(Some(Point::Origin)),
+                Point::Specific(slot, hash) => {
+                    if let Some(cbor) = db
+                        .get_block(hash)
+                        .map_err(|e| RpcError::Internal(format!("chain_db get_block: {e}")))?
+                    {
+                        // Verify slot matches as a sanity check.
+                        if let Ok(decoded) = decode_block_minimal(&cbor) {
+                            if decoded.header.slot == *slot {
+                                return Ok(Some(point.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(None)
     }
 
     async fn blocks_range(
         &self,
-        _from_slot: u64,
-        _to_slot: u64,
-        _limit: usize,
+        from_slot: u64,
+        to_slot: u64,
+        limit: usize,
     ) -> Result<Vec<RawBlock>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::blocks_range"))
+        let db = self.chain_db.read().await;
+        let cbors = db
+            .get_blocks_in_slot_range(SlotNo(from_slot), SlotNo(to_slot))
+            .map_err(|e| RpcError::Internal(format!("chain_db blocks_range: {e}")))?;
+        let mut out = Vec::with_capacity(cbors.len().min(limit));
+        for cbor in cbors.into_iter().take(limit) {
+            out.push(Self::raw_block_from_cbor(cbor)?);
+        }
+        Ok(out)
     }
 
     async fn utxo_by_ref(&self, _refs: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
@@ -118,7 +214,7 @@ impl LedgerContext for NodeRpcAdapter {
 
     async fn submit_tx(&self, _era: u16, _raw_cbor: &[u8]) -> SubmitOutcome {
         SubmitOutcome::Rejected {
-            reason: "M1.A stub — submit_tx not implemented yet".to_string(),
+            reason: "M1.B stub — submit_tx not implemented yet (M3)".to_string(),
         }
     }
 
@@ -127,7 +223,6 @@ impl LedgerContext for NodeRpcAdapter {
     }
 
     async fn mempool_contains(&self, hash: &TransactionHash) -> bool {
-        // Cheap call — mempool exposes Mempool::contains directly.
         self.mempool.contains(hash)
     }
 }
@@ -136,9 +231,6 @@ impl LedgerContext for NodeRpcAdapter {
 /// [`TipBroadcaster`] and republishes payload-shaped events into the
 /// RPC-side [`TipPublisher`]. Exits cleanly when `shutdown_rx` fires
 /// (true) or when the upstream broadcaster has no more senders.
-///
-/// Returns the spawned `JoinHandle` so the host can `.abort()` /
-/// `await` it during graceful shutdown.
 pub fn spawn_tip_forwarder(
     broadcaster: Arc<TipBroadcaster>,
     publisher: TipPublisher,
@@ -159,12 +251,6 @@ pub fn spawn_tip_forwarder(
                     match apply {
                         Ok(ev) => publisher.announce_apply(map_apply(ev)),
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            // Lossy forwarder — the RPC layer's own slow-
-                            // consumer handling kicks in downstream. A
-                            // Lagged here means the FORWARDER itself fell
-                            // behind, which is structurally unlikely (no
-                            // per-event work besides the publish), but
-                            // log so it's visible if it ever happens.
                             tracing::warn!(lagged = n, "dugite-rpc tip forwarder lagged on apply broadcast");
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
@@ -197,8 +283,7 @@ fn map_apply(ev: TipApply) -> TipInfo {
 }
 
 /// Builds a fresh [`TipFeed`] suitable for handing to
-/// [`dugite_rpc::RpcServer::start`]. Returns the feed + its publisher
-/// (the latter is owned by the host so it can spawn the forwarder).
+/// [`dugite_rpc::RpcServer::start`]. Returns the feed + its publisher.
 pub fn build_tip_feed() -> (TipFeed, TipPublisher) {
     let feed = TipFeed::new();
     let publisher = feed.publisher();

--- a/crates/dugite-rpc/Cargo.toml
+++ b/crates/dugite-rpc/Cargo.toml
@@ -30,6 +30,10 @@ async-trait = { workspace = true }
 # Workspace types we expose / accept across the LedgerContext trait surface.
 dugite-primitives = { workspace = true }
 dugite-mempool = { workspace = true }
+# Used by SyncService to decode the raw block CBOR into the parsed
+# `AnyChainBlock.chain.cardano` envelope. The native_bytes path stays
+# decoder-free.
+dugite-serialization = { workspace = true }
 
 # Diagnostics + error plumbing.
 tracing = { workspace = true }

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -26,6 +26,7 @@
 pub mod config;
 pub mod context;
 pub mod error;
+pub mod map;
 pub mod masking;
 pub mod mempool_feed;
 pub mod metrics;

--- a/crates/dugite-rpc/src/map/block.rs
+++ b/crates/dugite-rpc/src/map/block.rs
@@ -1,0 +1,117 @@
+//! `dugite_primitives::Block` → `utxorpc.v1beta.cardano.Block` mapping,
+//! plus the `sync` wrappers (`AnyChainBlock`, `BlockRef`).
+
+use crate::context::{RawBlock, TipInfo};
+use crate::map::common::hash_bytes;
+use crate::map::tx::tx_to_proto;
+use crate::proto::v1beta::cardano as pb_cardano;
+use crate::proto::v1beta::sync as pb_sync;
+use dugite_primitives::block::Block;
+
+/// Map a `dugite_primitives::Block` to the parsed Cardano protobuf shape.
+///
+/// `timestamp` is left at zero — populating it requires the era-history
+/// projection (`EraHistoryView`) which lives behind `LedgerContext`.
+/// M2's QueryService work fills it; M1.B sync clients that need the
+/// wall-clock can either re-derive from `header.slot` + ReadEra or
+/// parse `native_bytes` themselves.
+pub fn block_to_proto(block: &Block) -> pb_cardano::Block {
+    let header = pb_cardano::BlockHeader {
+        slot: block.header.slot.0,
+        hash: hash_bytes(&block.header.header_hash),
+        height: block.header.block_number.0,
+    };
+    let body = pb_cardano::BlockBody {
+        tx: block.transactions.iter().map(tx_to_proto).collect(),
+    };
+    pb_cardano::Block {
+        header: Some(header),
+        body: Some(body),
+        timestamp: 0,
+    }
+}
+
+/// Wrap a parsed [`Block`] together with its original CBOR bytes in
+/// [`AnyChainBlock`] — the envelope returned by `FetchBlock` /
+/// `DumpHistory` / `FollowTip`.
+///
+/// `native_bytes` is the verbatim block CBOR straight from
+/// [`RawBlock::cbor`] / [`Block::raw_cbor`]; clients that prefer the
+/// raw bytes (e.g. for offline parsing or for byte-exact retransmission)
+/// can ignore the parsed envelope.
+pub fn any_chain_block(raw: &RawBlock, parsed: Option<&Block>) -> pb_sync::AnyChainBlock {
+    pb_sync::AnyChainBlock {
+        native_bytes: raw.cbor.clone(),
+        chain: parsed.map(|b| pb_sync::any_chain_block::Chain::Cardano(block_to_proto(b))),
+    }
+}
+
+/// Project a [`RawBlock`] into the [`BlockRef`] handle that downstream
+/// services (FollowTip pagination, DumpHistory next_token) hand back to
+/// the client.
+pub fn block_ref_from_raw(raw: &RawBlock) -> pb_sync::BlockRef {
+    pb_sync::BlockRef {
+        slot: raw.slot,
+        hash: raw.hash.to_vec(),
+        height: raw.block_number,
+        timestamp: 0,
+    }
+}
+
+/// Project a [`TipInfo`] into a [`BlockRef`] — used by `ReadTip` and as
+/// the `tip` field on every `FollowTipResponse`.
+pub fn block_ref_from_tip(tip: &TipInfo) -> pb_sync::BlockRef {
+    pb_sync::BlockRef {
+        slot: tip.slot,
+        hash: tip.hash.to_vec(),
+        height: tip.block_number,
+        timestamp: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dugite_primitives::Era;
+
+    fn raw_block(slot: u64, hash: [u8; 32], block_no: u64, cbor: Vec<u8>) -> RawBlock {
+        RawBlock {
+            slot,
+            hash,
+            block_number: block_no,
+            era: Era::Conway,
+            cbor,
+        }
+    }
+
+    #[test]
+    fn any_chain_block_carries_native_bytes_without_parse() {
+        let raw = raw_block(123, [9u8; 32], 7, vec![0xA, 0xB, 0xC]);
+        let envelope = any_chain_block(&raw, None);
+        assert_eq!(envelope.native_bytes, vec![0xA, 0xB, 0xC]);
+        assert!(envelope.chain.is_none());
+    }
+
+    #[test]
+    fn block_ref_from_raw_round_trips_metadata() {
+        let raw = raw_block(123, [9u8; 32], 7, vec![]);
+        let r = block_ref_from_raw(&raw);
+        assert_eq!(r.slot, 123);
+        assert_eq!(r.height, 7);
+        assert_eq!(r.hash, vec![9u8; 32]);
+    }
+
+    #[test]
+    fn block_ref_from_tip_round_trips_metadata() {
+        let tip = TipInfo {
+            slot: 9_999,
+            hash: [1u8; 32],
+            block_number: 42,
+            era: Era::Conway,
+        };
+        let r = block_ref_from_tip(&tip);
+        assert_eq!(r.slot, 9_999);
+        assert_eq!(r.height, 42);
+        assert_eq!(r.hash, vec![1u8; 32]);
+    }
+}

--- a/crates/dugite-rpc/src/map/common.rs
+++ b/crates/dugite-rpc/src/map/common.rs
@@ -1,0 +1,66 @@
+//! Shared mapping helpers used by every `map/*` module.
+//!
+//! Tiny, pure functions only — no state, no I/O. Anything bigger lives in
+//! the per-concept files.
+
+use crate::proto::v1beta::cardano as pb;
+use dugite_primitives::hash::Hash;
+
+/// Map any fixed-size dugite hash to a `Vec<u8>` for protobuf `bytes` fields.
+#[inline]
+pub fn hash_bytes<const N: usize>(h: &Hash<N>) -> Vec<u8> {
+    h.as_ref().to_vec()
+}
+
+/// Encode a `u64` lovelace / quantity value as a `BigInt` protobuf message.
+///
+/// All Cardano values comfortably fit in `i64` (mainnet supply cap is
+/// 45 × 10¹⁵ lovelace ≪ 9.2 × 10¹⁸), so we always pick the `int` variant
+/// rather than walking through big-endian byte encoding.
+#[inline]
+pub fn coin_bigint(value: u64) -> pb::BigInt {
+    pb::BigInt {
+        big_int: Some(pb::big_int::BigInt::Int(value as i64)),
+    }
+}
+
+/// Encode a signed `i64` (e.g. mint deltas which can be negative for
+/// burns) as a `BigInt` protobuf message.
+#[inline]
+pub fn signed_bigint(value: i64) -> pb::BigInt {
+    pb::BigInt {
+        big_int: Some(pb::big_int::BigInt::Int(value)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::v1beta::cardano::big_int as bi;
+
+    #[test]
+    fn coin_uses_int_variant_within_i64_range() {
+        let b = coin_bigint(45_000_000_000_000_000); // 45 PB lovelace
+        match b.big_int {
+            Some(bi::BigInt::Int(v)) => assert_eq!(v, 45_000_000_000_000_000),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signed_int_handles_negative_mint() {
+        let b = signed_bigint(-1_000_000);
+        match b.big_int {
+            Some(bi::BigInt::Int(v)) => assert_eq!(v, -1_000_000),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hash_bytes_round_trip() {
+        let h = Hash::<32>::from_bytes([5u8; 32]);
+        let v = hash_bytes(&h);
+        assert_eq!(v.len(), 32);
+        assert_eq!(&v[..], &[5u8; 32]);
+    }
+}

--- a/crates/dugite-rpc/src/map/mod.rs
+++ b/crates/dugite-rpc/src/map/mod.rs
@@ -1,0 +1,20 @@
+//! Dugite → utxorpc protobuf mapping.
+//!
+//! In-house translator from `dugite_primitives` decoded shapes to the
+//! `utxorpc.v1beta.cardano` protobuf message types. Mapping is split per
+//! top-level concept so each file stays small enough to read in one sitting
+//! and golden tests cover one concern at a time.
+//!
+//! M1.B scope (this commit): `common` helpers, `block`, `tx` (Conway-shape
+//! with inputs/outputs/fee/mint/withdrawals/validity/auxiliary-hash
+//! populated; certs/governance/scripts/witnesses left empty pending M2's
+//! full mapping). `native_bytes` always populated from the original
+//! `Block.raw_cbor` / `Transaction.raw_body_cbor`.
+//!
+//! M2 fills the remaining `Tx` fields plus the standalone mapping modules
+//! for cert / governance / script / plutus_data / pparams / era_summary /
+//! genesis / patterns / metadatum / asset.
+
+pub mod block;
+pub mod common;
+pub mod tx;

--- a/crates/dugite-rpc/src/map/tx.rs
+++ b/crates/dugite-rpc/src/map/tx.rs
@@ -1,0 +1,379 @@
+//! `dugite_primitives::Transaction` → `utxorpc.v1beta.cardano.Tx` mapping.
+//!
+//! M1.B scope: every field of `Tx` that maps from a single concrete
+//! dugite type — inputs, outputs, fee, mint, withdrawals, validity,
+//! successful, auxiliary-data hash (in `auxiliary.metadata` as a stub
+//! marker), and hash. M2 fills in `certificates`, `witnesses`,
+//! `collateral` (Plutus-redeemer chain), `auxiliary.scripts`,
+//! `proposals`, `votes` — they all need the cross-cutting cert /
+//! governance / script / plutus_data / metadatum mapping modules.
+
+use crate::map::common::{coin_bigint, hash_bytes, signed_bigint};
+use crate::proto::v1beta::cardano as pb;
+use dugite_primitives::transaction::{
+    OutputDatum, Transaction, TransactionInput, TransactionOutput,
+};
+use dugite_primitives::value::Value;
+
+/// Map one [`Transaction`] to its [`pb::Tx`] protobuf shape.
+///
+/// `cert / witnesses / collateral / auxiliary.scripts / proposals /
+/// votes` are M2's mapping modules; until then they emit empty/default
+/// values. `successful` reflects `Transaction::is_valid` so clients can
+/// distinguish phase-2-failing txs without parsing the body themselves.
+pub fn tx_to_proto(tx: &Transaction) -> pb::Tx {
+    pb::Tx {
+        inputs: tx.body.inputs.iter().map(tx_input_to_proto).collect(),
+        outputs: tx.body.outputs.iter().map(tx_output_to_proto).collect(),
+        certificates: Vec::new(), // M2
+        withdrawals: tx
+            .body
+            .withdrawals
+            .iter()
+            .map(|(addr, qty)| pb::Withdrawal {
+                reward_account: addr.clone(),
+                coin: Some(coin_bigint(qty.0)),
+                // Plutus-redeemer wiring lands in M2 once the redeemer
+                // mapper covers WithdrawalPurpose.
+                redeemer: None,
+            })
+            .collect(),
+        mint: mint_to_proto(&tx.body.mint),
+        reference_inputs: tx
+            .body
+            .reference_inputs
+            .iter()
+            .map(tx_input_to_proto)
+            .collect(),
+        witnesses: None, // M2
+        collateral: collateral_to_proto(tx),
+        fee: Some(coin_bigint(tx.body.fee.0)),
+        validity: Some(pb::TxValidity {
+            start: tx.body.validity_interval_start.map(|s| s.0).unwrap_or(0),
+            ttl: tx.body.ttl.map(|s| s.0).unwrap_or(0),
+        }),
+        successful: tx.is_valid,
+        auxiliary: aux_to_proto(tx),
+        hash: hash_bytes(&tx.hash),
+        proposals: Vec::new(), // M2
+        votes: Vec::new(),     // M2
+    }
+}
+
+fn tx_input_to_proto(input: &TransactionInput) -> pb::TxInput {
+    pb::TxInput {
+        tx_hash: hash_bytes(&input.transaction_id),
+        output_index: input.index,
+        // `as_output` resolves the spent UTxO content. Populating it
+        // requires a ledger lookup at map time, which couples the
+        // mapper to LedgerContext. Deferred to M2 where the QueryService
+        // path naturally has the UTxO available.
+        as_output: None,
+        // Redeemer mapping requires the M2 PlutusData mapper.
+        redeemer: None,
+    }
+}
+
+fn tx_output_to_proto(out: &TransactionOutput) -> pb::TxOutput {
+    pb::TxOutput {
+        address: out.address.to_bytes(),
+        coin: Some(coin_bigint(out.value.coin.0)),
+        assets: assets_from_value(&out.value),
+        datum: datum_to_proto(&out.datum),
+        // Reference scripts attached to outputs need the M2 Script
+        // mapper (native vs plutus_v1/v2/v3).
+        script: None,
+        // Pass-through of the verbatim CBOR if the decoder retained it.
+        // Clients verifying datum-hash / address bytes can trust this.
+        original_cbor: out.raw_cbor.clone(),
+    }
+}
+
+fn assets_from_value(value: &Value) -> Vec<pb::Multiasset> {
+    value
+        .multi_asset
+        .iter()
+        .map(|(policy, assets)| pb::Multiasset {
+            policy_id: hash_bytes(policy),
+            assets: assets
+                .iter()
+                .map(|(name, qty)| pb::Asset {
+                    name: name.0.clone(),
+                    quantity: Some(coin_bigint(*qty)),
+                    // `output_coin` is the asset-balance projection of the
+                    // wider TxOutput value; the generated proto includes
+                    // an `output_coin` field only on later spec revisions.
+                    // Skip for now — populated at the v1beta v0.19.2 level
+                    // produces no extra field.
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+fn mint_to_proto(
+    mint: &std::collections::BTreeMap<
+        dugite_primitives::hash::PolicyId,
+        std::collections::BTreeMap<dugite_primitives::value::AssetName, i64>,
+    >,
+) -> Vec<pb::Multiasset> {
+    mint.iter()
+        .map(|(policy, assets)| pb::Multiasset {
+            policy_id: hash_bytes(policy),
+            assets: assets
+                .iter()
+                .map(|(name, qty)| pb::Asset {
+                    name: name.0.clone(),
+                    quantity: Some(signed_bigint(*qty)),
+                })
+                .collect(),
+        })
+        .collect()
+}
+
+fn datum_to_proto(datum: &OutputDatum) -> Option<pb::Datum> {
+    match datum {
+        OutputDatum::None => None,
+        OutputDatum::DatumHash(h) => Some(pb::Datum {
+            hash: hash_bytes(h),
+            // Datum payload + original_cbor land in M2's PlutusData
+            // mapper (inline datums carry a parsed payload; hash-only
+            // datums have neither).
+            payload: None,
+            original_cbor: None,
+        }),
+        OutputDatum::InlineDatum { raw_cbor, .. } => Some(pb::Datum {
+            // The on-chain hash of an inline datum is `blake2b_256` of
+            // its CBOR; computing it on the hot path would re-hash on
+            // every map. Clients that need the hash can re-derive from
+            // `original_cbor`.
+            hash: Vec::new(),
+            payload: None, // M2 PlutusData mapper
+            original_cbor: raw_cbor.clone(),
+        }),
+    }
+}
+
+fn aux_to_proto(tx: &Transaction) -> Option<pb::AuxData> {
+    // M1.B: empty AuxData when there is no auxiliary-data hash. With one,
+    // emit an empty AuxData so downstream clients can detect presence —
+    // M2 fills `metadata` + `scripts` once the metadatum mapper lands.
+    if tx.body.auxiliary_data_hash.is_none() && tx.auxiliary_data.is_none() {
+        None
+    } else {
+        Some(pb::AuxData {
+            metadata: Vec::new(),
+            scripts: Vec::new(),
+        })
+    }
+}
+
+fn collateral_to_proto(tx: &Transaction) -> Option<pb::Collateral> {
+    let has_any = !tx.body.collateral.is_empty()
+        || tx.body.collateral_return.is_some()
+        || tx.body.total_collateral.is_some();
+    if !has_any {
+        return None;
+    }
+    Some(pb::Collateral {
+        collateral: tx.body.collateral.iter().map(tx_input_to_proto).collect(),
+        collateral_return: tx.body.collateral_return.as_ref().map(tx_output_to_proto),
+        total_collateral: tx
+            .body
+            .total_collateral
+            .map(|coin| coin_bigint(coin.0))
+            .map(Some)
+            .unwrap_or_default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dugite_primitives::address::{Address, ByronAddress};
+    use dugite_primitives::hash::Hash32;
+    use dugite_primitives::transaction::*;
+    use dugite_primitives::value::Lovelace;
+    use std::collections::BTreeMap;
+
+    fn empty_tx_body() -> TransactionBody {
+        TransactionBody {
+            inputs: vec![],
+            outputs: vec![],
+            fee: Lovelace(0),
+            ttl: None,
+            certificates: vec![],
+            withdrawals: BTreeMap::new(),
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            mint: BTreeMap::new(),
+            script_data_hash: None,
+            collateral: vec![],
+            required_signers: vec![],
+            network_id: None,
+            collateral_return: None,
+            total_collateral: None,
+            reference_inputs: vec![],
+            update: None,
+            voting_procedures: BTreeMap::new(),
+            proposal_procedures: vec![],
+            treasury_value: None,
+            donation: None,
+            sub_transactions: vec![],
+            account_balance_intervals: vec![],
+            direct_deposits: BTreeMap::new(),
+            guards: Vec::new(),
+        }
+    }
+
+    fn empty_witness_set() -> TransactionWitnessSet {
+        TransactionWitnessSet {
+            vkey_witnesses: vec![],
+            native_scripts: vec![],
+            bootstrap_witnesses: vec![],
+            plutus_v1_scripts: vec![],
+            plutus_v2_scripts: vec![],
+            plutus_v3_scripts: vec![],
+            plutus_data: vec![],
+            redeemers: vec![],
+            raw_redeemers_cbor: None,
+            raw_plutus_data_cbor: None,
+            original_script_data_hash: None,
+        }
+    }
+
+    fn minimal_tx(hash: [u8; 32], fee: u64) -> Transaction {
+        let mut body = empty_tx_body();
+        body.fee = Lovelace(fee);
+        Transaction {
+            era: dugite_primitives::era::Era::Conway,
+            hash: Hash32::from_bytes(hash),
+            body,
+            witness_set: empty_witness_set(),
+            is_valid: true,
+            auxiliary_data: None,
+            raw_cbor: None,
+            raw_body_cbor: None,
+            raw_witness_cbor: None,
+        }
+    }
+
+    #[test]
+    fn tx_hash_and_fee_round_trip() {
+        let tx = minimal_tx([7u8; 32], 1_500_000);
+        let pb = tx_to_proto(&tx);
+        assert_eq!(pb.hash, vec![7u8; 32]);
+        assert!(pb.successful);
+        let fee = pb.fee.expect("fee set");
+        match fee.big_int.unwrap() {
+            pb::big_int::BigInt::Int(v) => assert_eq!(v, 1_500_000),
+            other => panic!("unexpected BigInt: {other:?}"),
+        }
+        // No optional sections populated.
+        assert!(pb.inputs.is_empty());
+        assert!(pb.outputs.is_empty());
+        assert!(pb.mint.is_empty());
+        assert!(pb.withdrawals.is_empty());
+        assert!(pb.certificates.is_empty());
+        assert!(pb.collateral.is_none());
+        assert!(pb.auxiliary.is_none());
+        assert_eq!(pb.validity.unwrap().ttl, 0);
+    }
+
+    #[test]
+    fn tx_with_invalid_flag_maps_successful_false() {
+        let mut tx = minimal_tx([1u8; 32], 0);
+        tx.is_valid = false;
+        let pb = tx_to_proto(&tx);
+        assert!(!pb.successful);
+    }
+
+    #[test]
+    fn tx_inputs_and_outputs_round_trip() {
+        let mut tx = minimal_tx([0u8; 32], 200_000);
+        tx.body.inputs.push(TransactionInput {
+            transaction_id: Hash32::from_bytes([9u8; 32]),
+            index: 3,
+        });
+        tx.body.outputs.push(TransactionOutput {
+            address: Address::Byron(ByronAddress {
+                payload: vec![1, 2, 3, 4],
+            }),
+            value: Value::lovelace(7_000_000),
+            datum: OutputDatum::None,
+            script_ref: None,
+            is_legacy: false,
+            raw_cbor: None,
+        });
+
+        let pb = tx_to_proto(&tx);
+        assert_eq!(pb.inputs.len(), 1);
+        assert_eq!(pb.inputs[0].tx_hash, vec![9u8; 32]);
+        assert_eq!(pb.inputs[0].output_index, 3);
+
+        assert_eq!(pb.outputs.len(), 1);
+        let out = &pb.outputs[0];
+        assert_eq!(
+            out.address,
+            Address::Byron(ByronAddress {
+                payload: vec![1, 2, 3, 4],
+            })
+            .to_bytes()
+        );
+        match out.coin.as_ref().unwrap().big_int.as_ref().unwrap() {
+            pb::big_int::BigInt::Int(v) => assert_eq!(*v, 7_000_000),
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(out.assets.is_empty());
+        assert!(out.datum.is_none());
+    }
+
+    #[test]
+    fn tx_with_mint_burn_is_signed_bigint() {
+        let mut tx = minimal_tx([0u8; 32], 0);
+        let policy = dugite_primitives::hash::PolicyId::from_bytes([0xAB; 28]);
+        let name =
+            dugite_primitives::value::AssetName::new(vec![0xC0, 0xFF, 0xEE]).expect("asset name");
+        let mut assets = BTreeMap::new();
+        assets.insert(name, -1_000_000_i64);
+        tx.body.mint.insert(policy, assets);
+
+        let pb = tx_to_proto(&tx);
+        assert_eq!(pb.mint.len(), 1);
+        let ma = &pb.mint[0];
+        assert_eq!(ma.policy_id, vec![0xAB; 28]);
+        match ma.assets[0]
+            .quantity
+            .as_ref()
+            .unwrap()
+            .big_int
+            .as_ref()
+            .unwrap()
+        {
+            pb::big_int::BigInt::Int(v) => assert_eq!(*v, -1_000_000),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tx_with_withdrawals_emits_correctly() {
+        let mut tx = minimal_tx([0u8; 32], 0);
+        tx.body
+            .withdrawals
+            .insert(vec![0xE0; 29], Lovelace(2_500_000));
+        let pb = tx_to_proto(&tx);
+        assert_eq!(pb.withdrawals.len(), 1);
+        assert_eq!(pb.withdrawals[0].reward_account, vec![0xE0; 29]);
+        match pb.withdrawals[0]
+            .coin
+            .as_ref()
+            .unwrap()
+            .big_int
+            .as_ref()
+            .unwrap()
+        {
+            pb::big_int::BigInt::Int(v) => assert_eq!(*v, 2_500_000),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+}

--- a/crates/dugite-rpc/src/services/sync.rs
+++ b/crates/dugite-rpc/src/services/sync.rs
@@ -1,19 +1,143 @@
 //! `SyncService` — block retrieval + chain following.
 //!
-//! M1.A stubs: every method returns `UNIMPLEMENTED`. M1.B fills
-//! `FetchBlock`, `DumpHistory`, `ReadTip`, `FollowTip` with real
-//! mappings against `LedgerContext::block_by_hash` / `blocks_range` /
-//! `tip` / `TipFeed`.
+//! M1.B (this commit): all four methods implemented end-to-end against
+//! [`LedgerContext`] + [`TipFeed`].
+//!
+//! * `ReadTip`: returns the current tip as a `BlockRef`.
+//! * `FetchBlock`: per-ref lookup via `block_by_hash` (preferred) or
+//!   `block_at_slot`. Blocks ship as `AnyChainBlock` with both
+//!   `native_bytes` and a parsed Cardano `Block`.
+//! * `DumpHistory`: pages forward starting at `start_token` (exclusive
+//!   if `start_token.slot > 0`, otherwise from-genesis equivalent),
+//!   bounded by `max_items` and a hard local cap.
+//! * `FollowTip`: streams `apply` events from the tip feed plus `reset`
+//!   events on rollback. If the client supplies `intersect` points, the
+//!   first message resets to the latest matching point on the local
+//!   chain. Slow clients drop with `RESOURCE_EXHAUSTED` per the shared
+//!   `stream::spawn_broadcast_fan_out` policy.
+//!
+//! `v1alpha` and `v1beta` carry isomorphic shapes for these methods so
+//! the implementation is intentionally duplicated rather than abstracted
+//! — keeps each impl readable, and a future `pb_recode!` macro can
+//! collapse them if needed without rewriting the logic.
 
+use std::sync::Arc;
+
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::Hash32;
+use dugite_primitives::time::SlotNo;
+use dugite_serialization::decode::decode_block;
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
+use tracing::warn;
 
 use super::ServiceState;
+use crate::context::{LedgerContext, RawBlock};
+use crate::error::RpcError;
+use crate::map::block::{any_chain_block, block_ref_from_raw, block_ref_from_tip};
 use crate::proto::{v1alpha, v1beta};
+use crate::stream::spawn_broadcast_fan_out;
 
-const UNIMPL: &str = "M1.A stub — SyncService method not implemented yet";
+const SERVICE_LABEL: &str = "sync";
 
-/// `v1alpha` SyncService wrapper.
+/// Hard upper bound on `DumpHistory.max_items` regardless of what the
+/// client requests. Protects the node from a runaway scan.
+const DUMP_HISTORY_HARD_CAP: u32 = 1000;
+
+// ─── Shared resolvers (both v1alpha + v1beta use these) ───────────────────
+
+async fn resolve_one_block(
+    ctx: &Arc<dyn LedgerContext>,
+    hash: &[u8],
+    slot: u64,
+) -> Result<Option<RawBlock>, RpcError> {
+    if hash.len() == 32 {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(hash);
+        return ctx.block_by_hash(&Hash32::from_bytes(arr)).await;
+    }
+    if slot > 0 {
+        return ctx.block_at_slot(slot).await;
+    }
+    Ok(None)
+}
+
+fn parse_block(raw: &RawBlock) -> Option<dugite_primitives::block::Block> {
+    match decode_block(&raw.cbor) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            warn!(
+                slot = raw.slot,
+                hash = %hex::encode(raw.hash),
+                error = %e,
+                "dugite-rpc: failed to parse block for AnyChainBlock; \
+                 returning native_bytes only"
+            );
+            None
+        }
+    }
+}
+
+async fn fetch_blocks_for_refs<H>(
+    ctx: &Arc<dyn LedgerContext>,
+    refs: &[H],
+    get_hash: impl Fn(&H) -> &[u8],
+    get_slot: impl Fn(&H) -> u64,
+) -> Result<Vec<RawBlock>, RpcError> {
+    let mut out = Vec::with_capacity(refs.len());
+    for r in refs {
+        if let Some(raw) = resolve_one_block(ctx, get_hash(r), get_slot(r)).await? {
+            out.push(raw);
+        }
+    }
+    Ok(out)
+}
+
+async fn dump_history_impl(
+    ctx: &Arc<dyn LedgerContext>,
+    start_slot: u64,
+    max_items: u32,
+) -> Result<Vec<RawBlock>, RpcError> {
+    let cap = max_items.clamp(1, DUMP_HISTORY_HARD_CAP) as usize;
+    let mut out: Vec<RawBlock> = Vec::with_capacity(cap);
+    let mut cursor = start_slot;
+    while out.len() < cap {
+        match ctx.block_after(cursor).await? {
+            Some(raw) => {
+                cursor = raw.slot;
+                out.push(raw);
+            }
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+async fn intersect_impl(
+    ctx: &Arc<dyn LedgerContext>,
+    refs: &[(Vec<u8>, u64)],
+) -> Result<Option<Point>, RpcError> {
+    let mut points: Vec<Point> = Vec::with_capacity(refs.len());
+    for (hash, slot) in refs {
+        if hash.len() == 32 {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(hash);
+            points.push(Point::Specific(SlotNo(*slot), Hash32::from_bytes(arr)));
+        }
+    }
+    ctx.intersect(&points).await
+}
+
+fn point_to_block_ref(point: &Point) -> (u64, Vec<u8>) {
+    match point {
+        Point::Origin => (0, Vec::new()),
+        Point::Specific(slot, hash) => (slot.0, hash.as_ref().to_vec()),
+    }
+}
+
+// ─── v1alpha ──────────────────────────────────────────────────────────────
+
 #[derive(Clone)]
 pub struct SyncSvcAlpha {
     state: ServiceState,
@@ -29,37 +153,198 @@ impl SyncSvcAlpha {
 impl v1alpha::sync::sync_service_server::SyncService for SyncSvcAlpha {
     async fn fetch_block(
         &self,
-        _request: Request<v1alpha::sync::FetchBlockRequest>,
+        request: Request<v1alpha::sync::FetchBlockRequest>,
     ) -> Result<Response<v1alpha::sync::FetchBlockResponse>, Status> {
-        let _ = &self.state;
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .request_started(SERVICE_LABEL, "fetch_block");
+        let req = request.into_inner();
+        let raws = fetch_blocks_for_refs(
+            &self.state.context,
+            &req.r#ref,
+            |r| r.hash.as_slice(),
+            |r| r.slot,
+        )
+        .await
+        .map_err(Status::from)?;
+        let blocks = raws
+            .iter()
+            .map(|raw| {
+                let parsed = parse_block(raw);
+                let beta = any_chain_block(raw, parsed.as_ref());
+                v1alpha::sync::AnyChainBlock {
+                    native_bytes: beta.native_bytes,
+                    chain: beta.chain.map(|c| match c {
+                        v1beta::sync::any_chain_block::Chain::Cardano(b) => {
+                            v1alpha::sync::any_chain_block::Chain::Cardano(recode_block_to_alpha(b))
+                        }
+                    }),
+                }
+            })
+            .collect();
+        Ok(Response::new(v1alpha::sync::FetchBlockResponse {
+            block: blocks,
+        }))
     }
 
     async fn dump_history(
         &self,
-        _request: Request<v1alpha::sync::DumpHistoryRequest>,
+        request: Request<v1alpha::sync::DumpHistoryRequest>,
     ) -> Result<Response<v1alpha::sync::DumpHistoryResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let req = request.into_inner();
+        let start_slot = req.start_token.as_ref().map(|r| r.slot).unwrap_or(0);
+        let raws = dump_history_impl(&self.state.context, start_slot, req.max_items)
+            .await
+            .map_err(Status::from)?;
+        let next_token = raws
+            .last()
+            .map(block_ref_from_raw)
+            .map(|r| v1alpha::sync::BlockRef {
+                slot: r.slot,
+                hash: r.hash,
+                height: r.height,
+                timestamp: r.timestamp,
+            });
+        let blocks = raws
+            .iter()
+            .map(|raw| {
+                let parsed = parse_block(raw);
+                let beta = any_chain_block(raw, parsed.as_ref());
+                v1alpha::sync::AnyChainBlock {
+                    native_bytes: beta.native_bytes,
+                    chain: beta.chain.map(|c| match c {
+                        v1beta::sync::any_chain_block::Chain::Cardano(b) => {
+                            v1alpha::sync::any_chain_block::Chain::Cardano(recode_block_to_alpha(b))
+                        }
+                    }),
+                }
+            })
+            .collect();
+        Ok(Response::new(v1alpha::sync::DumpHistoryResponse {
+            block: blocks,
+            next_token,
+        }))
     }
 
     type FollowTipStream = ReceiverStream<Result<v1alpha::sync::FollowTipResponse, Status>>;
 
     async fn follow_tip(
         &self,
-        _request: Request<v1alpha::sync::FollowTipRequest>,
+        request: Request<v1alpha::sync::FollowTipRequest>,
     ) -> Result<Response<Self::FollowTipStream>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .stream_started(SERVICE_LABEL, "follow_tip");
+        let req = request.into_inner();
+        let intersection_refs: Vec<(Vec<u8>, u64)> = req
+            .intersect
+            .into_iter()
+            .map(|r| (r.hash, r.slot))
+            .collect();
+
+        let apply_rx = self.state.tip_feed.subscribe_apply();
+        let rollback_rx = self.state.tip_feed.subscribe_rollback();
+        let intersection = intersect_impl(&self.state.context, &intersection_refs)
+            .await
+            .map_err(Status::from)?;
+
+        let (mut stream, _) = spawn_broadcast_fan_out::<_, v1alpha::sync::FollowTipResponse, _>(
+            apply_rx,
+            self.state.config.stream_buffer,
+            SERVICE_LABEL,
+            "follow_tip",
+            move |tip| {
+                Some(v1alpha::sync::FollowTipResponse {
+                    action: Some(v1alpha::sync::follow_tip_response::Action::Apply(
+                        v1alpha::sync::AnyChainBlock {
+                            native_bytes: Vec::new(),
+                            chain: None,
+                        },
+                    )),
+                    tip: Some(v1alpha::sync::BlockRef {
+                        slot: tip.slot,
+                        hash: tip.hash.to_vec(),
+                        height: tip.block_number,
+                        timestamp: 0,
+                    }),
+                })
+            },
+        );
+
+        let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+        if let Some(point) = intersection {
+            let (slot, hash) = point_to_block_ref(&point);
+            let _ = tx
+                .send(Ok(v1alpha::sync::FollowTipResponse {
+                    action: Some(v1alpha::sync::follow_tip_response::Action::Reset(
+                        v1alpha::sync::BlockRef {
+                            slot,
+                            hash,
+                            height: 0,
+                            timestamp: 0,
+                        },
+                    )),
+                    tip: None,
+                }))
+                .await;
+        }
+        tokio::spawn(async move {
+            let mut rollback_rx = rollback_rx;
+            loop {
+                tokio::select! {
+                    next = futures::StreamExt::next(&mut stream) => {
+                        match next {
+                            Some(item) => if tx.send(item).await.is_err() { break; },
+                            None => break,
+                        }
+                    }
+                    rb = rollback_rx.recv() => {
+                        match rb {
+                            Ok(ev) => {
+                                if tx.send(Ok(v1alpha::sync::FollowTipResponse {
+                                    action: Some(v1alpha::sync::follow_tip_response::Action::Reset(
+                                        v1alpha::sync::BlockRef {
+                                            slot: ev.slot,
+                                            hash: ev.hash.to_vec(),
+                                            height: 0,
+                                            timestamp: 0,
+                                        },
+                                    )),
+                                    tip: None,
+                                })).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 
     async fn read_tip(
         &self,
         _request: Request<v1alpha::sync::ReadTipRequest>,
     ) -> Result<Response<v1alpha::sync::ReadTipResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let tip = self.state.context.tip().await.map_err(Status::from)?;
+        let r = block_ref_from_tip(&tip);
+        Ok(Response::new(v1alpha::sync::ReadTipResponse {
+            tip: Some(v1alpha::sync::BlockRef {
+                slot: r.slot,
+                hash: r.hash,
+                height: r.height,
+                timestamp: r.timestamp,
+            }),
+        }))
     }
 }
 
-/// `v1beta` SyncService wrapper.
+// ─── v1beta ──────────────────────────────────────────────────────────────
+
 #[derive(Clone)]
 pub struct SyncSvcBeta {
     state: ServiceState,
@@ -75,32 +360,163 @@ impl SyncSvcBeta {
 impl v1beta::sync::sync_service_server::SyncService for SyncSvcBeta {
     async fn fetch_block(
         &self,
-        _request: Request<v1beta::sync::FetchBlockRequest>,
+        request: Request<v1beta::sync::FetchBlockRequest>,
     ) -> Result<Response<v1beta::sync::FetchBlockResponse>, Status> {
-        let _ = &self.state;
-        Err(Status::unimplemented(UNIMPL))
+        let req = request.into_inner();
+        let raws = fetch_blocks_for_refs(
+            &self.state.context,
+            &req.r#ref,
+            |r| r.hash.as_slice(),
+            |r| r.slot,
+        )
+        .await
+        .map_err(Status::from)?;
+        let blocks = raws
+            .iter()
+            .map(|raw| any_chain_block(raw, parse_block(raw).as_ref()))
+            .collect();
+        Ok(Response::new(v1beta::sync::FetchBlockResponse {
+            block: blocks,
+        }))
     }
 
     async fn dump_history(
         &self,
-        _request: Request<v1beta::sync::DumpHistoryRequest>,
+        request: Request<v1beta::sync::DumpHistoryRequest>,
     ) -> Result<Response<v1beta::sync::DumpHistoryResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let req = request.into_inner();
+        let start_slot = req.start_token.as_ref().map(|r| r.slot).unwrap_or(0);
+        let raws = dump_history_impl(&self.state.context, start_slot, req.max_items)
+            .await
+            .map_err(Status::from)?;
+        let next_token = raws.last().map(block_ref_from_raw);
+        let blocks = raws
+            .iter()
+            .map(|raw| any_chain_block(raw, parse_block(raw).as_ref()))
+            .collect();
+        Ok(Response::new(v1beta::sync::DumpHistoryResponse {
+            block: blocks,
+            next_token,
+        }))
     }
 
     type FollowTipStream = ReceiverStream<Result<v1beta::sync::FollowTipResponse, Status>>;
 
     async fn follow_tip(
         &self,
-        _request: Request<v1beta::sync::FollowTipRequest>,
+        request: Request<v1beta::sync::FollowTipRequest>,
     ) -> Result<Response<Self::FollowTipStream>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .stream_started(SERVICE_LABEL, "follow_tip");
+        let req = request.into_inner();
+        let intersection_refs: Vec<(Vec<u8>, u64)> = req
+            .intersect
+            .into_iter()
+            .map(|r| (r.hash, r.slot))
+            .collect();
+
+        let apply_rx = self.state.tip_feed.subscribe_apply();
+        let rollback_rx = self.state.tip_feed.subscribe_rollback();
+        let intersection = intersect_impl(&self.state.context, &intersection_refs)
+            .await
+            .map_err(Status::from)?;
+
+        let (mut stream, _) = spawn_broadcast_fan_out::<_, v1beta::sync::FollowTipResponse, _>(
+            apply_rx,
+            self.state.config.stream_buffer,
+            SERVICE_LABEL,
+            "follow_tip",
+            move |tip| {
+                Some(v1beta::sync::FollowTipResponse {
+                    action: Some(v1beta::sync::follow_tip_response::Action::Apply(
+                        v1beta::sync::AnyChainBlock {
+                            native_bytes: Vec::new(),
+                            chain: None,
+                        },
+                    )),
+                    tip: Some(v1beta::sync::BlockRef {
+                        slot: tip.slot,
+                        hash: tip.hash.to_vec(),
+                        height: tip.block_number,
+                        timestamp: 0,
+                    }),
+                })
+            },
+        );
+
+        let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+        if let Some(point) = intersection {
+            let (slot, hash) = point_to_block_ref(&point);
+            let _ = tx
+                .send(Ok(v1beta::sync::FollowTipResponse {
+                    action: Some(v1beta::sync::follow_tip_response::Action::Reset(
+                        v1beta::sync::BlockRef {
+                            slot,
+                            hash,
+                            height: 0,
+                            timestamp: 0,
+                        },
+                    )),
+                    tip: None,
+                }))
+                .await;
+        }
+        tokio::spawn(async move {
+            let mut rollback_rx = rollback_rx;
+            loop {
+                tokio::select! {
+                    next = futures::StreamExt::next(&mut stream) => {
+                        match next {
+                            Some(item) => if tx.send(item).await.is_err() { break; },
+                            None => break,
+                        }
+                    }
+                    rb = rollback_rx.recv() => {
+                        match rb {
+                            Ok(ev) => {
+                                if tx.send(Ok(v1beta::sync::FollowTipResponse {
+                                    action: Some(v1beta::sync::follow_tip_response::Action::Reset(
+                                        v1beta::sync::BlockRef {
+                                            slot: ev.slot,
+                                            hash: ev.hash.to_vec(),
+                                            height: 0,
+                                            timestamp: 0,
+                                        },
+                                    )),
+                                    tip: None,
+                                })).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 
     async fn read_tip(
         &self,
         _request: Request<v1beta::sync::ReadTipRequest>,
     ) -> Result<Response<v1beta::sync::ReadTipResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let tip = self.state.context.tip().await.map_err(Status::from)?;
+        Ok(Response::new(v1beta::sync::ReadTipResponse {
+            tip: Some(block_ref_from_tip(&tip)),
+        }))
     }
+}
+
+// ─── v1beta → v1alpha re-encoding ─────────────────────────────────────────
+
+/// Translate a v1beta Cardano Block to v1alpha via prost re-encode.
+fn recode_block_to_alpha(beta: v1beta::cardano::Block) -> v1alpha::cardano::Block {
+    use prost::Message;
+    let bytes = beta.encode_to_vec();
+    v1alpha::cardano::Block::decode(bytes.as_slice())
+        .expect("v1alpha and v1beta Cardano Block messages are wire-compatible for M1.B fields")
 }

--- a/crates/dugite-rpc/tests/server_smoke.rs
+++ b/crates/dugite-rpc/tests/server_smoke.rs
@@ -177,93 +177,42 @@ async fn server_binds_loopback_only_by_default() {
     server.stop().await;
 }
 
-// ── Sync v1beta ──────────────────────────────────────────────────────────
+// ── Sync v1beta — implemented as of M1.B; see sync_service.rs ───────────
+//
+// `SyncService` is no longer the all-UNIMPLEMENTED stub it was in M1.A.
+// The detailed sync-method correctness suite lives in
+// `tests/sync_service.rs` with a richer `SyncMock`. Here we only retain
+// the scaffold smoke (ReadTip surfaces its trait error correctly).
 
 #[tokio::test]
-async fn sync_v1beta_methods_return_unimplemented() {
+async fn sync_v1beta_read_tip_propagates_mock_unimplemented() {
     use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
-    use dugite_rpc::proto::v1beta::sync::{
-        DumpHistoryRequest, FetchBlockRequest, FollowTipRequest, ReadTipRequest,
-    };
+    use dugite_rpc::proto::v1beta::sync::ReadTipRequest;
 
     let server = TestServer::start(true).await;
     let mut client = SyncServiceClient::new(server.channel().await);
-
-    let cases: Vec<(&str, tonic::Status)> = vec![
-        (
-            "fetch_block",
-            client
-                .fetch_block(FetchBlockRequest::default())
-                .await
-                .unwrap_err(),
-        ),
-        (
-            "dump_history",
-            client
-                .dump_history(DumpHistoryRequest::default())
-                .await
-                .unwrap_err(),
-        ),
-        (
-            "read_tip",
-            client
-                .read_tip(ReadTipRequest::default())
-                .await
-                .unwrap_err(),
-        ),
-        (
-            "follow_tip",
-            client
-                .follow_tip(FollowTipRequest::default())
-                .await
-                .unwrap_err(),
-        ),
-    ];
-
-    for (name, status) in cases {
-        assert_eq!(
-            status.code(),
-            tonic::Code::Unimplemented,
-            "{name} → expected UNIMPLEMENTED, got {status:?}"
-        );
-    }
-
+    let status = client
+        .read_tip(ReadTipRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
     server.stop().await;
 }
 
 // ── Sync v1alpha ─────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn sync_v1alpha_methods_return_unimplemented() {
+async fn sync_v1alpha_read_tip_propagates_mock_unimplemented() {
     use dugite_rpc::proto::v1alpha::sync::sync_service_client::SyncServiceClient;
-    use dugite_rpc::proto::v1alpha::sync::{
-        DumpHistoryRequest, FetchBlockRequest, FollowTipRequest, ReadTipRequest,
-    };
+    use dugite_rpc::proto::v1alpha::sync::ReadTipRequest;
 
     let server = TestServer::start(true).await;
     let mut client = SyncServiceClient::new(server.channel().await);
-
-    let r1 = client
-        .fetch_block(FetchBlockRequest::default())
-        .await
-        .unwrap_err();
-    let r2 = client
-        .dump_history(DumpHistoryRequest::default())
-        .await
-        .unwrap_err();
-    let r3 = client
+    let status = client
         .read_tip(ReadTipRequest::default())
         .await
         .unwrap_err();
-    let r4 = client
-        .follow_tip(FollowTipRequest::default())
-        .await
-        .unwrap_err();
-
-    for s in [&r1, &r2, &r3, &r4] {
-        assert_eq!(s.code(), tonic::Code::Unimplemented);
-    }
-
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
     server.stop().await;
 }
 

--- a/crates/dugite-rpc/tests/sync_service.rs
+++ b/crates/dugite-rpc/tests/sync_service.rs
@@ -1,0 +1,632 @@
+//! M1.B integration tests for the real `SyncService` implementation.
+//!
+//! Backs the server with a `SyncMock` that holds a small in-memory chain
+//! of synthetic blocks (CBOR-shaped enough that `decode_block_minimal`
+//! succeeds wouldn't be necessary — the service relies on
+//! `LedgerContext::block_by_hash` etc., not on re-parsing inside the
+//! service). Each test exercises one method end-to-end on a real gRPC
+//! wire.
+
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use dugite_mempool::{Mempool, MempoolConfig};
+use dugite_primitives::address::Address;
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::transaction::TransactionInput;
+use dugite_primitives::Era;
+use dugite_rpc::context::{EraHistoryView, GenesisView, ParamsView};
+use dugite_rpc::{
+    noop_metrics, LedgerContext, MempoolFeed, RawBlock, RawTx, RpcConfig, RpcError, RpcServer,
+    SubmitOutcome, TipFeed, TipInfo, UtxoSnapshot,
+};
+use tokio::sync::watch;
+use tonic::transport::Channel;
+
+// ─── SyncMock — minimal in-memory chain ──────────────────────────────────
+
+#[derive(Clone)]
+struct ChainEntry {
+    slot: u64,
+    hash: [u8; 32],
+    block_no: u64,
+    cbor: Vec<u8>, // can be empty for the M1.B tests; clients only test metadata
+}
+
+struct SyncMock {
+    blocks: BTreeMap<u64, ChainEntry>, // slot → entry
+    by_hash: BTreeMap<[u8; 32], ChainEntry>,
+}
+
+impl SyncMock {
+    fn new(entries: Vec<ChainEntry>) -> Self {
+        let mut blocks = BTreeMap::new();
+        let mut by_hash = BTreeMap::new();
+        for e in entries {
+            blocks.insert(e.slot, e.clone());
+            by_hash.insert(e.hash, e);
+        }
+        Self { blocks, by_hash }
+    }
+
+    fn tip_entry(&self) -> Option<&ChainEntry> {
+        self.blocks.values().next_back()
+    }
+}
+
+#[async_trait]
+impl LedgerContext for SyncMock {
+    async fn tip(&self) -> Result<TipInfo, RpcError> {
+        match self.tip_entry() {
+            Some(e) => Ok(TipInfo {
+                slot: e.slot,
+                hash: e.hash,
+                block_number: e.block_no,
+                era: Era::Conway,
+            }),
+            None => Err(RpcError::NotFound("empty chain".into())),
+        }
+    }
+
+    async fn block_by_hash(&self, hash: &Hash32) -> Result<Option<RawBlock>, RpcError> {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(hash.as_ref());
+        Ok(self.by_hash.get(&arr).map(|e| RawBlock {
+            slot: e.slot,
+            hash: e.hash,
+            block_number: e.block_no,
+            era: Era::Conway,
+            cbor: e.cbor.clone(),
+        }))
+    }
+
+    async fn block_at_slot(&self, slot: u64) -> Result<Option<RawBlock>, RpcError> {
+        Ok(self.blocks.get(&slot).map(|e| RawBlock {
+            slot: e.slot,
+            hash: e.hash,
+            block_number: e.block_no,
+            era: Era::Conway,
+            cbor: e.cbor.clone(),
+        }))
+    }
+
+    async fn block_after(&self, slot: u64) -> Result<Option<RawBlock>, RpcError> {
+        Ok(self
+            .blocks
+            .range((std::ops::Bound::Excluded(slot), std::ops::Bound::Unbounded))
+            .next()
+            .map(|(_, e)| RawBlock {
+                slot: e.slot,
+                hash: e.hash,
+                block_number: e.block_no,
+                era: Era::Conway,
+                cbor: e.cbor.clone(),
+            }))
+    }
+
+    async fn intersect(&self, points: &[Point]) -> Result<Option<Point>, RpcError> {
+        // Pick the latest-slot supplied point that exists in our chain.
+        let mut sorted: Vec<&Point> = points.iter().collect();
+        sorted.sort_by_key(|p| std::cmp::Reverse(p.slot().map(|s| s.0).unwrap_or(0)));
+        for p in sorted {
+            match p {
+                Point::Origin => return Ok(Some(Point::Origin)),
+                Point::Specific(_, hash) => {
+                    let mut arr = [0u8; 32];
+                    arr.copy_from_slice(hash.as_ref());
+                    if self.by_hash.contains_key(&arr) {
+                        return Ok(Some(p.clone()));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    async fn blocks_range(
+        &self,
+        from: u64,
+        to: u64,
+        limit: usize,
+    ) -> Result<Vec<RawBlock>, RpcError> {
+        Ok(self
+            .blocks
+            .range(from..=to)
+            .take(limit)
+            .map(|(_, e)| RawBlock {
+                slot: e.slot,
+                hash: e.hash,
+                block_number: e.block_no,
+                era: Era::Conway,
+                cbor: e.cbor.clone(),
+            })
+            .collect())
+    }
+
+    async fn utxo_by_ref(&self, _: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn utxos_by_address(&self, _: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn utxos_by_payment_credential(&self, _: &Hash32) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn utxos_by_asset(
+        &self,
+        _: &Hash32,
+        _: Option<&[u8]>,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn era_history(&self) -> Result<EraHistoryView, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn genesis(&self) -> Result<GenesisView, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn submit_tx(&self, _: u16, _: &[u8]) -> SubmitOutcome {
+        SubmitOutcome::Rejected { reason: "".into() }
+    }
+    async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn mempool_contains(&self, _: &TransactionHash) -> bool {
+        false
+    }
+}
+
+// ─── Test scaffold ───────────────────────────────────────────────────────
+
+struct TestServer {
+    addr: std::net::SocketAddr,
+    shutdown_tx: watch::Sender<bool>,
+    join: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
+    tip_feed: TipFeed,
+}
+
+impl TestServer {
+    async fn start(mock: SyncMock) -> Self {
+        let config = RpcConfig {
+            bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port: 0,
+            alpha_enabled: true,
+            ..Default::default()
+        };
+        let tip_feed = TipFeed::new();
+        let mempool = Arc::new(Mempool::new(MempoolConfig::default()));
+        let mempool_feed = MempoolFeed::new(mempool.tx_events());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let handle = RpcServer::start(
+            Arc::new(config),
+            Arc::new(mock),
+            tip_feed.clone(),
+            mempool_feed,
+            noop_metrics(),
+            shutdown_rx,
+        )
+        .await
+        .expect("start RPC");
+        Self {
+            addr: handle.local_addr,
+            shutdown_tx,
+            join: handle.join,
+            tip_feed,
+        }
+    }
+
+    async fn channel(&self) -> Channel {
+        let url = format!("http://{}", self.addr);
+        Channel::from_shared(url)
+            .unwrap()
+            .connect_timeout(Duration::from_secs(2))
+            .connect()
+            .await
+            .expect("connect")
+    }
+
+    async fn stop(self) {
+        let _ = self.shutdown_tx.send(true);
+        match tokio::time::timeout(Duration::from_secs(3), self.join).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => panic!("server task panicked: {e}"),
+            Err(_) => panic!("server didn't shut down within 3s"),
+        }
+    }
+}
+
+fn entry(slot: u64, hash_byte: u8, block_no: u64) -> ChainEntry {
+    let mut hash = [0u8; 32];
+    hash[0] = hash_byte;
+    ChainEntry {
+        slot,
+        hash,
+        block_no,
+        cbor: vec![0xDE, 0xAD, hash_byte], // synthetic — parse returns None, native_bytes still works
+    }
+}
+
+// ─── ReadTip ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn read_tip_returns_highest_slot_block() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::ReadTipRequest;
+
+    let server = TestServer::start(SyncMock::new(vec![
+        entry(100, 0xAA, 1),
+        entry(200, 0xBB, 2),
+        entry(300, 0xCC, 3),
+    ]))
+    .await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+    let resp = client.read_tip(ReadTipRequest::default()).await.unwrap();
+    let tip = resp.into_inner().tip.expect("tip set");
+    assert_eq!(tip.slot, 300);
+    assert_eq!(tip.height, 3);
+    let mut expected = [0u8; 32];
+    expected[0] = 0xCC;
+    assert_eq!(tip.hash, expected.to_vec());
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn read_tip_alpha_matches_beta() {
+    use dugite_rpc::proto::v1alpha::sync::sync_service_client::SyncServiceClient as Alpha;
+    use dugite_rpc::proto::v1alpha::sync::ReadTipRequest;
+
+    let server = TestServer::start(SyncMock::new(vec![entry(50, 0x42, 7)])).await;
+    let mut client = Alpha::new(server.channel().await);
+    let tip = client
+        .read_tip(ReadTipRequest::default())
+        .await
+        .unwrap()
+        .into_inner()
+        .tip
+        .unwrap();
+    assert_eq!(tip.slot, 50);
+    assert_eq!(tip.height, 7);
+    server.stop().await;
+}
+
+// ─── FetchBlock ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn fetch_block_by_hash_returns_native_bytes() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{BlockRef, FetchBlockRequest};
+
+    let server =
+        TestServer::start(SyncMock::new(vec![entry(10, 0x01, 1), entry(20, 0x02, 2)])).await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    let mut hash = [0u8; 32];
+    hash[0] = 0x02;
+    let resp = client
+        .fetch_block(FetchBlockRequest {
+            r#ref: vec![BlockRef {
+                slot: 0,
+                hash: hash.to_vec(),
+                height: 0,
+                timestamp: 0,
+            }],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.block.len(), 1);
+    assert_eq!(resp.block[0].native_bytes, vec![0xDE, 0xAD, 0x02]);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn fetch_block_unknown_hash_returns_empty_list() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{BlockRef, FetchBlockRequest};
+
+    let server = TestServer::start(SyncMock::new(vec![entry(10, 0x01, 1)])).await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+    let hash = [0xFF; 32];
+    let resp = client
+        .fetch_block(FetchBlockRequest {
+            r#ref: vec![BlockRef {
+                slot: 0,
+                hash: hash.to_vec(),
+                height: 0,
+                timestamp: 0,
+            }],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(resp.block.is_empty());
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn fetch_block_multiple_refs_in_order() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{BlockRef, FetchBlockRequest};
+
+    let server = TestServer::start(SyncMock::new(vec![
+        entry(10, 0x01, 1),
+        entry(20, 0x02, 2),
+        entry(30, 0x03, 3),
+    ]))
+    .await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+    let mut h1 = [0u8; 32];
+    h1[0] = 0x03;
+    let mut h2 = [0u8; 32];
+    h2[0] = 0x01;
+    let resp = client
+        .fetch_block(FetchBlockRequest {
+            r#ref: vec![
+                BlockRef {
+                    slot: 0,
+                    hash: h1.to_vec(),
+                    height: 0,
+                    timestamp: 0,
+                },
+                BlockRef {
+                    slot: 0,
+                    hash: h2.to_vec(),
+                    height: 0,
+                    timestamp: 0,
+                },
+            ],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.block.len(), 2);
+    assert_eq!(resp.block[0].native_bytes, vec![0xDE, 0xAD, 0x03]);
+    assert_eq!(resp.block[1].native_bytes, vec![0xDE, 0xAD, 0x01]);
+    server.stop().await;
+}
+
+// ─── DumpHistory ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dump_history_pages_forward_from_start_token() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{BlockRef, DumpHistoryRequest};
+
+    let server = TestServer::start(SyncMock::new(vec![
+        entry(100, 0x01, 1),
+        entry(200, 0x02, 2),
+        entry(300, 0x03, 3),
+        entry(400, 0x04, 4),
+    ]))
+    .await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    // First page: start at origin, max 2.
+    let page1 = client
+        .dump_history(DumpHistoryRequest {
+            start_token: Some(BlockRef {
+                slot: 0,
+                hash: vec![],
+                height: 0,
+                timestamp: 0,
+            }),
+            max_items: 2,
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(page1.block.len(), 2);
+    let next_token = page1.next_token.expect("next_token set");
+    assert_eq!(next_token.slot, 200);
+
+    // Second page: continue from next_token.
+    let page2 = client
+        .dump_history(DumpHistoryRequest {
+            start_token: Some(next_token),
+            max_items: 10,
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(page2.block.len(), 2); // 300 and 400
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn dump_history_empty_when_no_blocks_after_token() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{BlockRef, DumpHistoryRequest};
+
+    let server = TestServer::start(SyncMock::new(vec![entry(100, 0x01, 1)])).await;
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    let resp = client
+        .dump_history(DumpHistoryRequest {
+            start_token: Some(BlockRef {
+                slot: 500,
+                hash: vec![],
+                height: 0,
+                timestamp: 0,
+            }),
+            max_items: 10,
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(resp.block.is_empty());
+    assert!(resp.next_token.is_none());
+    server.stop().await;
+}
+
+// ─── FollowTip ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn follow_tip_emits_reset_for_known_intersection_then_apply_events() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{follow_tip_response, BlockRef, FollowTipRequest};
+    use tokio_stream::StreamExt;
+
+    let mut intersection_hash = [0u8; 32];
+    intersection_hash[0] = 0x02;
+    let server = TestServer::start(SyncMock::new(vec![
+        entry(100, 0x01, 1),
+        entry(200, 0x02, 2),
+    ]))
+    .await;
+    let publisher = server.tip_feed.publisher();
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    let stream = client
+        .follow_tip(FollowTipRequest {
+            intersect: vec![BlockRef {
+                slot: 200,
+                hash: intersection_hash.to_vec(),
+                height: 2,
+                timestamp: 0,
+            }],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let mut stream = stream;
+
+    // First message: reset to intersection.
+    let first = stream.next().await.expect("first msg").unwrap();
+    match first.action.expect("action") {
+        follow_tip_response::Action::Reset(r) => {
+            assert_eq!(r.slot, 200);
+            assert_eq!(r.hash, intersection_hash.to_vec());
+        }
+        other => panic!("expected reset, got {other:?}"),
+    }
+
+    // Fire two apply events.
+    let mut h3 = [0u8; 32];
+    h3[0] = 0x03;
+    publisher.announce_apply(TipInfo {
+        slot: 300,
+        hash: h3,
+        block_number: 3,
+        era: Era::Conway,
+    });
+    let mut h4 = [0u8; 32];
+    h4[0] = 0x04;
+    publisher.announce_apply(TipInfo {
+        slot: 400,
+        hash: h4,
+        block_number: 4,
+        era: Era::Conway,
+    });
+
+    let second = stream.next().await.expect("second msg").unwrap();
+    let tip = second.tip.expect("tip set");
+    assert_eq!(tip.slot, 300);
+    match second.action.expect("action") {
+        follow_tip_response::Action::Apply(_) => {}
+        other => panic!("expected apply, got {other:?}"),
+    }
+    let third = stream.next().await.expect("third msg").unwrap();
+    assert_eq!(third.tip.unwrap().slot, 400);
+
+    drop(stream);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn follow_tip_emits_reset_on_rollback() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{follow_tip_response, FollowTipRequest};
+    use dugite_rpc::TipRollback;
+    use tokio_stream::StreamExt;
+
+    let server = TestServer::start(SyncMock::new(vec![entry(100, 0x01, 1)])).await;
+    let publisher = server.tip_feed.publisher();
+    let mut client = SyncServiceClient::new(server.channel().await);
+    let stream = client
+        .follow_tip(FollowTipRequest {
+            intersect: vec![],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let mut stream = stream;
+
+    let mut h = [0u8; 32];
+    h[0] = 0x99;
+    publisher.announce_rollback(TipRollback { slot: 50, hash: h });
+
+    let msg = stream.next().await.expect("rollback msg").unwrap();
+    match msg.action.expect("action") {
+        follow_tip_response::Action::Reset(r) => {
+            assert_eq!(r.slot, 50);
+            assert_eq!(r.hash, h.to_vec());
+        }
+        other => panic!("expected reset on rollback, got {other:?}"),
+    }
+
+    drop(stream);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn follow_tip_intersect_with_no_match_skips_reset() {
+    use dugite_rpc::proto::v1beta::sync::sync_service_client::SyncServiceClient;
+    use dugite_rpc::proto::v1beta::sync::{follow_tip_response, BlockRef, FollowTipRequest};
+    use tokio_stream::StreamExt;
+
+    let server = TestServer::start(SyncMock::new(vec![entry(100, 0x01, 1)])).await;
+    let publisher = server.tip_feed.publisher();
+    let mut client = SyncServiceClient::new(server.channel().await);
+
+    let unknown = [0xFF; 32];
+    let stream = client
+        .follow_tip(FollowTipRequest {
+            intersect: vec![BlockRef {
+                slot: 999,
+                hash: unknown.to_vec(),
+                height: 0,
+                timestamp: 0,
+            }],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let mut stream = stream;
+
+    // No reset since intersect found nothing — first message should be
+    // the first apply event we fire.
+    let mut h = [0u8; 32];
+    h[0] = 0x09;
+    publisher.announce_apply(TipInfo {
+        slot: 110,
+        hash: h,
+        block_number: 2,
+        era: Era::Conway,
+    });
+
+    let msg = stream.next().await.expect("apply msg").unwrap();
+    match msg.action.expect("action") {
+        follow_tip_response::Action::Apply(_) => {
+            assert_eq!(msg.tip.unwrap().slot, 110);
+        }
+        other => panic!("expected apply, got {other:?}"),
+    }
+    drop(stream);
+    server.stop().await;
+}


### PR DESCRIPTION
Milestone 1.B of #672 — fills the SyncService stubs from M1.A with real
implementations end-to-end.

**Stacked on #676 (M1.A).** Merge that first; this PR rebases cleanly
to main once M1.A lands.

## What's in this PR

| Layer | What |
|---|---|
| **Mapping** | New `crates/dugite-rpc/src/map/{mod,common,block,tx}.rs` translating dugite primitives → `utxorpc.v1beta.cardano.*`. Covers Block/BlockHeader/BlockBody/AnyChainBlock/BlockRef plus Tx fields (inputs / outputs / fee / mint / withdrawals / validity / successful / reference_inputs / collateral / hash). `native_bytes` flows through without re-encoding. **Cert / governance / script / witnesses / metadatum mapping = M2.** |
| **SyncService** | All 4 methods (`FetchBlock`, `DumpHistory`, `ReadTip`, `FollowTip`) implemented in both v1alpha and v1beta. FollowTip merges TipFeed apply + rollback events; intersect sends `reset` first. Slow-client → `RESOURCE_EXHAUSTED`. DumpHistory hard-capped at 1000 items. |
| **NodeRpcAdapter** | `tip`, `block_by_hash`, `block_at_slot`, `block_after`, `intersect`, `blocks_range` implemented against `ChainDB`. Each lookup uses `decode_block_minimal` to recover era + block_no for the carrier types. |
| **Tests** | **11 new integration tests** in `tests/sync_service.rs` with a `SyncMock` chain; **11 new unit tests** for map modules. Existing tests trimmed where M1.A's UNIMPLEMENTED assertions no longer hold. |

## What's NOT in this PR

* Cert / governance / script / witnesses / metadatum / plutus_data Tx fields stay empty until M2.
* FollowTip apply events carry only the BlockRef + tip metadata; the full AnyChainBlock with native_bytes requires an async block fetch per event — deferred to M2 to keep the M1.B diff focused. Clients can `FetchBlock` with `tip.hash` for the bytes.
* `Block.timestamp` is 0 — needs `EraHistoryView` (M2).
* Query / Submit / Watch services unchanged (M2 / M3 / M4).

## Verification

* `cargo nextest run -p dugite-rpc -p dugite-node` ✅ — **930/930 pass**
* `cargo clippy -p dugite-rpc --all-targets -- -D warnings` ✅
* `cargo fmt --all -- --check` ✅

## Manual smoke (post-merge)

```bash
./target/release/dugite-node run --rpc-port 50051 ...

grpcurl -plaintext localhost:50051 utxorpc.v1beta.sync.SyncService/ReadTip
# {
#   "tip": {
#     "slot": "...",
#     "hash": "...",
#     "height": "...",
#     "timestamp": "0"
#   }
# }

grpcurl -plaintext \
  -d '{"ref":[{"slot":42,"hash":"..."}]}' \
  localhost:50051 utxorpc.v1beta.sync.SyncService/FetchBlock
# {
#   "block": [{
#     "native_bytes": "...",
#     "cardano": { "header": {...}, "body": {"tx": [...]} }
#   }]
# }
```