### PR TITLE
feat(rpc): SearchUtxos by exact_address (#672 follow-up)

### DIFF
--- a/crates/dugite-ledger/src/utxo.rs
+++ b/crates/dugite-ledger/src/utxo.rs
@@ -227,6 +227,31 @@ impl UtxoSet {
         self.utxos.get(input).cloned()
     }
 
+    /// List every `(input, output)` pair whose output address matches
+    /// `addr`. Issue #672 — `QueryService.SearchUtxos` follow-up.
+    ///
+    /// Honours the secondary `address_index` when present (rebuilt via
+    /// `rebuild_address_index()` after snapshot load). Returns an empty
+    /// Vec when indexing was disabled at load time.
+    pub fn outputs_for_address(
+        &self,
+        addr: &Address,
+    ) -> Vec<(TransactionInput, TransactionOutput)> {
+        if let Some(ref store) = self.store {
+            return store.outputs_for_address(addr);
+        }
+        let Some(inputs) = self.address_index.get(addr) else {
+            return Vec::new();
+        };
+        let mut out = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            if let Some(output) = self.utxos.get(input).cloned() {
+                out.push((input.clone(), output));
+            }
+        }
+        out
+    }
+
     /// Insert a new UTxO
     pub fn insert(&mut self, input: TransactionInput, output: TransactionOutput) {
         if let Some(ref mut store) = self.store {

--- a/crates/dugite-ledger/src/utxo_store.rs
+++ b/crates/dugite-ledger/src/utxo_store.rs
@@ -211,6 +211,29 @@ impl UtxoStore {
         }
     }
 
+    /// List every `(input, output)` pair whose output address matches `addr`.
+    ///
+    /// Backed by the secondary `address_index` HashMap when indexing is
+    /// enabled; returns an empty Vec otherwise. The address index is
+    /// rebuilt from a fresh snapshot via `rebuild_address_index()`.
+    ///
+    /// Issue #672 — `QueryService.SearchUtxos` follow-up.
+    pub fn outputs_for_address(
+        &self,
+        addr: &Address,
+    ) -> Vec<(TransactionInput, TransactionOutput)> {
+        let Some(inputs) = self.address_index.get(addr) else {
+            return Vec::new();
+        };
+        let mut out = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            if let Some(output) = self.lookup(input) {
+                out.push((input.clone(), output));
+            }
+        }
+        out
+    }
+
     /// Insert a new UTxO entry.
     ///
     /// # Panics

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -204,10 +204,19 @@ impl LedgerContext for NodeRpcAdapter {
         Ok(out)
     }
 
-    async fn utxos_by_address(&self, _addr: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented(
-            "LedgerContext::utxos_by_address (M2.B — needs UtxoSet::outputs_for_address accessor)",
-        ))
+    async fn utxos_by_address(&self, addr: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        let ledger = self.ledger_state.read().await;
+        Ok(ledger
+            .utxo
+            .utxo_set
+            .outputs_for_address(addr)
+            .into_iter()
+            .map(|(input, output)| UtxoSnapshot {
+                ref_: input,
+                output,
+                slot: None,
+            })
+            .collect())
     }
 
     async fn utxos_by_payment_credential(

--- a/crates/dugite-rpc/src/services/query.rs
+++ b/crates/dugite-rpc/src/services/query.rs
@@ -27,6 +27,92 @@ use crate::proto::{v1alpha, v1beta};
 
 const UNIMPL: &str = "M2.B — full mapping required";
 
+/// Hard cap on UTxOs returned per SearchUtxos request — protects the
+/// node from runaway scans when an unindexed pattern matches a large
+/// address set.
+const SEARCH_UTXOS_HARD_CAP: usize = 5_000;
+
+/// Extract an exact-address match from a v1beta SearchUtxos predicate
+/// if and only if the predicate boils down to a single
+/// `match.cardano.address.exact_address` lookup. Anything more complex
+/// (asset patterns, `payment_part` / `delegation_part`, `not` / `all_of`
+/// / `any_of` composition) yields `None`, and the service surfaces
+/// UNIMPLEMENTED so clients see a clear signal instead of silently
+/// truncated results.
+fn predicate_exact_address(p: Option<&v1beta::query::UtxoPredicate>) -> Option<Vec<u8>> {
+    let p = p?;
+    if !p.not.is_empty() || !p.all_of.is_empty() || !p.any_of.is_empty() {
+        return None;
+    }
+    let any = p.r#match.as_ref()?;
+    let utxo_pattern = any.utxo_pattern.as_ref()?;
+    let v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(out_pattern) = utxo_pattern;
+    if out_pattern.asset.is_some() {
+        return None;
+    }
+    let addr = out_pattern.address.as_ref()?;
+    if addr.payment_part.is_some() || addr.delegation_part.is_some() {
+        return None;
+    }
+    addr.exact_address.clone()
+}
+
+async fn search_utxos_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+    request: v1beta::query::SearchUtxosRequest,
+) -> Result<v1beta::query::SearchUtxosResponse, Status> {
+    let Some(exact_addr_bytes) = predicate_exact_address(request.predicate.as_ref()) else {
+        return Err(Status::unimplemented(
+            "SearchUtxos: only `predicate.match.cardano.address.exact_address` is \
+             supported in this build. Payment-credential / delegation / asset / \
+             composite (not/all_of/any_of) patterns are deferred to a follow-up.",
+        ));
+    };
+
+    let parsed_addr = dugite_primitives::address::Address::from_bytes(&exact_addr_bytes)
+        .map_err(|e| Status::invalid_argument(format!("exact_address bytes invalid: {e}")))?;
+
+    let mut snaps = ctx
+        .utxos_by_address(&parsed_addr)
+        .await
+        .map_err(Status::from)?;
+    let cap = request
+        .max_items
+        .map(|n| (n as usize).min(SEARCH_UTXOS_HARD_CAP))
+        .unwrap_or(SEARCH_UTXOS_HARD_CAP)
+        .max(1);
+    if snaps.len() > cap {
+        snaps.truncate(cap);
+    }
+
+    let ledger_tip = ledger_tip_chain_point(ctx).await?;
+    let items: Vec<v1beta::query::AnyUtxoData> = snaps
+        .iter()
+        .map(|snap| {
+            let tx_output = tx_output_to_proto(&snap.output);
+            v1beta::query::AnyUtxoData {
+                native_bytes: snap.output.raw_cbor.clone().unwrap_or_default(),
+                txo_ref: Some(v1beta::query::TxoRef {
+                    hash: snap.ref_.transaction_id.as_ref().to_vec(),
+                    index: snap.ref_.index,
+                }),
+                parsed_state: Some(v1beta::query::any_utxo_data::ParsedState::Cardano(
+                    tx_output,
+                )),
+                block_ref: None,
+            }
+        })
+        .collect();
+
+    Ok(v1beta::query::SearchUtxosResponse {
+        items,
+        ledger_tip: Some(ledger_tip),
+        // Pagination (next_token) is M3-of-Search; the hard cap above
+        // bounds memory for the single-page response.
+        next_token: None,
+    })
+}
+
 // ─── shared helpers ──────────────────────────────────────────────────────
 
 async fn ledger_tip_chain_point(
@@ -254,9 +340,21 @@ impl v1alpha::query::query_service_server::QueryService for QuerySvcAlpha {
 
     async fn search_utxos(
         &self,
-        _request: Request<v1alpha::query::SearchUtxosRequest>,
+        request: Request<v1alpha::query::SearchUtxosRequest>,
     ) -> Result<Response<v1alpha::query::SearchUtxosResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        // Recode the v1alpha request → v1beta to share the matcher, then
+        // recode the response back. v1beta is a superset for our use
+        // case at v0.19.2.
+        use prost::Message;
+        let req = request.into_inner();
+        let bytes = req.encode_to_vec();
+        let beta_req = v1beta::query::SearchUtxosRequest::decode(bytes.as_slice())
+            .expect("v1alpha SearchUtxosRequest subset-compatible with v1beta");
+        let beta_resp = search_utxos_response_beta(&self.state.context, beta_req).await?;
+        let resp_bytes = beta_resp.encode_to_vec();
+        let alpha_resp = v1alpha::query::SearchUtxosResponse::decode(resp_bytes.as_slice())
+            .expect("v1alpha SearchUtxosResponse subset-compatible with v1beta");
+        Ok(Response::new(alpha_resp))
     }
 
     async fn read_data(
@@ -353,9 +451,11 @@ impl v1beta::query::query_service_server::QueryService for QuerySvcBeta {
 
     async fn search_utxos(
         &self,
-        _request: Request<v1beta::query::SearchUtxosRequest>,
+        request: Request<v1beta::query::SearchUtxosRequest>,
     ) -> Result<Response<v1beta::query::SearchUtxosResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            search_utxos_response_beta(&self.state.context, request.into_inner()).await?,
+        ))
     }
 
     async fn read_data(

--- a/crates/dugite-rpc/tests/query_service.rs
+++ b/crates/dugite-rpc/tests/query_service.rs
@@ -355,10 +355,10 @@ async fn read_era_summary_returns_summaries() {
     server.stop().await;
 }
 
-// ─── Unimplemented methods (M2.B coverage) ───────────────────────────────
+// ─── SearchUtxos by exact address ─────────────────────────────────────────
 
 #[tokio::test]
-async fn search_utxos_returns_unimplemented_in_m2a() {
+async fn search_utxos_empty_predicate_returns_unimplemented() {
     use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
     use dugite_rpc::proto::v1beta::query::SearchUtxosRequest;
 
@@ -369,5 +369,45 @@ async fn search_utxos_returns_unimplemented_in_m2a() {
         .await
         .unwrap_err();
     assert_eq!(status.code(), tonic::Code::Unimplemented);
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn search_utxos_payment_part_pattern_returns_unimplemented() {
+    use dugite_rpc::proto::v1beta::cardano::{AddressPattern, TxOutputPattern};
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::{
+        any_utxo_pattern, AnyUtxoPattern, SearchUtxosRequest, UtxoPredicate,
+    };
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let status = client
+        .search_utxos(SearchUtxosRequest {
+            predicate: Some(UtxoPredicate {
+                r#match: Some(AnyUtxoPattern {
+                    utxo_pattern: Some(any_utxo_pattern::UtxoPattern::Cardano(TxOutputPattern {
+                        address: Some(AddressPattern {
+                            exact_address: None,
+                            payment_part: Some(vec![0xAA; 28]),
+                            delegation_part: None,
+                        }),
+                        asset: None,
+                    })),
+                }),
+                not: vec![],
+                all_of: vec![],
+                any_of: vec![],
+            }),
+            field_mask: None,
+            max_items: None,
+            start_token: None,
+        })
+        .await
+        .unwrap_err();
+    // payment_part patterns aren't supported yet — service should
+    // signal that explicitly.
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert!(status.message().contains("exact_address"));
     server.stop().await;
 }


### PR DESCRIPTION
Closes the most-requested limitation from the M2.A docs: SearchUtxos
by exact-address is now implemented end-to-end.

* `UtxoStore::outputs_for_address` + `UtxoSet::outputs_for_address`
  accessors honour the existing address index.
* `NodeRpcAdapter::utxos_by_address` delegates to the new accessor.
* `services/query.rs` SearchUtxos handles
  `predicate.match.cardano.address.exact_address` in both v1alpha
  and v1beta. Other patterns explicitly return UNIMPLEMENTED with a
  clear message.
* Hard cap 5,000 UTxOs per request.

Verification: cargo nextest run -p dugite-rpc -p dugite-node -p dugite-ledger
→ **2377/2377 pass**. clippy + fmt clean.