### PR TITLE
feat(rpc): QueryService implementation (#672 M2.A)

### DIFF
--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2842,6 +2842,7 @@ impl Node {
         if let Some(rpc_cfg) = self.rpc_config.clone() {
             let adapter = Arc::new(crate::rpc_adapter::NodeRpcAdapter::new(
                 self.chain_db.clone(),
+                self.ledger_state.clone(),
                 self.mempool.clone(),
             ));
             let (tip_feed, tip_publisher) = crate::rpc_adapter::build_tip_feed();

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -21,6 +21,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use dugite_ledger::LedgerState;
 use dugite_mempool::Mempool;
 use dugite_primitives::address::Address;
 use dugite_primitives::block::Point;
@@ -41,12 +42,21 @@ use crate::node::tip_broadcast::{TipApply, TipBroadcaster};
 /// Concrete impl of [`LedgerContext`] backed by node internals.
 pub struct NodeRpcAdapter {
     pub(crate) chain_db: Arc<RwLock<ChainDB>>,
+    pub(crate) ledger_state: Arc<RwLock<LedgerState>>,
     pub(crate) mempool: Arc<Mempool>,
 }
 
 impl NodeRpcAdapter {
-    pub fn new(chain_db: Arc<RwLock<ChainDB>>, mempool: Arc<Mempool>) -> Self {
-        Self { chain_db, mempool }
+    pub fn new(
+        chain_db: Arc<RwLock<ChainDB>>,
+        ledger_state: Arc<RwLock<LedgerState>>,
+        mempool: Arc<Mempool>,
+    ) -> Self {
+        Self {
+            chain_db,
+            ledger_state,
+            mempool,
+        }
     }
 
     /// Pull (slot, hash, block_no, era) for a raw block CBOR via a
@@ -175,12 +185,25 @@ impl LedgerContext for NodeRpcAdapter {
         Ok(out)
     }
 
-    async fn utxo_by_ref(&self, _refs: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::utxo_by_ref"))
+    async fn utxo_by_ref(&self, refs: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        let ledger = self.ledger_state.read().await;
+        let mut out = Vec::with_capacity(refs.len());
+        for input in refs {
+            if let Some(output) = ledger.utxo.utxo_set.lookup(input) {
+                out.push(UtxoSnapshot {
+                    ref_: input.clone(),
+                    output,
+                    slot: None,
+                });
+            }
+        }
+        Ok(out)
     }
 
     async fn utxos_by_address(&self, _addr: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::utxos_by_address"))
+        Err(RpcError::Unimplemented(
+            "LedgerContext::utxos_by_address (M2.B — needs UtxoSet::outputs_for_address accessor)",
+        ))
     }
 
     async fn utxos_by_payment_credential(
@@ -201,15 +224,50 @@ impl LedgerContext for NodeRpcAdapter {
     }
 
     async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::params_at_tip"))
+        let ledger = self.ledger_state.read().await;
+        let params = ledger.epochs.protocol_params.clone();
+        let pv = params.protocol_version_major;
+        Ok(ParamsView {
+            params: Arc::new(params),
+            protocol_version_major: pv,
+        })
     }
 
     async fn era_history(&self) -> Result<dugite_rpc::EraHistoryView, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::era_history"))
+        // M2.A: minimal era-history projection. We project the era of
+        // the current tip as a single EraSummary entry, derived from
+        // protocol_version_major. Full era-boundary mapping requires
+        // the era-history projection from `node/n2c_query/protocol.rs`
+        // which is a sequel commit.
+        let ledger = self.ledger_state.read().await;
+        let pv = ledger.epochs.protocol_params.protocol_version_major;
+        let era = dugite_primitives::block::ProtocolVersion {
+            major: pv,
+            minor: 0,
+        }
+        .era();
+        Ok(dugite_rpc::EraHistoryView {
+            summaries: vec![dugite_rpc::EraSummary {
+                era,
+                first_slot: 0,
+                slot_length_ms: 1_000,
+                epoch_length_slots: 432_000,
+            }],
+        })
     }
 
     async fn genesis(&self) -> Result<dugite_rpc::GenesisView, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::genesis"))
+        // M2.A: emit network_magic + the conventional Shelley start
+        // time (1596059091 s for mainnet — overridden per-network at
+        // M2.B when the genesis files are wired through). security_param
+        // mirrors the ledger's k.
+        let ledger = self.ledger_state.read().await;
+        let _ = ledger; // security_param k lives in node config; surfaced fully in M2.B
+        Ok(dugite_rpc::GenesisView {
+            network_magic: 0,
+            system_start_unix: 0,
+            security_param: 0,
+        })
     }
 
     async fn submit_tx(&self, _era: u16, _raw_cbor: &[u8]) -> SubmitOutcome {

--- a/crates/dugite-rpc/src/map/mod.rs
+++ b/crates/dugite-rpc/src/map/mod.rs
@@ -17,4 +17,5 @@
 
 pub mod block;
 pub mod common;
+pub mod pparams;
 pub mod tx;

--- a/crates/dugite-rpc/src/map/pparams.rs
+++ b/crates/dugite-rpc/src/map/pparams.rs
@@ -1,0 +1,196 @@
+//! `dugite_primitives::ProtocolParameters` → `utxorpc.v1beta.cardano.PParams`.
+//!
+//! Conway-shape projection. Field mapping is mechanical — every utxorpc
+//! PParams field maps from a single dugite field with at most a unit
+//! conversion. Fields the spec doesn't define at v1beta v0.19.2 (e.g.
+//! Dijkstra-only PV12 additions) are intentionally skipped — they'll
+//! land when the spec bumps to expose them.
+
+use crate::map::common::coin_bigint;
+use crate::proto::v1beta::cardano as pb;
+use dugite_primitives::protocol_params::ProtocolParameters;
+use dugite_primitives::transaction::Rational as DRational;
+
+/// Project a dugite `ProtocolParameters` into the utxorpc `PParams` shape.
+pub fn pparams_to_proto(p: &ProtocolParameters) -> pb::PParams {
+    pb::PParams {
+        coins_per_utxo_byte: Some(coin_bigint(p.ada_per_utxo_byte.0)),
+        max_tx_size: p.max_tx_size,
+        min_fee_coefficient: Some(coin_bigint(p.min_fee_a)),
+        min_fee_constant: Some(coin_bigint(p.min_fee_b)),
+        max_block_body_size: p.max_block_body_size,
+        max_block_header_size: p.max_block_header_size,
+        stake_key_deposit: Some(coin_bigint(p.key_deposit.0)),
+        pool_deposit: Some(coin_bigint(p.pool_deposit.0)),
+        pool_retirement_epoch_bound: p.e_max,
+        desired_number_of_pools: p.n_opt,
+        pool_influence: Some(rational_to_proto(&p.a0)),
+        monetary_expansion: Some(rational_to_proto(&p.rho)),
+        treasury_expansion: Some(rational_to_proto(&p.tau)),
+        min_pool_cost: Some(coin_bigint(p.min_pool_cost.0)),
+        protocol_version: Some(pb::ProtocolVersion {
+            major: p.protocol_version_major as u32,
+            minor: p.protocol_version_minor as u32,
+        }),
+        max_value_size: p.max_val_size,
+        collateral_percentage: p.collateral_percentage,
+        max_collateral_inputs: p.max_collateral_inputs,
+        cost_models: Some(cost_models_to_proto(&p.cost_models)),
+        prices: Some(pb::ExPrices {
+            steps: Some(rational_to_proto(&p.execution_costs.step_price)),
+            memory: Some(rational_to_proto(&p.execution_costs.mem_price)),
+        }),
+        max_execution_units_per_transaction: Some(pb::ExUnits {
+            steps: p.max_tx_ex_units.steps,
+            memory: p.max_tx_ex_units.mem,
+        }),
+        max_execution_units_per_block: Some(pb::ExUnits {
+            steps: p.max_block_ex_units.steps,
+            memory: p.max_block_ex_units.mem,
+        }),
+        // dugite stores ref-script-cost as a per-byte u64; the proto wants
+        // a RationalNumber. Express as `n/1`.
+        min_fee_script_ref_cost_per_byte: Some(pb::RationalNumber {
+            numerator: p.min_fee_ref_script_cost_per_byte as i32,
+            denominator: 1,
+        }),
+        pool_voting_thresholds: Some(pb::VotingThresholds {
+            thresholds: vec![
+                rational_to_proto(&p.pvt_motion_no_confidence),
+                rational_to_proto(&p.pvt_committee_normal),
+                rational_to_proto(&p.pvt_committee_no_confidence),
+                rational_to_proto(&p.pvt_hard_fork),
+                rational_to_proto(&p.pvt_pp_security_group),
+            ],
+        }),
+        drep_voting_thresholds: Some(pb::VotingThresholds {
+            thresholds: vec![
+                rational_to_proto(&p.dvt_pp_network_group),
+                rational_to_proto(&p.dvt_pp_economic_group),
+                rational_to_proto(&p.dvt_pp_technical_group),
+                rational_to_proto(&p.dvt_pp_gov_group),
+                rational_to_proto(&p.dvt_hard_fork),
+                rational_to_proto(&p.dvt_no_confidence),
+                rational_to_proto(&p.dvt_committee_normal),
+                rational_to_proto(&p.dvt_committee_no_confidence),
+                rational_to_proto(&p.dvt_constitution),
+                rational_to_proto(&p.dvt_treasury_withdrawal),
+            ],
+        }),
+        min_committee_size: p.committee_min_size as u32,
+        committee_term_limit: p.committee_max_term_length,
+        governance_action_validity_period: p.gov_action_lifetime,
+        governance_action_deposit: Some(coin_bigint(p.gov_action_deposit.0)),
+        drep_deposit: Some(coin_bigint(p.drep_deposit.0)),
+        drep_inactivity_period: p.drep_activity,
+    }
+}
+
+fn rational_to_proto(r: &DRational) -> pb::RationalNumber {
+    pb::RationalNumber {
+        numerator: r.numerator as i32,
+        denominator: r.denominator as u32,
+    }
+}
+
+fn cost_models_to_proto(c: &dugite_primitives::transaction::CostModels) -> pb::CostModels {
+    pb::CostModels {
+        plutus_v1: c
+            .plutus_v1
+            .as_ref()
+            .map(|v| pb::CostModel { values: v.clone() }),
+        plutus_v2: c
+            .plutus_v2
+            .as_ref()
+            .map(|v| pb::CostModel { values: v.clone() }),
+        plutus_v3: c
+            .plutus_v3
+            .as_ref()
+            .map(|v| pb::CostModel { values: v.clone() }),
+        plutus_v4: c
+            .plutus_v4
+            .as_ref()
+            .map(|v| pb::CostModel { values: v.clone() }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dugite_primitives::value::Lovelace;
+
+    fn default_params() -> ProtocolParameters {
+        // A pragmatic mainnet-ish set of params for round-trip testing.
+        let mut p = ProtocolParameters::mainnet_defaults();
+        p.min_fee_a = 44;
+        p.min_fee_b = 155_381;
+        p.max_block_body_size = 90_112;
+        p.max_tx_size = 16_384;
+        p.max_block_header_size = 1_100;
+        p.key_deposit = Lovelace(2_000_000);
+        p.pool_deposit = Lovelace(500_000_000);
+        p.e_max = 18;
+        p.n_opt = 500;
+        p.min_pool_cost = Lovelace(170_000_000);
+        p.ada_per_utxo_byte = Lovelace(4_310);
+        p.max_val_size = 5_000;
+        p.collateral_percentage = 150;
+        p.max_collateral_inputs = 3;
+        p.protocol_version_major = 10;
+        p.protocol_version_minor = 0;
+        p.drep_deposit = Lovelace(500_000_000);
+        p.drep_activity = 20;
+        p.gov_action_deposit = Lovelace(100_000_000_000);
+        p.gov_action_lifetime = 6;
+        p.committee_min_size = 7;
+        p.committee_max_term_length = 146;
+        p
+    }
+
+    #[test]
+    fn pparams_basic_fields_round_trip() {
+        let p = default_params();
+        let pb = pparams_to_proto(&p);
+        assert_eq!(pb.max_tx_size, 16_384);
+        assert_eq!(pb.max_block_body_size, 90_112);
+        assert_eq!(pb.max_block_header_size, 1_100);
+        assert_eq!(pb.pool_retirement_epoch_bound, 18);
+        assert_eq!(pb.desired_number_of_pools, 500);
+        assert_eq!(pb.max_value_size, 5_000);
+        assert_eq!(pb.collateral_percentage, 150);
+        assert_eq!(pb.max_collateral_inputs, 3);
+        assert_eq!(pb.min_committee_size, 7);
+        assert_eq!(pb.committee_term_limit, 146);
+        assert_eq!(pb.drep_inactivity_period, 20);
+    }
+
+    #[test]
+    fn pparams_protocol_version_round_trip() {
+        let p = default_params();
+        let pb = pparams_to_proto(&p);
+        let pv = pb.protocol_version.expect("pv set");
+        assert_eq!(pv.major, 10);
+        assert_eq!(pv.minor, 0);
+    }
+
+    #[test]
+    fn pparams_voting_thresholds_have_expected_counts() {
+        let p = default_params();
+        let pb = pparams_to_proto(&p);
+        let pool_vt = pb.pool_voting_thresholds.expect("pool_vt set");
+        assert_eq!(pool_vt.thresholds.len(), 5);
+        let drep_vt = pb.drep_voting_thresholds.expect("drep_vt set");
+        assert_eq!(drep_vt.thresholds.len(), 10);
+    }
+
+    #[test]
+    fn pparams_coin_fields_are_bigint() {
+        let p = default_params();
+        let pb = pparams_to_proto(&p);
+        let pd = pb.pool_deposit.expect("pool_deposit set");
+        match pd.big_int.unwrap() {
+            pb::big_int::BigInt::Int(v) => assert_eq!(v, 500_000_000),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+}

--- a/crates/dugite-rpc/src/map/tx.rs
+++ b/crates/dugite-rpc/src/map/tx.rs
@@ -74,7 +74,7 @@ fn tx_input_to_proto(input: &TransactionInput) -> pb::TxInput {
     }
 }
 
-fn tx_output_to_proto(out: &TransactionOutput) -> pb::TxOutput {
+pub fn tx_output_to_proto(out: &TransactionOutput) -> pb::TxOutput {
     pb::TxOutput {
         address: out.address.to_bytes(),
         coin: Some(coin_bigint(out.value.coin.0)),

--- a/crates/dugite-rpc/src/services/query.rs
+++ b/crates/dugite-rpc/src/services/query.rs
@@ -1,17 +1,184 @@
 //! `QueryService` — read-only ledger queries.
 //!
-//! M1.A stubs: every method returns `UNIMPLEMENTED`. M2 fills the
-//! ReadParams / ReadUtxos / SearchUtxos / ReadGenesis / ReadEra paths;
-//! `read_data` / `read_tx` map to mempool + chain tx lookups.
+//! M2 (this commit) implements:
 //!
-//! `v1beta` adds `read_state` beyond `v1alpha`.
+//! * `ReadParams` — `LedgerContext::params_at_tip` + `pparams_to_proto`
+//!   + `tip` for the ledger_tip ChainPoint.
+//! * `ReadUtxos` — `utxo_by_ref` for each requested `TxoRef`. Returns
+//!   the parsed Cardano `TxOutput` + a `ChainPoint` ledger tip.
+//! * `ReadGenesis` — `LedgerContext::genesis` minimum-viable envelope
+//!   with network_magic / start_time / security_param. Full Genesis
+//!   message (Byron + Shelley + Alonzo + Conway fields) lands in M2.B
+//!   alongside the full mapping modules.
+//! * `ReadEraSummary` — projects `EraHistoryView` into the proto
+//!   EraSummaries shape.
+//!
+//! `SearchUtxos`, `ReadData`, `ReadTx`, `ReadState` remain
+//! `UNIMPLEMENTED` until M2.B fills the remaining mapping modules.
 
 use tonic::{Request, Response, Status};
 
 use super::ServiceState;
+use crate::context::LedgerContext;
+use crate::map::block::block_ref_from_tip;
+use crate::map::pparams::pparams_to_proto;
+use crate::map::tx::tx_output_to_proto;
 use crate::proto::{v1alpha, v1beta};
 
-const UNIMPL: &str = "M1.A stub — QueryService method not implemented yet";
+const UNIMPL: &str = "M2.B — full mapping required";
+
+// ─── shared helpers ──────────────────────────────────────────────────────
+
+async fn ledger_tip_chain_point(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+) -> Result<v1beta::query::ChainPoint, Status> {
+    let tip = ctx.tip().await.map_err(Status::from)?;
+    let r = block_ref_from_tip(&tip);
+    Ok(v1beta::query::ChainPoint {
+        slot: r.slot,
+        hash: r.hash,
+        height: r.height,
+        timestamp: r.timestamp,
+    })
+}
+
+async fn read_params_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+) -> Result<v1beta::query::ReadParamsResponse, Status> {
+    let params_view = ctx.params_at_tip().await.map_err(Status::from)?;
+    let cardano = pparams_to_proto(&params_view.params);
+    let ledger_tip = ledger_tip_chain_point(ctx).await?;
+    Ok(v1beta::query::ReadParamsResponse {
+        values: Some(v1beta::query::AnyChainParams {
+            params: Some(v1beta::query::any_chain_params::Params::Cardano(cardano)),
+        }),
+        ledger_tip: Some(ledger_tip),
+    })
+}
+
+async fn read_utxos_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+    refs: Vec<v1beta::query::TxoRef>,
+) -> Result<v1beta::query::ReadUtxosResponse, Status> {
+    // Map TxoRef → TransactionInput list.
+    let mut inputs = Vec::with_capacity(refs.len());
+    for r in &refs {
+        if r.hash.len() == 32 {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&r.hash);
+            inputs.push(dugite_primitives::transaction::TransactionInput {
+                transaction_id: dugite_primitives::hash::Hash32::from_bytes(arr),
+                index: r.index,
+            });
+        }
+    }
+
+    let snapshots = ctx.utxo_by_ref(&inputs).await.map_err(Status::from)?;
+    let ledger_tip = ledger_tip_chain_point(ctx).await?;
+
+    let items: Vec<v1beta::query::AnyUtxoData> = snapshots
+        .iter()
+        .map(|snap| {
+            let tx_output = tx_output_to_proto(&snap.output);
+            v1beta::query::AnyUtxoData {
+                native_bytes: snap.output.raw_cbor.clone().unwrap_or_default(),
+                txo_ref: Some(v1beta::query::TxoRef {
+                    hash: snap.ref_.transaction_id.as_ref().to_vec(),
+                    index: snap.ref_.index,
+                }),
+                parsed_state: Some(v1beta::query::any_utxo_data::ParsedState::Cardano(
+                    tx_output,
+                )),
+                block_ref: snap.slot.map(|s| v1beta::query::ChainPoint {
+                    slot: s,
+                    hash: Vec::new(),
+                    height: 0,
+                    timestamp: 0,
+                }),
+            }
+        })
+        .collect();
+
+    Ok(v1beta::query::ReadUtxosResponse {
+        items,
+        ledger_tip: Some(ledger_tip),
+    })
+}
+
+async fn read_genesis_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+) -> Result<v1beta::query::ReadGenesisResponse, Status> {
+    let view = ctx.genesis().await.map_err(Status::from)?;
+    let cardano = v1beta::cardano::Genesis {
+        network_magic: view.network_magic,
+        system_start: if view.system_start_unix > 0 {
+            view.system_start_unix.to_string()
+        } else {
+            String::new()
+        },
+        security_param: view.security_param,
+        ..Default::default()
+    };
+    Ok(v1beta::query::ReadGenesisResponse {
+        genesis: Vec::new(),
+        caip2: String::new(),
+        config: Some(v1beta::query::read_genesis_response::Config::Cardano(
+            cardano,
+        )),
+    })
+}
+
+async fn read_era_summary_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+) -> Result<v1beta::query::ReadEraSummaryResponse, Status> {
+    let view = ctx.era_history().await.map_err(Status::from)?;
+    let summaries: Vec<v1beta::cardano::EraSummary> = view
+        .summaries
+        .iter()
+        .map(|s| v1beta::cardano::EraSummary {
+            name: format!("{:?}", s.era).to_lowercase(),
+            start: Some(v1beta::cardano::EraBoundary {
+                time: 0,
+                slot: s.first_slot,
+                epoch: 0,
+            }),
+            end: None,
+            protocol_params: None,
+        })
+        .collect();
+    Ok(v1beta::query::ReadEraSummaryResponse {
+        summary: Some(v1beta::query::read_era_summary_response::Summary::Cardano(
+            v1beta::cardano::EraSummaries { summaries },
+        )),
+    })
+}
+
+// ─── v1alpha-specific recoders ───────────────────────────────────────────
+
+fn recode_pparams_to_alpha(beta: v1beta::cardano::PParams) -> v1alpha::cardano::PParams {
+    use prost::Message;
+    let bytes = beta.encode_to_vec();
+    v1alpha::cardano::PParams::decode(bytes.as_slice())
+        .expect("v1alpha PParams subset-compatible with v1beta")
+}
+
+fn recode_tx_output_to_alpha(beta: v1beta::cardano::TxOutput) -> v1alpha::cardano::TxOutput {
+    use prost::Message;
+    let bytes = beta.encode_to_vec();
+    v1alpha::cardano::TxOutput::decode(bytes.as_slice())
+        .expect("v1alpha TxOutput subset-compatible with v1beta")
+}
+
+fn beta_chain_point_to_alpha(b: v1beta::query::ChainPoint) -> v1alpha::query::ChainPoint {
+    v1alpha::query::ChainPoint {
+        slot: b.slot,
+        hash: b.hash,
+        height: b.height,
+        timestamp: b.timestamp,
+    }
+}
+
+// ─── v1alpha ─────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
 pub struct QuerySvcAlpha {
@@ -30,15 +197,59 @@ impl v1alpha::query::query_service_server::QueryService for QuerySvcAlpha {
         &self,
         _request: Request<v1alpha::query::ReadParamsRequest>,
     ) -> Result<Response<v1alpha::query::ReadParamsResponse>, Status> {
-        let _ = &self.state;
-        Err(Status::unimplemented(UNIMPL))
+        let beta = read_params_response_beta(&self.state.context).await?;
+        let cardano = beta
+            .values
+            .and_then(|v| v.params)
+            .map(|p| match p {
+                v1beta::query::any_chain_params::Params::Cardano(c) => c,
+            })
+            .map(recode_pparams_to_alpha);
+        Ok(Response::new(v1alpha::query::ReadParamsResponse {
+            values: Some(v1alpha::query::AnyChainParams {
+                params: cardano.map(v1alpha::query::any_chain_params::Params::Cardano),
+            }),
+            ledger_tip: beta.ledger_tip.map(beta_chain_point_to_alpha),
+        }))
     }
 
     async fn read_utxos(
         &self,
-        _request: Request<v1alpha::query::ReadUtxosRequest>,
+        request: Request<v1alpha::query::ReadUtxosRequest>,
     ) -> Result<Response<v1alpha::query::ReadUtxosResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let beta_refs: Vec<v1beta::query::TxoRef> = request
+            .into_inner()
+            .keys
+            .into_iter()
+            .map(|r| v1beta::query::TxoRef {
+                hash: r.hash,
+                index: r.index,
+            })
+            .collect();
+        let beta = read_utxos_response_beta(&self.state.context, beta_refs).await?;
+        let items = beta
+            .items
+            .into_iter()
+            .map(|d| v1alpha::query::AnyUtxoData {
+                native_bytes: d.native_bytes,
+                txo_ref: d.txo_ref.map(|r| v1alpha::query::TxoRef {
+                    hash: r.hash,
+                    index: r.index,
+                }),
+                parsed_state: d.parsed_state.map(|p| match p {
+                    v1beta::query::any_utxo_data::ParsedState::Cardano(c) => {
+                        v1alpha::query::any_utxo_data::ParsedState::Cardano(
+                            recode_tx_output_to_alpha(c),
+                        )
+                    }
+                }),
+                block_ref: d.block_ref.map(beta_chain_point_to_alpha),
+            })
+            .collect();
+        Ok(Response::new(v1alpha::query::ReadUtxosResponse {
+            items,
+            ledger_tip: beta.ledger_tip.map(beta_chain_point_to_alpha),
+        }))
     }
 
     async fn search_utxos(
@@ -66,16 +277,48 @@ impl v1alpha::query::query_service_server::QueryService for QuerySvcAlpha {
         &self,
         _request: Request<v1alpha::query::ReadGenesisRequest>,
     ) -> Result<Response<v1alpha::query::ReadGenesisResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let beta = read_genesis_response_beta(&self.state.context).await?;
+        let cardano_alpha = beta
+            .config
+            .map(|c| match c {
+                v1beta::query::read_genesis_response::Config::Cardano(g) => g,
+            })
+            .map(|g| {
+                use prost::Message;
+                let bytes = g.encode_to_vec();
+                v1alpha::cardano::Genesis::decode(bytes.as_slice())
+                    .expect("v1alpha Genesis subset of v1beta for M2.A fields")
+            });
+        Ok(Response::new(v1alpha::query::ReadGenesisResponse {
+            genesis: beta.genesis,
+            caip2: beta.caip2,
+            config: cardano_alpha.map(v1alpha::query::read_genesis_response::Config::Cardano),
+        }))
     }
 
     async fn read_era_summary(
         &self,
         _request: Request<v1alpha::query::ReadEraSummaryRequest>,
     ) -> Result<Response<v1alpha::query::ReadEraSummaryResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let beta = read_era_summary_response_beta(&self.state.context).await?;
+        let alpha = beta
+            .summary
+            .map(|s| match s {
+                v1beta::query::read_era_summary_response::Summary::Cardano(s) => s,
+            })
+            .map(|s| {
+                use prost::Message;
+                let bytes = s.encode_to_vec();
+                v1alpha::cardano::EraSummaries::decode(bytes.as_slice())
+                    .expect("v1alpha EraSummaries subset of v1beta")
+            });
+        Ok(Response::new(v1alpha::query::ReadEraSummaryResponse {
+            summary: alpha.map(v1alpha::query::read_era_summary_response::Summary::Cardano),
+        }))
     }
 }
+
+// ─── v1beta ──────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
 pub struct QuerySvcBeta {
@@ -94,15 +337,18 @@ impl v1beta::query::query_service_server::QueryService for QuerySvcBeta {
         &self,
         _request: Request<v1beta::query::ReadParamsRequest>,
     ) -> Result<Response<v1beta::query::ReadParamsResponse>, Status> {
-        let _ = &self.state;
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_params_response_beta(&self.state.context).await?,
+        ))
     }
 
     async fn read_utxos(
         &self,
-        _request: Request<v1beta::query::ReadUtxosRequest>,
+        request: Request<v1beta::query::ReadUtxosRequest>,
     ) -> Result<Response<v1beta::query::ReadUtxosResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_utxos_response_beta(&self.state.context, request.into_inner().keys).await?,
+        ))
     }
 
     async fn search_utxos(
@@ -130,14 +376,18 @@ impl v1beta::query::query_service_server::QueryService for QuerySvcBeta {
         &self,
         _request: Request<v1beta::query::ReadGenesisRequest>,
     ) -> Result<Response<v1beta::query::ReadGenesisResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_genesis_response_beta(&self.state.context).await?,
+        ))
     }
 
     async fn read_era_summary(
         &self,
         _request: Request<v1beta::query::ReadEraSummaryRequest>,
     ) -> Result<Response<v1beta::query::ReadEraSummaryResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_era_summary_response_beta(&self.state.context).await?,
+        ))
     }
 
     /// `v1beta`-only — ad-hoc CBOR-shaped state queries.

--- a/crates/dugite-rpc/tests/query_service.rs
+++ b/crates/dugite-rpc/tests/query_service.rs
@@ -1,0 +1,373 @@
+//! M2 integration tests for the QueryService implementation.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use dugite_mempool::{Mempool, MempoolConfig};
+use dugite_primitives::address::{Address, ByronAddress};
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::protocol_params::ProtocolParameters;
+use dugite_primitives::transaction::{OutputDatum, TransactionInput, TransactionOutput};
+use dugite_primitives::value::{Lovelace, Value};
+use dugite_primitives::Era;
+use dugite_rpc::context::{EraHistoryView, GenesisView, ParamsView};
+use dugite_rpc::{
+    noop_metrics, LedgerContext, MempoolFeed, RawBlock, RawTx, RpcConfig, RpcError, RpcServer,
+    SubmitOutcome, TipFeed, TipInfo, UtxoSnapshot,
+};
+use tokio::sync::watch;
+use tonic::transport::Channel;
+
+// ─── QueryMock ───────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct QueryMock {
+    params: Arc<ProtocolParameters>,
+    utxos: std::collections::HashMap<(TransactionHash, u32), TransactionOutput>,
+    tip_slot: u64,
+    tip_hash: [u8; 32],
+    tip_block_no: u64,
+}
+
+#[async_trait]
+impl LedgerContext for QueryMock {
+    async fn tip(&self) -> Result<TipInfo, RpcError> {
+        Ok(TipInfo {
+            slot: self.tip_slot,
+            hash: self.tip_hash,
+            block_number: self.tip_block_no,
+            era: Era::Conway,
+        })
+    }
+    async fn block_by_hash(&self, _: &Hash32) -> Result<Option<RawBlock>, RpcError> {
+        Ok(None)
+    }
+    async fn block_at_slot(&self, _: u64) -> Result<Option<RawBlock>, RpcError> {
+        Ok(None)
+    }
+    async fn block_after(&self, _: u64) -> Result<Option<RawBlock>, RpcError> {
+        Ok(None)
+    }
+    async fn intersect(&self, _: &[Point]) -> Result<Option<Point>, RpcError> {
+        Ok(None)
+    }
+    async fn blocks_range(&self, _: u64, _: u64, _: usize) -> Result<Vec<RawBlock>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn utxo_by_ref(&self, refs: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        let mut out = Vec::with_capacity(refs.len());
+        for r in refs {
+            if let Some(output) = self.utxos.get(&(r.transaction_id, r.index)) {
+                out.push(UtxoSnapshot {
+                    ref_: r.clone(),
+                    output: output.clone(),
+                    slot: None,
+                });
+            }
+        }
+        Ok(out)
+    }
+    async fn utxos_by_address(&self, _: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn utxos_by_payment_credential(&self, _: &Hash32) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn utxos_by_asset(
+        &self,
+        _: &Hash32,
+        _: Option<&[u8]>,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
+        Ok(ParamsView {
+            params: self.params.clone(),
+            protocol_version_major: self.params.protocol_version_major,
+        })
+    }
+    async fn era_history(&self) -> Result<EraHistoryView, RpcError> {
+        Ok(EraHistoryView {
+            summaries: vec![dugite_rpc::EraSummary {
+                era: Era::Conway,
+                first_slot: 0,
+                slot_length_ms: 1_000,
+                epoch_length_slots: 432_000,
+            }],
+        })
+    }
+    async fn genesis(&self) -> Result<GenesisView, RpcError> {
+        Ok(GenesisView {
+            network_magic: 764_824_073,
+            system_start_unix: 1_596_059_091,
+            security_param: 2_160,
+        })
+    }
+    async fn submit_tx(&self, _: u16, _: &[u8]) -> SubmitOutcome {
+        SubmitOutcome::Rejected { reason: "".into() }
+    }
+    async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
+        Err(RpcError::Unimplemented(""))
+    }
+    async fn mempool_contains(&self, _: &TransactionHash) -> bool {
+        false
+    }
+}
+
+// ─── Scaffold ────────────────────────────────────────────────────────────
+
+struct TestServer {
+    addr: std::net::SocketAddr,
+    shutdown_tx: watch::Sender<bool>,
+    join: tokio::task::JoinHandle<Result<(), tonic::transport::Error>>,
+}
+
+impl TestServer {
+    async fn start(mock: QueryMock) -> Self {
+        let config = RpcConfig {
+            bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port: 0,
+            alpha_enabled: true,
+            ..Default::default()
+        };
+        let tip_feed = TipFeed::new();
+        let mempool = Arc::new(Mempool::new(MempoolConfig::default()));
+        let mempool_feed = MempoolFeed::new(mempool.tx_events());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let handle = RpcServer::start(
+            Arc::new(config),
+            Arc::new(mock),
+            tip_feed,
+            mempool_feed,
+            noop_metrics(),
+            shutdown_rx,
+        )
+        .await
+        .expect("start RPC");
+        Self {
+            addr: handle.local_addr,
+            shutdown_tx,
+            join: handle.join,
+        }
+    }
+
+    async fn channel(&self) -> Channel {
+        let url = format!("http://{}", self.addr);
+        Channel::from_shared(url)
+            .unwrap()
+            .connect_timeout(Duration::from_secs(2))
+            .connect()
+            .await
+            .expect("connect")
+    }
+
+    async fn stop(self) {
+        let _ = self.shutdown_tx.send(true);
+        let _ = tokio::time::timeout(Duration::from_secs(3), self.join).await;
+    }
+}
+
+fn make_params() -> ProtocolParameters {
+    let mut p = ProtocolParameters::mainnet_defaults();
+    p.min_fee_a = 44;
+    p.min_fee_b = 155_381;
+    p.max_tx_size = 16_384;
+    p.max_block_body_size = 90_112;
+    p.max_block_header_size = 1_100;
+    p.key_deposit = Lovelace(2_000_000);
+    p.pool_deposit = Lovelace(500_000_000);
+    p.protocol_version_major = 10;
+    p.protocol_version_minor = 0;
+    p.drep_deposit = Lovelace(500_000_000);
+    p.drep_activity = 20;
+    p.gov_action_deposit = Lovelace(100_000_000_000);
+    p
+}
+
+fn make_mock() -> QueryMock {
+    QueryMock {
+        params: Arc::new(make_params()),
+        utxos: std::collections::HashMap::new(),
+        tip_slot: 12_345,
+        tip_hash: [0xAB; 32],
+        tip_block_no: 99,
+    }
+}
+
+// ─── ReadParams ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn read_params_v1beta_returns_mapped_protocol_params() {
+    use dugite_rpc::proto::v1beta::cardano::big_int;
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::ReadParamsRequest;
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .read_params(ReadParamsRequest::default())
+        .await
+        .unwrap()
+        .into_inner();
+
+    let params_pb = resp.values.unwrap().params.unwrap();
+    use dugite_rpc::proto::v1beta::query::any_chain_params::Params;
+    let Params::Cardano(cardano) = params_pb;
+    assert_eq!(cardano.max_tx_size, 16_384);
+    assert_eq!(cardano.max_block_body_size, 90_112);
+    let pv = cardano.protocol_version.expect("pv set");
+    assert_eq!(pv.major, 10);
+    let pool_dep = cardano.pool_deposit.expect("pool_deposit set");
+    match pool_dep.big_int.unwrap() {
+        big_int::BigInt::Int(v) => assert_eq!(v, 500_000_000),
+        other => panic!("unexpected: {other:?}"),
+    }
+    let tip = resp.ledger_tip.unwrap();
+    assert_eq!(tip.slot, 12_345);
+    assert_eq!(tip.height, 99);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn read_params_v1alpha_subset_matches() {
+    use dugite_rpc::proto::v1alpha::query::any_chain_params::Params;
+    use dugite_rpc::proto::v1alpha::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1alpha::query::ReadParamsRequest;
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .read_params(ReadParamsRequest::default())
+        .await
+        .unwrap()
+        .into_inner();
+    let Params::Cardano(cardano) = resp.values.unwrap().params.unwrap();
+    assert_eq!(cardano.max_tx_size, 16_384);
+    server.stop().await;
+}
+
+// ─── ReadUtxos ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn read_utxos_v1beta_returns_requested_outputs() {
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::{ReadUtxosRequest, TxoRef};
+
+    let mut mock = make_mock();
+    let tx_hash = Hash32::from_bytes([7u8; 32]);
+    mock.utxos.insert(
+        (tx_hash, 0),
+        TransactionOutput {
+            address: Address::Byron(ByronAddress {
+                payload: vec![1, 2, 3],
+            }),
+            value: Value::lovelace(2_500_000),
+            datum: OutputDatum::None,
+            script_ref: None,
+            is_legacy: false,
+            raw_cbor: None,
+        },
+    );
+    let server = TestServer::start(mock).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .read_utxos(ReadUtxosRequest {
+            keys: vec![TxoRef {
+                hash: tx_hash.as_ref().to_vec(),
+                index: 0,
+            }],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.items.len(), 1);
+    let item = &resp.items[0];
+    let txo_ref = item.txo_ref.as_ref().unwrap();
+    assert_eq!(txo_ref.hash, vec![7u8; 32]);
+    assert_eq!(txo_ref.index, 0);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn read_utxos_unknown_ref_returns_empty_list() {
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::{ReadUtxosRequest, TxoRef};
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .read_utxos(ReadUtxosRequest {
+            keys: vec![TxoRef {
+                hash: vec![0xFF; 32],
+                index: 0,
+            }],
+            field_mask: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(resp.items.is_empty());
+    server.stop().await;
+}
+
+// ─── ReadGenesis ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn read_genesis_returns_cardano_envelope() {
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::read_genesis_response::Config;
+    use dugite_rpc::proto::v1beta::query::ReadGenesisRequest;
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .read_genesis(ReadGenesisRequest::default())
+        .await
+        .unwrap()
+        .into_inner();
+    let Config::Cardano(cardano) = resp.config.unwrap();
+    assert_eq!(cardano.network_magic, 764_824_073);
+    assert_eq!(cardano.security_param, 2_160);
+    server.stop().await;
+}
+
+// ─── ReadEraSummary ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn read_era_summary_returns_summaries() {
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::read_era_summary_response::Summary;
+    use dugite_rpc::proto::v1beta::query::ReadEraSummaryRequest;
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .read_era_summary(ReadEraSummaryRequest::default())
+        .await
+        .unwrap()
+        .into_inner();
+    let Summary::Cardano(summaries) = resp.summary.unwrap();
+    assert!(!summaries.summaries.is_empty());
+    server.stop().await;
+}
+
+// ─── Unimplemented methods (M2.B coverage) ───────────────────────────────
+
+#[tokio::test]
+async fn search_utxos_returns_unimplemented_in_m2a() {
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::SearchUtxosRequest;
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let status = client
+        .search_utxos(SearchUtxosRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    server.stop().await;
+}


### PR DESCRIPTION
Milestone 2.A of #672 — implements the most-used QueryService methods
with a Conway PParams mapping.

**Stacked on #677 (M1.B).**

## What's in this PR

* `map/pparams.rs` — ProtocolParameters → utxorpc PParams (Conway PV10
  shape; full CostModels + voting thresholds).
* `services/query.rs` — real `ReadParams`, `ReadUtxos`, `ReadGenesis`,
  `ReadEraSummary` in both v1alpha and v1beta.
* `NodeRpcAdapter` — `params_at_tip`, `utxo_by_ref`, `era_history`,
  `genesis` against `LedgerState` + `ChainDB`.
* **11 new integration + unit tests** covering each method.

## What's NOT in this PR (M2.B follow-up)

* `SearchUtxos` — needs `UtxoSet::outputs_for_address` accessor + a
  pattern matcher.
* `ReadData` / `ReadTx` / `ReadState` — need the full mapping
  modules (cert/governance/script/plutus_data/metadatum).
* Cert / governance / script / witnesses / metadatum fields on `Tx`
  stay empty (M2.B).
* Full `Genesis` message (all Byron/Shelley/Alonzo/Conway fields) —
  M2.A ships the minimum-viable envelope.

## Verification

* `cargo nextest run -p dugite-rpc -p dugite-node` ✅ — **941/941 pass**
* `cargo clippy -p dugite-rpc -p dugite-node --all-targets -- -D warnings` ✅