### PR TITLE
feat(uplc): capture trace strings from Phase-2 redeemer eval

### DIFF
--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -267,14 +267,30 @@ pub fn evaluate_plutus_scripts(
             Ok(())
         }
         Err(e) => {
+            // Surface trace logs in the error message when the script emitted
+            // `trace` strings before failing — mirrors `cardano-cli`'s
+            // "Trace logs: [...]" output (Haskell `evalTxExUnitsWithLogs`,
+            // `Cardano.Ledger.Alonzo.Plutus.Evaluate`).
+            let error_msg = match &e {
+                dugite_uplc::phase_two::PhaseTwoError::ScriptEvaluationFailedWithLogs {
+                    error,
+                    logs,
+                } => {
+                    let joined = logs
+                        .iter()
+                        .map(|s| format!("[{s}]"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("eval_phase_two_raw error: {error}; Trace logs: {joined}")
+                }
+                _ => format!("eval_phase_two_raw error: {e}"),
+            };
             debug!(
                 tx_hash = %tx.hash.to_hex(),
-                error = %e,
+                error = %error_msg,
                 "Plutus evaluation error"
             );
-            Err(PlutusError::EvalFailed(format!(
-                "eval_phase_two_raw error: {e}"
-            )))
+            Err(PlutusError::EvalFailed(error_msg))
         }
     }
 }

--- a/crates/dugite-uplc/src/builtin/denotations.rs
+++ b/crates/dugite-uplc/src/builtin/denotations.rs
@@ -22,7 +22,17 @@ type ValueMap = BTreeMap<Vec<u8>, BTreeMap<Vec<u8>, i128>>;
 /// Saturated-application denotation. The CEK dispatcher calls this
 /// once both the force count and the value-argument count match the
 /// builtin's arity.
-pub fn denote(id: BuiltinId, args: Vec<Value>) -> Result<Value, UplcError> {
+///
+/// `trace_log` is an optional mutable reference to the caller's trace
+/// accumulator. When `Some`, the `Trace` builtin appends its first
+/// (string) argument here before returning the second. This mirrors
+/// the Haskell CEK `emit` mechanism (`traceDenotation text a = a <$
+/// emit text`, see `PlutusCore.Default.Builtins`).
+pub fn denote(
+    id: BuiltinId,
+    args: Vec<Value>,
+    trace_log: Option<&mut Vec<String>>,
+) -> Result<Value, UplcError> {
     use BuiltinId::*;
     match id {
         // ── Integer arithmetic (V1) ─────────────────────────────────
@@ -98,13 +108,29 @@ pub fn denote(id: BuiltinId, args: Vec<Value>) -> Result<Value, UplcError> {
             }
         }
 
-        // Trace: emit a log message (currently discarded — the CEK
-        // machine's `EvalResult.logs` will accumulate them once the
-        // tracer is wired) and return the second argument.
+        // Trace: emit a log message and return the second argument unchanged.
+        //
+        // Haskell reference: `traceDenotation text a = a <$ emit text`
+        // (`PlutusCore.Default.Builtins`, `PlutusCore.Builtin.Emitter`).
+        // The `Trace` builtin has Plutus type `all a. text -> a -> a`;
+        // the `emit` call appends to the CEK machine's internal log list.
+        // Logs are UTF-8 `Text` values, collected in emission order (FIFO).
+        //
+        // The caller threads `trace_log` in so the CEK dispatch layer can
+        // accumulate strings without needing a global side-channel.
         Trace => {
             let mut it = args.into_iter();
-            let _msg = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            let msg = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
             let rest = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
+            // Extract the string from the first arg; any non-String value is
+            // silently ignored (matches Haskell's `Text` expectation — the
+            // type system ensures it's always a String at the Plutus level,
+            // but we stay defensive here).
+            if let Some(log) = trace_log {
+                if let Value::Const(Constant::String(s)) = &msg {
+                    log.push(s.clone());
+                }
+            }
             Ok(rest)
         }
 
@@ -1729,7 +1755,15 @@ mod tests {
     }
 
     fn run(id: BuiltinId, args: Vec<Value>) -> Result<Value, UplcError> {
-        denote(id, args)
+        denote(id, args, None)
+    }
+
+    fn run_with_log(
+        id: BuiltinId,
+        args: Vec<Value>,
+        log: &mut Vec<String>,
+    ) -> Result<Value, UplcError> {
+        denote(id, args, Some(log))
     }
 
     // ── Integer arithmetic ─────────────────────────────────────────
@@ -1930,6 +1964,7 @@ mod tests {
 
     #[test]
     fn trace_returns_second_arg() {
+        // Trace still returns its second arg regardless of whether a log is provided.
         assert_eq!(
             run(
                 BuiltinId::Trace,
@@ -1938,6 +1973,74 @@ mod tests {
             .unwrap(),
             int(99)
         );
+    }
+
+    #[test]
+    fn trace_appends_string_to_log() {
+        let mut log: Vec<String> = Vec::new();
+        let result = run_with_log(
+            BuiltinId::Trace,
+            vec![
+                Value::Const(Constant::String("hello world".into())),
+                int(42),
+            ],
+            &mut log,
+        )
+        .unwrap();
+        assert_eq!(result, int(42), "trace must return its second argument");
+        assert_eq!(
+            log,
+            vec!["hello world"],
+            "trace must append the string to the log"
+        );
+    }
+
+    #[test]
+    fn trace_multiple_calls_ordered_fifo() {
+        // Simulate two sequential trace calls — logs must be in emission order.
+        let mut log: Vec<String> = Vec::new();
+        run_with_log(
+            BuiltinId::Trace,
+            vec![Value::Const(Constant::String("first".into())), int(1)],
+            &mut log,
+        )
+        .unwrap();
+        run_with_log(
+            BuiltinId::Trace,
+            vec![Value::Const(Constant::String("second".into())), int(2)],
+            &mut log,
+        )
+        .unwrap();
+        run_with_log(
+            BuiltinId::Trace,
+            vec![Value::Const(Constant::String("third".into())), int(3)],
+            &mut log,
+        )
+        .unwrap();
+        assert_eq!(log, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn trace_without_log_does_not_capture() {
+        // When trace_log is None the builtin must still succeed and return arg2,
+        // but nothing is captured — no panic, no error.
+        let result = run(
+            BuiltinId::Trace,
+            vec![Value::Const(Constant::String("discarded".into())), int(7)],
+        )
+        .unwrap();
+        assert_eq!(result, int(7));
+    }
+
+    #[test]
+    fn trace_non_string_first_arg_does_not_panic() {
+        // If the first arg is not a String (shouldn't happen in well-typed
+        // Plutus, but we must not panic defensively), the log remains empty
+        // and the second arg is still returned.
+        let mut log: Vec<String> = Vec::new();
+        let result = run_with_log(BuiltinId::Trace, vec![int(999), int(42)], &mut log).unwrap();
+        assert_eq!(result, int(42));
+        assert!(log.is_empty(), "non-String arg must not write to log");
     }
 
     #[test]

--- a/crates/dugite-uplc/src/builtin/dispatch.rs
+++ b/crates/dugite-uplc/src/builtin/dispatch.rs
@@ -38,11 +38,15 @@ pub enum ForceOutcome {
 /// the budget the moment the denotation fires (mirrors the Haskell
 /// reference's `chargeAndRun` semantics — cost is charged BEFORE the
 /// denotation's computation, never after).
+///
+/// `trace_log` is threaded through to the denotation for the `Trace`
+/// builtin to append its string argument.
 pub fn force_builtin(
     id: BuiltinId,
     forces: u8,
     args: Vec<Value>,
     tracker: Option<&mut BudgetTracker>,
+    trace_log: Option<&mut Vec<String>>,
 ) -> Result<ForceOutcome, UplcError> {
     let (required_forces, required_arity) = arity_of(id);
     if forces < required_forces {
@@ -59,7 +63,7 @@ pub fn force_builtin(
                 let cost = BuiltinCosts::DEFAULT.charge_for_args(id, &[]);
                 t.charge(cost)?;
             }
-            let result = denote(id, vec![])?;
+            let result = denote(id, vec![], trace_log)?;
             return Ok(ForceOutcome::Done(result));
         }
         Ok(ForceOutcome::Pending(v))
@@ -74,12 +78,16 @@ pub fn force_builtin(
 ///
 /// When `tracker` is `Some`, the per-builtin cost is charged at
 /// saturation (see [`force_builtin`] for the same semantics).
+///
+/// `trace_log` is threaded through to the denotation for the `Trace`
+/// builtin to append its string argument.
 pub fn apply_builtin(
     id: BuiltinId,
     forces: u8,
     mut args: Vec<Value>,
     arg: Value,
     tracker: Option<&mut BudgetTracker>,
+    trace_log: Option<&mut Vec<String>>,
 ) -> Result<Value, UplcError> {
     let (required_forces, required_arity) = arity_of(id);
     if forces < required_forces {
@@ -119,7 +127,7 @@ pub fn apply_builtin(
         let cost = BuiltinCosts::DEFAULT.charge_for_args(id, &args);
         t.charge(cost)?;
     }
-    denote(id, args)
+    denote(id, args, trace_log)
 }
 
 /// Return a `'static str` identifier for the builtin (alias for the
@@ -142,7 +150,7 @@ mod tests {
     #[test]
     fn force_zero_force_builtin_returns_excess_on_first_force() {
         // AddInteger needs 0 forces. The first force is already excess.
-        match force_builtin(BuiltinId::AddInteger, 0, vec![], None).unwrap() {
+        match force_builtin(BuiltinId::AddInteger, 0, vec![], None, None).unwrap() {
             ForceOutcome::Excess => {}
             other => panic!("expected Excess, got {other:?}"),
         }
@@ -151,7 +159,7 @@ mod tests {
     #[test]
     fn force_one_force_builtin_becomes_pending_then_excess() {
         // IfThenElse needs 1 force.
-        let v1 = match force_builtin(BuiltinId::IfThenElse, 0, vec![], None).unwrap() {
+        let v1 = match force_builtin(BuiltinId::IfThenElse, 0, vec![], None, None).unwrap() {
             ForceOutcome::Pending(v) => v,
             other => panic!("expected Pending, got {other:?}"),
         };
@@ -163,7 +171,7 @@ mod tests {
             _ => panic!("expected Value::Builtin"),
         }
         // Forcing again is excess.
-        match force_builtin(BuiltinId::IfThenElse, 1, vec![], None).unwrap() {
+        match force_builtin(BuiltinId::IfThenElse, 1, vec![], None, None).unwrap() {
             ForceOutcome::Excess => {}
             other => panic!("expected Excess, got {other:?}"),
         }
@@ -173,14 +181,15 @@ mod tests {
     fn applying_before_forces_satisfied_errors() {
         // IfThenElse needs 1 force; applying an arg first is a
         // builtin-type error.
-        let err = apply_builtin(BuiltinId::IfThenElse, 0, vec![], int_val(1), None).unwrap_err();
+        let err =
+            apply_builtin(BuiltinId::IfThenElse, 0, vec![], int_val(1), None, None).unwrap_err();
         assert!(matches!(err, UplcError::BuiltinTypeError { .. }));
     }
 
     #[test]
     fn apply_under_arity_returns_partial() {
         // AddInteger arity (0, 2) — applying just one arg is still partial.
-        let v = apply_builtin(BuiltinId::AddInteger, 0, vec![], int_val(1), None).unwrap();
+        let v = apply_builtin(BuiltinId::AddInteger, 0, vec![], int_val(1), None, None).unwrap();
         match v {
             Value::Builtin { id, args, .. } => {
                 assert_eq!(id, BuiltinId::AddInteger);

--- a/crates/dugite-uplc/src/eval_redeemer.rs
+++ b/crates/dugite-uplc/src/eval_redeemer.rs
@@ -139,10 +139,34 @@ pub fn eval_resolved_redeemer(
         }
     };
 
-    // 4. Run the CEK machine with budget tracking.
+    // 4. Run the CEK machine with budget tracking and trace capture.
+    //
+    // `trace_log` collects strings emitted by the `Trace` builtin during
+    // script execution, in emission order. The Haskell reference surfaces
+    // these in `ValidationFailure logs` and in `cardano-cli`'s
+    // "Trace logs: ..." error output.  We populate `RedeemerEvalOutcome.logs`
+    // so callers (dugite-ledger Phase-2 error path and the CLI EvalTx
+    // response) can mirror that behaviour.
+    let mut trace_log: Vec<String> = Vec::new();
     let mut tracker = BudgetTracker::new(initial_budget);
-    let value = evaluate_with_budget(applied_term, &mut tracker)
-        .map_err(PhaseTwoError::ScriptEvaluationFailed)?;
+    let value = evaluate_with_budget(applied_term, &mut tracker, Some(&mut trace_log)).map_err(
+        |error| {
+            // If any trace strings were emitted before the error, surface
+            // them in the richer `ScriptEvaluationFailedWithLogs` variant
+            // so callers can render "Trace logs: [...]" before the error
+            // (matching Haskell `cardano-cli transaction submit` output).
+            // When no traces were emitted, use the simpler variant to keep
+            // the error message clean.
+            if trace_log.is_empty() {
+                PhaseTwoError::ScriptEvaluationFailed(error)
+            } else {
+                PhaseTwoError::ScriptEvaluationFailedWithLogs {
+                    error,
+                    logs: trace_log.clone(),
+                }
+            }
+        },
+    )?;
 
     // 5. Classify the CEK result.
     //
@@ -182,7 +206,7 @@ pub fn eval_resolved_redeemer(
     Ok(RedeemerEvalOutcome {
         consumed: tracker.consumed(),
         result_term,
-        logs: Vec::new(), // trace-string capture is a follow-up
+        logs: trace_log,
     })
 }
 
@@ -460,5 +484,309 @@ mod tests {
         .expect("V3 unit script runs");
         assert!(matches!(outcome.result_term, Term::Const(Constant::Unit)));
         assert!(outcome.consumed.cpu > 0);
+        // No trace calls in this script — logs must be empty.
+        assert!(outcome.logs.is_empty(), "no trace calls → empty logs");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Trace capture tests
+    //
+    // The Plutus `trace` builtin has Plutus type `all a. text -> a -> a`
+    // and requires 1 force before use (`arity = (1, 2)`). So the UPLC
+    // term shape is:
+    //
+    //   (force builtin(trace)) "msg" continuation
+    //
+    // We build minimal V3-compatible programs that call `trace` once (or
+    // multiple times) before returning `()` or before erroring, to verify:
+    //   1. Successful eval surfaces logged strings in `outcome.logs`.
+    //   2. Failed eval (error term) surfaces logs in the error variant.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Build a V3 script that emits `msg` via `trace` then returns `()`.
+    /// Term shape:
+    ///   lam ctx.
+    ///     (force trace) "msg" ()
+    fn trace_then_unit_v3_script(msg: &str) -> Vec<u8> {
+        use crate::term::BuiltinId;
+        // (force builtin(trace)) "msg" (con unit ())
+        let trace_call = Term::App(
+            Box::new(Term::App(
+                Box::new(Term::Force(Box::new(Term::Builtin(BuiltinId::Trace)))),
+                Box::new(Term::Const(Constant::String(msg.to_string()))),
+            )),
+            Box::new(Term::Const(Constant::Unit)),
+        );
+        // Wrap in lam so the V3 single-arg calling convention is satisfied.
+        let program = Program {
+            version: (1, 0, 0),
+            term: Term::Lam(Box::new(trace_call)),
+        };
+        program.to_cbor().unwrap()
+    }
+
+    /// Build a V3 script that emits multiple trace messages in FIFO order
+    /// then returns `()`.
+    ///
+    /// The CEK machine evaluates arguments in applicative order (innermost
+    /// first). To get FIFO emission order `[first, second, third]`, we chain
+    /// the traces via sequential lambda application so each message is
+    /// evaluated as a function argument left-to-right:
+    ///
+    ///   lam ctx.
+    ///     (lam _.
+    ///       (lam _.
+    ///         ()
+    ///       ) ((force trace) "second" ())
+    ///     ) ((force trace) "first" ())
+    ///
+    /// Wait — that still evaluates "first" (the outer arg) before "second"
+    /// (the inner body's arg), which means:
+    ///   evaluation: outer arg "first" → outer body → inner arg "second" → ...
+    ///
+    /// Actually the right structure for `[first, second, third]` in FIFO is:
+    ///   (lam _ (lam _ (lam _ ()) trace("third")) trace("second")) trace("first")
+    ///
+    /// Because: evaluate outer arg trace("first") first, then enter body,
+    /// evaluate inner arg trace("second"), then evaluate innermost arg trace("third").
+    fn trace_triple_v3_script() -> Vec<u8> {
+        use crate::term::BuiltinId;
+        fn trace_call(msg: &str) -> Term {
+            Term::App(
+                Box::new(Term::App(
+                    Box::new(Term::Force(Box::new(Term::Builtin(BuiltinId::Trace)))),
+                    Box::new(Term::Const(Constant::String(msg.to_string()))),
+                )),
+                Box::new(Term::Const(Constant::Unit)),
+            )
+        }
+        // (lam _ (lam _ (lam _ ()) trace("third")) trace("second")) trace("first")
+        //   → evaluates trace("first") → enters body → evaluates trace("second")
+        //   → enters body → evaluates trace("third") → returns ()
+        let body = Term::App(
+            Box::new(Term::App(
+                Box::new(Term::App(
+                    Box::new(Term::Lam(Box::new(Term::Lam(Box::new(Term::Lam(
+                        Box::new(Term::Const(Constant::Unit)),
+                    )))))),
+                    Box::new(trace_call("first")),
+                )),
+                Box::new(trace_call("second")),
+            )),
+            Box::new(trace_call("third")),
+        );
+        let program = Program {
+            version: (1, 0, 0),
+            term: Term::Lam(Box::new(body)),
+        };
+        program.to_cbor().unwrap()
+    }
+
+    /// Build a V3 script that emits a trace message then errors.
+    ///
+    /// The trace must FIRE before the error. In applicative order the second
+    /// arg to trace is evaluated first (to get its value), so passing
+    /// `Term::Error` directly as the second arg causes the error before trace
+    /// fires. Instead we have trace return `()` and then error in the
+    /// continuation:
+    ///
+    ///   lam ctx.
+    ///     (lam _. error)             -- continuation: ignores the Unit, errors
+    ///       ((force trace) "msg" ()) -- evaluates trace first, returns ()
+    fn trace_then_error_v3_script(msg: &str) -> Vec<u8> {
+        use crate::term::BuiltinId;
+        // (force trace) "msg" () → fires trace, returns ()
+        let trace_call = Term::App(
+            Box::new(Term::App(
+                Box::new(Term::Force(Box::new(Term::Builtin(BuiltinId::Trace)))),
+                Box::new(Term::Const(Constant::String(msg.to_string()))),
+            )),
+            Box::new(Term::Const(Constant::Unit)),
+        );
+        // (lam _. error) trace_call → evaluates trace_call (fires trace),
+        //   binds result to _, then reduces body to error → ScriptError
+        let body = Term::App(
+            Box::new(Term::Lam(Box::new(Term::Error))),
+            Box::new(trace_call),
+        );
+        let program = Program {
+            version: (1, 0, 0),
+            term: Term::Lam(Box::new(body)),
+        };
+        program.to_cbor().unwrap()
+    }
+
+    /// Build a minimal V3 `ResolvedRedeemer` using the supplied script bytes.
+    /// Returns `(tx, resolved, resolved_redeemer)` ready for `eval_resolved_redeemer`.
+    #[allow(clippy::type_complexity)]
+    fn minimal_v3_setup(
+        script_cbor: Vec<u8>,
+    ) -> (
+        dugite_primitives::transaction::Transaction,
+        Vec<(
+            dugite_primitives::transaction::TransactionInput,
+            dugite_primitives::transaction::TransactionOutput,
+            Vec<u8>,
+        )>,
+        crate::redeemer_resolve::ResolvedRedeemer,
+    ) {
+        use dugite_primitives::address::{Address, EnterpriseAddress};
+        use dugite_primitives::credentials::Credential as PrimCred;
+        use dugite_primitives::era::Era;
+        use dugite_primitives::hash::Hash;
+        use dugite_primitives::network::NetworkId;
+        use dugite_primitives::transaction::{
+            ExUnits, OutputDatum as PrimOutputDatum, PlutusData as PrimPlutusData, Redeemer,
+            RedeemerTag, Transaction, TransactionBody, TransactionInput, TransactionOutput,
+            TransactionWitnessSet,
+        };
+        use dugite_primitives::value::{Lovelace, Value};
+        use std::collections::BTreeMap;
+
+        let inner = {
+            let mut d = minicbor::Decoder::new(&script_cbor);
+            d.bytes().unwrap().to_vec()
+        };
+        let mut buf = vec![3u8];
+        buf.extend_from_slice(&inner);
+        let script_hash = dugite_primitives::hash::blake2b_224(&buf).0;
+        let input = TransactionInput {
+            transaction_id: Hash::<32>([0xcc; 32]),
+            index: 0,
+        };
+        let spent_out = TransactionOutput {
+            address: Address::Enterprise(EnterpriseAddress {
+                network: NetworkId::Testnet,
+                payment: PrimCred::Script(Hash::<28>(script_hash)),
+            }),
+            value: Value::lovelace(1),
+            datum: PrimOutputDatum::None,
+            script_ref: None,
+            is_legacy: false,
+            raw_cbor: None,
+        };
+        let body = TransactionBody {
+            inputs: vec![input.clone()],
+            outputs: vec![],
+            fee: Lovelace(0),
+            ttl: None,
+            certificates: vec![],
+            withdrawals: BTreeMap::new(),
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            mint: BTreeMap::new(),
+            script_data_hash: None,
+            collateral: vec![],
+            required_signers: vec![],
+            network_id: None,
+            collateral_return: None,
+            total_collateral: None,
+            reference_inputs: vec![],
+            update: None,
+            voting_procedures: BTreeMap::new(),
+            proposal_procedures: vec![],
+            treasury_value: None,
+            donation: None,
+            sub_transactions: vec![],
+            account_balance_intervals: vec![],
+            direct_deposits: BTreeMap::new(),
+            guards: Vec::new(),
+        };
+        let ws = TransactionWitnessSet {
+            vkey_witnesses: vec![],
+            native_scripts: vec![],
+            bootstrap_witnesses: vec![],
+            plutus_v1_scripts: vec![],
+            plutus_v2_scripts: vec![],
+            plutus_v3_scripts: vec![inner.clone()],
+            plutus_data: vec![],
+            redeemers: vec![Redeemer {
+                tag: RedeemerTag::Spend,
+                index: 0,
+                data: PrimPlutusData::Integer(BigInt::from(0)),
+                ex_units: ExUnits {
+                    mem: 1_000_000,
+                    steps: 100_000_000,
+                },
+            }],
+            raw_redeemers_cbor: None,
+            raw_plutus_data_cbor: None,
+            original_script_data_hash: None,
+        };
+        let tx = Transaction {
+            hash: Hash::<32>([0; 32]),
+            era: Era::Conway,
+            body,
+            witness_set: ws,
+            is_valid: true,
+            auxiliary_data: None,
+            raw_cbor: None,
+            raw_body_cbor: None,
+            raw_witness_cbor: None,
+        };
+        let resolved = vec![(input, spent_out, vec![])];
+        let resolved_redeemer = crate::redeemer_resolve::resolve_redeemers(&tx, &resolved)
+            .expect("redeemer resolves")
+            .into_iter()
+            .next()
+            .unwrap();
+        (tx, resolved, resolved_redeemer)
+    }
+
+    #[test]
+    fn trace_single_message_captured_in_logs() {
+        let script_cbor = trace_then_unit_v3_script("hello from plutus");
+        let (tx, resolved, r) = minimal_v3_setup(script_cbor);
+        let budget = ExBudget {
+            cpu: 100_000_000,
+            mem: 1_000_000,
+        };
+        let outcome = eval_resolved_redeemer(&tx, &resolved, &r, &slot_cfg(), budget, None)
+            .expect("trace+unit script should succeed");
+        assert_eq!(
+            outcome.logs,
+            vec!["hello from plutus"],
+            "single trace call must appear in logs"
+        );
+    }
+
+    #[test]
+    fn trace_multiple_messages_captured_in_fifo_order() {
+        let script_cbor = trace_triple_v3_script();
+        let (tx, resolved, r) = minimal_v3_setup(script_cbor);
+        let budget = ExBudget {
+            cpu: 100_000_000,
+            mem: 1_000_000,
+        };
+        let outcome = eval_resolved_redeemer(&tx, &resolved, &r, &slot_cfg(), budget, None)
+            .expect("triple-trace script should succeed");
+        assert_eq!(
+            outcome.logs,
+            vec!["first", "second", "third"],
+            "trace calls must appear in emission (FIFO) order"
+        );
+    }
+
+    #[test]
+    fn trace_before_error_surfaces_in_error_path() {
+        let script_cbor = trace_then_error_v3_script("pre-error trace");
+        let (tx, resolved, r) = minimal_v3_setup(script_cbor);
+        let budget = ExBudget {
+            cpu: 100_000_000,
+            mem: 1_000_000,
+        };
+        let err = eval_resolved_redeemer(&tx, &resolved, &r, &slot_cfg(), budget, None)
+            .expect_err("trace+error script must fail");
+        // The error variant must carry the trace log.
+        match err {
+            PhaseTwoError::ScriptEvaluationFailedWithLogs { logs, .. } => {
+                assert_eq!(
+                    logs,
+                    vec!["pre-error trace"],
+                    "trace emitted before error must appear in error logs"
+                );
+            }
+            other => panic!("expected ScriptEvaluationFailedWithLogs, got: {other:?}"),
+        }
     }
 }

--- a/crates/dugite-uplc/src/machine/step.rs
+++ b/crates/dugite-uplc/src/machine/step.rs
@@ -20,7 +20,7 @@ pub fn evaluate(term: Term) -> Result<Value, UplcError> {
         kont: Kont::new(),
     };
     loop {
-        state = step(state, None)?;
+        state = step(state, None, None)?;
         if let State::Done(v) = state {
             return Ok(v);
         }
@@ -34,9 +34,16 @@ pub fn evaluate(term: Term) -> Result<Value, UplcError> {
 /// otherwise free.  Startup cost is charged once by
 /// `BudgetTracker::new`.  On success, `tracker.consumed()` reports the
 /// budget actually used.
+///
+/// `trace_log`, when `Some`, receives every string emitted by the
+/// `Trace` builtin during evaluation, in emission order (FIFO). This
+/// mirrors the Haskell CEK `emit` mechanism. Pass `None` to discard
+/// trace output (e.g. when running the conformance suite without log
+/// capture).
 pub fn evaluate_with_budget(
     term: Term,
     tracker: &mut crate::machine::cost::BudgetTracker,
+    mut trace_log: Option<&mut Vec<String>>,
 ) -> Result<Value, UplcError> {
     let mut state = State::Compute {
         term,
@@ -47,7 +54,7 @@ pub fn evaluate_with_budget(
         if let State::Compute { ref term, .. } = state {
             tracker.compute_step(term)?;
         }
-        state = step(state, Some(&mut *tracker))?;
+        state = step(state, Some(&mut *tracker), trace_log.as_deref_mut())?;
         if let State::Done(v) = state {
             tracker.flush()?;
             return Ok(v);
@@ -58,10 +65,11 @@ pub fn evaluate_with_budget(
 fn step(
     state: State,
     tracker: Option<&mut crate::machine::cost::BudgetTracker>,
+    trace_log: Option<&mut Vec<String>>,
 ) -> Result<State, UplcError> {
     match state {
         State::Compute { term, env, kont } => compute(term, env, kont),
-        State::Return { value, kont } => return_compute(value, kont, tracker),
+        State::Return { value, kont } => return_compute(value, kont, tracker, trace_log),
         State::Done(_) => Err(UplcError::Internal("step called on Done state".into())),
     }
 }
@@ -184,6 +192,7 @@ fn return_compute(
     value: Value,
     mut kont: Kont,
     tracker: Option<&mut crate::machine::cost::BudgetTracker>,
+    trace_log: Option<&mut Vec<String>>,
 ) -> Result<State, UplcError> {
     let frame = match kont.pop() {
         None => return Ok(State::Done(value)),
@@ -201,9 +210,9 @@ fn return_compute(
                 kont,
             })
         }
-        Frame::AwaitArg { function, .. } => apply(function, value, kont, tracker),
-        Frame::Force => force_value(value, kont, tracker),
-        Frame::ApplyValue { argument } => apply(value, argument, kont, tracker),
+        Frame::AwaitArg { function, .. } => apply(function, value, kont, tracker, trace_log),
+        Frame::Force => force_value(value, kont, tracker, trace_log),
+        Frame::ApplyValue { argument } => apply(value, argument, kont, tracker, trace_log),
         Frame::Constr {
             tag,
             mut pending,
@@ -364,6 +373,7 @@ fn apply(
     argument: Value,
     kont: Kont,
     tracker: Option<&mut crate::machine::cost::BudgetTracker>,
+    trace_log: Option<&mut Vec<String>>,
 ) -> Result<State, UplcError> {
     match function {
         Value::Lambda { body, env } => Ok(State::Compute {
@@ -372,7 +382,9 @@ fn apply(
             kont,
         }),
         Value::Builtin { id, forces, args } => {
-            let v = crate::builtin::dispatch::apply_builtin(id, forces, args, argument, tracker)?;
+            let v = crate::builtin::dispatch::apply_builtin(
+                id, forces, args, argument, tracker, trace_log,
+            )?;
             Ok(State::Return { value: v, kont })
         }
         Value::Const(_) | Value::Delay { .. } | Value::Constr { .. } => {
@@ -388,6 +400,7 @@ fn force_value(
     value: Value,
     kont: Kont,
     tracker: Option<&mut crate::machine::cost::BudgetTracker>,
+    trace_log: Option<&mut Vec<String>>,
 ) -> Result<State, UplcError> {
     match value {
         Value::Delay { body, env } => Ok(State::Compute {
@@ -397,7 +410,7 @@ fn force_value(
         }),
         Value::Builtin { id, forces, args } => {
             use crate::builtin::dispatch::{force_builtin, ForceOutcome};
-            match force_builtin(id, forces, args, tracker)? {
+            match force_builtin(id, forces, args, tracker, trace_log)? {
                 ForceOutcome::Pending(v) | ForceOutcome::Done(v) => {
                     Ok(State::Return { value: v, kont })
                 }

--- a/crates/dugite-uplc/src/phase_two.rs
+++ b/crates/dugite-uplc/src/phase_two.rs
@@ -148,6 +148,17 @@ pub enum PhaseTwoError {
     /// CEK evaluation failed.
     #[error("script evaluation failed: {0}")]
     ScriptEvaluationFailed(#[from] crate::UplcError),
+    /// CEK evaluation failed and the script emitted trace strings before
+    /// the error. Mirrors the Haskell `ValidationFailure exUnits err logs`
+    /// constructor (`Cardano.Ledger.Alonzo.Plutus.Evaluate`).
+    /// Callers that display errors to users should render the logs as
+    /// "Trace logs: [...]" preceding the evaluation error (matching
+    /// `cardano-cli transaction submit` output).
+    #[error("script evaluation failed: {error}; trace logs: {logs:?}")]
+    ScriptEvaluationFailedWithLogs {
+        error: crate::UplcError,
+        logs: Vec<String>,
+    },
     /// Generic internal error.
     #[error("internal phase-2 error: {0}")]
     Internal(String),

--- a/crates/dugite-uplc/tests/conformance.rs
+++ b/crates/dugite-uplc/tests/conformance.rs
@@ -88,7 +88,9 @@ fn run_conformance_test(
     // Counting mode mirrors `evaluateCekNoEmit` in counting mode: costs
     // accumulate with saturation but never block evaluation.
     let mut tracker = BudgetTracker::new_counting();
-    let eval = evaluate_with_budget(input_prog.term.clone(), &mut tracker);
+    // Conformance tests don't exercise trace output — pass `None` to
+    // discard any `trace` builtin emissions (mirrors `evaluateCekNoEmit`).
+    let eval = evaluate_with_budget(input_prog.term.clone(), &mut tracker, None);
 
     let value = match eval {
         Ok(v) => v,


### PR DESCRIPTION
## Summary

- **Threads a `trace_log: Option<&mut Vec<String>>` sink** through the CEK machine dispatch layer (`denote` → `apply_builtin`/`force_builtin` → `step`/`return_compute`/`apply`/`force_value` → `evaluate_with_budget`) so the `Trace` builtin appends its string argument before returning its second arg unchanged.
- **Populates `RedeemerEvalOutcome::logs`** (was `Vec::new()`) with per-redeemer trace strings emitted during script execution.
- **Adds `ScriptEvaluationFailedWithLogs { error, logs }`** to `PhaseTwoError` so traces emitted before a script error are surfaced to callers, mirroring Haskell's `ValidationFailure exUnits err [Text]`.
- **Renders "Trace logs: [msg]"** in `dugite-ledger`'s Phase-2 `EvalFailed` error message, matching `cardano-cli transaction submit` output.

## Haskell cross-validation

Confirmed against:
- `PlutusCore.Default.Builtins`: `traceDenotation text a = a <$ emit text` — trace appends string to CEK log via `emit`, returns second arg unchanged.
- `PlutusCore.Builtin.Emitter`: `emit :: Text -> Emitter ()` — logs are UTF-8 `Text`, collected in emission order (FIFO).
- `Cardano.Ledger.Alonzo.Plutus.Evaluate`: `ValidationFailure exUnits err logs` carries `![Text]` alongside the error; `evalTxExUnitsWithLogs` returns `(logs, Left err)` for failing scripts.

## Test plan

- [ ] `cargo nextest run -p dugite-uplc -E 'test(trace)'` — 8 new trace tests pass
- [ ] `cargo nextest run --workspace` — 6521/6521 pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] UPLC conformance suite (100% pass, gated by `DUGITE_REQUIRE_UPSTREAM=1`) — conformance harness passes `None` for trace_log, mirroring `evaluateCekNoEmit`

Closes #707