### PR TITLE
feat(rpc): EvalTx — non-committing Phase-1 + Phase-2 evaluation (#672 follow-up)

### DIFF
--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -399,6 +399,29 @@ impl LedgerContext for NodeRpcAdapter {
         }
     }
 
+    async fn eval_tx(&self, era: u16, raw_cbor: &[u8]) -> dugite_rpc::EvalOutcome {
+        // Phase-1 + Phase-2 validation via the same LedgerTxValidator
+        // instance N2C uses. Failure messages flow through verbatim so
+        // clients see the structured TxValidationError reason.
+        let validation = self.tx_validator.validate_tx(era, raw_cbor);
+
+        // Decode separately to extract the fee for the response. If the
+        // decode fails, we can still report the validation error and
+        // leave fee = 0.
+        let fee = match dugite_serialization::decode_transaction(era, raw_cbor) {
+            Ok(tx) => tx.body.fee.0,
+            Err(_) => 0,
+        };
+
+        dugite_rpc::EvalOutcome {
+            fee,
+            error: match validation {
+                Ok(()) => None,
+                Err(e) => Some(format!("{e:?}")),
+            },
+        }
+    }
+
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         let hashes = self.mempool.tx_hashes_ordered();
         let mut out = Vec::with_capacity(hashes.len());

--- a/crates/dugite-rpc/src/context.rs
+++ b/crates/dugite-rpc/src/context.rs
@@ -132,6 +132,16 @@ pub enum SubmitOutcome {
     Rejected { reason: String },
 }
 
+/// Outcome of a non-committing transaction evaluation (SubmitService.EvalTx).
+#[derive(Clone, Debug)]
+pub struct EvalOutcome {
+    /// The transaction's declared fee (in lovelace).
+    pub fee: u64,
+    /// `None` on successful evaluation; `Some(reason)` carries the
+    /// structured `TxValidationError` message on failure.
+    pub error: Option<String>,
+}
+
 // ─── The trait ────────────────────────────────────────────────────────────
 
 /// The full API surface the RPC server uses to talk to the node.
@@ -200,6 +210,11 @@ pub trait LedgerContext: Send + Sync + 'static {
     /// CBOR (`u16`, 0 = Byron, 1 = Shelley, …); the validator double-
     /// checks against the body shape.
     async fn submit_tx(&self, era: u16, raw_cbor: &[u8]) -> SubmitOutcome;
+
+    /// Non-committing Phase-1 + Phase-2 evaluation. Runs the same
+    /// validation pipeline as `submit_tx` but does NOT admit the tx
+    /// to the mempool — suitable for `SubmitService.EvalTx` dry-runs.
+    async fn eval_tx(&self, era: u16, raw_cbor: &[u8]) -> EvalOutcome;
 
     // ── mempool snapshot (live feed lives in MempoolFeed) ────────────────
 

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -38,8 +38,8 @@ pub mod tip_feed;
 
 pub use config::{RpcConfig, RpcTlsConfig};
 pub use context::{
-    EraHistoryView, EraSummary, GenesisView, LedgerContext, ParamsView, RawBlock, RawTx,
-    SubmitOutcome, TipInfo, UtxoSnapshot,
+    EraHistoryView, EraSummary, EvalOutcome, GenesisView, LedgerContext, ParamsView, RawBlock,
+    RawTx, SubmitOutcome, TipInfo, UtxoSnapshot,
 };
 pub use error::RpcError;
 pub use mempool_feed::{MempoolEvent, MempoolFeed, MempoolRemoveReason};

--- a/crates/dugite-rpc/src/services/submit.rs
+++ b/crates/dugite-rpc/src/services/submit.rs
@@ -18,14 +18,34 @@ use tonic::{Request, Response, Status};
 
 use super::ServiceState;
 use crate::proto::{v1alpha, v1beta};
-use crate::SubmitOutcome;
+use crate::{EvalOutcome, SubmitOutcome};
 
 const SERVICE_LABEL: &str = "submit";
-const EVAL_UNIMPL: &str =
-    "EvalTx requires a non-committing UPLC evaluation helper; deferred follow-up";
 
 /// Conway-era CBOR tag the spec uses for txs at PV9+ today.
 const DEFAULT_ERA_ID: u16 = 6;
+
+/// Build the v1beta TxEval envelope from an [`EvalOutcome`].
+fn eval_outcome_to_proto_beta(outcome: EvalOutcome) -> v1beta::cardano::TxEval {
+    v1beta::cardano::TxEval {
+        fee: Some(crate::map::common::coin_bigint(outcome.fee)),
+        ex_units: Some(v1beta::cardano::ExUnits {
+            steps: 0,
+            memory: 0,
+        }),
+        errors: outcome
+            .error
+            .into_iter()
+            .map(|msg| v1beta::cardano::EvalReport {
+                msg,
+                purpose: v1beta::cardano::RedeemerPurpose::Unspecified as i32,
+                index: 0,
+            })
+            .collect(),
+        traces: Vec::new(),
+        redeemers: Vec::new(),
+    }
+}
 
 fn extract_raw_tx_beta(req_tx: &Option<v1beta::submit::AnyChainTx>) -> Option<&[u8]> {
     req_tx
@@ -62,9 +82,21 @@ impl SubmitSvcAlpha {
 impl v1alpha::submit::submit_service_server::SubmitService for SubmitSvcAlpha {
     async fn eval_tx(
         &self,
-        _request: Request<v1alpha::submit::EvalTxRequest>,
+        request: Request<v1alpha::submit::EvalTxRequest>,
     ) -> Result<Response<v1alpha::submit::EvalTxResponse>, Status> {
-        Err(Status::unimplemented(EVAL_UNIMPL))
+        let req = request.into_inner();
+        let raw = extract_raw_tx_alpha(&req.tx)
+            .ok_or_else(|| Status::invalid_argument("EvalTxRequest.tx.raw is required"))?;
+        let outcome = self.state.context.eval_tx(DEFAULT_ERA_ID, raw).await;
+        let beta = eval_outcome_to_proto_beta(outcome);
+        use prost::Message;
+        let alpha = v1alpha::cardano::TxEval::decode(beta.encode_to_vec().as_slice())
+            .expect("v1alpha TxEval subset-compatible with v1beta");
+        Ok(Response::new(v1alpha::submit::EvalTxResponse {
+            report: Some(v1alpha::submit::AnyChainEval {
+                chain: Some(v1alpha::submit::any_chain_eval::Chain::Cardano(alpha)),
+            }),
+        }))
     }
 
     async fn submit_tx(
@@ -236,9 +268,18 @@ impl SubmitSvcBeta {
 impl v1beta::submit::submit_service_server::SubmitService for SubmitSvcBeta {
     async fn eval_tx(
         &self,
-        _request: Request<v1beta::submit::EvalTxRequest>,
+        request: Request<v1beta::submit::EvalTxRequest>,
     ) -> Result<Response<v1beta::submit::EvalTxResponse>, Status> {
-        Err(Status::unimplemented(EVAL_UNIMPL))
+        let req = request.into_inner();
+        let raw = extract_raw_tx_beta(&req.tx)
+            .ok_or_else(|| Status::invalid_argument("EvalTxRequest.tx.raw is required"))?;
+        let outcome = self.state.context.eval_tx(DEFAULT_ERA_ID, raw).await;
+        let beta = eval_outcome_to_proto_beta(outcome);
+        Ok(Response::new(v1beta::submit::EvalTxResponse {
+            report: Some(v1beta::submit::AnyChainEval {
+                chain: Some(v1beta::submit::any_chain_eval::Chain::Cardano(beta)),
+            }),
+        }))
     }
 
     async fn submit_tx(

--- a/crates/dugite-rpc/tests/query_service.rs
+++ b/crates/dugite-rpc/tests/query_service.rs
@@ -111,6 +111,12 @@ impl LedgerContext for QueryMock {
     async fn submit_tx(&self, _: u16, _: &[u8]) -> SubmitOutcome {
         SubmitOutcome::Rejected { reason: "".into() }
     }
+    async fn eval_tx(&self, _: u16, _: &[u8]) -> dugite_rpc::EvalOutcome {
+        dugite_rpc::EvalOutcome {
+            fee: 0,
+            error: Some("".into()),
+        }
+    }
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         Err(RpcError::Unimplemented(""))
     }

--- a/crates/dugite-rpc/tests/server_smoke.rs
+++ b/crates/dugite-rpc/tests/server_smoke.rs
@@ -86,6 +86,12 @@ impl LedgerContext for MockLedgerContext {
             reason: "mock::submit_tx not implemented".into(),
         }
     }
+    async fn eval_tx(&self, _: u16, _: &[u8]) -> dugite_rpc::EvalOutcome {
+        dugite_rpc::EvalOutcome {
+            fee: 0,
+            error: Some("mock::eval_tx not implemented".into()),
+        }
+    }
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         Err(RpcError::Unimplemented("mock::mempool_snapshot"))
     }
@@ -268,21 +274,19 @@ async fn query_v1beta_methods_return_unimplemented() {
 
 // ── Submit v1beta ────────────────────────────────────────────────────────
 //
-// Submit methods are implemented as of M3; eval_tx is the only one that
-// still returns UNIMPLEMENTED (needs a non-committing UPLC helper).
-// SubmitTx with no `raw` field returns INVALID_ARGUMENT; the richer
+// All Submit methods are implemented as of the EvalTx follow-up. SubmitTx
+// / EvalTx with no `raw` field return INVALID_ARGUMENT; the richer
 // integration suite for SubmitService lives in submit_service.rs.
 
 #[tokio::test]
-async fn submit_v1beta_eval_tx_returns_unimplemented() {
+async fn submit_v1beta_eval_tx_with_empty_request_returns_invalid_argument() {
     use dugite_rpc::proto::v1beta::submit::submit_service_client::SubmitServiceClient;
     use dugite_rpc::proto::v1beta::submit::EvalTxRequest;
 
     let server = TestServer::start(true).await;
     let mut client = SubmitServiceClient::new(server.channel().await);
     let status = client.eval_tx(EvalTxRequest::default()).await.unwrap_err();
-    assert_eq!(status.code(), tonic::Code::Unimplemented);
-    assert!(status.message().contains("EvalTx"));
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
     server.stop().await;
 }
 

--- a/crates/dugite-rpc/tests/sync_service.rs
+++ b/crates/dugite-rpc/tests/sync_service.rs
@@ -175,6 +175,12 @@ impl LedgerContext for SyncMock {
     async fn submit_tx(&self, _: u16, _: &[u8]) -> SubmitOutcome {
         SubmitOutcome::Rejected { reason: "".into() }
     }
+    async fn eval_tx(&self, _: u16, _: &[u8]) -> dugite_rpc::EvalOutcome {
+        dugite_rpc::EvalOutcome {
+            fee: 0,
+            error: Some("".into()),
+        }
+    }
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         Err(RpcError::Unimplemented(""))
     }


### PR DESCRIPTION
Closes the final deferred item from M2.A docs. EvalTx now runs the same Phase-1 + Phase-2 validation as SubmitTx without admitting to the mempool.

Limits: ex_units / per-redeemer breakdown not yet plumbed (underlying evaluate_plutus_scripts returns pass/fail only). Future follow-up.

Verified: **81/81 dugite-rpc tests pass**, clippy + fmt clean.