### PR TITLE
fix(ci): suppress dead-code warning on peersharing_client_channel

### DIFF
--- a/crates/dugite-node/src/node/peer_connection.rs
+++ b/crates/dugite-node/src/node/peer_connection.rs
@@ -157,6 +157,7 @@ pub struct PeerConnection {
     /// sends a MsgShareRequest. The initiator sends requests periodically from
     /// the Governor. Currently subscribed but no task is spawned for it —
     /// PeerSharing integration is tracked separately.
+    #[allow(dead_code)]
     pub(crate) peersharing_client_channel: Option<MuxChannel>,
 
     // ── Server protocol channels ──


### PR DESCRIPTION
## Summary

The `coverage` CI job has been failing on `main` because it runs `cargo llvm-cov --all-features` with `RUSTFLAGS=-D warnings`. Enabling `test-utils` exposes a dead-code warning on `peersharing_client_channel` which is subscribed at connect/accept time but never read.

The `build-and-test` job did **not** catch this because it uses `cargo clippy --all-targets -- -D warnings` without `--all-features`, so `test-utils` stayed off there.

## Why the field is unused

`peersharing_client_channel` was added during the unified-mux refactor (#207). Before that, PeerSharing client requests opened separate fresh N2N connections per request (commit 407a116, closed by #198). The unified path subscribes the channel on every connection but no task ever consumes it — so PeerSharing client outreach is currently inert.

`#[allow(dead_code)]` keeps the wire-level mux entry so re-wiring is a small change. Follow-up tracking issue filed separately.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p dugite-node --all-targets --all-features` clean locally
- [x] `RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --all-features` clean locally
- [ ] CI coverage job green