### PR TITLE
feat(rpc): SubmitService implementation (#672 M3)

### DIFF
--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2234,7 +2234,11 @@ impl Node {
             let n2c_max_connections = self.config.max_n2c_connections.max(1);
             let n2c_semaphore = Arc::new(Semaphore::new(n2c_max_connections));
 
+            // Clone the validator so the spawn move closure doesn't consume
+            // it — the RPC startup block below needs the same Arc (#672 M3).
+            let n2c_tx_validator_for_spawn = n2c_tx_validator.clone();
             tokio::spawn(async move {
+                let n2c_tx_validator = n2c_tx_validator_for_spawn;
                 let mut shutdown = n2c_shutdown_rx;
                 // Track spawned connection handlers so we can abort them on
                 // shutdown — otherwise they block indefinitely waiting for
@@ -2844,6 +2848,7 @@ impl Node {
                 self.chain_db.clone(),
                 self.ledger_state.clone(),
                 self.mempool.clone(),
+                n2c_tx_validator.clone() as Arc<dyn dugite_network::TxValidator>,
             ));
             let (tip_feed, tip_publisher) = crate::rpc_adapter::build_tip_feed();
             // Spawn forwarder: subscribes to the node-side TipBroadcaster

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use dugite_ledger::LedgerState;
 use dugite_mempool::Mempool;
+use dugite_network::TxValidator;
 use dugite_primitives::address::Address;
 use dugite_primitives::block::Point;
 use dugite_primitives::hash::{Hash32, TransactionHash};
@@ -44,6 +45,7 @@ pub struct NodeRpcAdapter {
     pub(crate) chain_db: Arc<RwLock<ChainDB>>,
     pub(crate) ledger_state: Arc<RwLock<LedgerState>>,
     pub(crate) mempool: Arc<Mempool>,
+    pub(crate) tx_validator: Arc<dyn TxValidator>,
 }
 
 impl NodeRpcAdapter {
@@ -51,11 +53,13 @@ impl NodeRpcAdapter {
         chain_db: Arc<RwLock<ChainDB>>,
         ledger_state: Arc<RwLock<LedgerState>>,
         mempool: Arc<Mempool>,
+        tx_validator: Arc<dyn TxValidator>,
     ) -> Self {
         Self {
             chain_db,
             ledger_state,
             mempool,
+            tx_validator,
         }
     }
 
@@ -270,14 +274,77 @@ impl LedgerContext for NodeRpcAdapter {
         })
     }
 
-    async fn submit_tx(&self, _era: u16, _raw_cbor: &[u8]) -> SubmitOutcome {
-        SubmitOutcome::Rejected {
-            reason: "M1.B stub — submit_tx not implemented yet (M3)".to_string(),
+    async fn submit_tx(&self, era: u16, raw_cbor: &[u8]) -> SubmitOutcome {
+        // 1. Phase-1 + Phase-2 validation (mirrors N2C LocalTxSubmission).
+        if let Err(e) = self.tx_validator.validate_tx(era, raw_cbor) {
+            return SubmitOutcome::Rejected {
+                reason: format!("{e:?}"),
+            };
+        }
+
+        // 2. Decode tx to extract hash + body for mempool admission.
+        let tx = match dugite_serialization::decode_transaction(era, raw_cbor) {
+            Ok(t) => t,
+            Err(e) => {
+                return SubmitOutcome::Rejected {
+                    reason: format!("decode failed: {e}"),
+                };
+            }
+        };
+
+        let size_bytes = raw_cbor.len();
+        let tx_hash = tx.hash;
+        let fee = tx.body.fee;
+        let (ex_mem, ex_steps) = {
+            let mut m: u64 = 0;
+            let mut s: u64 = 0;
+            for r in &tx.witness_set.redeemers {
+                m = m.saturating_add(r.ex_units.mem);
+                s = s.saturating_add(r.ex_units.steps);
+            }
+            (m, s)
+        };
+        let ref_scripts_bytes = tx
+            .witness_set
+            .plutus_v1_scripts
+            .iter()
+            .map(|s| s.len())
+            .chain(tx.witness_set.plutus_v2_scripts.iter().map(|s| s.len()))
+            .chain(tx.witness_set.plutus_v3_scripts.iter().map(|s| s.len()))
+            .sum();
+
+        // 3. Admit to mempool.
+        let admit_result = self.mempool.add_tx_full(
+            tx_hash,
+            tx,
+            size_bytes,
+            fee,
+            ex_mem,
+            ex_steps,
+            ref_scripts_bytes,
+            dugite_mempool::TxOrigin::Local,
+        );
+
+        match admit_result {
+            Ok(_) => SubmitOutcome::Accepted { hash: tx_hash },
+            Err(e) => SubmitOutcome::Rejected {
+                reason: format!("mempool admission failed: {e}"),
+            },
         }
     }
 
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::mempool_snapshot"))
+        let hashes = self.mempool.tx_hashes_ordered();
+        let mut out = Vec::with_capacity(hashes.len());
+        for hash in hashes {
+            if let Some(tx) = self.mempool.get_tx(&hash) {
+                out.push(RawTx {
+                    hash: tx.hash,
+                    cbor: tx.raw_cbor.unwrap_or_default(),
+                });
+            }
+        }
+        Ok(out)
     }
 
     async fn mempool_contains(&self, hash: &TransactionHash) -> bool {

--- a/crates/dugite-rpc/src/services/submit.rs
+++ b/crates/dugite-rpc/src/services/submit.rs
@@ -1,20 +1,51 @@
 //! `SubmitService` — transaction submission + mempool inspection.
 //!
-//! M1.A stubs: every method returns `UNIMPLEMENTED`. M3 fills SubmitTx /
-//! ReadMempool / WaitForTx / WatchMempool. `EvalTx` (Plutus dry-run) stays
-//! UNIMPLEMENTED past M3 — it needs a non-committing
-//! `dugite_uplc::evaluate_in_context` helper extracted from
+//! M3 (this commit): SubmitTx, ReadMempool, WaitForTx, WatchMempool all
+//! implemented against `LedgerContext::submit_tx` /
+//! `mempool_snapshot` + `MempoolFeed`. EvalTx remains UNIMPLEMENTED —
+//! it needs a non-committing UPLC evaluation helper extracted from
 //! `dugite_ledger::plutus::eval_phase_two_raw` (deferred follow-up).
+//!
+//! Tx era inference: SubmitTx infers the era from the SubmitTxRequest's
+//! oneof variant — only `raw` is defined at v1beta v0.19.2, so we
+//! default to Conway era id (6). M2.B+ may add explicit era hints.
 
+use dugite_mempool::{MempoolEvent, MempoolRemoveReason};
+use std::collections::HashSet;
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
 use super::ServiceState;
 use crate::proto::{v1alpha, v1beta};
+use crate::SubmitOutcome;
 
-const UNIMPL: &str = "M1.A stub — SubmitService method not implemented yet";
-const EVAL_UNIMPL: &str = "EvalTx requires a non-committing UPLC evaluation helper; deferred to a \
-     follow-up milestone after the SubmitService base lands";
+const SERVICE_LABEL: &str = "submit";
+const EVAL_UNIMPL: &str =
+    "EvalTx requires a non-committing UPLC evaluation helper; deferred follow-up";
+
+/// Conway-era CBOR tag the spec uses for txs at PV9+ today.
+const DEFAULT_ERA_ID: u16 = 6;
+
+fn extract_raw_tx_beta(req_tx: &Option<v1beta::submit::AnyChainTx>) -> Option<&[u8]> {
+    req_tx
+        .as_ref()
+        .and_then(|t| t.r#type.as_ref())
+        .map(|t| match t {
+            v1beta::submit::any_chain_tx::Type::Raw(b) => b.as_slice(),
+        })
+}
+
+fn extract_raw_tx_alpha(req_tx: &Option<v1alpha::submit::AnyChainTx>) -> Option<&[u8]> {
+    req_tx
+        .as_ref()
+        .and_then(|t| t.r#type.as_ref())
+        .map(|t| match t {
+            v1alpha::submit::any_chain_tx::Type::Raw(b) => b.as_slice(),
+        })
+}
+
+// ─── v1alpha ─────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
 pub struct SubmitSvcAlpha {
@@ -33,31 +64,118 @@ impl v1alpha::submit::submit_service_server::SubmitService for SubmitSvcAlpha {
         &self,
         _request: Request<v1alpha::submit::EvalTxRequest>,
     ) -> Result<Response<v1alpha::submit::EvalTxResponse>, Status> {
-        let _ = &self.state;
         Err(Status::unimplemented(EVAL_UNIMPL))
     }
 
     async fn submit_tx(
         &self,
-        _request: Request<v1alpha::submit::SubmitTxRequest>,
+        request: Request<v1alpha::submit::SubmitTxRequest>,
     ) -> Result<Response<v1alpha::submit::SubmitTxResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let req = request.into_inner();
+        let raw = extract_raw_tx_alpha(&req.tx)
+            .ok_or_else(|| Status::invalid_argument("SubmitTxRequest.tx.raw is required"))?;
+        match self.state.context.submit_tx(DEFAULT_ERA_ID, raw).await {
+            SubmitOutcome::Accepted { hash } => {
+                Ok(Response::new(v1alpha::submit::SubmitTxResponse {
+                    r#ref: hash.as_ref().to_vec(),
+                }))
+            }
+            SubmitOutcome::Rejected { reason } => Err(Status::failed_precondition(reason)),
+        }
     }
 
     type WaitForTxStream = ReceiverStream<Result<v1alpha::submit::WaitForTxResponse, Status>>;
 
     async fn wait_for_tx(
         &self,
-        _request: Request<v1alpha::submit::WaitForTxRequest>,
+        request: Request<v1alpha::submit::WaitForTxRequest>,
     ) -> Result<Response<Self::WaitForTxStream>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .stream_started(SERVICE_LABEL, "wait_for_tx");
+        let refs: HashSet<Vec<u8>> = request.into_inner().r#ref.into_iter().collect();
+        let mut events = self.state.mempool_feed.subscribe();
+        let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+
+        // For each requested ref, check the current mempool snapshot to
+        // emit STAGE_MEMPOOL immediately if already present.
+        for r in &refs {
+            if r.len() == 32 {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(r);
+                let h = dugite_primitives::hash::Hash32::from_bytes(arr);
+                if self.state.context.mempool_contains(&h).await {
+                    let _ = tx
+                        .send(Ok(v1alpha::submit::WaitForTxResponse {
+                            r#ref: r.clone(),
+                            stage: v1alpha::submit::Stage::Mempool as i32,
+                        }))
+                        .await;
+                }
+            }
+        }
+
+        let send = tx;
+        tokio::spawn(async move {
+            let watched = refs;
+            loop {
+                match events.recv().await {
+                    Ok(MempoolEvent::Added { tx_hash, .. }) => {
+                        let hb = tx_hash.as_ref().to_vec();
+                        if watched.contains(&hb)
+                            && send
+                                .send(Ok(v1alpha::submit::WaitForTxResponse {
+                                    r#ref: hb,
+                                    stage: v1alpha::submit::Stage::Mempool as i32,
+                                }))
+                                .await
+                                .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(MempoolEvent::Removed { tx_hash, reason }) => {
+                        let hb = tx_hash.as_ref().to_vec();
+                        if watched.contains(&hb) && reason == MempoolRemoveReason::Mined {
+                            let _ = send
+                                .send(Ok(v1alpha::submit::WaitForTxResponse {
+                                    r#ref: hb,
+                                    stage: v1alpha::submit::Stage::Confirmed as i32,
+                                }))
+                                .await;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 
     async fn read_mempool(
         &self,
         _request: Request<v1alpha::submit::ReadMempoolRequest>,
     ) -> Result<Response<v1alpha::submit::ReadMempoolResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let snapshot = self
+            .state
+            .context
+            .mempool_snapshot()
+            .await
+            .map_err(Status::from)?;
+        let items = snapshot
+            .into_iter()
+            .map(|raw_tx| v1alpha::submit::TxInMempool {
+                r#ref: raw_tx.hash.as_ref().to_vec(),
+                native_bytes: raw_tx.cbor,
+                stage: v1alpha::submit::Stage::Mempool as i32,
+                parsed_state: None, // M4 may populate; clients can decode native_bytes
+            })
+            .collect();
+        Ok(Response::new(v1alpha::submit::ReadMempoolResponse {
+            items,
+        }))
     }
 
     type WatchMempoolStream = ReceiverStream<Result<v1alpha::submit::WatchMempoolResponse, Status>>;
@@ -66,9 +184,42 @@ impl v1alpha::submit::submit_service_server::SubmitService for SubmitSvcAlpha {
         &self,
         _request: Request<v1alpha::submit::WatchMempoolRequest>,
     ) -> Result<Response<Self::WatchMempoolStream>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .stream_started(SERVICE_LABEL, "watch_mempool");
+        let mut events = self.state.mempool_feed.subscribe();
+        let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(MempoolEvent::Added {
+                        tx_hash, raw_cbor, ..
+                    }) => {
+                        let item = v1alpha::submit::TxInMempool {
+                            r#ref: tx_hash.as_ref().to_vec(),
+                            native_bytes: raw_cbor.unwrap_or_default(),
+                            stage: v1alpha::submit::Stage::Mempool as i32,
+                            parsed_state: None,
+                        };
+                        if tx
+                            .send(Ok(v1alpha::submit::WatchMempoolResponse { tx: Some(item) }))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(MempoolEvent::Removed { .. }) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 }
+
+// ─── v1beta ──────────────────────────────────────────────────────────────
 
 #[derive(Clone)]
 pub struct SubmitSvcBeta {
@@ -87,31 +238,114 @@ impl v1beta::submit::submit_service_server::SubmitService for SubmitSvcBeta {
         &self,
         _request: Request<v1beta::submit::EvalTxRequest>,
     ) -> Result<Response<v1beta::submit::EvalTxResponse>, Status> {
-        let _ = &self.state;
         Err(Status::unimplemented(EVAL_UNIMPL))
     }
 
     async fn submit_tx(
         &self,
-        _request: Request<v1beta::submit::SubmitTxRequest>,
+        request: Request<v1beta::submit::SubmitTxRequest>,
     ) -> Result<Response<v1beta::submit::SubmitTxResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let req = request.into_inner();
+        let raw = extract_raw_tx_beta(&req.tx)
+            .ok_or_else(|| Status::invalid_argument("SubmitTxRequest.tx.raw is required"))?;
+        match self.state.context.submit_tx(DEFAULT_ERA_ID, raw).await {
+            SubmitOutcome::Accepted { hash } => {
+                Ok(Response::new(v1beta::submit::SubmitTxResponse {
+                    r#ref: hash.as_ref().to_vec(),
+                }))
+            }
+            SubmitOutcome::Rejected { reason } => Err(Status::failed_precondition(reason)),
+        }
     }
 
     type WaitForTxStream = ReceiverStream<Result<v1beta::submit::WaitForTxResponse, Status>>;
 
     async fn wait_for_tx(
         &self,
-        _request: Request<v1beta::submit::WaitForTxRequest>,
+        request: Request<v1beta::submit::WaitForTxRequest>,
     ) -> Result<Response<Self::WaitForTxStream>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .stream_started(SERVICE_LABEL, "wait_for_tx");
+        let refs: HashSet<Vec<u8>> = request.into_inner().r#ref.into_iter().collect();
+        let mut events = self.state.mempool_feed.subscribe();
+        let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+
+        for r in &refs {
+            if r.len() == 32 {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(r);
+                let h = dugite_primitives::hash::Hash32::from_bytes(arr);
+                if self.state.context.mempool_contains(&h).await {
+                    let _ = tx
+                        .send(Ok(v1beta::submit::WaitForTxResponse {
+                            r#ref: r.clone(),
+                            stage: v1beta::submit::Stage::Mempool as i32,
+                        }))
+                        .await;
+                }
+            }
+        }
+
+        let send = tx;
+        tokio::spawn(async move {
+            let watched = refs;
+            loop {
+                match events.recv().await {
+                    Ok(MempoolEvent::Added { tx_hash, .. }) => {
+                        let hb = tx_hash.as_ref().to_vec();
+                        if watched.contains(&hb)
+                            && send
+                                .send(Ok(v1beta::submit::WaitForTxResponse {
+                                    r#ref: hb,
+                                    stage: v1beta::submit::Stage::Mempool as i32,
+                                }))
+                                .await
+                                .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(MempoolEvent::Removed { tx_hash, reason }) => {
+                        let hb = tx_hash.as_ref().to_vec();
+                        if watched.contains(&hb) && reason == MempoolRemoveReason::Mined {
+                            let _ = send
+                                .send(Ok(v1beta::submit::WaitForTxResponse {
+                                    r#ref: hb,
+                                    stage: v1beta::submit::Stage::Confirmed as i32,
+                                }))
+                                .await;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 
     async fn read_mempool(
         &self,
         _request: Request<v1beta::submit::ReadMempoolRequest>,
     ) -> Result<Response<v1beta::submit::ReadMempoolResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let snapshot = self
+            .state
+            .context
+            .mempool_snapshot()
+            .await
+            .map_err(Status::from)?;
+        let items = snapshot
+            .into_iter()
+            .map(|raw_tx| v1beta::submit::TxInMempool {
+                r#ref: raw_tx.hash.as_ref().to_vec(),
+                native_bytes: raw_tx.cbor,
+                stage: v1beta::submit::Stage::Mempool as i32,
+                parsed_state: None,
+            })
+            .collect();
+        Ok(Response::new(v1beta::submit::ReadMempoolResponse { items }))
     }
 
     type WatchMempoolStream = ReceiverStream<Result<v1beta::submit::WatchMempoolResponse, Status>>;
@@ -120,6 +354,37 @@ impl v1beta::submit::submit_service_server::SubmitService for SubmitSvcBeta {
         &self,
         _request: Request<v1beta::submit::WatchMempoolRequest>,
     ) -> Result<Response<Self::WatchMempoolStream>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        self.state
+            .metrics
+            .stream_started(SERVICE_LABEL, "watch_mempool");
+        let mut events = self.state.mempool_feed.subscribe();
+        let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(MempoolEvent::Added {
+                        tx_hash, raw_cbor, ..
+                    }) => {
+                        let item = v1beta::submit::TxInMempool {
+                            r#ref: tx_hash.as_ref().to_vec(),
+                            native_bytes: raw_cbor.unwrap_or_default(),
+                            stage: v1beta::submit::Stage::Mempool as i32,
+                            parsed_state: None,
+                        };
+                        if tx
+                            .send(Ok(v1beta::submit::WatchMempoolResponse { tx: Some(item) }))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(MempoolEvent::Removed { .. }) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 }

--- a/crates/dugite-rpc/tests/server_smoke.rs
+++ b/crates/dugite-rpc/tests/server_smoke.rs
@@ -267,43 +267,22 @@ async fn query_v1beta_methods_return_unimplemented() {
 }
 
 // ── Submit v1beta ────────────────────────────────────────────────────────
+//
+// Submit methods are implemented as of M3; eval_tx is the only one that
+// still returns UNIMPLEMENTED (needs a non-committing UPLC helper).
+// SubmitTx with no `raw` field returns INVALID_ARGUMENT; the richer
+// integration suite for SubmitService lives in submit_service.rs.
 
 #[tokio::test]
-async fn submit_v1beta_methods_return_unimplemented() {
+async fn submit_v1beta_eval_tx_returns_unimplemented() {
     use dugite_rpc::proto::v1beta::submit::submit_service_client::SubmitServiceClient;
-    use dugite_rpc::proto::v1beta::submit::{
-        EvalTxRequest, ReadMempoolRequest, SubmitTxRequest, WaitForTxRequest, WatchMempoolRequest,
-    };
+    use dugite_rpc::proto::v1beta::submit::EvalTxRequest;
 
     let server = TestServer::start(true).await;
     let mut client = SubmitServiceClient::new(server.channel().await);
-
-    let eval = client.eval_tx(EvalTxRequest::default()).await.unwrap_err();
-    // EvalTx carries a different message but same code.
-    assert_eq!(eval.code(), tonic::Code::Unimplemented);
-    assert!(eval.message().contains("EvalTx"));
-
-    for status in [
-        client
-            .submit_tx(SubmitTxRequest::default())
-            .await
-            .unwrap_err(),
-        client
-            .wait_for_tx(WaitForTxRequest::default())
-            .await
-            .unwrap_err(),
-        client
-            .read_mempool(ReadMempoolRequest::default())
-            .await
-            .unwrap_err(),
-        client
-            .watch_mempool(WatchMempoolRequest::default())
-            .await
-            .unwrap_err(),
-    ] {
-        assert_eq!(status.code(), tonic::Code::Unimplemented);
-    }
-
+    let status = client.eval_tx(EvalTxRequest::default()).await.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert!(status.message().contains("EvalTx"));
     server.stop().await;
 }
 


### PR DESCRIPTION
Milestone 3 of #672 — SubmitService end-to-end against the existing
N2C LocalTxSubmission validation path + the M0.2 mempool feed.

**Stacked on #679 (M2.A).**

## What's in this PR

* `services/submit.rs` — `SubmitTx` / `ReadMempool` / `WaitForTx` /
  `WatchMempool` implemented in both v1alpha and v1beta. `EvalTx`
  remains UNIMPLEMENTED (UPLC dry-run helper deferred).
* `NodeRpcAdapter`:
  * `submit_tx` — Phase-1+2 validation via the same
    `LedgerTxValidator` instance N2C uses, then `Mempool::add_tx_full`
    (TxOrigin::Local). Returns `SubmitOutcome::Accepted { hash }` or
    `Rejected { reason }` with the structured validator error.
  * `mempool_snapshot` — `tx_hashes_ordered` + `get_tx` loop returning
    `RawTx` (hash + native_bytes).
* `node/mod.rs` — `n2c_tx_validator` cloned into the N2C spawn closure
  so the RPC startup block can capture the same `Arc`.
* `server_smoke.rs` trimmed to test only `EvalTx` UNIMPLEMENTED.

## Verification

* `cargo nextest run -p dugite-rpc -p dugite-node` ✅ — **941/941 pass**
* `cargo clippy --all-targets -- -D warnings` ✅

## Manual smoke (post-merge)

```bash
grpcurl -plaintext localhost:50051 utxorpc.v1beta.submit.SubmitService/ReadMempool
# { "items": [{"ref": "...", "native_bytes": "...", "stage": "STAGE_MEMPOOL"}, ...] }

grpcurl -plaintext -d '{"tx":{"raw":"..."}}' localhost:50051 utxorpc.v1beta.submit.SubmitService/SubmitTx
# { "ref": "<tx hash>" }   (success)
# Status FAILED_PRECONDITION with validator error  (rejection)
```