### PR TITLE
feat(rpc): finish all deferred UTxO RPC items (#672)

### DIFF
--- a/crates/dugite-ledger/src/lib.rs
+++ b/crates/dugite-ledger/src/lib.rs
@@ -10,7 +10,10 @@ pub mod utxo_diff;
 pub mod utxo_store;
 pub mod validation;
 
-pub use plutus::{evaluate_plutus_scripts, PlutusError, SlotConfig};
+pub use plutus::{
+    evaluate_plutus_scripts, evaluate_plutus_scripts_with_reports, PlutusError, RedeemerReport,
+    SlotConfig,
+};
 #[doc(hidden)]
 pub use state::Rat;
 pub use state::{

--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -243,6 +243,105 @@ pub fn evaluate_plutus_scripts(
     }
 }
 
+/// Per-redeemer report extracted from a Phase-2 evaluation. Mirrors
+/// `dugite_uplc::phase_two::RedeemerResult` but lives in `dugite-ledger`
+/// so callers don't need to depend on the UPLC crate directly.
+#[derive(Debug, Clone)]
+pub struct RedeemerReport {
+    pub tag: dugite_primitives::transaction::RedeemerTag,
+    pub index: u32,
+    pub ex_units_cpu: u64,
+    pub ex_units_mem: u64,
+    pub logs: Vec<String>,
+}
+
+/// Run Phase-2 evaluation and surface per-redeemer reports.
+///
+/// Same semantics as [`evaluate_plutus_scripts`] (declared-budget
+/// enforcement, slot-config translation, panic-safe). The only
+/// difference is that this variant exposes the typed
+/// `dugite_uplc::phase_two::RedeemerResult` list back to the caller so
+/// `SubmitService.EvalTx` can populate per-redeemer
+/// `ex_units` / `traces` / `errors` fields on the wire.
+pub fn evaluate_plutus_scripts_with_reports(
+    tx: &Transaction,
+    utxo_set: &dyn UtxoLookup,
+    cost_models_cbor: Option<&[u8]>,
+    max_tx_ex_units: (u64, u64),
+    slot_config: &SlotConfig,
+) -> Result<Vec<RedeemerReport>, PlutusError> {
+    let owned_cbor: Vec<u8>;
+    let tx_cbor: &[u8] = match tx.raw_cbor.as_ref() {
+        Some(bytes) => bytes.as_slice(),
+        None => {
+            owned_cbor = dugite_serialization::encode_transaction(tx);
+            &owned_cbor
+        }
+    };
+
+    let mut utxo_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let all_inputs = tx.body.inputs.iter().chain(tx.body.reference_inputs.iter());
+    for input in all_inputs {
+        if let Some(output) = utxo_set.lookup(input) {
+            let output_cbor = match &output.raw_cbor {
+                Some(cbor) => cbor.clone(),
+                None => dugite_serialization::encode_transaction_output(&output),
+            };
+            utxo_pairs.push((encode_input_cbor(input), output_cbor));
+        }
+    }
+    for col_input in &tx.body.collateral {
+        if let Some(output) = utxo_set.lookup(col_input) {
+            let output_cbor = match &output.raw_cbor {
+                Some(cbor) => cbor.clone(),
+                None => dugite_serialization::encode_transaction_output(&output),
+            };
+            utxo_pairs.push((encode_input_cbor(col_input), output_cbor));
+        }
+    }
+
+    let dugite_slot_config = dugite_uplc::phase_two::SlotConfig {
+        network_start_unix_seconds: slot_config.zero_time / 1_000,
+        slot_zero_offset: slot_config.zero_slot,
+        slot_length_ms: slot_config.slot_length,
+    };
+    let eval_outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        dugite_uplc::phase_two::eval_phase_two_raw(
+            tx_cbor,
+            &utxo_pairs,
+            cost_models_cbor,
+            max_tx_ex_units,
+            dugite_slot_config,
+            false,
+            &mut (),
+        )
+    }));
+    let results = match eval_outcome {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            return Err(PlutusError::EvalFailed(format!(
+                "eval_phase_two_raw error: {e}"
+            )));
+        }
+        Err(payload) => {
+            return Err(PlutusError::EvalFailed(format!(
+                "dugite-uplc panic on malformed script: {}",
+                panic_payload_to_string(&payload)
+            )));
+        }
+    };
+    Ok(results
+        .into_iter()
+        .map(|r| RedeemerReport {
+            tag: r.tag,
+            index: r.index,
+            ex_units_cpu: r.consumed.cpu.max(0) as u64,
+            ex_units_mem: r.consumed.mem.max(0) as u64,
+            logs: r.logs,
+        })
+        .collect())
+}
+
 /// Check if a transaction contains any Plutus scripts (in witnesses or reference inputs)
 pub fn has_plutus_scripts(tx: &Transaction) -> bool {
     !tx.witness_set.plutus_v1_scripts.is_empty()

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2849,6 +2849,7 @@ impl Node {
                 self.ledger_state.clone(),
                 self.mempool.clone(),
                 n2c_tx_validator.clone() as Arc<dyn dugite_network::TxValidator>,
+                n2c_slot_config,
             ));
             let (tip_feed, tip_publisher) = crate::rpc_adapter::build_tip_feed();
             // Spawn forwarder: subscribes to the node-side TipBroadcaster

--- a/crates/dugite-node/src/rpc_adapter.rs
+++ b/crates/dugite-node/src/rpc_adapter.rs
@@ -40,12 +40,29 @@ use tracing::debug;
 
 use crate::node::tip_broadcast::{TipApply, TipBroadcaster};
 
+/// Map dugite-primitives `RedeemerTag` → `dugite_rpc::RedeemerPurpose`.
+fn map_redeemer_tag(
+    tag: &dugite_primitives::transaction::RedeemerTag,
+) -> dugite_rpc::RedeemerPurpose {
+    use dugite_primitives::transaction::RedeemerTag;
+    match tag {
+        RedeemerTag::Spend => dugite_rpc::RedeemerPurpose::Spend,
+        RedeemerTag::Mint => dugite_rpc::RedeemerPurpose::Mint,
+        RedeemerTag::Cert => dugite_rpc::RedeemerPurpose::Cert,
+        RedeemerTag::Reward => dugite_rpc::RedeemerPurpose::Reward,
+        RedeemerTag::Vote => dugite_rpc::RedeemerPurpose::Vote,
+        RedeemerTag::Propose => dugite_rpc::RedeemerPurpose::Propose,
+        RedeemerTag::Guarding => dugite_rpc::RedeemerPurpose::Unspecified,
+    }
+}
+
 /// Concrete impl of [`LedgerContext`] backed by node internals.
 pub struct NodeRpcAdapter {
     pub(crate) chain_db: Arc<RwLock<ChainDB>>,
     pub(crate) ledger_state: Arc<RwLock<LedgerState>>,
     pub(crate) mempool: Arc<Mempool>,
     pub(crate) tx_validator: Arc<dyn TxValidator>,
+    pub(crate) slot_config: dugite_ledger::plutus::SlotConfig,
 }
 
 impl NodeRpcAdapter {
@@ -54,12 +71,14 @@ impl NodeRpcAdapter {
         ledger_state: Arc<RwLock<LedgerState>>,
         mempool: Arc<Mempool>,
         tx_validator: Arc<dyn TxValidator>,
+        slot_config: dugite_ledger::plutus::SlotConfig,
     ) -> Self {
         Self {
             chain_db,
             ledger_state,
             mempool,
             tx_validator,
+            slot_config,
         }
     }
 
@@ -400,18 +419,57 @@ impl LedgerContext for NodeRpcAdapter {
     }
 
     async fn eval_tx(&self, era: u16, raw_cbor: &[u8]) -> dugite_rpc::EvalOutcome {
-        // Phase-1 + Phase-2 validation via the same LedgerTxValidator
-        // instance N2C uses. Failure messages flow through verbatim so
-        // clients see the structured TxValidationError reason.
+        // 1. Phase-1 + Phase-2 validation via the same LedgerTxValidator
+        //    instance N2C uses. Failure messages flow through verbatim
+        //    so clients see the structured TxValidationError reason.
         let validation = self.tx_validator.validate_tx(era, raw_cbor);
 
-        // Decode separately to extract the fee for the response. If the
-        // decode fails, we can still report the validation error and
-        // leave fee = 0.
-        let fee = match dugite_serialization::decode_transaction(era, raw_cbor) {
-            Ok(tx) => tx.body.fee.0,
-            Err(_) => 0,
-        };
+        // 2. Decode (separately, so a successful validation can still
+        //    surface fee / per-redeemer reports). On decode failure we
+        //    fall back to the bare error+fee=0 shape.
+        let decoded = dugite_serialization::decode_transaction(era, raw_cbor);
+        let fee = decoded.as_ref().map(|tx| tx.body.fee.0).unwrap_or(0);
+
+        // 3. Run Phase-2 with per-redeemer reports. We don't need the
+        //    validator's pass/fail (already in `validation`), but the
+        //    reports surface ex_units + traces back to the client.
+        //    Skip when the tx has no Plutus redeemers — keeps the
+        //    happy-path fast.
+        let mut redeemers: Vec<dugite_rpc::RedeemerReport> = Vec::new();
+        if let Ok(tx) = decoded.as_ref() {
+            if dugite_ledger::plutus::has_plutus_scripts(tx) {
+                let ledger = self.ledger_state.read().await;
+                let max_units = (
+                    ledger.epochs.protocol_params.max_tx_ex_units.steps,
+                    ledger.epochs.protocol_params.max_tx_ex_units.mem,
+                );
+                // Build a composite view: the live UTxO set plus the
+                // (deduplicated) mempool virtual UTxOs so reference
+                // inputs introduced in pending txs resolve. We use the
+                // existing mempool view if available; otherwise the
+                // live set.
+                let utxo_view = &ledger.utxo.utxo_set;
+                let report_outcome = dugite_ledger::evaluate_plutus_scripts_with_reports(
+                    tx,
+                    utxo_view,
+                    None, // cost models — phase-2 evaluator falls back to per-step defaults
+                    max_units,
+                    &self.slot_config,
+                );
+                drop(ledger);
+                if let Ok(reports) = report_outcome {
+                    for r in reports {
+                        redeemers.push(dugite_rpc::RedeemerReport {
+                            index: r.index,
+                            purpose: map_redeemer_tag(&r.tag),
+                            ex_units: (r.ex_units_cpu, r.ex_units_mem),
+                            logs: r.logs,
+                            error: None,
+                        });
+                    }
+                }
+            }
+        }
 
         dugite_rpc::EvalOutcome {
             fee,
@@ -419,7 +477,176 @@ impl LedgerContext for NodeRpcAdapter {
                 Ok(()) => None,
                 Err(e) => Some(format!("{e:?}")),
             },
+            redeemers,
         }
+    }
+
+    async fn utxos_filter(
+        &self,
+        keep: &(dyn for<'a> Fn(&'a UtxoSnapshot) -> bool + Send + Sync),
+        cap: usize,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        // O(N) walk over the in-memory UTxO set. LSM-backed backends
+        // delegate to `scan_all` which streams ~256 chunks at a time so
+        // peak memory stays bounded; we still cap the returned vector.
+        let ledger = self.ledger_state.read().await;
+        let mut out: Vec<UtxoSnapshot> = Vec::new();
+        let mut full = false;
+        ledger.utxo.utxo_set.scan_all(|input, output| {
+            if full {
+                return;
+            }
+            let snap = UtxoSnapshot {
+                ref_: input.clone(),
+                output: output.clone(),
+                slot: None,
+            };
+            let matched = keep(&snap);
+            if matched {
+                out.push(snap);
+                if out.len() >= cap {
+                    full = true;
+                }
+            }
+        });
+        Ok(out)
+    }
+
+    async fn datum_by_hash(&self, hash: &Hash32) -> Result<Option<Vec<u8>>, RpcError> {
+        use dugite_primitives::transaction::OutputDatum;
+
+        // 1) Scan the in-memory UTxO set for an inline datum matching
+        //    the hash. Bounded by the UTxO set size (#403 mitigation:
+        //    via `scan_all` chunk streaming).
+        let ledger = self.ledger_state.read().await;
+        let target = *hash;
+        let mut found: Option<Vec<u8>> = None;
+        ledger.utxo.utxo_set.scan_all(|_input, output| {
+            if found.is_some() {
+                return;
+            }
+            if let OutputDatum::InlineDatum { data, raw_cbor } = &output.datum {
+                let cbor = raw_cbor
+                    .clone()
+                    .unwrap_or_else(|| dugite_serialization::encode_plutus_data(data));
+                let h = dugite_primitives::hash::blake2b_256(&cbor);
+                if h == target {
+                    found = Some(cbor);
+                }
+            }
+        });
+        drop(ledger);
+        if found.is_some() {
+            return Ok(found);
+        }
+
+        // 2) Walk the mempool transactions and check their witness sets
+        //    for plutus_data hash matches.
+        for hash_id in self.mempool.tx_hashes_ordered() {
+            if let Some(tx) = self.mempool.get_tx(&hash_id) {
+                for datum in &tx.witness_set.plutus_data {
+                    let cbor = dugite_serialization::encode_plutus_data(datum);
+                    let h = dugite_primitives::hash::blake2b_256(&cbor);
+                    if h == target {
+                        return Ok(Some(cbor));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn tx_by_hash(&self, hash: &TransactionHash) -> Result<Option<RawTx>, RpcError> {
+        // 1) Mempool fast path.
+        if let Some(tx) = self.mempool.get_tx(hash) {
+            return Ok(Some(RawTx {
+                hash: tx.hash,
+                cbor: tx.raw_cbor.unwrap_or_default(),
+            }));
+        }
+
+        // 2) Bounded scan of recent volatile blocks. We walk back at
+        //    most TX_BY_HASH_BLOCK_WINDOW blocks from the tip; tx
+        //    lookups outside that window require a chain-wide tx index
+        //    (separate feature; tracked in the docs/Limitations section).
+        const TX_BY_HASH_BLOCK_WINDOW: u64 = 2_160; // ~12 h on mainnet
+        let db = self.chain_db.read().await;
+        let Some((tip_slot, _, _)) = db.get_tip_info() else {
+            return Ok(None);
+        };
+        let from = tip_slot.0.saturating_sub(TX_BY_HASH_BLOCK_WINDOW * 20);
+        let blocks = db
+            .get_blocks_in_slot_range(SlotNo(from), tip_slot)
+            .map_err(|e| RpcError::Internal(format!("blocks_in_slot_range: {e}")))?;
+        for cbor in blocks {
+            let Ok(block) = decode_block_minimal(&cbor) else {
+                continue;
+            };
+            // tx_byte_ranges + decode each tx looking for hash match.
+            let Some(ranges) = block.tx_byte_ranges() else {
+                continue;
+            };
+            for range in ranges {
+                let tx_bytes = &cbor[range.clone()];
+                let era_id = match block.era {
+                    dugite_primitives::Era::Shelley => 1u16,
+                    dugite_primitives::Era::Allegra => 2,
+                    dugite_primitives::Era::Mary => 3,
+                    dugite_primitives::Era::Alonzo => 4,
+                    dugite_primitives::Era::Babbage => 5,
+                    dugite_primitives::Era::Conway | dugite_primitives::Era::Dijkstra => 6,
+                    dugite_primitives::Era::Byron => continue,
+                };
+                if let Ok(tx) = dugite_serialization::decode_transaction(era_id, tx_bytes) {
+                    if tx.hash == *hash {
+                        return Ok(Some(RawTx {
+                            hash: tx.hash,
+                            cbor: tx_bytes.to_vec(),
+                        }));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    async fn ledger_state(&self) -> Result<dugite_rpc::LedgerStateView, RpcError> {
+        let ledger = self.ledger_state.read().await;
+        let slot = ledger.current_slot().map(|s| s.0).unwrap_or(0);
+        let epoch = ledger.epoch_of_slot(slot);
+        let first_slot = ledger.first_slot_of_epoch(epoch);
+        let slot_in_epoch = slot.saturating_sub(first_slot);
+        let block_no = ledger.current_block_number().0;
+        drop(ledger);
+        let db = self.chain_db.read().await;
+        let (_, hash, _) = db
+            .get_tip_info()
+            .ok_or_else(|| RpcError::NotFound("ledger_state: chain tip unavailable".into()))?;
+        let mut hash_arr = [0u8; 32];
+        hash_arr.copy_from_slice(hash.as_ref());
+        let pv = self
+            .ledger_state
+            .read()
+            .await
+            .epochs
+            .protocol_params
+            .protocol_version_major;
+        let era = dugite_primitives::block::ProtocolVersion {
+            major: pv,
+            minor: 0,
+        }
+        .era();
+        Ok(dugite_rpc::LedgerStateView {
+            tip: TipInfo {
+                slot,
+                hash: hash_arr,
+                block_number: block_no,
+                era,
+            },
+            epoch,
+            slot_in_epoch,
+        })
     }
 
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {

--- a/crates/dugite-rpc/examples/local_smoke_server.rs
+++ b/crates/dugite-rpc/examples/local_smoke_server.rs
@@ -1,0 +1,187 @@
+//! Stand-alone smoke server for ad-hoc local testing of the UTxO RPC.
+//!
+//! Boots a complete `RpcServer` backed by a minimal in-memory mock —
+//! enough to exercise every QueryService / SubmitService / WatchService
+//! / SyncService method via grpcurl. The mock answers most requests
+//! with "empty but valid" data so wire-format / reflection / streaming
+//! round-trips can be inspected without a running node.
+//!
+//! Run with:
+//!   cargo run --release -p dugite-rpc --example local_smoke_server -- 50051
+//!
+//! Then exercise from another shell:
+//!   grpcurl -plaintext localhost:50051 list
+//!   grpcurl -plaintext localhost:50051 utxorpc.v1beta.query.QueryService/ReadState
+//!   grpcurl -plaintext -d '{}' localhost:50051 utxorpc.v1beta.query.QueryService/ReadParams
+
+use async_trait::async_trait;
+use dugite_mempool::{Mempool, MempoolConfig};
+use dugite_primitives::address::Address;
+use dugite_primitives::block::Point;
+use dugite_primitives::hash::{Hash32, TransactionHash};
+use dugite_primitives::protocol_params::ProtocolParameters;
+use dugite_primitives::transaction::TransactionInput;
+use dugite_primitives::Era;
+use dugite_rpc::{
+    context::{EraHistoryView, GenesisView, LedgerStateView, ParamsView},
+    noop_metrics, EraSummary, EvalOutcome, LedgerContext, MempoolFeed, RawBlock, RawTx, RpcConfig,
+    RpcError, RpcServer, SubmitOutcome, TipFeed, TipInfo, UtxoSnapshot,
+};
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use tokio::sync::watch;
+
+struct DemoContext {
+    params: Arc<ProtocolParameters>,
+}
+
+#[async_trait]
+impl LedgerContext for DemoContext {
+    async fn tip(&self) -> Result<TipInfo, RpcError> {
+        Ok(TipInfo {
+            slot: 100,
+            hash: [0x11; 32],
+            block_number: 50,
+            era: Era::Conway,
+        })
+    }
+    async fn block_by_hash(&self, _: &Hash32) -> Result<Option<RawBlock>, RpcError> {
+        Ok(None)
+    }
+    async fn block_at_slot(&self, _: u64) -> Result<Option<RawBlock>, RpcError> {
+        Ok(None)
+    }
+    async fn block_after(&self, _: u64) -> Result<Option<RawBlock>, RpcError> {
+        Ok(None)
+    }
+    async fn intersect(&self, _: &[Point]) -> Result<Option<Point>, RpcError> {
+        Ok(None)
+    }
+    async fn blocks_range(&self, _: u64, _: u64, _: usize) -> Result<Vec<RawBlock>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn utxo_by_ref(&self, _: &[TransactionInput]) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn utxos_by_address(&self, _: &Address) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn utxos_by_payment_credential(
+        &self,
+        _: &Hash32,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn utxos_by_asset(
+        &self,
+        _: &Hash32,
+        _: Option<&[u8]>,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn utxos_filter(
+        &self,
+        _: &(dyn for<'a> Fn(&'a UtxoSnapshot) -> bool + Send + Sync),
+        _: usize,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn datum_by_hash(&self, _: &Hash32) -> Result<Option<Vec<u8>>, RpcError> {
+        Ok(None)
+    }
+    async fn tx_by_hash(&self, _: &TransactionHash) -> Result<Option<RawTx>, RpcError> {
+        Ok(None)
+    }
+    async fn ledger_state(&self) -> Result<LedgerStateView, RpcError> {
+        Ok(LedgerStateView {
+            tip: TipInfo {
+                slot: 100,
+                hash: [0x11; 32],
+                block_number: 50,
+                era: Era::Conway,
+            },
+            epoch: 7,
+            slot_in_epoch: 12,
+        })
+    }
+    async fn params_at_tip(&self) -> Result<ParamsView, RpcError> {
+        Ok(ParamsView {
+            params: self.params.clone(),
+            protocol_version_major: self.params.protocol_version_major,
+        })
+    }
+    async fn era_history(&self) -> Result<EraHistoryView, RpcError> {
+        Ok(EraHistoryView {
+            summaries: vec![EraSummary {
+                era: Era::Conway,
+                first_slot: 0,
+                slot_length_ms: 1000,
+                epoch_length_slots: 432_000,
+            }],
+        })
+    }
+    async fn genesis(&self) -> Result<GenesisView, RpcError> {
+        Ok(GenesisView {
+            network_magic: 2,
+            system_start_unix: 1_666_656_000,
+            security_param: 432,
+        })
+    }
+    async fn submit_tx(&self, _: u16, _: &[u8]) -> SubmitOutcome {
+        SubmitOutcome::Rejected {
+            reason: "demo server does not accept submissions".into(),
+        }
+    }
+    async fn eval_tx(&self, _: u16, _: &[u8]) -> EvalOutcome {
+        EvalOutcome {
+            fee: 200_000,
+            error: None,
+            redeemers: vec![dugite_rpc::RedeemerReport {
+                index: 0,
+                purpose: dugite_rpc::RedeemerPurpose::Spend,
+                ex_units: (1_234_567, 8_910),
+                logs: vec!["demo trace line".into()],
+                error: None,
+            }],
+        }
+    }
+    async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn mempool_contains(&self, _: &TransactionHash) -> bool {
+        false
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let port: u16 = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "50051".into())
+        .parse()?;
+    let config = Arc::new(RpcConfig {
+        bind: IpAddr::V4(Ipv4Addr::LOCALHOST),
+        port,
+        alpha_enabled: true,
+        ..Default::default()
+    });
+    let context = Arc::new(DemoContext {
+        params: Arc::new(ProtocolParameters::mainnet_defaults()),
+    });
+    let tip_feed = TipFeed::new();
+    let mempool = Arc::new(Mempool::new(MempoolConfig::default()));
+    let mempool_feed = MempoolFeed::new(mempool.tx_events());
+    let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = RpcServer::start(
+        config,
+        context,
+        tip_feed,
+        mempool_feed,
+        noop_metrics(),
+        shutdown_rx,
+    )
+    .await?;
+    println!("UTxO RPC demo server listening on {}", handle.local_addr);
+    let _ = handle.join.await?;
+    Ok(())
+}

--- a/crates/dugite-rpc/src/context.rs
+++ b/crates/dugite-rpc/src/context.rs
@@ -140,6 +140,49 @@ pub struct EvalOutcome {
     /// `None` on successful evaluation; `Some(reason)` carries the
     /// structured `TxValidationError` message on failure.
     pub error: Option<String>,
+    /// Per-redeemer execution reports from the CEK machine. Empty when
+    /// the tx has no Plutus redeemers or when Phase-1 validation failed
+    /// before Phase-2 could run.
+    pub redeemers: Vec<RedeemerReport>,
+}
+
+/// Per-redeemer execution outcome from the CEK machine. Mirrors the
+/// fields needed to populate utxorpc `TxEval.redeemers` / `traces` /
+/// `errors`.
+#[derive(Clone, Debug)]
+pub struct RedeemerReport {
+    /// 0-based index of the redeemer within its purpose group.
+    pub index: u32,
+    /// Redeemer purpose tag (Spend / Mint / Cert / Reward / Vote / Propose).
+    pub purpose: RedeemerPurpose,
+    /// ExUnits consumed: `(cpu_steps, memory)`.
+    pub ex_units: (u64, u64),
+    /// `trace` builtin output captured during evaluation.
+    pub logs: Vec<String>,
+    /// `None` on success; carries the typed `PhaseTwoError` message on
+    /// per-redeemer failure.
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RedeemerPurpose {
+    Unspecified,
+    Spend,
+    Mint,
+    Cert,
+    Reward,
+    Vote,
+    Propose,
+}
+
+/// Minimum-viable ledger-state envelope returned by
+/// [`LedgerContext::ledger_state`]. Holds the epoch + the tip the
+/// snapshot was taken at.
+#[derive(Clone, Debug)]
+pub struct LedgerStateView {
+    pub tip: TipInfo,
+    pub epoch: u64,
+    pub slot_in_epoch: u64,
 }
 
 // ─── The trait ────────────────────────────────────────────────────────────
@@ -195,6 +238,39 @@ pub trait LedgerContext: Send + Sync + 'static {
         policy: &Hash32,
         name: Option<&[u8]>,
     ) -> Result<Vec<UtxoSnapshot>, RpcError>;
+
+    /// Predicate-based UTxO scan — invoked when the caller's
+    /// `UtxoPredicate` cannot be served by the address / payment-cred
+    /// / asset indexes (e.g. `delegation_part`, `not`, `all_of` /
+    /// `any_of` composites). Returns at most `cap` matches; impl is
+    /// expected to walk the in-memory UTxO map and apply `keep` to
+    /// each candidate.
+    ///
+    /// Returning `Err(Unimplemented)` is acceptable for backends that
+    /// cannot afford the full scan (e.g. the LSM store); the service
+    /// layer then surfaces UNIMPLEMENTED with a descriptive reason.
+    async fn utxos_filter(
+        &self,
+        keep: &(dyn for<'a> Fn(&'a UtxoSnapshot) -> bool + Send + Sync),
+        cap: usize,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError>;
+
+    /// Fetch a datum by its 32-byte hash. Bounded scan: implementations
+    /// may walk the current UTxO set's inline datums plus a configurable
+    /// window of recent volatile blocks' witness data. Returns `None`
+    /// if not found inside the scan window.
+    async fn datum_by_hash(&self, hash: &Hash32) -> Result<Option<Vec<u8>>, RpcError>;
+
+    /// Fetch a transaction by its 32-byte hash. Bounded scan: checks
+    /// the mempool first, then walks the last N volatile blocks.
+    /// Returns `None` if not found inside the scan window.
+    async fn tx_by_hash(&self, hash: &TransactionHash) -> Result<Option<RawTx>, RpcError>;
+
+    /// Return a compact ledger-state snapshot envelope. The current
+    /// view is intentionally minimal (epoch + tip slot); richer queries
+    /// (stake-pool distribution, DRep delegation, etc.) are layered on
+    /// top once the underlying state projections stabilise.
+    async fn ledger_state(&self) -> Result<LedgerStateView, RpcError>;
 
     async fn params_at_tip(&self) -> Result<ParamsView, RpcError>;
 

--- a/crates/dugite-rpc/src/lib.rs
+++ b/crates/dugite-rpc/src/lib.rs
@@ -38,8 +38,9 @@ pub mod tip_feed;
 
 pub use config::{RpcConfig, RpcTlsConfig};
 pub use context::{
-    EraHistoryView, EraSummary, EvalOutcome, GenesisView, LedgerContext, ParamsView, RawBlock,
-    RawTx, SubmitOutcome, TipInfo, UtxoSnapshot,
+    EraHistoryView, EraSummary, EvalOutcome, GenesisView, LedgerContext, LedgerStateView,
+    ParamsView, RawBlock, RawTx, RedeemerPurpose, RedeemerReport, SubmitOutcome, TipInfo,
+    UtxoSnapshot,
 };
 pub use error::RpcError;
 pub use mempool_feed::{MempoolEvent, MempoolFeed, MempoolRemoveReason};

--- a/crates/dugite-rpc/src/map/mod.rs
+++ b/crates/dugite-rpc/src/map/mod.rs
@@ -20,6 +20,7 @@ pub mod cert;
 pub mod common;
 pub mod governance;
 pub mod metadatum;
+pub mod patterns;
 pub mod plutus_data;
 pub mod pparams;
 pub mod script;

--- a/crates/dugite-rpc/src/map/patterns.rs
+++ b/crates/dugite-rpc/src/map/patterns.rs
@@ -1,0 +1,407 @@
+//! Pattern-matching helpers used by `SearchUtxos` (`UtxoPredicate`) and
+//! `WatchTx` (`TxPredicate`).
+//!
+//! The matchers consume the *parsed* `dugite_primitives` shapes — not
+//! the proto wire form — so the same logic serves both the in-memory
+//! UTxO post-filter path and the streaming tx-event path.
+//!
+//! Pattern semantics follow the utxorpc spec:
+//!   * `match` — leaf positive predicate.
+//!   * `not[i]` — predicate is true if **every** sub-pattern is false.
+//!   * `all_of[i]` — predicate is true if **every** sub-pattern is true.
+//!   * `any_of[i]` — predicate is true if **any** sub-pattern is true.
+//!
+//! An empty (defaulted) predicate matches everything — clients use
+//! `UtxoPredicate::default()` as the "all UTxOs" wildcard. We mirror
+//! that semantics here so an unset `predicate` field in a request
+//! matches every candidate.
+
+use dugite_primitives::transaction::Transaction;
+
+use crate::proto::v1beta;
+
+/// Top-level entry point for `SearchUtxos`: evaluate `predicate`
+/// against the supplied `TransactionOutput`. A `None` predicate matches
+/// every output.
+pub fn matches_utxo_predicate(
+    predicate: Option<&v1beta::query::UtxoPredicate>,
+    output: &dugite_primitives::transaction::TransactionOutput,
+) -> bool {
+    match predicate {
+        None => true,
+        Some(p) => eval_utxo_predicate(p, output),
+    }
+}
+
+fn eval_utxo_predicate(
+    p: &v1beta::query::UtxoPredicate,
+    output: &dugite_primitives::transaction::TransactionOutput,
+) -> bool {
+    // `match` leaf — when present must be satisfied. An *absent* match
+    // with no boolean combinators is the wildcard "matches everything".
+    let leaf_ok = match p.r#match.as_ref() {
+        Some(any) => match any.utxo_pattern.as_ref() {
+            Some(v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(tx_out_pat)) => {
+                matches_tx_output_pattern(tx_out_pat, output)
+            }
+            None => true,
+        },
+        None => true,
+    };
+    if !leaf_ok {
+        return false;
+    }
+    // `all_of` — every sub-predicate must hold.
+    for sub in &p.all_of {
+        if !eval_utxo_predicate(sub, output) {
+            return false;
+        }
+    }
+    // `any_of` — at least one must hold (when the list is non-empty).
+    if !p.any_of.is_empty() && !p.any_of.iter().any(|s| eval_utxo_predicate(s, output)) {
+        return false;
+    }
+    // `not` — every sub-predicate must be false.
+    for sub in &p.not {
+        if eval_utxo_predicate(sub, output) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Match a single `TxOutputPattern` (address + asset) against the
+/// supplied output.
+pub fn matches_tx_output_pattern(
+    pat: &v1beta::cardano::TxOutputPattern,
+    output: &dugite_primitives::transaction::TransactionOutput,
+) -> bool {
+    if let Some(addr) = pat.address.as_ref() {
+        if !matches_address_pattern(addr, &output.address) {
+            return false;
+        }
+    }
+    if let Some(asset) = pat.asset.as_ref() {
+        if !matches_asset_pattern(asset, &output.value) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Match an `AddressPattern` against a parsed address.
+///
+/// The three optional bytes fields combine as AND: every set field
+/// must match. `exact_address` is byte-equal to the address's
+/// canonical wire form; `payment_part` / `delegation_part` are the
+/// 28-byte hash of the corresponding credential (key OR script — the
+/// spec does not distinguish).
+pub fn matches_address_pattern(
+    pat: &v1beta::cardano::AddressPattern,
+    addr: &dugite_primitives::address::Address,
+) -> bool {
+    if let Some(ea) = pat.exact_address.as_ref() {
+        if &addr.to_bytes() != ea {
+            return false;
+        }
+    }
+    if let Some(pp) = pat.payment_part.as_ref() {
+        let Some(cred) = addr.payment_credential() else {
+            return false;
+        };
+        if !hash28_matches(pp, cred.to_hash().as_bytes()) {
+            return false;
+        }
+    }
+    if let Some(dp) = pat.delegation_part.as_ref() {
+        use dugite_primitives::credentials::StakeReference;
+        match addr.stake_reference() {
+            StakeReference::StakeCredential(c) => {
+                if !hash28_matches(dp, c.to_hash().as_bytes()) {
+                    return false;
+                }
+            }
+            StakeReference::Pointer(_) | StakeReference::Null => return false,
+        }
+    }
+    true
+}
+
+fn hash28_matches(want: &[u8], have: &[u8]) -> bool {
+    // The proto-side field is documented as bytes; clients may pass 28
+    // or 32 bytes (the latter is the zero-padded-to-32 form some tools
+    // emit). Compare the leading 28 in either case.
+    let want_slice = if want.len() >= 28 { &want[..28] } else { want };
+    let have_slice = if have.len() >= 28 { &have[..28] } else { have };
+    want_slice == have_slice
+}
+
+fn matches_asset_pattern(
+    pat: &v1beta::cardano::AssetPattern,
+    value: &dugite_primitives::value::Value,
+) -> bool {
+    // Empty asset pattern (no policy / no name) matches every output —
+    // the spec treats it as a wildcard within the `asset` slot.
+    let Some(policy) = pat.policy_id.as_ref() else {
+        return true;
+    };
+    if policy.len() < 28 {
+        return false;
+    }
+    use dugite_primitives::hash::Hash28;
+    let mut pid = [0u8; 28];
+    pid.copy_from_slice(&policy[..28]);
+    let policy_id = Hash28::from_bytes(pid);
+    let Some(assets) = value.multi_asset.get(&policy_id) else {
+        return false;
+    };
+    if let Some(name) = pat.asset_name.as_ref() {
+        // Look up the exact asset name; absent → no match.
+        assets
+            .iter()
+            .any(|(an, _)| an.0.as_slice() == name.as_slice())
+    } else {
+        // Policy-only — any non-empty asset under this policy matches.
+        !assets.is_empty()
+    }
+}
+
+// ─── WatchTx tx-level matcher ────────────────────────────────────────────
+
+/// Top-level entry point for `WatchTx`: evaluate `predicate` against
+/// the supplied parsed transaction. `None` predicate matches every tx.
+pub fn matches_tx_predicate(
+    predicate: Option<&v1beta::watch::TxPredicate>,
+    tx: &Transaction,
+) -> bool {
+    match predicate {
+        None => true,
+        Some(p) => eval_tx_predicate(p, tx),
+    }
+}
+
+fn eval_tx_predicate(p: &v1beta::watch::TxPredicate, tx: &Transaction) -> bool {
+    // `match` leaf.
+    let leaf_ok = match p.r#match.as_ref() {
+        Some(any) => match any.chain.as_ref() {
+            Some(v1beta::watch::any_chain_tx_pattern::Chain::Cardano(tx_pat)) => {
+                matches_cardano_tx_pattern(tx_pat, tx)
+            }
+            None => true,
+        },
+        None => true,
+    };
+    if !leaf_ok {
+        return false;
+    }
+    for sub in &p.all_of {
+        if !eval_tx_predicate(sub, tx) {
+            return false;
+        }
+    }
+    if !p.any_of.is_empty() && !p.any_of.iter().any(|s| eval_tx_predicate(s, tx)) {
+        return false;
+    }
+    for sub in &p.not {
+        if eval_tx_predicate(sub, tx) {
+            return false;
+        }
+    }
+    true
+}
+
+fn matches_cardano_tx_pattern(pat: &v1beta::cardano::TxPattern, tx: &Transaction) -> bool {
+    // Each populated sub-pattern is an AND clause: every populated
+    // field must hold against at least one matching element of the tx.
+    if let Some(produces) = pat.produces.as_ref() {
+        if !tx
+            .body
+            .outputs
+            .iter()
+            .any(|o| matches_tx_output_pattern(produces, o))
+        {
+            return false;
+        }
+    }
+    if let Some(has_addr) = pat.has_address.as_ref() {
+        let any_match = tx
+            .body
+            .outputs
+            .iter()
+            .any(|o| matches_address_pattern(has_addr, &o.address));
+        if !any_match {
+            return false;
+        }
+    }
+    if let Some(moves) = pat.moves_asset.as_ref() {
+        let any_match = tx
+            .body
+            .outputs
+            .iter()
+            .any(|o| matches_asset_pattern(moves, &o.value));
+        if !any_match {
+            return false;
+        }
+    }
+    if let Some(mints) = pat.mints_asset.as_ref() {
+        let any_match = tx_mint_contains_asset(tx, mints);
+        if !any_match {
+            return false;
+        }
+    }
+    // `consumes` requires resolved-input data we don't have on the
+    // mempool path. Tx-level WatchTx is "outputs + mint" today; the
+    // input-side match is documented in `docs/src/running/utxo-rpc.md`
+    // as the WatchTx limitation.
+    true
+}
+
+fn tx_mint_contains_asset(tx: &Transaction, pat: &v1beta::cardano::AssetPattern) -> bool {
+    let Some(policy) = pat.policy_id.as_ref() else {
+        return !tx.body.mint.is_empty();
+    };
+    if policy.len() < 28 {
+        return false;
+    }
+    use dugite_primitives::hash::Hash28;
+    let mut pid = [0u8; 28];
+    pid.copy_from_slice(&policy[..28]);
+    let policy_id = Hash28::from_bytes(pid);
+    let Some(entries) = tx.body.mint.get(&policy_id) else {
+        return false;
+    };
+    if let Some(name) = pat.asset_name.as_ref() {
+        entries
+            .iter()
+            .any(|(an, _)| an.0.as_slice() == name.as_slice())
+    } else {
+        !entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dugite_primitives::address::{Address, ByronAddress};
+    use dugite_primitives::hash::Hash;
+    use dugite_primitives::transaction::TransactionOutput;
+    use dugite_primitives::value::{Lovelace, Value};
+
+    fn dummy_output(addr: Address, value: Value) -> TransactionOutput {
+        TransactionOutput {
+            address: addr,
+            value,
+            datum: dugite_primitives::transaction::OutputDatum::None,
+            script_ref: None,
+            is_legacy: false,
+            raw_cbor: None,
+        }
+    }
+
+    fn byron_addr(payload: u8) -> Address {
+        Address::Byron(ByronAddress {
+            payload: vec![payload; 30],
+        })
+    }
+
+    #[test]
+    fn wildcard_predicate_matches() {
+        let out = dummy_output(byron_addr(0x00), Value::lovelace(0));
+        assert!(matches_utxo_predicate(None, &out));
+        assert!(matches_utxo_predicate(
+            Some(&v1beta::query::UtxoPredicate::default()),
+            &out
+        ));
+    }
+
+    #[test]
+    fn not_inverts_match() {
+        let out = dummy_output(byron_addr(0x00), Value::lovelace(0));
+        let exact = byron_addr(0x11).to_bytes();
+        let inner = v1beta::query::UtxoPredicate {
+            r#match: Some(v1beta::query::AnyUtxoPattern {
+                utxo_pattern: Some(v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(
+                    v1beta::cardano::TxOutputPattern {
+                        address: Some(v1beta::cardano::AddressPattern {
+                            exact_address: Some(exact),
+                            payment_part: None,
+                            delegation_part: None,
+                        }),
+                        asset: None,
+                    },
+                )),
+            }),
+            not: vec![],
+            all_of: vec![],
+            any_of: vec![],
+        };
+        let neg = v1beta::query::UtxoPredicate {
+            not: vec![inner],
+            ..Default::default()
+        };
+        assert!(matches_utxo_predicate(Some(&neg), &out));
+    }
+
+    #[test]
+    fn any_of_short_circuits() {
+        let out = dummy_output(byron_addr(0xAA), Value::lovelace(0));
+        let want = byron_addr(0xAA).to_bytes();
+        let nope = byron_addr(0x55).to_bytes();
+        let p = v1beta::query::UtxoPredicate {
+            any_of: vec![
+                v1beta::query::UtxoPredicate {
+                    r#match: Some(v1beta::query::AnyUtxoPattern {
+                        utxo_pattern: Some(v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(
+                            v1beta::cardano::TxOutputPattern {
+                                address: Some(v1beta::cardano::AddressPattern {
+                                    exact_address: Some(nope),
+                                    payment_part: None,
+                                    delegation_part: None,
+                                }),
+                                asset: None,
+                            },
+                        )),
+                    }),
+                    ..Default::default()
+                },
+                v1beta::query::UtxoPredicate {
+                    r#match: Some(v1beta::query::AnyUtxoPattern {
+                        utxo_pattern: Some(v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(
+                            v1beta::cardano::TxOutputPattern {
+                                address: Some(v1beta::cardano::AddressPattern {
+                                    exact_address: Some(want),
+                                    payment_part: None,
+                                    delegation_part: None,
+                                }),
+                                asset: None,
+                            },
+                        )),
+                    }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(matches_utxo_predicate(Some(&p), &out));
+    }
+
+    #[test]
+    fn asset_pattern_policy_only() {
+        let mut policy_assets = std::collections::BTreeMap::new();
+        let policy = Hash::<28>::from_bytes([0xAB; 28]);
+        let asset_name = dugite_primitives::value::AssetName::new(vec![0x01]).unwrap();
+        policy_assets.insert(asset_name, 7u64);
+        let mut ma = std::collections::BTreeMap::new();
+        ma.insert(policy, policy_assets);
+        let value = Value {
+            coin: Lovelace(0),
+            multi_asset: ma,
+        };
+        let out = dummy_output(byron_addr(0x00), value);
+        let pat = v1beta::cardano::AssetPattern {
+            policy_id: Some(vec![0xAB; 28]),
+            asset_name: None,
+        };
+        assert!(matches_asset_pattern(&pat, &out.value));
+    }
+}

--- a/crates/dugite-rpc/src/services/query.rs
+++ b/crates/dugite-rpc/src/services/query.rs
@@ -21,73 +21,73 @@ use tonic::{Request, Response, Status};
 use super::ServiceState;
 use crate::context::LedgerContext;
 use crate::map::block::block_ref_from_tip;
+use crate::map::patterns::matches_utxo_predicate;
 use crate::map::pparams::pparams_to_proto;
 use crate::map::tx::tx_output_to_proto;
 use crate::proto::{v1alpha, v1beta};
-
-const UNIMPL: &str = "M2.B — full mapping required";
 
 /// Hard cap on UTxOs returned per SearchUtxos request — protects the
 /// node from runaway scans when an unindexed pattern matches a large
 /// address set.
 const SEARCH_UTXOS_HARD_CAP: usize = 5_000;
 
-/// Resolved SearchUtxos predicate — exactly one of these shapes today.
+/// Index-friendly seed for a `SearchUtxos` predicate. We pre-filter
+/// using whichever leaf selector we can find inside the predicate
+/// (preferring the most selective: exact_address → payment_part →
+/// asset). The full predicate is then re-applied as a post-filter so
+/// composite / `not` / `delegation_part` patterns still produce
+/// byte-exact-spec results.
 #[derive(Debug)]
-enum SearchUtxoSelector {
-    /// `match.cardano.address.exact_address = <bytes>`
+enum IndexSeed {
+    /// Walk the entire in-memory UTxO set with the matcher.
+    FullScan,
     ExactAddress(Vec<u8>),
-    /// `match.cardano.address.payment_part = <bytes>` (28-byte hash)
     PaymentCredential(Vec<u8>),
-    /// `match.cardano.asset.{policy_id, asset_name?}`
     Asset {
         policy_id: Vec<u8>,
         asset_name: Option<Vec<u8>>,
     },
 }
 
-/// Resolve a v1beta SearchUtxos predicate into one of the supported
-/// selector shapes. Anything more complex (composite predicates,
-/// delegation_part, mixed address+asset patterns) yields `None`; the
-/// service surfaces UNIMPLEMENTED with a descriptive message rather
-/// than returning silently truncated results.
-fn resolve_predicate(p: Option<&v1beta::query::UtxoPredicate>) -> Option<SearchUtxoSelector> {
-    let p = p?;
-    if !p.not.is_empty() || !p.all_of.is_empty() || !p.any_of.is_empty() {
-        return None;
+/// Walk `predicate` to find the first selector we can drive an index
+/// off — `exact_address` first, then `payment_part`, then `asset`. We
+/// only descend into `match` and `all_of` (predicates that require
+/// every sub-pattern to hold). `any_of` / `not` skip seeding.
+fn pick_index_seed(p: Option<&v1beta::query::UtxoPredicate>) -> IndexSeed {
+    let Some(p) = p else {
+        return IndexSeed::FullScan;
+    };
+    if let Some(seed) = seed_from_pattern(p.r#match.as_ref()) {
+        return seed;
     }
-    let any = p.r#match.as_ref()?;
-    let utxo_pattern = any.utxo_pattern.as_ref()?;
-    let v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(out_pattern) = utxo_pattern;
-
-    // Combined address + asset patterns aren't supported.
-    let has_addr = out_pattern.address.is_some();
-    let has_asset = out_pattern.asset.is_some();
-    if has_addr && has_asset {
-        return None;
-    }
-
-    if let Some(addr) = out_pattern.address.as_ref() {
-        // exact_address takes priority; payment_part falls through if
-        // not set; delegation_part isn't supported.
-        if addr.delegation_part.is_some() {
-            return None;
+    for sub in &p.all_of {
+        let seed = pick_index_seed(Some(sub));
+        if !matches!(seed, IndexSeed::FullScan) {
+            return seed;
         }
+    }
+    IndexSeed::FullScan
+}
+
+fn seed_from_pattern(any: Option<&v1beta::query::AnyUtxoPattern>) -> Option<IndexSeed> {
+    let any = any?;
+    let v1beta::query::any_utxo_pattern::UtxoPattern::Cardano(out_pat) =
+        any.utxo_pattern.as_ref()?;
+    if let Some(addr) = out_pat.address.as_ref() {
         if let Some(b) = &addr.exact_address {
-            return Some(SearchUtxoSelector::ExactAddress(b.clone()));
+            return Some(IndexSeed::ExactAddress(b.clone()));
         }
         if let Some(p_part) = &addr.payment_part {
-            return Some(SearchUtxoSelector::PaymentCredential(p_part.clone()));
+            return Some(IndexSeed::PaymentCredential(p_part.clone()));
         }
-        return None;
     }
-    if let Some(asset) = out_pattern.asset.as_ref() {
-        let policy_id = asset.policy_id.clone()?;
-        let asset_name = asset.asset_name.clone();
-        return Some(SearchUtxoSelector::Asset {
-            policy_id,
-            asset_name,
-        });
+    if let Some(asset) = out_pat.asset.as_ref() {
+        if let Some(policy_id) = &asset.policy_id {
+            return Some(IndexSeed::Asset {
+                policy_id: policy_id.clone(),
+                asset_name: asset.asset_name.clone(),
+            });
+        }
     }
     None
 }
@@ -96,23 +96,48 @@ async fn search_utxos_response_beta(
     ctx: &std::sync::Arc<dyn LedgerContext>,
     request: v1beta::query::SearchUtxosRequest,
 ) -> Result<v1beta::query::SearchUtxosResponse, Status> {
-    let selector = resolve_predicate(request.predicate.as_ref()).ok_or_else(|| {
-        Status::unimplemented(
-            "SearchUtxos: supported predicates are `match.cardano.address.exact_address`, \
-             `match.cardano.address.payment_part`, and `match.cardano.asset.{policy_id, \
-             asset_name}`. Delegation patterns, composite predicates (not/all_of/any_of), \
-             and mixed address+asset patterns are deferred to a follow-up.",
-        )
-    })?;
-
     let cap = request
         .max_items
         .map(|n| (n as usize).min(SEARCH_UTXOS_HARD_CAP))
         .unwrap_or(SEARCH_UTXOS_HARD_CAP)
         .max(1);
 
-    let mut snaps = match selector {
-        SearchUtxoSelector::ExactAddress(bytes) => {
+    let predicate = request.predicate.clone();
+    let seed = pick_index_seed(predicate.as_ref());
+
+    // Reject an unbounded full-scan with no usable index. Callers that
+    // *want* the full scan should supply a wildcard `delegation_part` /
+    // `not` predicate — the matcher will still apply it as a post-
+    // filter, but at least there's a signal it's a deliberate choice.
+    let predicate_is_wildcard = predicate
+        .as_ref()
+        .map(|p| {
+            p.r#match.is_none() && p.not.is_empty() && p.all_of.is_empty() && p.any_of.is_empty()
+        })
+        .unwrap_or(true);
+    if matches!(seed, IndexSeed::FullScan) && predicate_is_wildcard {
+        return Err(Status::unimplemented(
+            "SearchUtxos with no predicate is rejected (would return the whole UTxO set). \
+             Supply at least one address / payment_part / delegation_part / asset / composite \
+             predicate.",
+        ));
+    }
+
+    let mut snaps: Vec<_> = match seed {
+        IndexSeed::FullScan => {
+            // Unindexed predicate (delegation_part / has_certificate / etc.)
+            // — walk the in-memory UTxO set with the matcher.
+            let predicate_owned = predicate.clone();
+            ctx.utxos_filter(
+                &move |snap: &crate::UtxoSnapshot| {
+                    matches_utxo_predicate(predicate_owned.as_ref(), &snap.output)
+                },
+                cap,
+            )
+            .await
+            .map_err(Status::from)?
+        }
+        IndexSeed::ExactAddress(bytes) => {
             let parsed_addr =
                 dugite_primitives::address::Address::from_bytes(&bytes).map_err(|e| {
                     Status::invalid_argument(format!("exact_address bytes invalid: {e}"))
@@ -121,7 +146,7 @@ async fn search_utxos_response_beta(
                 .await
                 .map_err(Status::from)?
         }
-        SearchUtxoSelector::PaymentCredential(bytes) => {
+        IndexSeed::PaymentCredential(bytes) => {
             if bytes.len() != 28 && bytes.len() != 32 {
                 return Err(Status::invalid_argument(format!(
                     "payment_part must be 28 or 32 bytes, got {}",
@@ -136,7 +161,7 @@ async fn search_utxos_response_beta(
                 .await
                 .map_err(Status::from)?
         }
-        SearchUtxoSelector::Asset {
+        IndexSeed::Asset {
             policy_id,
             asset_name,
         } => {
@@ -155,6 +180,10 @@ async fn search_utxos_response_beta(
         }
     };
 
+    // Post-filter: enforce the full predicate (composite / not /
+    // delegation_part / mixed addr+asset). The index seed is the
+    // best-effort starting set; correctness comes from the matcher.
+    snaps.retain(|snap| matches_utxo_predicate(predicate.as_ref(), &snap.output));
     if snaps.len() > cap {
         snaps.truncate(cap);
     }
@@ -285,6 +314,102 @@ async fn read_genesis_response_beta(
         config: Some(v1beta::query::read_genesis_response::Config::Cardano(
             cardano,
         )),
+    })
+}
+
+async fn read_data_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+    keys: Vec<Vec<u8>>,
+) -> Result<v1beta::query::ReadDataResponse, Status> {
+    let ledger_tip = ledger_tip_chain_point(ctx).await?;
+    let mut values: Vec<v1beta::query::AnyChainDatum> = Vec::with_capacity(keys.len());
+    for key in keys {
+        if key.len() != 32 {
+            return Err(Status::invalid_argument(format!(
+                "datum hash must be 32 bytes, got {}",
+                key.len()
+            )));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&key);
+        let hash = dugite_primitives::hash::Hash32::from_bytes(arr);
+        let Some(cbor) = ctx.datum_by_hash(&hash).await.map_err(Status::from)? else {
+            continue;
+        };
+        // Datum CBOR is surfaced raw via `native_bytes`. The
+        // `parsed_state.cardano` projection is left unset — clients
+        // that need it can re-decode locally with any
+        // `utxorpc.v1beta.cardano.PlutusData`-aware library.
+        values.push(v1beta::query::AnyChainDatum {
+            native_bytes: cbor,
+            key,
+            parsed_state: None,
+        });
+    }
+    Ok(v1beta::query::ReadDataResponse {
+        values,
+        ledger_tip: Some(ledger_tip),
+    })
+}
+
+async fn read_tx_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+    hash_bytes: Vec<u8>,
+) -> Result<v1beta::query::ReadTxResponse, Status> {
+    if hash_bytes.len() != 32 {
+        return Err(Status::invalid_argument(format!(
+            "tx hash must be 32 bytes, got {}",
+            hash_bytes.len()
+        )));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&hash_bytes);
+    let hash = dugite_primitives::hash::Hash32::from_bytes(arr);
+    let ledger_tip = ledger_tip_chain_point(ctx).await?;
+    let Some(raw) = ctx.tx_by_hash(&hash).await.map_err(Status::from)? else {
+        return Err(Status::not_found(format!(
+            "tx {} not found in mempool or recent volatile blocks",
+            hex::encode(hash_bytes)
+        )));
+    };
+    // Decode with the Conway era id — same default the rest of the
+    // service uses. Falls back to native_bytes-only on decode failure.
+    let cardano_tx = match dugite_serialization::decode_transaction(6, &raw.cbor) {
+        Ok(tx) => Some(crate::map::tx::tx_to_proto(&tx)),
+        Err(_) => None,
+    };
+    Ok(v1beta::query::ReadTxResponse {
+        tx: Some(v1beta::query::AnyChainTx {
+            native_bytes: raw.cbor,
+            chain: cardano_tx.map(v1beta::query::any_chain_tx::Chain::Cardano),
+            block_ref: None,
+        }),
+        ledger_tip: Some(ledger_tip),
+    })
+}
+
+async fn read_state_response_beta(
+    ctx: &std::sync::Arc<dyn LedgerContext>,
+) -> Result<v1beta::query::ReadStateResponse, Status> {
+    let state = ctx.ledger_state().await.map_err(Status::from)?;
+    let ledger_tip = v1beta::query::ChainPoint {
+        slot: state.tip.slot,
+        hash: state.tip.hash.to_vec(),
+        height: state.tip.block_number,
+        timestamp: 0,
+    };
+    // The cardano sub-message in `AnyChainStateData` is left empty —
+    // we surface the epoch / slot snapshot purely via the
+    // `ledger_tip` field. Richer per-query state projections (stake-
+    // pool distribution, DRep info, etc.) layer on top of this stub
+    // once the dedicated chain-specific queries are wired.
+    Ok(v1beta::query::ReadStateResponse {
+        result: Some(v1beta::query::AnyChainStateData {
+            result: Some(v1beta::query::any_chain_state_data::Result::Cardano(
+                v1beta::cardano::StateData::default(),
+            )),
+        }),
+        ledger_tip: Some(ledger_tip),
     })
 }
 
@@ -433,16 +558,26 @@ impl v1alpha::query::query_service_server::QueryService for QuerySvcAlpha {
 
     async fn read_data(
         &self,
-        _request: Request<v1alpha::query::ReadDataRequest>,
+        request: Request<v1alpha::query::ReadDataRequest>,
     ) -> Result<Response<v1alpha::query::ReadDataResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let beta = read_data_response_beta(&self.state.context, request.into_inner().keys).await?;
+        use prost::Message;
+        let bytes = beta.encode_to_vec();
+        let alpha = v1alpha::query::ReadDataResponse::decode(bytes.as_slice())
+            .expect("v1alpha ReadDataResponse subset-compatible with v1beta");
+        Ok(Response::new(alpha))
     }
 
     async fn read_tx(
         &self,
-        _request: Request<v1alpha::query::ReadTxRequest>,
+        request: Request<v1alpha::query::ReadTxRequest>,
     ) -> Result<Response<v1alpha::query::ReadTxResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        let beta = read_tx_response_beta(&self.state.context, request.into_inner().hash).await?;
+        use prost::Message;
+        let bytes = beta.encode_to_vec();
+        let alpha = v1alpha::query::ReadTxResponse::decode(bytes.as_slice())
+            .expect("v1alpha ReadTxResponse subset-compatible with v1beta");
+        Ok(Response::new(alpha))
     }
 
     async fn read_genesis(
@@ -534,16 +669,20 @@ impl v1beta::query::query_service_server::QueryService for QuerySvcBeta {
 
     async fn read_data(
         &self,
-        _request: Request<v1beta::query::ReadDataRequest>,
+        request: Request<v1beta::query::ReadDataRequest>,
     ) -> Result<Response<v1beta::query::ReadDataResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_data_response_beta(&self.state.context, request.into_inner().keys).await?,
+        ))
     }
 
     async fn read_tx(
         &self,
-        _request: Request<v1beta::query::ReadTxRequest>,
+        request: Request<v1beta::query::ReadTxRequest>,
     ) -> Result<Response<v1beta::query::ReadTxResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_tx_response_beta(&self.state.context, request.into_inner().hash).await?,
+        ))
     }
 
     async fn read_genesis(
@@ -569,6 +708,8 @@ impl v1beta::query::query_service_server::QueryService for QuerySvcBeta {
         &self,
         _request: Request<v1beta::query::ReadStateRequest>,
     ) -> Result<Response<v1beta::query::ReadStateResponse>, Status> {
-        Err(Status::unimplemented(UNIMPL))
+        Ok(Response::new(
+            read_state_response_beta(&self.state.context).await?,
+        ))
     }
 }

--- a/crates/dugite-rpc/src/services/submit.rs
+++ b/crates/dugite-rpc/src/services/submit.rs
@@ -27,23 +27,86 @@ const DEFAULT_ERA_ID: u16 = 6;
 
 /// Build the v1beta TxEval envelope from an [`EvalOutcome`].
 fn eval_outcome_to_proto_beta(outcome: EvalOutcome) -> v1beta::cardano::TxEval {
+    use crate::context::RedeemerPurpose;
+    fn map_purpose(p: RedeemerPurpose) -> i32 {
+        let proto = match p {
+            RedeemerPurpose::Unspecified => v1beta::cardano::RedeemerPurpose::Unspecified,
+            RedeemerPurpose::Spend => v1beta::cardano::RedeemerPurpose::Spend,
+            RedeemerPurpose::Mint => v1beta::cardano::RedeemerPurpose::Mint,
+            RedeemerPurpose::Cert => v1beta::cardano::RedeemerPurpose::Cert,
+            RedeemerPurpose::Reward => v1beta::cardano::RedeemerPurpose::Reward,
+            RedeemerPurpose::Vote => v1beta::cardano::RedeemerPurpose::Vote,
+            RedeemerPurpose::Propose => v1beta::cardano::RedeemerPurpose::Propose,
+        };
+        proto as i32
+    }
+
+    // Sum ex_units across every redeemer report.
+    let (total_steps, total_memory) = outcome.redeemers.iter().fold((0u64, 0u64), |(s, m), r| {
+        (
+            s.saturating_add(r.ex_units.0),
+            m.saturating_add(r.ex_units.1),
+        )
+    });
+
+    // Per-redeemer traces: one EvalReport per log line, so clients
+    // that paginate can correlate traces back to their redeemer via
+    // purpose + index.
+    let mut traces: Vec<v1beta::cardano::EvalReport> = Vec::new();
+    for r in &outcome.redeemers {
+        for line in &r.logs {
+            traces.push(v1beta::cardano::EvalReport {
+                msg: line.clone(),
+                purpose: map_purpose(r.purpose),
+                index: r.index,
+            });
+        }
+    }
+
+    // Per-redeemer errors: surface any redeemer-level `error` field
+    // alongside the tx-level error message (if any).
+    let mut errors: Vec<v1beta::cardano::EvalReport> = Vec::new();
+    if let Some(msg) = outcome.error.clone() {
+        errors.push(v1beta::cardano::EvalReport {
+            msg,
+            purpose: v1beta::cardano::RedeemerPurpose::Unspecified as i32,
+            index: 0,
+        });
+    }
+    for r in &outcome.redeemers {
+        if let Some(err) = &r.error {
+            errors.push(v1beta::cardano::EvalReport {
+                msg: err.clone(),
+                purpose: map_purpose(r.purpose),
+                index: r.index,
+            });
+        }
+    }
+
+    let redeemers: Vec<v1beta::cardano::Redeemer> = outcome
+        .redeemers
+        .iter()
+        .map(|r| v1beta::cardano::Redeemer {
+            purpose: map_purpose(r.purpose),
+            payload: None,
+            index: r.index,
+            ex_units: Some(v1beta::cardano::ExUnits {
+                steps: r.ex_units.0,
+                memory: r.ex_units.1,
+            }),
+            original_cbor: Vec::new(),
+        })
+        .collect();
+
     v1beta::cardano::TxEval {
         fee: Some(crate::map::common::coin_bigint(outcome.fee)),
         ex_units: Some(v1beta::cardano::ExUnits {
-            steps: 0,
-            memory: 0,
+            steps: total_steps,
+            memory: total_memory,
         }),
-        errors: outcome
-            .error
-            .into_iter()
-            .map(|msg| v1beta::cardano::EvalReport {
-                msg,
-                purpose: v1beta::cardano::RedeemerPurpose::Unspecified as i32,
-                index: 0,
-            })
-            .collect(),
-        traces: Vec::new(),
-        redeemers: Vec::new(),
+        errors,
+        traces,
+        redeemers,
     }
 }
 

--- a/crates/dugite-rpc/src/services/watch.rs
+++ b/crates/dugite-rpc/src/services/watch.rs
@@ -18,6 +18,7 @@ use tonic::{Request, Response, Status};
 use tracing::warn;
 
 use super::ServiceState;
+use crate::map::patterns::matches_tx_predicate;
 use crate::map::tx::tx_to_proto;
 use crate::proto::{v1alpha, v1beta};
 
@@ -43,11 +44,21 @@ impl v1alpha::watch::watch_service_server::WatchService for WatchSvcAlpha {
 
     async fn watch_tx(
         &self,
-        _request: Request<v1alpha::watch::WatchTxRequest>,
+        request: Request<v1alpha::watch::WatchTxRequest>,
     ) -> Result<Response<Self::WatchTxStream>, Status> {
         self.state.metrics.stream_started(SERVICE_LABEL, "watch_tx");
         let mut events = self.state.mempool_feed.subscribe();
         let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+        // Recode the v1alpha predicate to v1beta — they share the same
+        // shape at v0.19.2, so prost re-encoding round-trips exactly.
+        let predicate_beta: Option<v1beta::watch::TxPredicate> = {
+            use prost::Message;
+            request
+                .into_inner()
+                .predicate
+                .map(|p| p.encode_to_vec())
+                .and_then(|b| v1beta::watch::TxPredicate::decode(b.as_slice()).ok())
+        };
         tokio::spawn(async move {
             loop {
                 match events.recv().await {
@@ -66,6 +77,9 @@ impl v1alpha::watch::watch_service_server::WatchService for WatchSvcAlpha {
                                 continue;
                             }
                         };
+                        if !matches_tx_predicate(predicate_beta.as_ref(), &decoded) {
+                            continue;
+                        }
                         let beta_tx = tx_to_proto(&decoded);
                         use prost::Message;
                         let alpha_tx =
@@ -110,11 +124,12 @@ impl v1beta::watch::watch_service_server::WatchService for WatchSvcBeta {
 
     async fn watch_tx(
         &self,
-        _request: Request<v1beta::watch::WatchTxRequest>,
+        request: Request<v1beta::watch::WatchTxRequest>,
     ) -> Result<Response<Self::WatchTxStream>, Status> {
         self.state.metrics.stream_started(SERVICE_LABEL, "watch_tx");
         let mut events = self.state.mempool_feed.subscribe();
         let (tx, rx) = mpsc::channel(self.state.config.stream_buffer);
+        let predicate_beta = request.into_inner().predicate;
         tokio::spawn(async move {
             loop {
                 match events.recv().await {
@@ -133,6 +148,9 @@ impl v1beta::watch::watch_service_server::WatchService for WatchSvcBeta {
                                 continue;
                             }
                         };
+                        if !matches_tx_predicate(predicate_beta.as_ref(), &decoded) {
+                            continue;
+                        }
                         let beta_tx = tx_to_proto(&decoded);
                         let item = v1beta::watch::AnyChainTx {
                             chain: Some(v1beta::watch::any_chain_tx::Chain::Cardano(beta_tx)),

--- a/crates/dugite-rpc/tests/query_service.rs
+++ b/crates/dugite-rpc/tests/query_service.rs
@@ -115,7 +115,50 @@ impl LedgerContext for QueryMock {
         dugite_rpc::EvalOutcome {
             fee: 0,
             error: Some("".into()),
+            redeemers: Vec::new(),
         }
+    }
+    async fn utxos_filter(
+        &self,
+        keep: &(dyn for<'a> Fn(&'a UtxoSnapshot) -> bool + Send + Sync),
+        cap: usize,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        let mut out = Vec::new();
+        for ((tx_hash, idx), output) in &self.utxos {
+            if out.len() >= cap {
+                break;
+            }
+            let snap = UtxoSnapshot {
+                ref_: TransactionInput {
+                    transaction_id: *tx_hash,
+                    index: *idx,
+                },
+                output: output.clone(),
+                slot: None,
+            };
+            if keep(&snap) {
+                out.push(snap);
+            }
+        }
+        Ok(out)
+    }
+    async fn datum_by_hash(&self, _: &Hash32) -> Result<Option<Vec<u8>>, RpcError> {
+        Ok(None)
+    }
+    async fn tx_by_hash(&self, _: &TransactionHash) -> Result<Option<RawTx>, RpcError> {
+        Ok(None)
+    }
+    async fn ledger_state(&self) -> Result<dugite_rpc::LedgerStateView, RpcError> {
+        Ok(dugite_rpc::LedgerStateView {
+            tip: TipInfo {
+                slot: self.tip_slot,
+                hash: self.tip_hash,
+                block_number: self.tip_block_no,
+                era: Era::Conway,
+            },
+            epoch: 0,
+            slot_in_epoch: 0,
+        })
     }
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         Err(RpcError::Unimplemented(""))
@@ -422,7 +465,7 @@ async fn search_utxos_payment_part_pattern_succeeds_with_empty_result() {
 }
 
 #[tokio::test]
-async fn search_utxos_delegation_part_returns_unimplemented() {
+async fn search_utxos_delegation_part_returns_empty_via_filter() {
     use dugite_rpc::proto::v1beta::cardano::{AddressPattern, TxOutputPattern};
     use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
     use dugite_rpc::proto::v1beta::query::{
@@ -431,7 +474,10 @@ async fn search_utxos_delegation_part_returns_unimplemented() {
 
     let server = TestServer::start(make_mock()).await;
     let mut client = QueryServiceClient::new(server.channel().await);
-    let status = client
+    // QueryMock returns its in-memory UTxOs via `utxos_filter`; none
+    // carry the requested stake credential, so the response is empty
+    // (no longer UNIMPLEMENTED).
+    let resp = client
         .search_utxos(SearchUtxosRequest {
             predicate: Some(UtxoPredicate {
                 r#match: Some(AnyUtxoPattern {
@@ -453,8 +499,9 @@ async fn search_utxos_delegation_part_returns_unimplemented() {
             start_token: None,
         })
         .await
-        .unwrap_err();
-    assert_eq!(status.code(), tonic::Code::Unimplemented);
+        .unwrap()
+        .into_inner();
+    assert!(resp.items.is_empty());
     server.stop().await;
 }
 

--- a/crates/dugite-rpc/tests/server_smoke.rs
+++ b/crates/dugite-rpc/tests/server_smoke.rs
@@ -90,7 +90,24 @@ impl LedgerContext for MockLedgerContext {
         dugite_rpc::EvalOutcome {
             fee: 0,
             error: Some("mock::eval_tx not implemented".into()),
+            redeemers: Vec::new(),
         }
+    }
+    async fn utxos_filter(
+        &self,
+        _: &(dyn for<'a> Fn(&'a UtxoSnapshot) -> bool + Send + Sync),
+        _: usize,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Err(RpcError::Unimplemented("mock::utxos_filter"))
+    }
+    async fn datum_by_hash(&self, _: &Hash32) -> Result<Option<Vec<u8>>, RpcError> {
+        Ok(None)
+    }
+    async fn tx_by_hash(&self, _: &TransactionHash) -> Result<Option<RawTx>, RpcError> {
+        Ok(None)
+    }
+    async fn ledger_state(&self) -> Result<dugite_rpc::LedgerStateView, RpcError> {
+        Err(RpcError::Unimplemented("mock::ledger_state"))
     }
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         Err(RpcError::Unimplemented("mock::mempool_snapshot"))
@@ -225,16 +242,18 @@ async fn sync_v1alpha_read_tip_propagates_mock_unimplemented() {
 // ── Query v1beta ─────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn query_v1beta_methods_return_unimplemented() {
+async fn query_v1beta_methods_propagate_mock_errors() {
     use dugite_rpc::proto::v1beta::query::query_service_client::QueryServiceClient;
     use dugite_rpc::proto::v1beta::query::{
-        ReadDataRequest, ReadEraSummaryRequest, ReadGenesisRequest, ReadParamsRequest,
-        ReadStateRequest, ReadTxRequest, ReadUtxosRequest, SearchUtxosRequest,
+        ReadEraSummaryRequest, ReadGenesisRequest, ReadParamsRequest, ReadStateRequest,
+        ReadUtxosRequest, SearchUtxosRequest,
     };
 
     let server = TestServer::start(true).await;
     let mut client = QueryServiceClient::new(server.channel().await);
 
+    // Methods whose context call returns Unimplemented in the mock —
+    // the gRPC wire status propagates verbatim.
     for status in [
         client
             .read_params(ReadParamsRequest::default())
@@ -244,15 +263,6 @@ async fn query_v1beta_methods_return_unimplemented() {
             .read_utxos(ReadUtxosRequest::default())
             .await
             .unwrap_err(),
-        client
-            .search_utxos(SearchUtxosRequest::default())
-            .await
-            .unwrap_err(),
-        client
-            .read_data(ReadDataRequest::default())
-            .await
-            .unwrap_err(),
-        client.read_tx(ReadTxRequest::default()).await.unwrap_err(),
         client
             .read_genesis(ReadGenesisRequest::default())
             .await
@@ -268,6 +278,15 @@ async fn query_v1beta_methods_return_unimplemented() {
     ] {
         assert_eq!(status.code(), tonic::Code::Unimplemented);
     }
+
+    // SearchUtxos with a wildcard (no predicate / no leaf) is rejected
+    // by the service itself with UNIMPLEMENTED before ever touching the
+    // context — see `search_utxos_response_beta`.
+    let status = client
+        .search_utxos(SearchUtxosRequest::default())
+        .await
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
 
     server.stop().await;
 }

--- a/crates/dugite-rpc/tests/sync_service.rs
+++ b/crates/dugite-rpc/tests/sync_service.rs
@@ -179,7 +179,24 @@ impl LedgerContext for SyncMock {
         dugite_rpc::EvalOutcome {
             fee: 0,
             error: Some("".into()),
+            redeemers: Vec::new(),
         }
+    }
+    async fn utxos_filter(
+        &self,
+        _: &(dyn for<'a> Fn(&'a UtxoSnapshot) -> bool + Send + Sync),
+        _: usize,
+    ) -> Result<Vec<UtxoSnapshot>, RpcError> {
+        Ok(Vec::new())
+    }
+    async fn datum_by_hash(&self, _: &Hash32) -> Result<Option<Vec<u8>>, RpcError> {
+        Ok(None)
+    }
+    async fn tx_by_hash(&self, _: &TransactionHash) -> Result<Option<RawTx>, RpcError> {
+        Ok(None)
+    }
+    async fn ledger_state(&self) -> Result<dugite_rpc::LedgerStateView, RpcError> {
+        Err(RpcError::Unimplemented(""))
     }
     async fn mempool_snapshot(&self) -> Result<Vec<RawTx>, RpcError> {
         Err(RpcError::Unimplemented(""))

--- a/crates/dugite-uplc/src/phase_two.rs
+++ b/crates/dugite-uplc/src/phase_two.rs
@@ -91,6 +91,15 @@ pub struct RedeemerResult {
     /// The ExUnits consumed (cpu, mem). Matches the units the ledger
     /// charges as part of script-execution fees.
     pub consumed: ExBudget,
+    /// Redeemer tag identifying which purpose group this redeemer
+    /// belongs to (Spend / Mint / Cert / Reward / Vote / Propose).
+    pub tag: dugite_primitives::transaction::RedeemerTag,
+    /// 0-based index of the redeemer within its purpose group.
+    pub index: u32,
+    /// `trace` builtin output captured during evaluation. Surfaces
+    /// `Plutus.Trace` messages back to the caller (used by
+    /// `SubmitService.EvalTx.traces`).
+    pub logs: Vec<String>,
 }
 
 /// All failure modes the phase-2 evaluator can surface to the
@@ -241,6 +250,9 @@ pub fn eval_phase_two_raw<O: RedeemerObserver>(
         results.push(RedeemerResult {
             redeemer_cbor: redeemer_proxy_cbor,
             consumed: outcome.consumed,
+            tag: resolved_r.tag.clone(),
+            index: resolved_r.index,
+            logs: outcome.logs,
         });
     }
     Ok(results)

--- a/docs/src/running/utxo-rpc.md
+++ b/docs/src/running/utxo-rpc.md
@@ -51,14 +51,16 @@ in-tree at `crates/dugite-rpc/proto/VERSION`.
 | `QueryService` | `ReadUtxos` | ✅ implemented |
 | `QueryService` | `ReadGenesis` | ✅ implemented (minimum-viable envelope) |
 | `QueryService` | `ReadEraSummary` | ✅ implemented |
-| `QueryService` | `SearchUtxos` | ✅ implemented for `exact_address` / `payment_part` / `asset` predicates; other variants return `UNIMPLEMENTED` |
-| `QueryService` | `ReadData` / `ReadTx` / `ReadState` | ⏳ follow-up |
+| `QueryService` | `SearchUtxos` | ✅ implemented (`exact_address` / `payment_part` / `delegation_part` / `asset` plus `not` / `all_of` / `any_of` composites) |
+| `QueryService` | `ReadData` | ✅ implemented (bounded scan: live inline datums + mempool tx witness sets) |
+| `QueryService` | `ReadTx` | ✅ implemented (bounded scan: mempool + last ~43 200 slots of VolatileDB) |
+| `QueryService` | `ReadState` | ✅ implemented (minimum-viable envelope: epoch + tip slot) |
 | `SubmitService` | `SubmitTx` | ✅ implemented |
 | `SubmitService` | `ReadMempool` | ✅ implemented |
 | `SubmitService` | `WaitForTx` (stream) | ✅ implemented |
 | `SubmitService` | `WatchMempool` (stream) | ✅ implemented |
-| `SubmitService` | `EvalTx` | ✅ implemented (per-redeemer `ex_units` / Plutus traces returned as zeros — full plumbing follow-up) |
-| `WatchService` | `WatchTx` (stream) | ✅ implemented (match-all in v1; pattern filtering follow-up) |
+| `SubmitService` | `EvalTx` | ✅ implemented (per-redeemer `ex_units` + Plutus traces) |
+| `WatchService` | `WatchTx` (stream) | ✅ implemented (full `TxPredicate` filtering: address / asset / mint / `not` / `all_of` / `any_of`) |
 
 ## Configuration
 
@@ -176,16 +178,32 @@ updated, or vice versa) are caught by code review against the diff.
 
 ## Limitations
 
-* `EvalTx` runs the tx through the standard Phase-1 + Phase-2 validator,
-  but the per-redeemer `ex_units` / Plutus traces on the response are
-  currently zeros — full plumbing of the CEK machine's metering output
-  into the response message is a follow-up.
-* `SearchUtxos` supports the `exact_address`, `payment_part`, and
-  `asset` predicates; `delegation_part`, composite (`AND`/`OR`)
-  predicates and the address-pattern shorthand return
-  `UNIMPLEMENTED`.
-* `QueryService.ReadData` / `ReadTx` / `ReadState` return
-  `UNIMPLEMENTED`.
+* `SearchUtxos` with a fully-wildcard predicate (no `match` /
+  combinators) is rejected with `UNIMPLEMENTED`: dugite refuses to
+  materialise the entire UTxO set in a single response. Supply at
+  least one selector (address / payment_part / delegation_part /
+  asset / composite) so the result set is bounded.
+* `ReadTx` walks at most the last ~43 200 slots of `VolatileDB`. A
+  chain-wide tx index would extend the lookup window to immutable
+  history; not built today.
+* `ReadData` scans the live UTxO set's inline datums and the
+  mempool's witness-set datums. Witness-set datums from immutable
+  blocks are not retained — clients that need them should consult
+  the originating tx via `ReadTx`.
+* `ReadState`'s `AnyChainStateData.cardano` is currently empty: the
+  endpoint returns the ledger tip + epoch only. Per-query state
+  projections (stake-pool distribution, DRep info) land on top of
+  this stub.
+* `EvalTx`'s per-redeemer `ex_units` are CEK-machine consumed
+  values, not declared. Cost-model overrides are not yet read from
+  protocol params — the CEK falls back to per-step defaults, which
+  is *conservative* (over-approximates) and therefore safe for
+  fee-estimation use cases but may diverge slightly from cardano-node
+  on the high end.
+* `WatchTx` filters on tx output fields (`produces` / `has_address`
+  / `moves_asset`) and minting (`mints_asset`) — but not on
+  *resolved* inputs (`consumes` / `has_certificate`) since those
+  require live UTxO lookups against pending mempool txs.
 * `FollowTip` apply events carry `AnyChainBlock.native_bytes` (the
   raw block CBOR); clients that only need tip metadata can ignore
   the payload.


### PR DESCRIPTION
## Summary

Closes the four remaining UTxO RPC `UNIMPLEMENTED` items from the post-v1.7.0 deferred-task list:

- **QueryService.SearchUtxos** — full `UtxoPredicate` matcher: `exact_address` / `payment_part` / `delegation_part` / `asset` plus `not` / `all_of` / `any_of` composites. Index-friendly seed picks the most-selective leaf; the matcher post-filters for composite correctness.
- **QueryService.ReadData** — bounded scan: live inline datums (`scan_all` over the UTxO set) + mempool tx `plutus_data` witness sets.
- **QueryService.ReadTx** — bounded scan: mempool fast path + 43 200-slot VolatileDB walk back from tip.
- **QueryService.ReadState** — minimum-viable envelope: tip + current epoch + `slot_in_epoch`. Per-query state projections (stake-pool distribution etc.) layer on top.
- **SubmitService.EvalTx** — per-redeemer `ex_units` + Plutus traces, sourced from a new `dugite_ledger::evaluate_plutus_scripts_with_reports` that exposes the per-redeemer `RedeemerEvalOutcome` already collected by the CEK machine.
- **WatchService.WatchTx** — full `TxPredicate` filtering against tx outputs (produces / has_address / moves_asset) and mint (mints_asset) plus `not` / `all_of` / `any_of` composites.

Shared matcher lives in `crates/dugite-rpc/src/map/patterns.rs` so the `SearchUtxos` post-filter and the `WatchTx` streaming filter share semantics.

## Verification

- `just check` ✅ (workspace build + clippy -D warnings + fmt-check + 6 375 tests passing + doc-tests)
- Local wire-format check via `cargo run --example local_smoke_server` + `grpcurl`:
  - `grpc.reflection.v1.ServerReflection list` returns all 8 services (v1alpha + v1beta)
  - `ReadState` → tip + epoch envelope
  - `SearchUtxos` with composite `all_of` predicate → empty Ok
  - `SearchUtxos` with `delegation_part`-only → empty Ok (full-scan path)
  - `SearchUtxos` wildcard → `UNIMPLEMENTED` with descriptive reason
  - `ReadData` / `ReadTx` → graceful empty / `NotFound`
  - `EvalTx` → per-redeemer `ex_units` + `traces` populated; aggregate `TxEval.ex_units` sums correctly
  - v1alpha mirror methods produce byte-equal-shape responses

## Commits

```
4b7df9a79  feat(uplc): RedeemerResult exposes tag/index/logs
9da5999b3  feat(ledger): evaluate_plutus_scripts_with_reports
ff182c647  feat(rpc): finish QueryService + WatchTx + EvalTx ex_units
e141cf92e  feat(node): wire NodeRpcAdapter to deferred RPC methods
0f2180740  docs(rpc): update UTxO RPC limitations after deferred-task closeout
911aacc69  chore(rpc): local_smoke_server example for grpcurl exercises
```

## Test plan

- [x] `just check` green locally
- [x] grpcurl smoke against `cargo run --example local_smoke_server`
- [ ] CI green