### PR TITLE
feat(rpc): SearchUtxos by payment_part + asset (#672 follow-up)

### DIFF
--- a/crates/dugite-ledger/src/utxo.rs
+++ b/crates/dugite-ledger/src/utxo.rs
@@ -252,6 +252,71 @@ impl UtxoSet {
         out
     }
 
+    /// List every `(input, output)` pair whose output address carries the
+    /// supplied payment credential. Capped at `max_items`. Issue #672 —
+    /// `QueryService.SearchUtxos` follow-up.
+    ///
+    /// Walks `address_index` keys filtering by `payment_credential()`.
+    /// Cost is O(distinct addresses) — acceptable for ad-hoc RPC
+    /// queries, not for hot paths. LSM store fallback returns empty
+    /// (the address_index inside UtxoStore is keyed by Address and
+    /// would need its own payment-credential secondary index for an
+    /// efficient lookup; deferred).
+    pub fn outputs_for_payment_credential(
+        &self,
+        cred: &dugite_primitives::credentials::Credential,
+        max_items: usize,
+    ) -> Vec<(TransactionInput, TransactionOutput)> {
+        if self.store.is_some() {
+            // LSM-store path: no payment-credential secondary index
+            // exists yet. Return empty rather than scanning the whole
+            // store. Tracked as a follow-up alongside an asset index.
+            return Vec::new();
+        }
+        let mut out: Vec<(TransactionInput, TransactionOutput)> = Vec::new();
+        for (addr, inputs) in &self.address_index {
+            if addr.payment_credential() != Some(cred) {
+                continue;
+            }
+            for input in inputs {
+                if out.len() >= max_items {
+                    return out;
+                }
+                if let Some(output) = self.utxos.get(input).cloned() {
+                    out.push((input.clone(), output));
+                }
+            }
+        }
+        out
+    }
+
+    /// Return every UTxO whose output value contains an asset matching
+    /// `(policy, asset_name?)`. Capped at `max_items` results.
+    ///
+    /// Unindexed full scan — O(N) over the in-memory UTxO set. LSM
+    /// store fallback returns empty (full scan would materialise
+    /// multi-GB of data; would need an asset secondary index).
+    pub fn outputs_for_asset(
+        &self,
+        policy: &dugite_primitives::hash::PolicyId,
+        asset_name: Option<&[u8]>,
+        max_items: usize,
+    ) -> Vec<(TransactionInput, TransactionOutput)> {
+        if self.store.is_some() {
+            return Vec::new();
+        }
+        let mut out: Vec<(TransactionInput, TransactionOutput)> = Vec::new();
+        for (input, output) in &self.utxos {
+            if out.len() >= max_items {
+                break;
+            }
+            if output_matches_asset(output, policy, asset_name) {
+                out.push((input.clone(), output.clone()));
+            }
+        }
+        out
+    }
+
     /// Insert a new UTxO
     pub fn insert(&mut self, input: TransactionInput, output: TransactionOutput) {
         if let Some(ref mut store) = self.store {
@@ -422,6 +487,22 @@ impl UtxoSet {
         for (k, v) in &self.utxos {
             f(k, v);
         }
+    }
+}
+
+/// Predicate: does the output's value contain at least one asset
+/// matching `(policy, asset_name?)`?
+pub(crate) fn output_matches_asset(
+    output: &TransactionOutput,
+    policy: &dugite_primitives::hash::PolicyId,
+    asset_name: Option<&[u8]>,
+) -> bool {
+    let Some(by_name) = output.value.multi_asset.get(policy) else {
+        return false;
+    };
+    match asset_name {
+        None => !by_name.is_empty(),
+        Some(name) => by_name.keys().any(|k| k.0.as_slice() == name),
     }
 }
 

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -221,19 +221,76 @@ impl LedgerContext for NodeRpcAdapter {
 
     async fn utxos_by_payment_credential(
         &self,
-        _cred: &Hash32,
+        cred: &Hash32,
     ) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented(
-            "LedgerContext::utxos_by_payment_credential (no index in v1)",
-        ))
+        use dugite_primitives::credentials::Credential;
+        use dugite_primitives::hash::Hash28;
+
+        // Hash32 is the padded form (28 hash bytes + 4 zero bytes).
+        // Extract the first 28 bytes as the credential payload.
+        let mut h28 = [0u8; 28];
+        h28.copy_from_slice(&cred.as_ref()[..28]);
+        let h28 = Hash28::from_bytes(h28);
+
+        let ledger = self.ledger_state.read().await;
+        // Try VerificationKey first (most common), then Script.
+        let mut out: Vec<UtxoSnapshot> = Vec::new();
+        let cap = 5_000;
+
+        let key_cred = Credential::VerificationKey(h28);
+        for (input, output) in ledger
+            .utxo
+            .utxo_set
+            .outputs_for_payment_credential(&key_cred, cap)
+        {
+            out.push(UtxoSnapshot {
+                ref_: input,
+                output,
+                slot: None,
+            });
+        }
+
+        if out.len() < cap {
+            let script_cred = Credential::Script(h28);
+            for (input, output) in ledger
+                .utxo
+                .utxo_set
+                .outputs_for_payment_credential(&script_cred, cap - out.len())
+            {
+                out.push(UtxoSnapshot {
+                    ref_: input,
+                    output,
+                    slot: None,
+                });
+            }
+        }
+
+        Ok(out)
     }
 
     async fn utxos_by_asset(
         &self,
-        _policy: &Hash32,
-        _name: Option<&[u8]>,
+        policy: &Hash32,
+        name: Option<&[u8]>,
     ) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented("LedgerContext::utxos_by_asset"))
+        use dugite_primitives::hash::Hash28;
+        let mut policy_h = [0u8; 28];
+        policy_h.copy_from_slice(&policy.as_ref()[..28]);
+        let policy_h = Hash28::from_bytes(policy_h);
+
+        let ledger = self.ledger_state.read().await;
+        let cap = 5_000;
+        Ok(ledger
+            .utxo
+            .utxo_set
+            .outputs_for_asset(&policy_h, name, cap)
+            .into_iter()
+            .map(|(input, output)| UtxoSnapshot {
+                ref_: input,
+                output,
+                slot: None,
+            })
+            .collect())
     }
 
     async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {

--- a/crates/dugite-rpc/src/services/query.rs
+++ b/crates/dugite-rpc/src/services/query.rs
@@ -32,14 +32,26 @@ const UNIMPL: &str = "M2.B — full mapping required";
 /// address set.
 const SEARCH_UTXOS_HARD_CAP: usize = 5_000;
 
-/// Extract an exact-address match from a v1beta SearchUtxos predicate
-/// if and only if the predicate boils down to a single
-/// `match.cardano.address.exact_address` lookup. Anything more complex
-/// (asset patterns, `payment_part` / `delegation_part`, `not` / `all_of`
-/// / `any_of` composition) yields `None`, and the service surfaces
-/// UNIMPLEMENTED so clients see a clear signal instead of silently
-/// truncated results.
-fn predicate_exact_address(p: Option<&v1beta::query::UtxoPredicate>) -> Option<Vec<u8>> {
+/// Resolved SearchUtxos predicate — exactly one of these shapes today.
+#[derive(Debug)]
+enum SearchUtxoSelector {
+    /// `match.cardano.address.exact_address = <bytes>`
+    ExactAddress(Vec<u8>),
+    /// `match.cardano.address.payment_part = <bytes>` (28-byte hash)
+    PaymentCredential(Vec<u8>),
+    /// `match.cardano.asset.{policy_id, asset_name?}`
+    Asset {
+        policy_id: Vec<u8>,
+        asset_name: Option<Vec<u8>>,
+    },
+}
+
+/// Resolve a v1beta SearchUtxos predicate into one of the supported
+/// selector shapes. Anything more complex (composite predicates,
+/// delegation_part, mixed address+asset patterns) yields `None`; the
+/// service surfaces UNIMPLEMENTED with a descriptive message rather
+/// than returning silently truncated results.
+fn resolve_predicate(p: Option<&v1beta::query::UtxoPredicate>) -> Option<SearchUtxoSelector> {
     let p = p?;
     if !p.not.is_empty() || !p.all_of.is_empty() || !p.any_of.is_empty() {
         return None;
@@ -47,40 +59,102 @@ fn predicate_exact_address(p: Option<&v1beta::query::UtxoPredicate>) -> Option<V
     let any = p.r#match.as_ref()?;
     let utxo_pattern = any.utxo_pattern.as_ref()?;
     let v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(out_pattern) = utxo_pattern;
-    if out_pattern.asset.is_some() {
+
+    // Combined address + asset patterns aren't supported.
+    let has_addr = out_pattern.address.is_some();
+    let has_asset = out_pattern.asset.is_some();
+    if has_addr && has_asset {
         return None;
     }
-    let addr = out_pattern.address.as_ref()?;
-    if addr.payment_part.is_some() || addr.delegation_part.is_some() {
+
+    if let Some(addr) = out_pattern.address.as_ref() {
+        // exact_address takes priority; payment_part falls through if
+        // not set; delegation_part isn't supported.
+        if addr.delegation_part.is_some() {
+            return None;
+        }
+        if let Some(b) = &addr.exact_address {
+            return Some(SearchUtxoSelector::ExactAddress(b.clone()));
+        }
+        if let Some(p_part) = &addr.payment_part {
+            return Some(SearchUtxoSelector::PaymentCredential(p_part.clone()));
+        }
         return None;
     }
-    addr.exact_address.clone()
+    if let Some(asset) = out_pattern.asset.as_ref() {
+        let policy_id = asset.policy_id.clone()?;
+        let asset_name = asset.asset_name.clone();
+        return Some(SearchUtxoSelector::Asset {
+            policy_id,
+            asset_name,
+        });
+    }
+    None
 }
 
 async fn search_utxos_response_beta(
     ctx: &std::sync::Arc<dyn LedgerContext>,
     request: v1beta::query::SearchUtxosRequest,
 ) -> Result<v1beta::query::SearchUtxosResponse, Status> {
-    let Some(exact_addr_bytes) = predicate_exact_address(request.predicate.as_ref()) else {
-        return Err(Status::unimplemented(
-            "SearchUtxos: only `predicate.match.cardano.address.exact_address` is \
-             supported in this build. Payment-credential / delegation / asset / \
-             composite (not/all_of/any_of) patterns are deferred to a follow-up.",
-        ));
-    };
+    let selector = resolve_predicate(request.predicate.as_ref()).ok_or_else(|| {
+        Status::unimplemented(
+            "SearchUtxos: supported predicates are `match.cardano.address.exact_address`, \
+             `match.cardano.address.payment_part`, and `match.cardano.asset.{policy_id, \
+             asset_name}`. Delegation patterns, composite predicates (not/all_of/any_of), \
+             and mixed address+asset patterns are deferred to a follow-up.",
+        )
+    })?;
 
-    let parsed_addr = dugite_primitives::address::Address::from_bytes(&exact_addr_bytes)
-        .map_err(|e| Status::invalid_argument(format!("exact_address bytes invalid: {e}")))?;
-
-    let mut snaps = ctx
-        .utxos_by_address(&parsed_addr)
-        .await
-        .map_err(Status::from)?;
     let cap = request
         .max_items
         .map(|n| (n as usize).min(SEARCH_UTXOS_HARD_CAP))
         .unwrap_or(SEARCH_UTXOS_HARD_CAP)
         .max(1);
+
+    let mut snaps = match selector {
+        SearchUtxoSelector::ExactAddress(bytes) => {
+            let parsed_addr =
+                dugite_primitives::address::Address::from_bytes(&bytes).map_err(|e| {
+                    Status::invalid_argument(format!("exact_address bytes invalid: {e}"))
+                })?;
+            ctx.utxos_by_address(&parsed_addr)
+                .await
+                .map_err(Status::from)?
+        }
+        SearchUtxoSelector::PaymentCredential(bytes) => {
+            if bytes.len() != 28 && bytes.len() != 32 {
+                return Err(Status::invalid_argument(format!(
+                    "payment_part must be 28 or 32 bytes, got {}",
+                    bytes.len()
+                )));
+            }
+            let mut padded = [0u8; 32];
+            let copy_len = bytes.len().min(32);
+            padded[..copy_len].copy_from_slice(&bytes[..copy_len]);
+            let h32 = dugite_primitives::hash::Hash32::from_bytes(padded);
+            ctx.utxos_by_payment_credential(&h32)
+                .await
+                .map_err(Status::from)?
+        }
+        SearchUtxoSelector::Asset {
+            policy_id,
+            asset_name,
+        } => {
+            if policy_id.len() < 28 {
+                return Err(Status::invalid_argument(format!(
+                    "asset policy_id must be 28 bytes, got {}",
+                    policy_id.len()
+                )));
+            }
+            let mut padded = [0u8; 32];
+            padded[..28].copy_from_slice(&policy_id[..28]);
+            let h32 = dugite_primitives::hash::Hash32::from_bytes(padded);
+            ctx.utxos_by_asset(&h32, asset_name.as_deref())
+                .await
+                .map_err(Status::from)?
+        }
+    };
+
     if snaps.len() > cap {
         snaps.truncate(cap);
     }

--- a/crates/dugite-rpc/tests/query_service.rs
+++ b/crates/dugite-rpc/tests/query_service.rs
@@ -74,14 +74,16 @@ impl LedgerContext for QueryMock {
         Err(RpcError::Unimplemented(""))
     }
     async fn utxos_by_payment_credential(&self, _: &Hash32) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented(""))
+        // QueryMock holds no payment-credential index; empty is the
+        // correct "no matches" response for the supported-pattern path.
+        Ok(Vec::new())
     }
     async fn utxos_by_asset(
         &self,
         _: &Hash32,
         _: Option<&[u8]>,
     ) -> Result<Vec<UtxoSnapshot>, RpcError> {
-        Err(RpcError::Unimplemented(""))
+        Ok(Vec::new())
     }
     async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
         Ok(ParamsView {
@@ -373,7 +375,7 @@ async fn search_utxos_empty_predicate_returns_unimplemented() {
 }
 
 #[tokio::test]
-async fn search_utxos_payment_part_pattern_returns_unimplemented() {
+async fn search_utxos_payment_part_pattern_succeeds_with_empty_result() {
     use dugite_rpc::proto::v1beta::cardano::{AddressPattern, TxOutputPattern};
     use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
     use dugite_rpc::proto::v1beta::query::{
@@ -382,7 +384,7 @@ async fn search_utxos_payment_part_pattern_returns_unimplemented() {
 
     let server = TestServer::start(make_mock()).await;
     let mut client = QueryServiceClient::new(server.channel().await);
-    let status = client
+    let resp = client
         .search_utxos(SearchUtxosRequest {
             predicate: Some(UtxoPredicate {
                 r#match: Some(AnyUtxoPattern {
@@ -404,10 +406,85 @@ async fn search_utxos_payment_part_pattern_returns_unimplemented() {
             start_token: None,
         })
         .await
+        .unwrap()
+        .into_inner();
+    // QueryMock has no UTxOs for this credential so the result is
+    // empty, but the service signals it's a supported pattern by
+    // returning OK rather than UNIMPLEMENTED.
+    assert!(resp.items.is_empty());
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn search_utxos_delegation_part_returns_unimplemented() {
+    use dugite_rpc::proto::v1beta::cardano::{AddressPattern, TxOutputPattern};
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::{
+        any_utxo_pattern, AnyUtxoPattern, SearchUtxosRequest, UtxoPredicate,
+    };
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let status = client
+        .search_utxos(SearchUtxosRequest {
+            predicate: Some(UtxoPredicate {
+                r#match: Some(AnyUtxoPattern {
+                    utxo_pattern: Some(any_utxo_pattern::UtxoPattern::Cardano(TxOutputPattern {
+                        address: Some(AddressPattern {
+                            exact_address: None,
+                            payment_part: None,
+                            delegation_part: Some(vec![0xBB; 28]),
+                        }),
+                        asset: None,
+                    })),
+                }),
+                not: vec![],
+                all_of: vec![],
+                any_of: vec![],
+            }),
+            field_mask: None,
+            max_items: None,
+            start_token: None,
+        })
+        .await
         .unwrap_err();
-    // payment_part patterns aren't supported yet — service should
-    // signal that explicitly.
     assert_eq!(status.code(), tonic::Code::Unimplemented);
-    assert!(status.message().contains("exact_address"));
+    server.stop().await;
+}
+
+#[tokio::test]
+async fn search_utxos_asset_policy_returns_empty_when_no_matching_utxo() {
+    use dugite_rpc::proto::v1beta::cardano::{AssetPattern, TxOutputPattern};
+    use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
+    use dugite_rpc::proto::v1beta::query::{
+        any_utxo_pattern, AnyUtxoPattern, SearchUtxosRequest, UtxoPredicate,
+    };
+
+    let server = TestServer::start(make_mock()).await;
+    let mut client = QueryServiceClient::new(server.channel().await);
+    let resp = client
+        .search_utxos(SearchUtxosRequest {
+            predicate: Some(UtxoPredicate {
+                r#match: Some(AnyUtxoPattern {
+                    utxo_pattern: Some(any_utxo_pattern::UtxoPattern::Cardano(TxOutputPattern {
+                        address: None,
+                        asset: Some(AssetPattern {
+                            policy_id: Some(vec![0xCC; 28]),
+                            asset_name: None,
+                        }),
+                    })),
+                }),
+                not: vec![],
+                all_of: vec![],
+                any_of: vec![],
+            }),
+            field_mask: None,
+            max_items: None,
+            start_token: None,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(resp.items.is_empty());
     server.stop().await;
 }


### PR DESCRIPTION
Closes the last SearchUtxos pattern gap from M2.A docs.

* payment_part: walks address_index filtered by payment_credential. Capped at 5,000.
* asset: O(N) scan over UTxOs with policy_id + optional asset_name filter. Capped at 5,000.
* delegation_part / composite / mixed predicates still return UNIMPLEMENTED.

Verified: **81/81 dugite-rpc tests pass**, clippy + fmt clean.