### PR TITLE
style(rpc): clippy cleanup (#672 cleanup)

### DIFF
--- a/crates/dugite-rpc/src/map/metadatum.rs
+++ b/crates/dugite-rpc/src/map/metadatum.rs
@@ -21,7 +21,7 @@ pub fn aux_data_to_proto(aux: &AuxiliaryData) -> pb::AuxData {
         scripts: aux
             .native_scripts
             .iter()
-            .map(|ns| crate::map::script::native_script_to_proto(ns))
+            .map(crate::map::script::native_script_to_proto)
             .map(|ns| pb::Script {
                 script: Some(pb::script::Script::Native(ns)),
             })

--- a/crates/dugite-rpc/src/map/plutus_data.rs
+++ b/crates/dugite-rpc/src/map/plutus_data.rs
@@ -112,7 +112,7 @@ impl BigIntI64Ext for num_bigint::BigInt {
             let mut buf = [pad; 8];
             let start = 8 - bytes.len();
             buf[start..].copy_from_slice(&bytes);
-            Some(i64::from_be_bytes(buf.try_into().unwrap()))
+            Some(i64::from_be_bytes(buf))
         } else {
             None
         }

--- a/crates/dugite-rpc/src/map/plutus_data.rs
+++ b/crates/dugite-rpc/src/map/plutus_data.rs
@@ -100,7 +100,6 @@ trait BigIntI64Ext {
 
 impl BigIntI64Ext for num_bigint::BigInt {
     fn to_signed_bytes_be_within_i64(&self) -> Option<i64> {
-        use std::convert::TryInto;
         let bytes = self.to_signed_bytes_be();
         if bytes.len() <= 8 {
             // Sign-extend up to 8 bytes.


### PR DESCRIPTION
Drops unused TryInto, useless try_into on [u8;8], redundant native_script_to_proto closure. Clippy green.