### PR TITLE
release: v2.0.7 — Conway byte-exactness fixes + #760 genesis-CSJ wedge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-cli"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-config"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-conformance"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "cddl",
  "dugite-crypto",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-consensus"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-crypto"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "criterion",
  "curve25519-dalek 3.2.0 (git+https://github.com/iquerejeta/curve25519-dalek?branch=ietf03_vrf_compat_ell2)",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-golden-tests"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "dugite-crypto",
  "dugite-network",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-integration-tests"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "dugite-consensus",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-ledger"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "bincode 1.3.3",
  "criterion",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-lsm"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-mempool"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-monitor"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-network"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-node"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-primitives"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "bech32",
  "blake2 0.10.6",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-rpc"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-serialization"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-storage"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-uplc"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "amaru-uplc",
  "blake2 0.10.6",
@@ -7071,7 +7071,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.6"
+version = "2.0.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/michaeljfazio/dugite"

--- a/charts/dugite-node/Chart.yaml
+++ b/charts/dugite-node/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dugite-node
 description: A Helm chart for deploying Dugite, a Rust implementation of the Cardano node
 type: application
-version: 0.5.6
-appVersion: "2.0.6"
+version: 0.5.7
+appVersion: "2.0.7"
 kubeVersion: ">= 1.27.0-0"
 keywords:
   - cardano

--- a/crates/dugite-ledger/src/eras/conway.rs
+++ b/crates/dugite-ledger/src/eras/conway.rs
@@ -1192,6 +1192,34 @@ impl EraRules for ConwayRules {
             );
         }
 
+        // Step 1b (PParams upgrade): seed the PlutusV3 cost model.
+        //
+        // Haskell `upgradeConwayPParams` builds the Conway `cppCostModels` as
+        //   updateCostModels bppCostModels (mkCostModels {PlutusV3 -> ucppPlutusV3CostModel})
+        // i.e. a per-language INSERT of V3 over the Babbage {V1,V2} map — V1 and
+        // V2 are carried across unchanged; V3 comes from
+        // `cgUpgradePParams.ucppPlutusV3CostModel` in conway-genesis.json.
+        // (cardano-ledger eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs.)
+        //
+        // Without this, `cost_models.plutus_v3` stays `None` for the whole
+        // session: `encode_language_views(has_v3=true)` emits an empty map and
+        // every PlutusV3 tx gets a wrong `script_data_hash` (ScriptDataHashMismatch)
+        // plus default-cost-model budgets (spurious "budget exhausted"). The
+        // `is_none()` guard keeps a governance-updated V3 (e.g. the Plomin 297-entry
+        // expansion) from being overwritten on a re-entry, and leaves V1/V2 alone.
+        if let Some(genesis) = ctx.conway_genesis {
+            if let Some(ref v3) = genesis.plutus_v3_cost_model {
+                if epochs.protocol_params.cost_models.plutus_v3.is_none() {
+                    epochs.protocol_params.cost_models.plutus_v3 = Some(v3.clone());
+                    tracing::info!(
+                        entries = v3.len(),
+                        "Conway: seeded PlutusV3 cost model from genesis upgrade params \
+                         (per-language insert preserving V1/V2)"
+                    );
+                }
+            }
+        }
+
         // Step 3: VRF key hash -> pool ID map.
         // In Haskell this is built for the DRep pulser to identify which pool
         // produced a block. Dugite uses pool_id directly from block headers,
@@ -3245,6 +3273,93 @@ mod tests {
         assert_eq!(drep2.deposit.0, 1_000_000_000);
     }
 
+    /// Babbage→Conway must seed the PlutusV3 cost model from ConwayGenesis as a
+    /// per-language INSERT: V3 is set, V1/V2 carried from Babbage are untouched,
+    /// and an already-present V3 (e.g. a governance update) is NOT overwritten.
+    ///
+    /// Regression for the Conway ScriptDataHashMismatch + budget-exhausted
+    /// divergence cluster (mainnet epoch 507+, e.g. tx 31b6732d…): when V3 is
+    /// `None`, `encode_language_views` emits an empty map and every PlutusV3 tx
+    /// gets the wrong script_data_hash and default-cost-model budgets.
+    #[test]
+    fn test_on_era_transition_seeds_plutus_v3_cost_model() {
+        use crate::eras::ConwayGenesisInit;
+
+        let rules = ConwayRules::new();
+        let params = ProtocolParameters::mainnet_defaults();
+
+        // The first four mainnet V3 entries (conway-genesis.json plutusV3CostModel).
+        let v3_model = vec![100788i64, 420, 1, 1000];
+        let genesis = ConwayGenesisInit {
+            plutus_v3_cost_model: Some(v3_model.clone()),
+            ..Default::default()
+        };
+        let delegates = Box::leak(Box::new(HashMap::new()));
+        let ctx = RuleContext {
+            params: &params,
+            current_slot: 100,
+            current_epoch: EpochNo(507),
+            era: Era::Conway,
+            slot_config: None,
+            node_network: None,
+            genesis_delegates: delegates,
+            update_quorum: 5,
+            epoch_length: 432000,
+            shelley_transition_epoch: 0,
+            byron_epoch_length: 21600,
+            stability_window: 129600,
+            stability_window_3kf: 129600,
+            randomness_stabilisation_window: 129600,
+            tx_index: 0,
+            conway_genesis: Some(&genesis),
+            max_lovelace_supply: crate::state::MAX_LOVELACE_SUPPLY,
+        };
+
+        let run = |v3_pre: Option<Vec<i64>>| {
+            let mut utxo = make_utxo_sub(vec![]);
+            let mut certs = make_cert_sub();
+            let mut gov = make_gov_sub();
+            let mut consensus = make_consensus_sub();
+            let mut epochs = make_epoch_sub();
+            epochs.ptr_stake_excluded = false;
+            // Babbage carried V1/V2; V3 state varies per case.
+            epochs.protocol_params.cost_models.plutus_v1 = Some(vec![1, 2, 3]);
+            epochs.protocol_params.cost_models.plutus_v2 = Some(vec![4, 5, 6]);
+            epochs.protocol_params.cost_models.plutus_v3 = v3_pre;
+            rules
+                .on_era_transition(
+                    Era::Babbage,
+                    &ctx,
+                    &mut utxo,
+                    &mut certs,
+                    &mut gov,
+                    &mut consensus,
+                    &mut epochs,
+                )
+                .expect("era transition should succeed");
+            epochs.protocol_params.cost_models
+        };
+
+        // Case 1 — V3 absent: inserted from genesis, V1/V2 preserved.
+        let cm = run(None);
+        assert_eq!(
+            cm.plutus_v3,
+            Some(v3_model.clone()),
+            "V3 must be seeded from Conway genesis"
+        );
+        assert_eq!(cm.plutus_v1, Some(vec![1, 2, 3]), "V1 must be preserved");
+        assert_eq!(cm.plutus_v2, Some(vec![4, 5, 6]), "V2 must be preserved");
+
+        // Case 2 — V3 already present (e.g. governance-updated): NOT overwritten.
+        let existing = vec![9, 9, 9, 9, 9];
+        let cm = run(Some(existing.clone()));
+        assert_eq!(
+            cm.plutus_v3,
+            Some(existing),
+            "an already-present V3 cost model must not be clobbered by genesis"
+        );
+    }
+
     /// Verify committee members and threshold are set from ConwayGenesis.
     #[test]
     fn test_on_era_transition_seeds_committee() {
@@ -3454,6 +3569,7 @@ mod tests {
                 },
                 script_hash: None,
             }),
+            plutus_v3_cost_model: None,
         };
         let delegates = Box::leak(Box::new(HashMap::new()));
         let ctx = RuleContext {

--- a/crates/dugite-ledger/src/eras/dijkstra.rs
+++ b/crates/dugite-ledger/src/eras/dijkstra.rs
@@ -978,6 +978,7 @@ mod tests {
                 },
                 script_hash: None,
             }),
+            plutus_v3_cost_model: None,
         };
         let ctx = make_ctx(&params, &delegates, Some(&genesis));
 
@@ -1100,6 +1101,7 @@ mod tests {
             committee_members: vec![],
             committee_threshold: None,
             constitution: None,
+            plutus_v3_cost_model: None,
         };
         let ctx = make_ctx(&params, &delegates, Some(&genesis));
         let mut utxo = make_utxo_sub();

--- a/crates/dugite-ledger/src/eras/mod.rs
+++ b/crates/dugite-ledger/src/eras/mod.rs
@@ -40,6 +40,12 @@ pub struct ConwayGenesisInit {
     pub committee_threshold: Option<(u64, u64)>,
     /// Initial constitution
     pub constitution: Option<dugite_primitives::transaction::Constitution>,
+    /// Initial PlutusV3 cost model from `conway-genesis.json`
+    /// (`cgUpgradePParams.ucppPlutusV3CostModel`). Seeded into
+    /// `protocol_params.cost_models.plutus_v3` at the Babbage→Conway hard fork,
+    /// mirroring Haskell `upgradeConwayPParams` (a per-language INSERT that
+    /// preserves the V1/V2 cost models carried over from Babbage).
+    pub plutus_v3_cost_model: Option<Vec<i64>>,
 }
 
 /// Read-only context available to all era rules.

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -573,12 +573,18 @@ impl LedgerState {
             rules.validate_block_body(block, &body_ctx, &self.utxo)?;
         }
 
-        // Pre-compute cost_models CBOR once per block
-        let cost_models_cbor = if mode == BlockValidationMode::ValidateAll {
-            self.epochs.protocol_params.cost_models.to_cbor()
-        } else {
-            None
-        };
+        // Pre-compute cost_models CBOR once per block.
+        //
+        // This must be computed in BOTH modes, not just ValidateAll: the parallel
+        // (and sequential-fallback) phase-2 *divergence checker* runs even in
+        // ApplyOnly mode (it logs "Plutus evaluation divergence … trusting on-chain
+        // consensus" without gating). If we hand it `None`, `resolve_applied_costs`
+        // silently falls back to the DEFAULT cost model, which over-counts budget by
+        // a fixed margin and produces a flood of spurious "budget exhausted" Plutus
+        // divergences on every PlutusV3 transaction — masking real divergences. The
+        // ValidateAll gating path was already correct; ApplyOnly's diagnostic was
+        // not. `to_cbor()` is a cheap once-per-block encode of the cost-model arrays.
+        let cost_models_cbor = self.epochs.protocol_params.cost_models.to_cbor();
 
         // Track processed tx hashes to skip duplicates within a block
         let mut processed_tx_hashes =

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -573,18 +573,17 @@ impl LedgerState {
             rules.validate_block_body(block, &body_ctx, &self.utxo)?;
         }
 
-        // Pre-compute cost_models CBOR once per block.
-        //
-        // This must be computed in BOTH modes, not just ValidateAll: the parallel
-        // (and sequential-fallback) phase-2 *divergence checker* runs even in
-        // ApplyOnly mode (it logs "Plutus evaluation divergence … trusting on-chain
-        // consensus" without gating). If we hand it `None`, `resolve_applied_costs`
-        // silently falls back to the DEFAULT cost model, which over-counts budget by
-        // a fixed margin and produces a flood of spurious "budget exhausted" Plutus
-        // divergences on every PlutusV3 transaction — masking real divergences. The
-        // ValidateAll gating path was already correct; ApplyOnly's diagnostic was
-        // not. `to_cbor()` is a cheap once-per-block encode of the cost-model arrays.
-        let cost_models_cbor = self.epochs.protocol_params.cost_models.to_cbor();
+        // Pre-compute cost_models CBOR once per block, for the ValidateAll phase-2
+        // path only. All consumers (capture_phase2_work_item, the sequential
+        // evaluate_plutus_scripts, and the parallel divergence checker) live inside
+        // the `if mode == ValidateAll` block / are gated on ValidateAll — in
+        // ApplyOnly mode phase-2 is suppressed (SKIP_PHASE2_EVAL), so the value
+        // would be unused dead work on the bulk-sync hot path.
+        let cost_models_cbor = if mode == BlockValidationMode::ValidateAll {
+            self.epochs.protocol_params.cost_models.to_cbor()
+        } else {
+            None
+        };
 
         // Track processed tx hashes to skip duplicates within a block
         let mut processed_tx_hashes =

--- a/crates/dugite-ledger/src/validation/collateral.rs
+++ b/crates/dugite-ledger/src/validation/collateral.rs
@@ -443,14 +443,19 @@ pub(crate) fn check_script_redeemers(
     //   - VoteRegDeleg (credential must be Script)
     //   - CommitteeHotAuth (cold_credential must be Script)
     //   - CommitteeColdResign (cold_credential must be Script)
+    //   - RegDRep (credential must be Script)
     //   - UnregDRep (credential must be Script)
     //   - UpdateDRep (credential must be Script)
     //
     //   - ConwayStakeRegistration (deposit-bearing RegDepositTxCert — Conway)
     //
+    // All three DRep gov-certs (RegDRep / UnregDRep / UpdateDRep) are treated
+    // identically by Haskell `getScriptWitnessConwayTxCert.govWitness`, each
+    // returning `credScriptHash cred`. cardano-ledger-conway-1.23.0.0,
+    // eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs.
+    //
     // Certificates that do NOT require a redeemer regardless of credential type:
     //   - StakeRegistration (legacy no-deposit), PoolRegistration, PoolRetirement,
-    //     RegDRep (witness requirement under live re-verification — see below),
     //     GenesisKeyDelegation, MoveInstantaneousRewards
     //     (permissionless registration or pool-operator-only actions)
     let cert_indices: HashSet<u32> = tx
@@ -484,6 +489,11 @@ pub(crate) fn check_script_redeemers(
             Certificate::CommitteeColdResign {
                 cold_credential: c, ..
             } => Some(c),
+            // DRep registration: credential must sign. `getScriptWitnessConwayTxCert`
+            // returns `credScriptHash cred` for `ConwayRegDRep cred _ _` — identical
+            // to UnRegDRep/UpdateDRep (no asymmetry). When the credential is a Plutus
+            // script, the cert needs a Certifying redeemer.
+            Certificate::RegDRep { credential: c, .. } => Some(c),
             // DRep unregistration: credential must sign.
             Certificate::UnregDRep { credential: c, .. } => Some(c),
             // DRep update: credential must sign.
@@ -495,13 +505,10 @@ pub(crate) fn check_script_redeemers(
             // is StakeRegistration (in the None arm below).
             Certificate::ConwayStakeRegistration { credential: c, .. } => Some(c),
             // Legacy no-deposit registration and pool operations do not require a
-            // redeemer. (RegDRep witness requirement: under live re-verification —
-            // the cardano-ledger-oracle says it needs one, an existing test says it
-            // does not; deferred to avoid a false-rejection halt until confirmed.)
+            // redeemer (permissionless registration or pool-operator-only actions).
             Certificate::StakeRegistration(_)
             | Certificate::PoolRegistration(_)
             | Certificate::PoolRetirement { .. }
-            | Certificate::RegDRep { .. }
             | Certificate::GenesisKeyDelegation { .. }
             | Certificate::MoveInstantaneousRewards { .. } => None,
         };
@@ -733,6 +740,14 @@ pub(crate) fn check_extra_redeemers(
             } => Some(h),
             Certificate::CommitteeColdResign {
                 cold_credential: Credential::Script(h),
+                ..
+            } => Some(h),
+            // RegDRep with a script credential needs a Certifying redeemer, so its
+            // Cert redeemer is NEEDED — not extra. Haskell `govWitness` returns
+            // `credScriptHash cred` for `ConwayRegDRep cred _ _`, identical to
+            // UnRegDRep/UpdateDRep below.
+            Certificate::RegDRep {
+                credential: Credential::Script(h),
                 ..
             } => Some(h),
             Certificate::UnregDRep {

--- a/crates/dugite-ledger/src/validation/collateral.rs
+++ b/crates/dugite-ledger/src/validation/collateral.rs
@@ -1069,11 +1069,26 @@ pub(crate) fn redeemer_script_version_map(
                 cold_credential: Credential::Script(h),
                 ..
             } => Some(*h),
+            // RegDRep and the deposit-bearing ConwayStakeRegistration with a
+            // script credential are part of the certifying scripts-needed set
+            // (getScriptWitnessConwayTxCert returns credScriptHash for both), so
+            // they must be enumerated here too — otherwise the PV11 V3
+            // reference-input disjointness check (mod.rs) misses a V3 cert script
+            // and falsely accepts. Mirrors check_script_redeemers /
+            // check_extra_redeemers.
+            Certificate::RegDRep {
+                credential: Credential::Script(h),
+                ..
+            } => Some(*h),
             Certificate::UnregDRep {
                 credential: Credential::Script(h),
                 ..
             } => Some(*h),
             Certificate::UpdateDRep {
+                credential: Credential::Script(h),
+                ..
+            } => Some(*h),
+            Certificate::ConwayStakeRegistration {
                 credential: Credential::Script(h),
                 ..
             } => Some(*h),
@@ -1300,6 +1315,47 @@ mod tests {
             steps: 10_000_000_000,
         };
         p
+    }
+
+    /// `redeemer_script_version_map` must enumerate the deposit-bearing
+    /// `ConwayStakeRegistration` and `RegDRep` certs (script credential) so the
+    /// PV11 V3 reference-input disjointness check sees their V3 script. Mirrors
+    /// the check_script_redeemers / check_extra_redeemers cert set. Regression
+    /// for adversarial-review finding V207-CERT-REDEEMER-01.
+    #[test]
+    fn test_version_map_includes_conway_stake_reg_and_regdrep_certs() {
+        use super::redeemer_script_version_map;
+        let h_reg = Hash28::from_bytes([0x51; 28]);
+        let h_drep = Hash28::from_bytes([0x52; 28]);
+        let mut tx = make_plutus_tx(200_000, vec![]);
+        tx.body.certificates = vec![
+            Certificate::ConwayStakeRegistration {
+                credential: Credential::Script(h_reg),
+                deposit: Lovelace(2_000_000),
+            },
+            Certificate::RegDRep {
+                credential: Credential::Script(h_drep),
+                deposit: Lovelace(500_000_000),
+                anchor: None,
+            },
+        ];
+        let mut version_map: std::collections::HashMap<Hash28, u8> =
+            std::collections::HashMap::new();
+        version_map.insert(h_reg, 3);
+        version_map.insert(h_drep, 3);
+        let utxo = UtxoSet::new();
+        let result = redeemer_script_version_map(&tx, &utxo, &version_map);
+        // Cert tag = 2; cert index 0 = ConwayStakeRegistration, 1 = RegDRep.
+        assert_eq!(
+            result.get(&(2u8, 0u32)),
+            Some(&3u8),
+            "deposit-bearing ConwayStakeRegistration(script) must map to its V3 version"
+        );
+        assert_eq!(
+            result.get(&(2u8, 1u32)),
+            Some(&3u8),
+            "RegDRep(script) must map to its V3 version"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/dugite-ledger/src/validation/collateral.rs
+++ b/crates/dugite-ledger/src/validation/collateral.rs
@@ -446,10 +446,13 @@ pub(crate) fn check_script_redeemers(
     //   - UnregDRep (credential must be Script)
     //   - UpdateDRep (credential must be Script)
     //
+    //   - ConwayStakeRegistration (deposit-bearing RegDepositTxCert — Conway)
+    //
     // Certificates that do NOT require a redeemer regardless of credential type:
-    //   - StakeRegistration, ConwayStakeRegistration, PoolRegistration,
-    //     PoolRetirement, RegDRep, GenesisKeyDelegation, MoveInstantaneousRewards
-    //     (either registrations or pool-operator-only actions)
+    //   - StakeRegistration (legacy no-deposit), PoolRegistration, PoolRetirement,
+    //     RegDRep (witness requirement under live re-verification — see below),
+    //     GenesisKeyDelegation, MoveInstantaneousRewards
+    //     (permissionless registration or pool-operator-only actions)
     let cert_indices: HashSet<u32> = tx
         .witness_set
         .redeemers
@@ -485,9 +488,17 @@ pub(crate) fn check_script_redeemers(
             Certificate::UnregDRep { credential: c, .. } => Some(c),
             // DRep update: credential must sign.
             Certificate::UpdateDRep { credential: c, .. } => Some(c),
-            // Registrations and pool operations do not require a redeemer.
+            // Conway stake registration WITH a deposit (RegDepositTxCert) requires a
+            // witness (Haskell getScriptWitnessConwayTxCert: `ConwayRegCert cred
+            // (SJust _) -> credScriptHash cred`). dugite's ConwayStakeRegistration is
+            // ALWAYS the deposit-bearing form (CBOR tag 7); the legacy no-deposit form
+            // is StakeRegistration (in the None arm below).
+            Certificate::ConwayStakeRegistration { credential: c, .. } => Some(c),
+            // Legacy no-deposit registration and pool operations do not require a
+            // redeemer. (RegDRep witness requirement: under live re-verification —
+            // the cardano-ledger-oracle says it needs one, an existing test says it
+            // does not; deferred to avoid a false-rejection halt until confirmed.)
             Certificate::StakeRegistration(_)
-            | Certificate::ConwayStakeRegistration { .. }
             | Certificate::PoolRegistration(_)
             | Certificate::PoolRetirement { .. }
             | Certificate::RegDRep { .. }
@@ -729,6 +740,15 @@ pub(crate) fn check_extra_redeemers(
                 ..
             } => Some(h),
             Certificate::UpdateDRep {
+                credential: Credential::Script(h),
+                ..
+            } => Some(h),
+            // Conway deposit-bearing registration (RegDepositTxCert) requires a
+            // script witness, so its Cert redeemer is NEEDED — not extra (Haskell
+            // getScriptWitnessConwayTxCert returns credScriptHash for `ConwayRegCert
+            // cred (SJust _)`). dugite's ConwayStakeRegistration is always the deposit
+            // form (tag 7); the legacy no-deposit StakeRegistration is permissionless.
+            Certificate::ConwayStakeRegistration {
                 credential: Credential::Script(h),
                 ..
             } => Some(h),

--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -3452,20 +3452,32 @@ pub fn validate_transaction_with_pools(
     // ------------------------------------------------------------------
     // VRF key deduplication (Haskell `VRFKeyHashAlreadyRegistered`, Conway+)
     //
-    // From Conway (protocol >= 9), a pool registration certificate whose VRF
-    // key hash is already registered to a DIFFERENT pool is rejected. A pool
+    // From protocol version 11 onward, a pool registration certificate whose
+    // VRF key hash is already registered to a DIFFERENT pool is rejected. A pool
     // re-registering its own parameters with the same VRF key is permitted (the
     // key already belongs to that pool, so the new registration is not a
     // collision).
     //
+    // The gate is PV >= 11, NOT >= 9: Haskell
+    //   hardforkConwayDisallowDuplicatedVRFKeys pv = pvMajor pv > natVersion @10
+    // (eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs), consulted in the
+    // RegPool branch of Shelley.Rules.Pool. The check is INACTIVE at PV 9 and
+    // PV 10 — the whole Conway bootstrap + current mainnet — so two genuinely
+    // different pools (e.g. same operator) may legitimately share a VRF key
+    // until PV 11. Gating at >= 9 falsely rejected mainnet tx 054c270b… at
+    // epoch 523 (PV 9.0), which cardano-node accepts.
+    //
     // This check is only enforced when `registered_vrf_keys` is provided (block
     // validation mode). The map is keyed by VRF key hash (Hash32) and maps to
-    // the pool ID (Hash28) that currently holds that key.
+    // the pool ID (Hash28) that currently holds that key. (NOTE: at PV 11 the
+    // Haskell `psVRFKeyHashes` is a refcount map and a retiring pool keeps its
+    // key until POOLREAP — a refcount model will be needed then; mainnet is not
+    // yet at PV 11.)
     //
     // Reference: Haskell `VRFKeyHashAlreadyRegistered` in
-    // `cardano-ledger-conway:Cardano.Ledger.Conway.Rules.Pool`.
+    // `cardano-ledger:Cardano.Ledger.Shelley.Rules.Pool` (reused by Conway).
     // ------------------------------------------------------------------
-    if params.protocol_version_major >= 9 {
+    if params.protocol_version_major >= 11 {
         if let Some(vrf_keys) = registered_vrf_keys {
             for cert in &tx.body.certificates {
                 if let dugite_primitives::transaction::Certificate::PoolRegistration(pool_params) =

--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -3155,7 +3155,7 @@ pub fn validate_transaction_with_pools(
     }
 
     // ------------------------------------------------------------------
-    // DelegateeDRepNotRegisteredDELEG (Conway DELEG rule, PV >= 9)
+    // DelegateeDRepNotRegisteredDELEG (Conway DELEG rule, PV >= 10)
     //
     // A vote-delegation certificate that points to a specific DRep
     // (KeyHash or ScriptHash) is rejected when that DRep credential is
@@ -3175,13 +3175,22 @@ pub fn validate_transaction_with_pools(
     // evaluated, so the checks below honour the same sequential semantics
     // (tracking a per-tx `new_dreps` delta set).
     //
-    // This check is only enforced in Conway (protocol >= 9) and when
-    // `registered_dreps` is provided.
+    // This check is SKIPPED during the PV9 Conway bootstrap phase and only
+    // enforced at protocol >= 10 (when `registered_dreps` is provided). Haskell
+    // `Cardano.Ledger.Conway.Rules.Deleg.checkDRepRegistered`:
+    //   unless (hardforkConwayBootstrapPhase pv) $
+    //     targetDRep `Map.member` dReps ?! DelegateeDRepNotRegisteredDELEG
+    // with `hardforkConwayBootstrapPhase pv = pvMajor pv == 9`. So during PV9 a
+    // vote-delegation to a not-yet-registered DRep — including the on-chain
+    // self-register-then-self-delegate pattern (VoteDelegation cert[0] +
+    // RegDRep cert[1] in one tx, which the left-to-right new_dreps tracking
+    // below would otherwise reject) — is ACCEPTED. Gating this at >= 9 wrongly
+    // rejected 26 such mainnet txs at PV9 (epoch 507+).
     //
     // Reference: Haskell `DelegateeDRepNotRegisteredDELEG` in
     // `cardano-ledger-conway:Cardano.Ledger.Conway.Rules.Deleg`.
     // ------------------------------------------------------------------
-    if params.protocol_version_major >= 9 {
+    if params.protocol_version_major >= 10 {
         if let Some(dreps) = registered_dreps {
             // Track DRep credentials registered within THIS tx (RegDRep cert
             // preceding a VoteDelegation in the same tx is valid).

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -11410,15 +11410,16 @@ mod tests {
     }
 
     #[test]
-    fn test_vrf_key_already_registered_rejected_in_conway() {
+    fn test_vrf_key_already_registered_rejected_at_pv11() {
         // A new pool registration using a VRF key that belongs to a DIFFERENT
-        // registered pool must be rejected in Conway (proto >= 9).
+        // registered pool must be rejected only from PV 11 onward (Haskell
+        // hardforkConwayDisallowDuplicatedVRFKeys = pvMajor > 10).
         let pool_a = Hash28::from_bytes([0xA0u8; 28]);
         let pool_b = Hash28::from_bytes([0xB0u8; 28]);
         let shared_vrf = Hash32::from_bytes([0xCCu8; 32]);
 
         let mut params = ProtocolParameters::mainnet_defaults();
-        params.protocol_version_major = 9; // Conway
+        params.protocol_version_major = 11; // check active at PV >= 11
 
         let mut utxo_set = UtxoSet::new();
         let input = TransactionInput {
@@ -11481,7 +11482,7 @@ mod tests {
 
         assert!(
             result.is_err(),
-            "Expected VrfKeyHashAlreadyRegistered for duplicate VRF key in Conway; got Ok"
+            "Expected VrfKeyHashAlreadyRegistered for duplicate VRF key at PV11; got Ok"
         );
         let errors = result.unwrap_err();
         assert!(
@@ -11494,12 +11495,13 @@ mod tests {
 
     #[test]
     fn test_vrf_key_already_registered_same_pool_allowed() {
-        // A pool re-registering with its OWN VRF key must be accepted (no collision).
+        // A pool re-registering with its OWN VRF key must be accepted (no collision)
+        // even when the duplicate-VRF check is active (PV >= 11).
         let pool_a = Hash28::from_bytes([0xA0u8; 28]);
         let own_vrf = Hash32::from_bytes([0xCCu8; 32]);
 
         let mut params = ProtocolParameters::mainnet_defaults();
-        params.protocol_version_major = 9; // Conway
+        params.protocol_version_major = 11; // check active at PV >= 11
 
         let mut utxo_set = UtxoSet::new();
         let input = TransactionInput {
@@ -11569,8 +11571,9 @@ mod tests {
 
     #[test]
     fn test_vrf_key_dedup_skipped_pre_conway() {
-        // VRF key deduplication is only enforced in Conway (proto >= 9). In
-        // Babbage (proto = 8), duplicate VRF keys are allowed.
+        // VRF key deduplication is only enforced from PV 11 onward
+        // (hardforkConwayDisallowDuplicatedVRFKeys = pvMajor > 10). In Babbage
+        // (proto = 8) duplicate VRF keys are allowed.
         let pool_a = Hash28::from_bytes([0xA1u8; 28]);
         let pool_b = Hash28::from_bytes([0xB1u8; 28]);
         let shared_vrf = Hash32::from_bytes([0xDDu8; 32]);
@@ -11643,6 +11646,88 @@ mod tests {
         );
     }
 
+    /// Regression for the mainnet epoch-523 (PV 9.0) divergence: a NEW pool
+    /// registering with a VRF key already held by a DIFFERENT pool must be
+    /// ACCEPTED during the Conway bootstrap window (PV 9 and PV 10), because
+    /// `hardforkConwayDisallowDuplicatedVRFKeys = pvMajor > 10` is False there.
+    /// dugite previously gated at PV >= 9 and falsely rejected mainnet tx
+    /// 054c270b6fed2be05cec72077e5dea18c041eb33e9c632a8f9c750d70b1c02df.
+    #[test]
+    fn test_vrf_key_dedup_skipped_during_conway_bootstrap_pv9_pv10() {
+        for pv in [9u64, 10u64] {
+            let pool_a = Hash28::from_bytes([0xA3u8; 28]);
+            let pool_b = Hash28::from_bytes([0xB3u8; 28]);
+            let shared_vrf = Hash32::from_bytes([0xDFu8; 32]);
+
+            let mut params = ProtocolParameters::mainnet_defaults();
+            params.protocol_version_major = pv;
+
+            let mut utxo_set = UtxoSet::new();
+            let input = TransactionInput {
+                transaction_id: Hash32::from_bytes([0x05u8; 32]),
+                index: 0,
+            };
+            utxo_set.insert(
+                input.clone(),
+                TransactionOutput {
+                    address: Address::Byron(ByronAddress {
+                        payload: vec![0u8; 32],
+                    }),
+                    value: Value::lovelace(1_000_000_000),
+                    datum: OutputDatum::None,
+                    script_ref: None,
+                    is_legacy: false,
+                    raw_cbor: None,
+                },
+            );
+
+            let pool_deposit = params.pool_deposit.0;
+            let fee = 200_000u64;
+            let output = 1_000_000_000 - fee - pool_deposit;
+            let mut tx = make_simple_tx(input, output, fee);
+            tx.body
+                .certificates
+                .push(Certificate::PoolRegistration(make_pool_params_with_vrf(
+                    pool_b, shared_vrf,
+                )));
+
+            let mut registered_vrf_keys: std::collections::HashMap<Hash32, Hash28> =
+                std::collections::HashMap::new();
+            registered_vrf_keys.insert(shared_vrf, pool_a);
+            let registered_pools: std::collections::HashSet<Hash28> =
+                std::collections::HashSet::new();
+
+            let result = validate_transaction_with_pools(
+                &tx,
+                &utxo_set,
+                &params,
+                100,
+                300,
+                None,
+                Some(&registered_pools),
+                None,
+                None,
+                None,
+                None, // registered_dreps
+                Some(&registered_vrf_keys),
+                None, // node_network
+                None, // committee_members
+                None, // committee_resigned
+                None, // stake_key_deposits
+                None, // constitution_script_hash
+                None, // vote_delegations
+            );
+
+            let has_vrf_err = matches!(&result, Err(errors) if errors.iter().any(|e| {
+                matches!(e, ValidationError::VrfKeyHashAlreadyRegistered { .. })
+            }));
+            assert!(
+                !has_vrf_err,
+                "VRF key dedup must NOT fire during Conway bootstrap (PV {pv}); got: {result:?}"
+            );
+        }
+    }
+
     #[test]
     fn test_vrf_key_dedup_no_map_skips_check() {
         // When registered_vrf_keys is None, the VRF dedup check must be skipped.
@@ -11652,7 +11737,7 @@ mod tests {
         let shared_vrf = Hash32::from_bytes([0xEEu8; 32]);
 
         let mut params = ProtocolParameters::mainnet_defaults();
-        params.protocol_version_major = 9; // Conway — but map is None
+        params.protocol_version_major = 11; // check active at PV >= 11 — but map is None
 
         let mut utxo_set = UtxoSet::new();
         let input = TransactionInput {

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -10338,11 +10338,12 @@ mod tests {
     #[test]
     fn test_vote_deleg_to_unregistered_drep_rejected() {
         // VoteDelegation to an unregistered DRep must produce
-        // DelegateeDRepNotRegistered in Conway era.
+        // DelegateeDRepNotRegistered — but ONLY at PV >= 10. The PV9 Conway
+        // bootstrap phase skips the check (see the PV9-accept test below).
         let drep_cred_bytes = [0x40u8; 28];
         let stake_cred_bytes = [0x41u8; 28];
         let mut params = ProtocolParameters::mainnet_defaults();
-        params.protocol_version_major = 9; // Conway
+        params.protocol_version_major = 10; // PV10 — DRep-registered check active
 
         let drep_hash = Hash28::from_bytes(drep_cred_bytes).to_hash32_padded();
         // DRep target as a KeyHash DRep
@@ -10397,6 +10398,71 @@ mod tests {
                 .any(|e| matches!(e, ValidationError::DelegateeDRepNotRegistered { .. })),
             "Expected DelegateeDRepNotRegistered; got: {errors:?}"
         );
+    }
+
+    #[test]
+    fn test_vote_deleg_to_unregistered_drep_accepted_at_pv9_bootstrap() {
+        // During the PV9 Conway bootstrap phase the DRep-registered check is
+        // SKIPPED (hardforkConwayBootstrapPhase pvMajor==9). A VoteDelegation to
+        // a not-yet-registered DRep is ACCEPTED — the on-chain
+        // self-register-then-self-delegate pattern (VoteDelegation cert[0] +
+        // RegDRep cert[1]) that diverged 26× on mainnet at epoch 507+ before the
+        // >= 9 → >= 10 fix. Pins the bootstrap-phase relaxation.
+        let drep_cred_bytes = [0x40u8; 28];
+        let stake_cred_bytes = [0x41u8; 28];
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.protocol_version_major = 9; // PV9 — Conway bootstrap, check skipped
+
+        let drep_hash = Hash28::from_bytes(drep_cred_bytes).to_hash32_padded();
+        let drep = DRep::KeyHash(drep_hash);
+        let stake_cred = dugite_primitives::credentials::Credential::VerificationKey(
+            Hash28::from_bytes(stake_cred_bytes),
+        );
+
+        let mut utxo_set = UtxoSet::new();
+        let tx = make_vote_deleg_tx(
+            &mut utxo_set,
+            Certificate::VoteDelegation {
+                credential: stake_cred.clone(),
+                drep,
+            },
+        );
+
+        let registered_dreps: std::collections::HashSet<Hash32> = std::collections::HashSet::new();
+        let reward_accounts = make_reward_accounts_with_cred(stake_cred_bytes);
+
+        let result = validate_transaction_with_pools(
+            &tx,
+            &utxo_set,
+            &params,
+            100,
+            300,
+            None,
+            None,
+            None,
+            Some(&reward_accounts),
+            None,
+            Some(&registered_dreps),
+            None, // registered_vrf_keys
+            None, // node_network
+            None, // committee_members
+            None, // committee_resigned
+            None, // stake_key_deposits
+            None, // constitution_script_hash
+            None, // vote_delegations
+        );
+
+        // At PV9 the bootstrap phase skips the check — there must be NO
+        // DelegateeDRepNotRegistered error (other unrelated errors, if any, are
+        // not this rule).
+        if let Err(errors) = &result {
+            assert!(
+                !errors
+                    .iter()
+                    .any(|e| matches!(e, ValidationError::DelegateeDRepNotRegistered { .. })),
+                "PV9 bootstrap must NOT emit DelegateeDRepNotRegistered; got: {errors:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -5942,6 +5942,158 @@ mod tests {
         );
     }
 
+    /// A Conway `ConwayStakeRegistration` (deposit-bearing `RegDepositTxCert`,
+    /// CBOR tag 7) with a SCRIPT credential REQUIRES a Cert redeemer — unlike the
+    /// legacy no-deposit `StakeRegistration`, the deposit form carries a script
+    /// witness. Haskell `getScriptWitnessConwayTxCert`:
+    ///   `ConwayRegCert cred (SJust _) -> credScriptHash cred`.
+    ///
+    /// Without the matching Cert redeemer the tx must be rejected with
+    /// `MissingRedeemer { tag: "Cert", index: 0 }`; with one present (covered by
+    /// the converse check below) it must NOT appear as an `ExtraRedeemer`.
+    ///
+    /// Regression for the Conway ValidateAll `ExtraRedeemer(Cert)` divergence
+    /// observed on mainnet tx
+    /// fe8da9ad24251e3a5eba8efb6f7294e72a9820b5bd45c779365877f51a003118
+    /// (deposit-bearing registration of a script-credential stake key).
+    #[test]
+    fn test_cert_redeemer_conway_deposit_registration_script_requires_redeemer() {
+        use super::super::collateral::{check_extra_redeemers, check_script_redeemers};
+        use dugite_primitives::credentials::Credential;
+        use dugite_primitives::transaction::Certificate;
+        use dugite_primitives::value::Lovelace;
+
+        // Derive the credential hash from the actual Plutus V2 script so the
+        // version map recognises it as a Plutus (version > 0) credential.
+        let plutus_script = vec![0xC7u8];
+        let script_hash = dugite_primitives::hash::blake2b_224_tagged(2, &plutus_script);
+
+        let mut utxo_set = UtxoSet::new();
+        let input = TransactionInput {
+            transaction_id: Hash32::from_bytes([0x84; 32]),
+            index: 0,
+        };
+        utxo_set.insert(
+            input.clone(),
+            TransactionOutput {
+                address: Address::Byron(ByronAddress {
+                    payload: vec![0u8; 32],
+                }),
+                value: Value::lovelace(5_000_000),
+                datum: OutputDatum::None,
+                script_ref: None,
+                is_legacy: false,
+                raw_cbor: None,
+            },
+        );
+
+        let make_tx = |redeemers: Vec<Redeemer>| Transaction {
+            era: dugite_primitives::era::Era::Conway,
+            hash: Hash32::ZERO,
+            body: TransactionBody {
+                inputs: vec![input.clone()],
+                outputs: vec![TransactionOutput {
+                    address: Address::Byron(ByronAddress {
+                        payload: vec![0u8; 32],
+                    }),
+                    value: Value::lovelace(4_800_000),
+                    datum: OutputDatum::None,
+                    script_ref: None,
+                    is_legacy: false,
+                    raw_cbor: None,
+                }],
+                fee: Lovelace(200_000),
+                ttl: None,
+                certificates: vec![Certificate::ConwayStakeRegistration {
+                    credential: Credential::Script(script_hash),
+                    deposit: Lovelace(2_000_000),
+                }],
+                withdrawals: BTreeMap::new(),
+                auxiliary_data_hash: None,
+                validity_interval_start: None,
+                mint: BTreeMap::new(),
+                script_data_hash: None,
+                collateral: vec![],
+                required_signers: vec![],
+                network_id: None,
+                collateral_return: None,
+                total_collateral: None,
+                reference_inputs: vec![],
+                update: None,
+                voting_procedures: BTreeMap::new(),
+                proposal_procedures: vec![],
+                treasury_value: None,
+                donation: None,
+                sub_transactions: vec![],
+                account_balance_intervals: vec![],
+                direct_deposits: ::std::collections::BTreeMap::new(),
+                guards: Vec::new(),
+            },
+            witness_set: TransactionWitnessSet {
+                vkey_witnesses: vec![],
+                native_scripts: vec![],
+                bootstrap_witnesses: vec![],
+                plutus_v1_scripts: vec![],
+                plutus_v2_scripts: vec![plutus_script.clone()],
+                plutus_v3_scripts: vec![],
+                plutus_data: vec![],
+                redeemers,
+                raw_redeemers_cbor: None,
+                raw_plutus_data_cbor: None,
+                original_script_data_hash: None,
+            },
+            is_valid: true,
+            auxiliary_data: None,
+            raw_cbor: None,
+            raw_body_cbor: None,
+            raw_witness_cbor: None,
+        };
+
+        // Case 1 — missing redeemer: must be rejected with MissingRedeemer.
+        let tx_missing = make_tx(vec![]);
+        let mut errors: Vec<ValidationError> = Vec::new();
+        check_script_redeemers(
+            &tx_missing,
+            &utxo_set,
+            &super::super::collateral::plutus_script_version_map(&tx_missing, &utxo_set),
+            &mut errors,
+        );
+        assert!(
+            errors.iter().any(|e| matches!(
+                e,
+                ValidationError::MissingRedeemer { tag, index: 0 } if tag == "Cert"
+            )),
+            "deposit-bearing ConwayStakeRegistration with Script credential must \
+             require a Cert redeemer, got: {errors:?}"
+        );
+
+        // Case 2 — redeemer present: must NOT be flagged as an ExtraRedeemer.
+        let tx_present = make_tx(vec![Redeemer {
+            tag: RedeemerTag::Cert,
+            index: 0,
+            data: PlutusData::Integer(num_bigint::BigInt::from(0i64)),
+            ex_units: ExUnits {
+                mem: 100,
+                steps: 100,
+            },
+        }]);
+        let mut extra_errors: Vec<ValidationError> = Vec::new();
+        check_extra_redeemers(
+            &tx_present,
+            &utxo_set,
+            &super::super::collateral::plutus_script_version_map(&tx_present, &utxo_set),
+            &mut extra_errors,
+        );
+        assert!(
+            !extra_errors.iter().any(|e| matches!(
+                e,
+                ValidationError::ExtraRedeemer { tag, .. } if tag == "Cert"
+            )),
+            "Cert redeemer matching a deposit-bearing ConwayStakeRegistration must \
+             not be reported as extra, got: {extra_errors:?}"
+        );
+    }
+
     /// A `StakeDeregistration` with a VerificationKey credential must NOT
     /// require a Cert redeemer — only Script credentials need redeemers.
     #[test]

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -6356,11 +6356,15 @@ mod tests {
         );
     }
 
-    /// An `UnregDRep` certificate with a Script credential and no Cert redeemer
-    /// must be rejected.  `RegDRep` with the same credential must NOT require
-    /// a redeemer (DRep registration is one-sided, like stake registration).
+    /// Both `RegDRep` and `UnregDRep` with a Script credential and no Cert
+    /// redeemer must be rejected. Haskell `getScriptWitnessConwayTxCert.govWitness`
+    /// treats all three DRep gov-certs identically — `ConwayRegDRep cred _ _`,
+    /// `ConwayUnRegDRep cred _`, and `ConwayUpdateDRep cred _` each return
+    /// `credScriptHash cred` (cardano-ledger-conway-1.23.0.0,
+    /// eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs), so a Plutus-script
+    /// credential on any of them needs a Certifying redeemer.
     #[test]
-    fn test_cert_redeemer_drep_unreg_requires_cert_reg_does_not() {
+    fn test_cert_redeemer_drep_reg_and_unreg_both_require() {
         use super::super::collateral::check_script_redeemers;
         use dugite_primitives::credentials::Credential;
         use dugite_primitives::transaction::Certificate;
@@ -6389,7 +6393,7 @@ mod tests {
             },
         );
 
-        // --- Part A: RegDRep with Script credential — no redeemer required ---
+        // --- Part A: RegDRep with Script credential — redeemer REQUIRED ---
 
         let tx_reg = Transaction {
             era: dugite_primitives::era::Era::Conway,
@@ -6408,7 +6412,7 @@ mod tests {
                 }],
                 fee: Lovelace(200_000),
                 ttl: None,
-                // DRep registration — no redeemer required.
+                // DRep registration with a script credential — redeemer required.
                 certificates: vec![Certificate::RegDRep {
                     credential: Credential::Script(drep_script_hash),
                     deposit: Lovelace(500_000_000),
@@ -6464,10 +6468,10 @@ mod tests {
         );
 
         assert!(
-            !reg_errors.iter().any(
-                |e| matches!(e, ValidationError::MissingRedeemer { tag, .. } if tag == "Cert")
-            ),
-            "RegDRep must not require a Cert redeemer, got: {reg_errors:?}"
+            reg_errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::MissingRedeemer { tag, index: 0 } if tag == "Cert")),
+            "Expected MissingRedeemer {{ tag: Cert, index: 0 }} for RegDRep with Script credential, got: {reg_errors:?}"
         );
 
         // --- Part B: UnregDRep with Script credential — redeemer required ---

--- a/crates/dugite-node/src/csj.rs
+++ b/crates/dugite-node/src/csj.rs
@@ -162,6 +162,28 @@ impl CsjRegistry {
         self.enabled
     }
 
+    /// Head slot of a peer's current candidate (jump-info) fragment, if any.
+    ///
+    /// Used by the BlockFetch unproductive-dynamo watchdog (#760-A) to tell a
+    /// GENUINELY-SILENT dynamo (no headers ahead of our selected chain — the
+    /// #742 rotation target) from one that fed headers and is now legitimately
+    /// PARKED on the forecast horizon (its fragment leads our chain by ~a
+    /// stability window). Rotating the latter merely re-intersects a fresh
+    /// dynamo at the same frontier and re-parks it, producing the ~1 blk/min
+    /// cold-restart churn. Mirrors Haskell: a peer blocked at the forecast
+    /// horizon is not starving us — the ledger is catching up.
+    ///
+    /// `None` when the peer is unknown or has never delivered a header
+    /// (no `jump_info`, or its fragment is anchored at Origin).
+    pub fn fragment_head_slot(&self, addr: &SocketAddr) -> Option<u64> {
+        let inner = self.inner.lock().expect("csj lock");
+        let peer = inner.peers.get(addr)?;
+        match peer.jump_info.as_ref()?.fragment.head_slot() {
+            WithOrigin::At(s) => Some(s),
+            WithOrigin::Origin => None,
+        }
+    }
+
     /// `registerClient`: first peer (while not CaughtUp) becomes the
     /// dynamo; later peers become fresh jumpers pre-loaded with the
     /// dynamo's current jump info; peers connecting while CaughtUp are
@@ -1107,5 +1129,23 @@ mod tests {
             reg.next_instruction(&addr(2)),
             CsjInstruction::Restart
         ));
+    }
+
+    // #760-A: `fragment_head_slot` is the discriminator the BlockFetch
+    // unproductive-dynamo watchdog uses to tell a silent dynamo (rotate) from
+    // one parked on the forecast horizon (keep).
+    #[test]
+    fn fragment_head_slot_reports_fed_frontier_else_none() {
+        let reg = two_peer_registry();
+        // Dynamo p1 has not delivered a header yet → no jump_info → None.
+        assert_eq!(reg.fragment_head_slot(&addr(1)), None);
+        // Feed p1 a candidate fragment whose head is slot 5_000.
+        reg.update_jump_info(&addr(1), frag(FragAnchor::Origin, &[(100, 1), (5_000, 2)]));
+        assert_eq!(reg.fragment_head_slot(&addr(1)), Some(5_000));
+        // An unknown peer → None.
+        assert_eq!(reg.fragment_head_slot(&addr(99)), None);
+        // A jump_info whose fragment is empty (anchored at Origin) → None.
+        reg.update_jump_info(&addr(2), frag(FragAnchor::Origin, &[]));
+        assert_eq!(reg.fragment_head_slot(&addr(2)), None);
     }
 }

--- a/crates/dugite-node/src/main.rs
+++ b/crates/dugite-node/src/main.rs
@@ -693,6 +693,7 @@ async fn run_dump_snapshot(args: DumpSnapshotArgs) -> Result<()> {
     let mut conway_committee_members: Vec<([u8; 32], u64)> = Vec::new();
     let mut conway_constitution: Option<dugite_primitives::transaction::Constitution> = None;
     let mut conway_initial_dreps: Vec<(dugite_primitives::hash::Hash28, u64)> = Vec::new();
+    let mut conway_v3_cost_model: Option<Vec<i64>> = None;
     if let Some(ref genesis_path) = node_config.conway_genesis_file {
         let genesis_path = config_dir.join(genesis_path);
         if let Ok(genesis) = genesis::ConwayGenesis::load(&genesis_path) {
@@ -701,6 +702,7 @@ async fn run_dump_snapshot(args: DumpSnapshotArgs) -> Result<()> {
             conway_committee_members = genesis.committee_members();
             conway_constitution = genesis.to_ledger_constitution();
             conway_initial_dreps = genesis.initial_dreps_as_entries();
+            conway_v3_cost_model = genesis.plutus_v3_cost_model.clone();
             info!("Conway genesis loaded");
         }
     }
@@ -709,12 +711,14 @@ async fn run_dump_snapshot(args: DumpSnapshotArgs) -> Result<()> {
     let conway_genesis_init = if conway_committee_threshold.is_some()
         || !conway_committee_members.is_empty()
         || !conway_initial_dreps.is_empty()
+        || conway_v3_cost_model.is_some()
     {
         Some(dugite_ledger::eras::ConwayGenesisInit {
             initial_dreps: conway_initial_dreps.clone(),
             committee_members: conway_committee_members.clone(),
             committee_threshold: conway_committee_threshold,
             constitution: conway_constitution.clone(),
+            plutus_v3_cost_model: conway_v3_cost_model.clone(),
         })
     } else {
         None

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -2521,18 +2521,34 @@ impl ConnectionLifecycleManager {
                                             let cdb = chain_db.read().await;
                                             cdb.get_tip().point.slot().map(|s| s.0).unwrap_or(0)
                                         };
+                                        let fragment_head = cs.fragment_head_slot(&addr);
                                         let rotate = should_rotate_unproductive_dynamo(
-                                            cs.fragment_head_slot(&addr),
+                                            fragment_head,
                                             chain_tip_slot,
                                         );
-                                        if rotate && cs.rotate_dynamo(&addr) {
-                                            info!(
+                                        if rotate {
+                                            if cs.rotate_dynamo(&addr) {
+                                                info!(
+                                                    %addr,
+                                                    unproductive_secs =
+                                                        now_ms.saturating_sub(since) / 1000,
+                                                    "BlockFetch: silent dynamo unproductive past \
+                                                     watchdog with ChainSel starved (no headers \
+                                                     ahead) — rotating (#742/#760-A)"
+                                                );
+                                            }
+                                        } else {
+                                            // Parked-with-headers dynamo: KEEP it (the ledger is
+                                            // catching up to the forecast horizon). Log so an
+                                            // operator can tell "watchdog fired and correctly held
+                                            // the parked dynamo" from "watchdog never fired".
+                                            debug!(
                                                 %addr,
-                                                unproductive_secs =
-                                                    now_ms.saturating_sub(since) / 1000,
-                                                "BlockFetch: silent dynamo unproductive past \
-                                                 watchdog with ChainSel starved (no headers \
-                                                 ahead) — rotating (#742/#760-A)"
+                                                ahead = fragment_head
+                                                    .unwrap_or(0)
+                                                    .saturating_sub(chain_tip_slot),
+                                                "BlockFetch: unproductive dynamo KEPT — parked on \
+                                                 forecast horizon, not silent (#760-A)"
                                             );
                                         }
                                         unproductive_since_ms = None;

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -150,6 +150,44 @@ const _: () = assert!(
     "pipelined in-flight budget exceeds mux ingress limit: reduce BLOCKFETCH_PIPELINE_WINDOW or increase peer_connection::BLOCKFETCH_INGRESS_LIMIT"
 );
 
+/// Slots a dynamo's CSJ fragment must lead our selected chain by before the
+/// unproductive-dynamo watchdog (#742) treats it as legitimately PARKED on the
+/// forecast horizon and SKIPS rotation (#760-A). Chosen well below the smallest
+/// network forecast/stability window (preview `3k/f ≈ 25 920` slots) and well
+/// above streaming noise, so a parked dynamo (≈ a full stability window ahead)
+/// is never mistaken for a silent one, and a genuinely-silent dynamo (fragment
+/// at or near our tip) is always rotated.
+pub(crate) const GENESIS_PARKED_DYNAMO_MARGIN_SLOTS: u64 = 2_000;
+
+// Compile-time guard: the margin must stay below the smallest network
+// forecast/stability window (preview `3k/f = 3*432/0.05 = 25 920` slots) so a
+// dynamo parked on the horizon (≈ a full window ahead) is never mistaken for a
+// silent one on ANY network.
+const _: () = assert!(GENESIS_PARKED_DYNAMO_MARGIN_SLOTS < 25_920);
+
+/// Should an unproductive dynamo that has starved ChainSel past the watchdog
+/// window be ROTATED?
+///
+/// `#742` added this watchdog to rotate a dynamo that never feeds headers (the
+/// LoP cannot kill it because dugite pauses the LoP while a peer parks on the
+/// forecast horizon). But on a cold genesis restart a HEALTHY dynamo streams a
+/// full forecast window of headers, drains them, and then parks — and was being
+/// rotated too (`#760-A` ~1 blk/min churn). The discriminator: a dynamo whose
+/// CSJ fragment leads our selected chain by more than
+/// [`GENESIS_PARKED_DYNAMO_MARGIN_SLOTS`] has fed headers and is parked
+/// (don't rotate — the ledger is catching up); one at/near our tip, or with no
+/// fragment at all, is genuinely silent (rotate). Mirrors Haskell, where a peer
+/// blocked at the forecast horizon is not counted as starving us.
+pub(crate) fn should_rotate_unproductive_dynamo(
+    fragment_head_slot: Option<u64>,
+    chain_tip_slot: u64,
+) -> bool {
+    match fragment_head_slot {
+        Some(head) => head <= chain_tip_slot.saturating_add(GENESIS_PARKED_DYNAMO_MARGIN_SLOTS),
+        None => true,
+    }
+}
+
 /// Why a protocol task reported a peer to `peer_failure_tx` (#751).
 ///
 /// `ProtocolFault` is a PROVABLE protocol violation (mis-declared block
@@ -2465,13 +2503,36 @@ impl ConnectionLifecycleManager {
                                         && now_ms.saturating_sub(since) >= watchdog_ms
                                         && last_starvation_ms >= since.saturating_add(watchdog_ms)
                                     {
-                                        if cs.rotate_dynamo(&addr) {
+                                        // #760-A: only rotate a GENUINELY-SILENT
+                                        // dynamo. A dynamo that fed a forecast
+                                        // window of headers and is now PARKED on the
+                                        // horizon has its CSJ fragment far ahead of
+                                        // our selected chain; rotating it just
+                                        // re-intersects a fresh dynamo at the same
+                                        // frontier and re-parks it (~1 blk/min
+                                        // cold-restart churn). Mirror Haskell: a peer
+                                        // blocked at the forecast horizon is not
+                                        // starving us — the ledger is catching up.
+                                        // The #742 silent-dynamo case (fragment NOT
+                                        // ahead) is still rotated. The chain_db read
+                                        // is taken only here (≤ once per watchdog
+                                        // window), never on the hot per-tick path.
+                                        let chain_tip_slot = {
+                                            let cdb = chain_db.read().await;
+                                            cdb.get_tip().point.slot().map(|s| s.0).unwrap_or(0)
+                                        };
+                                        let rotate = should_rotate_unproductive_dynamo(
+                                            cs.fragment_head_slot(&addr),
+                                            chain_tip_slot,
+                                        );
+                                        if rotate && cs.rotate_dynamo(&addr) {
                                             info!(
                                                 %addr,
                                                 unproductive_secs =
                                                     now_ms.saturating_sub(since) / 1000,
-                                                "BlockFetch: dynamo unproductive past watchdog \
-                                                 with ChainSel starved — rotating (#742)"
+                                                "BlockFetch: silent dynamo unproductive past \
+                                                 watchdog with ChainSel starved (no headers \
+                                                 ahead) — rotating (#742/#760-A)"
                                             );
                                         }
                                         unproductive_since_ms = None;
@@ -6642,5 +6703,31 @@ mod range_byte_abort_751_tests {
             !range_all_declared(&headers),
             "Byron ranges must never arm the #751 abort"
         );
+    }
+
+    // #760-A: the unproductive-dynamo watchdog must rotate a GENUINELY-SILENT
+    // dynamo (preserving the #742 fix) but NOT a dynamo that fed a forecast
+    // window of headers and is now legitimately parked on the horizon.
+    #[test]
+    fn unproductive_watchdog_rotates_only_silent_dynamo() {
+        let tip = 1_000_000u64;
+        // No fragment at all → never fed headers → silent → rotate.
+        assert!(should_rotate_unproductive_dynamo(None, tip));
+        // Fragment exactly at our tip → silent → rotate.
+        assert!(should_rotate_unproductive_dynamo(Some(tip), tip));
+        // Fragment a few hundred slots ahead (within margin) → still silent.
+        assert!(should_rotate_unproductive_dynamo(Some(tip + 500), tip));
+        // Exactly at the margin boundary → still rotate (`<=`).
+        assert!(should_rotate_unproductive_dynamo(
+            Some(tip + GENESIS_PARKED_DYNAMO_MARGIN_SLOTS),
+            tip
+        ));
+        // Just past the margin → parked-with-headers → do NOT rotate.
+        assert!(!should_rotate_unproductive_dynamo(
+            Some(tip + GENESIS_PARKED_DYNAMO_MARGIN_SLOTS + 1),
+            tip
+        ));
+        // ~A full mainnet stability window ahead → clearly parked → keep it.
+        assert!(!should_rotate_unproductive_dynamo(Some(tip + 129_600), tip));
     }
 }

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1633,7 +1633,12 @@ impl Node {
         // hard fork (pv >= 9) and the snapshot is missing it. This is a per-language
         // insert — V1/V2 (and any governance-updated V3) are left untouched.
         if ledger.epochs.protocol_params.protocol_version_major >= 9
-            && ledger.epochs.protocol_params.cost_models.plutus_v3.is_none()
+            && ledger
+                .epochs
+                .protocol_params
+                .cost_models
+                .plutus_v3
+                .is_none()
         {
             if let Some(ref v3) = conway_v3_cost_model {
                 ledger.epochs.protocol_params.cost_models.plutus_v3 = Some(v3.clone());

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -6361,6 +6361,20 @@ impl Node {
                             ls.epochs.protocol_params.protocol_version_minor,
                         );
                         self.metrics.set_utxo_count(ls.utxo.utxo_set.len() as u64);
+                        // Keep the pots gauges live during catch-up too. These are
+                        // O(1) atomic stores (the heavy governance snapshot — dreps,
+                        // proposals, delegations — stays on the at-tip /
+                        // era-transition `publish_ledger_view` path above). Without
+                        // them `dugite_reserves_lovelace` / `dugite_treasury_lovelace`
+                        // froze at their startup values for the whole bulk sync,
+                        // making the pots appear stuck (cosmetic, but misleading for
+                        // boundary cross-checks).
+                        self.metrics
+                            .reserves_lovelace
+                            .store(ls.epochs.reserves.0, std::sync::atomic::Ordering::Relaxed);
+                        self.metrics
+                            .treasury_lovelace
+                            .store(ls.epochs.treasury.0, std::sync::atomic::Ordering::Relaxed);
                         let _ = self.ledger_tip_slot_tx.send(local_tip);
                     }
                     // Consume pending era transition and propagate to the HFC state machine.

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1628,11 +1628,18 @@ impl Node {
         // `None`) would compute the wrong `script_data_hash` and default-cost-model
         // budgets for every PlutusV3 transaction. The Babbage→Conway
         // `on_era_transition` only fires when crossing the hard fork during replay;
-        // for a node resuming directly from a Conway snapshot it never runs, so seed
-        // V3 here from the Conway genesis upgrade params when we are already past the
-        // hard fork (pv >= 9) and the snapshot is missing it. This is a per-language
-        // insert — V1/V2 (and any governance-updated V3) are left untouched.
-        if ledger.epochs.protocol_params.protocol_version_major >= 9
+        // for a node resuming directly from a Conway snapshot it never runs.
+        //
+        // The genesis `ucppPlutusV3CostModel` is the INITIAL (PV9) V3 model. From
+        // the Plomin HF (PV10) the on-chain V3 model is expanded (251→297, and
+        // PV11→350) via governance ParameterChange enactment, NOT via the genesis
+        // upgrade params. So only seed the genesis model when we are at PV9 (where
+        // it is exactly authoritative). At PV>9 a `None` V3 means a governance-
+        // enactment gap (or an unsupported snapshot) — seeding the stale 251-entry
+        // genesis model there would be WRONG, so we warn loudly instead and let the
+        // governance replay path populate the correct expanded model.
+        let pv = ledger.epochs.protocol_params.protocol_version_major;
+        if pv >= 9
             && ledger
                 .epochs
                 .protocol_params
@@ -1640,19 +1647,34 @@ impl Node {
                 .plutus_v3
                 .is_none()
         {
-            if let Some(ref v3) = conway_v3_cost_model {
-                ledger.epochs.protocol_params.cost_models.plutus_v3 = Some(v3.clone());
-                warn!(
-                    entries = v3.len(),
-                    "Seeded missing PlutusV3 cost model into Conway ledger state from genesis \
-                     (snapshot predates V3 seeding); this prevents ScriptDataHashMismatch and \
-                     spurious budget-exhausted divergences on PlutusV3 transactions"
-                );
-            } else {
-                warn!(
-                    "Conway ledger state has no PlutusV3 cost model and no Conway genesis V3 \
-                     cost model is available to seed it — PlutusV3 transactions will diverge"
-                );
+            match (pv, &conway_v3_cost_model) {
+                (9, Some(v3)) => {
+                    ledger.epochs.protocol_params.cost_models.plutus_v3 = Some(v3.clone());
+                    warn!(
+                        entries = v3.len(),
+                        "Seeded missing PlutusV3 cost model into Conway ledger state from genesis \
+                         (PV9 snapshot predates V3 seeding); this prevents ScriptDataHashMismatch \
+                         and spurious budget-exhausted divergences on PlutusV3 transactions"
+                    );
+                }
+                (9, None) => {
+                    warn!(
+                        "Conway PV9 ledger state has no PlutusV3 cost model and no Conway genesis \
+                         V3 cost model is available to seed it — PlutusV3 transactions will diverge"
+                    );
+                }
+                _ => {
+                    // pv > 9 with no V3: do NOT inject the stale genesis model.
+                    warn!(
+                        pv,
+                        "Conway PV{pv} ledger state has no PlutusV3 cost model. The genesis \
+                         (PV9) model is NOT authoritative at this PV (Plomin/PV11 expand V3 via \
+                         governance), so it is NOT being seeded — the governance ParameterChange \
+                         enactment must populate the correct expanded model. PlutusV3 transactions \
+                         will diverge until then; this indicates a governance-enactment gap or an \
+                         unsupported snapshot."
+                    );
+                }
             }
         }
 

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1086,6 +1086,7 @@ impl Node {
         let mut conway_constitution: Option<dugite_primitives::transaction::Constitution> = None;
         let mut conway_initial_dreps: Vec<(dugite_primitives::hash::Hash28, u64)> = Vec::new();
         let mut conway_genesis_file_hash: Option<dugite_primitives::hash::Hash32> = None;
+        let mut conway_v3_cost_model: Option<Vec<i64>> = None;
         if let Some(ref genesis_path) = args.config.conway_genesis_file {
             let genesis_path = config_dir.join(genesis_path);
             match ConwayGenesis::load_with_hash(&genesis_path) {
@@ -1101,6 +1102,7 @@ impl Node {
                     conway_committee_members = genesis.committee_members();
                     conway_constitution = genesis.to_ledger_constitution();
                     conway_initial_dreps = genesis.initial_dreps_as_entries();
+                    conway_v3_cost_model = genesis.plutus_v3_cost_model.clone();
                     genesis.apply_to_protocol_params(&mut protocol_params);
                 }
                 Err(e) => {
@@ -1608,14 +1610,44 @@ impl Node {
         {
             let has_data = conway_committee_threshold.is_some()
                 || !conway_committee_members.is_empty()
-                || !conway_initial_dreps.is_empty();
+                || !conway_initial_dreps.is_empty()
+                || conway_v3_cost_model.is_some();
             if has_data {
                 ledger.conway_genesis_init = Some(dugite_ledger::eras::ConwayGenesisInit {
                     initial_dreps: conway_initial_dreps,
                     committee_members: conway_committee_members,
                     committee_threshold: conway_committee_threshold,
                     constitution: ledger.gov.governance.constitution.clone(),
+                    plutus_v3_cost_model: conway_v3_cost_model.clone(),
                 });
+            }
+        }
+
+        // Safety net: a Conway-era ledger snapshot taken before the V3 cost-model
+        // seeding fix (or any Conway snapshot whose `cost_models.plutus_v3` is
+        // `None`) would compute the wrong `script_data_hash` and default-cost-model
+        // budgets for every PlutusV3 transaction. The Babbage→Conway
+        // `on_era_transition` only fires when crossing the hard fork during replay;
+        // for a node resuming directly from a Conway snapshot it never runs, so seed
+        // V3 here from the Conway genesis upgrade params when we are already past the
+        // hard fork (pv >= 9) and the snapshot is missing it. This is a per-language
+        // insert — V1/V2 (and any governance-updated V3) are left untouched.
+        if ledger.epochs.protocol_params.protocol_version_major >= 9
+            && ledger.epochs.protocol_params.cost_models.plutus_v3.is_none()
+        {
+            if let Some(ref v3) = conway_v3_cost_model {
+                ledger.epochs.protocol_params.cost_models.plutus_v3 = Some(v3.clone());
+                warn!(
+                    entries = v3.len(),
+                    "Seeded missing PlutusV3 cost model into Conway ledger state from genesis \
+                     (snapshot predates V3 seeding); this prevents ScriptDataHashMismatch and \
+                     spurious budget-exhausted divergences on PlutusV3 transactions"
+                );
+            } else {
+                warn!(
+                    "Conway ledger state has no PlutusV3 cost model and no Conway genesis V3 \
+                     cost model is available to seed it — PlutusV3 transactions will diverge"
+                );
             }
         }
 

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2624,6 +2624,22 @@ impl Node {
             if let Some(slot) = tip.point.slot() {
                 self.metrics.set_slot(slot.0);
                 self.metrics.set_block_number(tip.block_number.0);
+                // #742: seed the ledger-tip watch with the ChainDB tip so the
+                // forecast-horizon admission gate (forecast_park_or_disconnect)
+                // measures incoming headers against the node's EFFECTIVE tip,
+                // not the stale snapshot tip. The startup volatile replay
+                // (reapply mode) advances the ledger toward this tip but never
+                // fires `ledger_tip_slot_tx` (publish_ledger_view runs only on
+                // the live apply path). Without this seed, a restart with a
+                // large fetched-ahead volatile gap (e.g. blocks fetched past a
+                // block whose apply then halted) parks EVERY incoming header on
+                // "beyond forecast horizon" against the snapshot tip and wedges
+                // the whole sync (observed live: restart from an epoch-511
+                // snapshot whose ChainDB had fetched ~172k slots ahead). Only an
+                // admission gate — apply-time validation stays authoritative and
+                // the genesis LoE still caps adoption, so an optimistic seed
+                // during the brief local replay is safe.
+                let _ = self.ledger_tip_slot_tx.send(slot.0);
                 self.update_sync_progress(slot.0, &ls.slot_config).await;
                 // Era-aware tip-age computation (see Node::slot_to_wallclock_ms).
                 let slot_time_ms = self.slot_to_wallclock_ms(slot.0, &ls.slot_config).await;

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -3638,6 +3638,19 @@ fn classify_eager_validation_result(
     match result {
         Ok(()) => Ok(true),
         Err(dugite_consensus::ConsensusError::OpcertCounterOverIncremented { .. }) => Ok(false),
+        // The eager forecast horizon is checked against the lock-free `LedgerView`,
+        // whose `last_applied_slot` can LAG the live ledger tip — `publish_ledger_view`
+        // is throttled during catch-up (#698) and freezes entirely if the apply loop
+        // stalls. `forecast_park_or_disconnect` has ALREADY gated this header against
+        // the FRESH tip watch (`tip_rx`) at the call site, so a stale view that cannot
+        // yet forecast the slot is a FALSE negative — defer to the authoritative body
+        // apply (which forecasts against the live ledger state), never disconnect.
+        // Without this, a throttled view freezing ~a stability window behind the
+        // applied tip eager-rejects every in-range header and disconnects all peers →
+        // permanent wedge (observed live at the mainnet Babbage→Conway boundary,
+        // 2026-06-13: view frozen at slot 133109521 rejected the first Conway block at
+        // 133660855 while the applied tip was 133660799, churning all 40 peers).
+        Err(dugite_consensus::ConsensusError::OutsideForecast(_)) => Ok(false),
         Err(e) => Err(e),
     }
 }
@@ -6086,6 +6099,23 @@ mod seed_peer_counter_tests {
         // An unrelated crypto fault stays fatal.
         let bad = Err(ConsensusError::InvalidBlock("kes".into()));
         assert!(classify_eager_validation_result(bad).is_err());
+
+        // OutsideForecast → deliberate skip, NOT a peer fault. The eager forecast
+        // uses the throttled lock-free view (which can freeze far behind the applied
+        // tip); the FRESH tip watch already gated the header in forecast_park, and
+        // body apply re-forecasts authoritatively. Treating it as fatal here churned
+        // all peers at the mainnet Babbage→Conway boundary (2026-06-13).
+        let stale = Err(ConsensusError::OutsideForecast(
+            dugite_consensus::OutsideForecastRange {
+                at: Some(dugite_primitives::time::SlotNo(133_109_521)),
+                max_for: dugite_primitives::time::SlotNo(133_239_122),
+                requested: dugite_primitives::time::SlotNo(133_660_855),
+            },
+        ));
+        assert!(
+            !classify_eager_validation_result(stale).unwrap(),
+            "stale-view OutsideForecast must be deferred to body apply, never disconnect"
+        );
     }
 
     /// End-to-end of the regression: a peer map seeded from a snapshot global

--- a/crates/dugite-uplc/src/populate_gov.rs
+++ b/crates/dugite-uplc/src/populate_gov.rs
@@ -636,10 +636,23 @@ pub fn certificate_to_plutus_v1v2(c: &PrimCert) -> Result<TxCert, PhaseTwoError>
         ),
         PrimCert::GenesisKeyDelegation { .. } => Data::Constr(5, vec![]),
         PrimCert::MoveInstantaneousRewards { .. } => Data::Constr(6, vec![]),
-        // Conway-era certificate kinds — illegal alongside a V1/V2 script.
-        PrimCert::ConwayStakeRegistration { .. } => return conway_only("ConwayStakeRegistration"),
-        PrimCert::ConwayStakeDeregistration { .. } => {
-            return conway_only("ConwayStakeDeregistration")
+        // Conway registration / deregistration (with an explicit deposit /
+        // refund) translate to the SAME legacy V1/V2 `DCert` as the no-deposit
+        // Shelley form — the deposit / refund is silently DROPPED (the
+        // PlutusV1/V2 `DCert` has no deposit field). Byte-exact with
+        // cardano-ledger `Conway/TxInfo::transTxCertV1V2`:
+        //   RegDepositTxCert  cred _deposit -> DCertDelegRegKey   (StakingHash cred)  [Constr 0]
+        //   UnRegDepositTxCert cred _refund -> DCertDelegDeRegKey (StakingHash cred)  [Constr 1]
+        // A V1/V2 script witnessing one of these is VALID on-chain — rejecting
+        // it halted the node at mainnet epoch 511 (slot 135634801, the first
+        // Conway stake-registration-with-deposit witnessed by a cert-purpose
+        // V1/V2 script). The remaining Conway-only certs below have NO legacy
+        // `DCert` form, so they correctly stay `CertificateNotSupported`.
+        PrimCert::ConwayStakeRegistration { credential, .. } => {
+            Data::Constr(0, vec![staking_hash_data(credential)])
+        }
+        PrimCert::ConwayStakeDeregistration { credential, .. } => {
+            Data::Constr(1, vec![staking_hash_data(credential)])
         }
         PrimCert::RegStakeDeleg { .. } => return conway_only("RegStakeDeleg"),
         PrimCert::VoteDelegation { .. } => return conway_only("VoteDelegation"),
@@ -746,6 +759,45 @@ mod tests {
                     vec![Data::Constr(0, vec![Data::B(vec![0x11; 28])])]
                 )]
             )
+        );
+    }
+
+    #[test]
+    fn v1v2_dcert_conway_registration_with_deposit_drops_deposit() {
+        // Conway RegDepositTxCert (registration WITH a deposit) translates to
+        // the SAME legacy V1/V2 DCertDelegRegKey [Constr 0] as the no-deposit
+        // Shelley form — the deposit is DROPPED. Byte-exact with cardano-ledger
+        // Conway/TxInfo::transTxCertV1V2. Pins the mainnet epoch-511 halt fix
+        // (tx 360b9a34…, stake_registration deposit=2_000_000 witnessed by a
+        // cert-purpose V1/V2 script).
+        let reg = PrimCert::ConwayStakeRegistration {
+            credential: key_cred(0x11),
+            deposit: Lovelace(2_000_000),
+        };
+        assert_eq!(
+            certificate_to_plutus_v1v2(&reg).unwrap().0,
+            Data::Constr(
+                0,
+                vec![Data::Constr(
+                    0,
+                    vec![Data::Constr(0, vec![Data::B(vec![0x11; 28])])]
+                )]
+            ),
+        );
+        // UnRegDepositTxCert → DCertDelegDeRegKey [Constr 1], refund dropped.
+        let dereg = PrimCert::ConwayStakeDeregistration {
+            credential: script_cred(0x22),
+            refund: Lovelace(2_000_000),
+        };
+        assert_eq!(
+            certificate_to_plutus_v1v2(&dereg).unwrap().0,
+            Data::Constr(
+                1,
+                vec![Data::Constr(
+                    0,
+                    vec![Data::Constr(1, vec![Data::B(vec![0x22; 28])])]
+                )]
+            ),
         );
     }
 

--- a/reports/devnet-validate/v2.0.7.json
+++ b/reports/devnet-validate/v2.0.7.json
@@ -1,0 +1,205 @@
+{
+  "schema_version": 1,
+  "timestamp": "2026-06-13T16:45:20Z",
+  "git_rev": "71ec1ee6badb6627a4d3220009df7b0eabeeb82e",
+  "release_tag": null,
+  "preset": "extended",
+  "cardano_node_version": "11.0.1",
+  "cardano_cli_version": "11.0.0.0",
+  "rounds": [
+    {
+      "name": "baseline",
+      "pass": true,
+      "evidence_dir": "evidence-kept/round1-20260613T155821Z",
+      "duration_seconds": 180,
+      "git_rev": "71ec1ee6badb6627a4d3220009df7b0eabeeb82e",
+      "cardano_node_version": "11.0.1",
+      "cardano_cli_version": "11.0.0.0",
+      "blocks": {
+        "total_forges": 104,
+        "canonical": 104,
+        "orphans": 0,
+        "orphan_rate": 0.0000
+      },
+      "tip_age": {
+        "avg_seconds": 1.54,
+        "p99_seconds": 4.00
+      },
+      "chain_density": 0.575,
+      "tx_zoo": {
+        "pass": 0,
+        "fail": 0,
+        "skip": 0,
+        "total": 0
+      },
+      "predicates": {
+        "p1_forge_cross_check": true,
+        "p2_per_bp_attribution": true,
+        "p3_tx_inclusion": true,
+        "p4_tip_parity": true,
+        "p5_tip_age": true
+      },
+      "log_errors": {
+        "dugite-bp": {
+          "errors": 1,
+          "warns": 4
+        },
+        "dugite-relay": {
+          "errors": 20,
+          "warns": 38
+        },
+        "cardano-bp": {
+          "errors": 1,
+          "warns": 1
+        }
+      },
+      "anomalies": [],
+      "epoch_transitions_observed": 1,
+      "n2n_adversarial": {
+        "pass": 0,
+        "fail": 0,
+        "panic": 0,
+        "silent_skip": 0
+      },
+      "cli_parity": {
+        "equal": 0,
+        "divergent": 0,
+        "skip": 0,
+        "error": 0
+      }
+    },
+    {
+      "name": "epoch-boundary",
+      "pass": true,
+      "evidence_dir": "evidence-kept/round2-20260613T160957Z",
+      "duration_seconds": 180,
+      "git_rev": "71ec1ee6badb6627a4d3220009df7b0eabeeb82e",
+      "cardano_node_version": "11.0.1",
+      "cardano_cli_version": "11.0.0.0",
+      "blocks": {
+        "total_forges": 84,
+        "canonical": 84,
+        "orphans": 0,
+        "orphan_rate": 0.0000
+      },
+      "tip_age": {
+        "avg_seconds": 1.24,
+        "p99_seconds": 4.00
+      },
+      "chain_density": 0.464,
+      "tx_zoo": {
+        "pass": 0,
+        "fail": 0,
+        "skip": 0,
+        "total": 0
+      },
+      "predicates": {
+        "p1_forge_cross_check": true,
+        "p2_per_bp_attribution": true,
+        "p3_tx_inclusion": true,
+        "p4_tip_parity": true,
+        "p5_tip_age": true
+      },
+      "log_errors": {
+        "dugite-bp": {
+          "errors": 1,
+          "warns": 3
+        },
+        "dugite-relay": {
+          "errors": 20,
+          "warns": 37
+        },
+        "cardano-bp": {
+          "errors": 1,
+          "warns": 1
+        }
+      },
+      "anomalies": [],
+      "epoch_transitions_observed": 1,
+      "n2n_adversarial": {
+        "pass": 0,
+        "fail": 0,
+        "panic": 0,
+        "silent_skip": 0
+      },
+      "cli_parity": {
+        "equal": 0,
+        "divergent": 0,
+        "skip": 0,
+        "error": 0
+      }
+    },
+    {
+      "name": "restart",
+      "pass": true,
+      "evidence_dir": "evidence-kept/round3-20260613T163344Z",
+      "duration_seconds": 180,
+      "git_rev": "71ec1ee6badb6627a4d3220009df7b0eabeeb82e",
+      "cardano_node_version": "11.0.1",
+      "cardano_cli_version": "11.0.0.0",
+      "blocks": {
+        "total_forges": 84,
+        "canonical": 84,
+        "orphans": 0,
+        "orphan_rate": 0.0000
+      },
+      "tip_age": {
+        "avg_seconds": 1.00,
+        "p99_seconds": 5.00
+      },
+      "chain_density": 0.467,
+      "tx_zoo": {
+        "pass": 0,
+        "fail": 0,
+        "skip": 0,
+        "total": 0
+      },
+      "predicates": {
+        "p1_forge_cross_check": true,
+        "p2_per_bp_attribution": true,
+        "p3_tx_inclusion": true,
+        "p4_tip_parity": true,
+        "p5_tip_age": true
+      },
+      "log_errors": {
+        "dugite-bp": {
+          "errors": 1,
+          "warns": 3
+        },
+        "dugite-relay": {
+          "errors": 20,
+          "warns": 36
+        },
+        "cardano-bp": {
+          "errors": 1,
+          "warns": 1
+        }
+      },
+      "anomalies": [],
+      "epoch_transitions_observed": 1,
+      "n2n_adversarial": {
+        "pass": 0,
+        "fail": 0,
+        "panic": 0,
+        "silent_skip": 0
+      },
+      "cli_parity": {
+        "equal": 0,
+        "divergent": 0,
+        "skip": 0,
+        "error": 0
+      }
+    }
+  ],
+  "summary": {
+    "pass": true,
+    "rounds_pass": 3,
+    "rounds_fail": 0,
+    "total_canonical_blocks": 272,
+    "total_tx_zoo_pass": 0,
+    "total_tx_zoo_fail": 0,
+    "invalid_forges_detected": 0,
+    "critical_anomalies": 0
+  },
+  "trend": null
+}

--- a/reports/issue-760-oracle-correction.md
+++ b/reports/issue-760-oracle-correction.md
@@ -1,0 +1,76 @@
+# #760-A — Oracle correction: the original A1 fix design is Haskell-DIVERGENT
+
+Date: 2026-06-13. Source: cardano-haskell-oracle live read of IntersectMBO/
+ouroboros-consensus `Ouroboros.Consensus.MiniProtocol.ChainSync.Client(.Jumping)`
+and `Ouroboros.Consensus.Genesis.Governor`.
+
+## What the original design (reports/issue-760-genesis-csj-wedge-design.md) claimed
+A1: "record the RollForward header into pending_headers + candidate-fragment +
+CSJ FIRST, then apply forecast_park_or_disconnect as pipeline BACKPRESSURE" —
+justified by "Haskell, where ChainSync blocks at the forecast horizon only for
+issuing MsgRequestNext, while theirFrag/jTheirFragment already hold the streamed
+headers."
+
+## What Haskell ACTUALLY does (authoritative, source-grounded)
+`rollForward` ordering for ONE received header:
+1. `checkKnownInvalid`
+2. `Jumping.jgOnRollForward (blockPoint hdr)` — CSJ jump trigger. **READS** the
+   current `cschJumpInfo` to decide whether to schedule a jump; does **NOT**
+   update `jTheirFragment`.
+3. `setLatestSlot (NotOrigin slot)` — `csLatestSlot` set to the RAW received slot,
+   BEFORE the forecast. (This is the ONLY shared state ahead of the forecast.)
+4. `checkTime` — the forecast block. **STM-retries / BLOCKS here** if the slot is
+   `OutsideForecastRange` (> ledger_tip + 3k/f). LoP bucket paused for the wait.
+5. `checkValid` → appends header to `theirFrag` (LOCAL `kis` only).
+6. `checkLoP`.
+7. `atomically { updateJumpInfoSTM (jTheirFragment := theirFrag); setCandidate
+   (csCandidate := theirFrag) }` — the shared candidate fragment that BlockFetch
+   reads, AND the CSJ jump fragment, are BOTH written here, AFTER the forecast.
+8. `nextStep` → MsgRequestNext.
+
+**Therefore Haskell does NOT put beyond-horizon headers into `csCandidate` or
+`jTheirFragment`.** Buffering unvalidated/beyond-horizon headers into the
+candidate fragment (the original A1) would DIVERGE from Haskell — and could
+mis-feed LoE/GDD density and CSJ jumps. A1 as written is REJECTED.
+
+## The true deadlock condition (oracle)
+Haskell self-primes because `csCandidate` holds forecast-validated headers from
+`ledger_tip` up to `ledger_tip + 3k/f` (mainnet ≈ 8640 headers). BlockFetch
+fetches those bodies, applies them, the ledger advances, the forecast horizon
+advances, the parked header unblocks. The deadlock occurs ONLY when `csCandidate`
+is EMPTY/stuck at the ledger tip with nothing for BlockFetch — i.e. the FIRST
+header received after restart is already beyond the forecast horizon, so the
+candidate never fills.
+
+Haskell avoids this on cold restart because **the peer serves headers from the
+INTERSECTION POINT (at/near the snapshot tip), not from its tip** — the first
+headers are near the snapshot, within the just-loaded ledger's forecast horizon,
+so `csCandidate` fills before the horizon is reached.
+
+GDD/LoE detail: `loeFrag = sharedCandidatePrefix curChain (csCandidate <$> states)`;
+LoE tip = head of the longest common prefix of ALL peers' `csCandidate`. Chain
+selection is capped at the LoE tip (`trimToLoE`). The ledger advances up to the
+LoE tip via BlockFetch on headers already in `csCandidate`. GDD ALSO consults
+`csLatestSlot` for the `hasBlockAfter` genesis-window density bound (so a
+received-but-not-yet-in-csCandidate header still influences density correctly).
+BlockFetch reads `csCandidate` ONLY (no csLatestSlot fallback, no separate buffer).
+
+## Corrected direction for the dugite fix (to be confirmed by LIVE repro)
+The fix must make dugite mirror Haskell's self-priming, NOT buffer beyond-horizon
+headers. Candidate hypotheses for dugite's actual divergence (need live evidence):
+1. The dynamo's candidate fragment (`peer_state` / `pending_headers`) does fill
+   with in-horizon headers, but the LoE is pinned at the immutable tip because the
+   JUMPERS' fragments are empty until the dynamo broadcasts its first jump — and
+   something prevents the jump/jumper-advance/LoE-advance loop from priming
+   (dynamo rotation watchdog firing during legitimate parks? jump cadence vs
+   forecast interplay? csLatestSlot not fed to dugite's GDD hasBlockAfter?).
+2. The post-snapshot ChainSync intersection / `reintersect_promoted_peer` lands
+   somewhere that makes the dynamo stream headers immediately beyond the horizon
+   (so the candidate never fills) — the precise Haskell-avoidance mechanism.
+3. The forecast check incorrectly returns OutsideForecastRange for in-horizon
+   headers (stale view / wrong stability window).
+
+NEXT: reproduce the wedge live on db-mainnet-val (genesis cold restart) WITH
+diagnostics on (candidate-fragment length per peer, LoE tip slot, dynamo role +
+rotations, forecast park reasons), and read the ACTUAL stuck state before writing
+any fix. Do NOT implement the original A1.

--- a/reports/issue-760-rediagnosis.md
+++ b/reports/issue-760-rediagnosis.md
@@ -1,0 +1,518 @@
+# Issue #760-A — Re-diagnosis: genesis-mode cold-restart sync wedge
+
+Date: 2026-06-13. Based on live source reading of the working tree; all
+file:line references verified against HEAD.
+
+## Executive summary
+
+The original A1 design (buffer beyond-horizon headers into the candidate
+fragment before the forecast check) was **correctly rejected** by the oracle
+correction. This document provides the definitive root-cause analysis,
+alternative ranking, repro diagnostics, and a corrected fix design that
+mirrors Haskell without buffering beyond-horizon headers.
+
+**Primary root cause (confirmed by code): the #742 unproductive-dynamo
+watchdog fires on the legitimately-parked dynamo during genesis bulk sync,
+continuously rotating it and preventing the self-priming cycle from ever
+completing.**
+
+---
+
+## A — Primary root cause
+
+### The self-priming cycle (how it should work)
+
+In Haskell, genesis bulk sync self-primes because `csCandidate` fills with
+forecast-validated headers from the snapshot tip up to `snapshot_tip +
+stability_window` (≈ 8 640 headers on mainnet at k=2160, f=0.05). BlockFetch
+fetches those bodies, the ledger advances, the forecast horizon advances, the
+next parked header unblocks, and so on. The LoE tip is the shared prefix of
+all peers' `csCandidate`s, so as the dynamo's fragment fills the LoE tip
+advances, selection advances, and the cycle is self-sustaining.
+
+In dugite the analogous cycle is:
+1. Dynamo streams headers. Each in-horizon header passes `forecast_park_or_disconnect`
+   (`sync.rs:5247`), is pushed to `pending_headers` (`sync.rs:5372`), and
+   appended to `peer_state` (`sync.rs:5396`).
+2. BlockFetch sees `pending_headers` for the dynamo and fetches the bodies.
+3. Applied blocks advance `ledger_tip_rx`, which wakes any parked
+   `forecast_park_or_disconnect` loops.
+4. The dynamo's `peer_state` fragment grows → LoE tip advances (Syncing
+   branch of GSM actor, `gsm.rs:900-987`) → chain selection cap lifts →
+   ledger tip advances further.
+
+**The cycle CAN prime on a cold restart — the dynamo correctly intersects at
+the snapshot tip (see section A.1) and begins streaming in-horizon headers.**
+The wedge is upstream: the cycle IS priming, but it is being continuously
+aborted by the watchdog before it accumulates enough headers to become
+self-sustaining.
+
+### The watchdog kill loop (the actual bug)
+
+`connection_lifecycle.rs:2431-2484` — the "unproductive-claim" watchdog path:
+
+```
+if fetch_runs.is_empty() {           // <─── dynamo has nothing dispatchable for BlockFetch
+    …
+    if is_genesis_bulk_sync
+        && now_ms.saturating_sub(since) >= watchdog_ms        // unproductive ≥ 3×grace (30s)
+        && last_starvation_ms >= since.saturating_add(watchdog_ms)  // starvation concurrent
+    {
+        cs.rotate_dynamo(&addr);     // <─── KILL. The dynamo is rotated.
+```
+
+Definitions:
+- `watchdog_ms = 3 * block_fetch_grace_period.as_millis()` = 3 × 10 000 ms = **30 s**
+  (default `block_fetch_grace_period = 10.0s`, `config.rs:118`).
+- `last_starvation_ms = if starv == 0 { now_ms } else { starv }`. When
+  ChainSel queue is empty (starvation Ongoing, `starv == 0`), this equals
+  `now_ms`, so condition 2 collapses to the same test as condition 1.
+  Therefore the watchdog fires whenever: (a) in genesis bulk sync, (b) the
+  dynamo has been claimed-but-unproductive for ≥ 30 s continuously, AND (c)
+  ChainSel is starved (queue empty).
+
+**What "unproductive" means here:** `fetch_runs.is_empty()` is true when the
+dynamo's `pending_headers` is empty OR ALL headers in it already pass the
+`has_block`/`fetched_hashes` filter. On cold restart the dynamo's
+`pending_headers` IS empty — it has no headers yet because it is parked in
+`forecast_park_or_disconnect` (`sync.rs:5247`) waiting for the first in-horizon
+header. While it parks, its BlockFetch worker polls every 10 ms, claims the
+active-fetcher slot, sees `fetch_runs.is_empty()`, and increments
+`unproductive_since_ms`. After 30 s it rotates the dynamo.
+
+**What happens on rotation:** `rotate_dynamo` (csj.rs:491-529) demotes the
+dynamo to a fresh jumper (`Happy { fresh: true }`) and elects the next peer
+via `backfill_dynamo` → `promote_to_dynamo` (`csj.rs:568-649`). The new dynamo
+either exits `run_csj_jumper_loop` with `JumperExit::StreamReintersect` (if
+its server cursor jumped) or `JumperExit::Stream`. Either path calls
+`reintersect_promoted_peer` (`sync.rs:4348-4415`), which sends
+`MsgFindIntersect` with the current chain tip (still the snapshot tip, since
+no progress was made), gets `MsgIntersectFound`, anchors at the snapshot tip,
+and begins streaming. The new dynamo immediately hits `forecast_park_or_disconnect`
+for the same reason (all headers are beyond the horizon from the snapshot),
+parks for 30 s, gets rotated again.
+
+**Net result: each dynamo gets 30 s to prime, then rotates.** On mainnet with
+40 peers and a 138-epoch gap (~11M slots), stability_window ≈ 8640 slots.
+A full stability window of blocks at roughly 20 blk/s (rough mainnet throughput
+on a fast sync) would take ~7 min. The 30 s window expires before enough
+headers accumulate, the dynamo rotates, the new dynamo re-intersects at the
+same frozen tip, and the cycle repeats. Each rotation produces at most a handful
+of blocks: ~30 s × (blocks receivable before hitting the horizon) ≈ the
+headers that arrive within the forecast window before parking. With a far-below
+snapshot, the FIRST header is already beyond the horizon (see section A.1), so
+the cycle yields exactly 0 blocks per 30 s rotation → ~1 blk/min observed.
+
+### A.1 — Does the dynamo intersect at the snapshot tip?
+
+`reintersect_promoted_peer` (`sync.rs:4348-4415`) and the initial
+`build_known_points` path both use:
+1. `chain_db.get_tip_info()` — the selected chain tip (snapshot tip on cold restart)
+2. `db.get_chain_points(VOLATILE_POINTS_DEPTH)` — recent volatile points
+3. `db.get_immutable_tip_point()` — immutable tip
+
+The peer (a mainnet relay) is well ahead (~epoch 636 vs snapshot epoch 498),
+but it still holds our chain history, so `MsgIntersectFound` at our snapshot
+tip is expected and is confirmed by the "CSJ: promoted peer re-intersected at
+frontier" log. The first header streamed is therefore the block immediately
+AFTER the snapshot tip.
+
+On mainnet mainnet the snapshot tip is epoch ~498 (slot ~126M), live tip is
+epoch ~636 (slot ~162M), gap is ~36M slots. Stability window is
+`3k/f = 3×2160/0.05 = 129 600 slots`. The first header from the snapshot tip
+is at slot `snapshot_tip + 1`, which is far inside the forecast horizon
+(`snapshot_tip + 1 <= snapshot_tip + 129 600`). **The first header is
+in-horizon.** So the dynamo DOES start streaming in-horizon headers — the wedge
+is NOT the initial beyond-horizon hit. It is the watchdog firing before enough
+in-horizon headers accumulate to make BlockFetch productive.
+
+### A.2 — Why does BlockFetch show `fetch_runs.is_empty()` even when the dynamo has in-horizon headers?
+
+Two sub-cases:
+
+**Sub-case A.2a (first seconds):** The dynamo has just re-intersected and its
+`pending_headers` is empty. Its ChainSync task is in the pipeline loop sending
+`MsgRequestNext`s and awaiting responses. The first responses arrive, pass
+`forecast_park_or_disconnect`, and are pushed to `pending_headers`. This takes
+a few ms per header. Meanwhile BlockFetch polls every 10 ms. The first few
+polls may see an empty queue; after 50-100 ms headers accumulate.
+
+**Sub-case A.2b (after first stability window worth of headers):** The dynamo
+streams ≈ stability_window headers (in-horizon), then the NEXT header is at
+`snapshot_tip + stability_window + 1`, which is beyond the horizon. It parks in
+`forecast_park_or_disconnect` (`sync.rs:5247`), blocking further `pending_headers`
+growth. At this point `pending_headers` has ≈ stability_window headers. If
+BlockFetch is slow enough (or the contiguity guard at `connection_lifecycle.rs:2534`
+rejects some ranges), `pending_headers` may still contain headers. But if
+BlockFetch is FAST (it usually is; at 20 blk/s and 1 Hz ledger publish, a 10s
+burst fetches ~200 blocks), `pending_headers` drains before the ledger tip
+advances enough to unpark the dynamo. The dynamo parks with an empty
+`pending_headers`, BlockFetch sees `fetch_runs.is_empty()` for 30 s, rotates.
+
+In both sub-cases the rotate happens. Sub-case A.2b is the dominant steady-state
+failure mode once the cycle is running (i.e. a partial rotation, not a total
+freeze); the observed "~1 blk/min" is consistent with 30 s/rotation × N headers
+fetched before draining per rotation.
+
+### A.3 — The #735 contiguity guard interaction
+
+`connection_lifecycle.rs:2534-2613` — after promotion via
+`JumperExit::StreamReintersect`, the promoted dynamo re-intersects at the
+frontier. Its `pending_headers` are fresh (cleared at reintersect, new headers
+start from the frontier). The #735 guard checks `prev_hash` of the first
+pending header; since the dynamo streams from the frontier, this should match
+a stored block. However, on rotation under the watchdog, `pending_headers` from
+the previous (rotated) dynamo may not be cleared. The CandidateChainState entry
+persists in `candidate_chains` across dynamo rotations — it is only reset when
+the peer disconnects (`chains.remove(&peer_addr)` on task exit, not on role
+change). Therefore the NEW dynamo may inherit `pending_headers` from a
+partially-completed previous cycle, and the #735 contiguity guard may accept or
+reject those headers correctly; this is not the source of the wedge, but it
+does mean the "unproductive" diagnosis is accurate: after a rotation, the new
+dynamo briefly has stale headers, then fresh headers append. The key stall is
+the 30 s park window.
+
+---
+
+## B — Ranked alternative causes
+
+### B.1 — LoE pinned at immutable tip because jumpers' fragments are empty
+
+**Status: confirmed as a CONTRIBUTING factor, not the primary cause.**
+
+When the dynamo's `peer_state` fragment is empty or shallow (e.g., during the
+first seconds after re-intersection), the LoE computation at `gsm.rs:900-987`:
+
+```rust
+let sp = crate::genesis_governor::shared_candidate_prefix(selection_tip, &frags);
+```
+
+`shared_candidate_prefix` (`genesis_governor.rs:113-154`) takes the LONGEST
+COMMON PREFIX of ALL peers' fragments. Jumper fragments are advanced only when
+they accept a jump (`replace_fragment` called from `run_csj_jumper_loop:4325`
+on `JumpInfo` acceptance). On cold restart, the dynamo has just re-intersected
+and has 0 headers in its fragment. The jumpers have their `next_jump` pre-loaded
+from the dynamo's `jump_info` (`csj.rs:194-197`), but `jump_info` starts at
+`None` for a freshly-elected dynamo. The dynamo's `jump_info` is only set by
+`update_jump_info` (`csj.rs:377-391`), which is called at `sync.rs:5408` AFTER
+the header passes `forecast_park_or_disconnect`. Since all headers park
+immediately, `jump_info` is never set, no jumps are ever broadcast, and jumpers
+stay `Happy { fresh: true }` forever.
+
+In this state `shared_candidate_prefix` has:
+- Dynamo fragment: anchor = snapshot_tip, entries = [] (empty)
+- 39 jumper fragments: each has whatever `replace_fragment` set last — on fresh
+  start, their anchor is the initial intersection (`set_anchor` at `sync.rs:4870`)
+  = snapshot tip or Origin, entries = []
+
+All fragments empty → `suffix_at_imm_tip` returns empty for all → `shared_candidate_prefix` returns empty prefix → LoE tip = volatile_window tail (= snapshot_tip) → LoE = selection_tip → no advancement beyond the current selection.
+
+This means the LoE IS pinned at the snapshot tip, and chain selection will not
+advance past it. This IS a circular dependency contributing to the freeze, but
+it is secondary to the watchdog: even if we fixed the LoE pinning by other
+means (e.g. having the dynamo push headers before the forecast check), the
+watchdog would still rotate the dynamo every 30 s, preventing the fragment from
+ever growing enough to move the LoE.
+
+**Refute evidence for B.1 as the PRIMARY cause:** If LoE pinning were the
+primary cause, we would see the dynamo accumulate headers in `pending_headers`
+and `peer_state` up to stability_window, then stall on LoE not advancing. The
+reported symptom is ~1 blk/min, which corresponds to periodic 30 s bursts, not
+a clean plateau at stability_window blocks. The watchdog rotation period (30 s)
+matches the observed rate.
+
+### B.2 — First header beyond forecast horizon (original "far-ahead" hypothesis)
+
+**Status: REFUTED for the cold-restart case.**
+
+As shown in A.1, the first header is at snapshot_tip+1, which is within the
+forecast window of `snapshot_tip + stability_window`. The dynamo does stream
+in-horizon headers. The original design report's claim that "the first received
+header is already beyond the forecast horizon" was incorrect for the cold-restart
+case; it would only be true if the dynamo intersected at Origin (not the case
+after `reintersect_promoted_peer`).
+
+However, a secondary instance occurs after the dynamo has consumed all in-horizon
+headers and hits slot `snapshot_tip + stability_window + 1`: the first BEYOND-HORIZON
+header correctly parks. This is not the cause of ~1 blk/min; it is the natural
+steady-state behavior that should self-resolve as BlockFetch fetches the
+in-horizon batch and the ledger advances.
+
+### B.3 — stale LedgerView (#742) — tip-watch not updated after snapshot restore
+
+**Status: ALREADY FIXED (`forecast_park_or_disconnect` uses `ledger_tip_rx`,
+not `view.last_applied_slot`).** The `tip_rx` watch channel is updated
+separately on each block apply (`sync.rs:3733-3738`). Not a current regression.
+
+### B.4 — GDD disconnects the dynamo as low-density
+
+**Status: UNLIKELY but not fully excludable.**
+
+During the freeze, the dynamo's candidate suffix beyond the LoE tip is empty
+(LoE = snapshot tip, fragment empty). GDD Guard 1: `idling || lower_bound > 0 ||
+has_block_after`. The dynamo is not idling (it is streaming), `lower_bound = 0`
+(empty suffix), `has_block_after = max(suffix_head_slot, latest_slot) >= first_slot_after_window`.
+`latest_slot` is set in `peer_state.on_roll_forward` BEFORE the fragment is
+appended (`genesis_peer_state.rs:231`), but only for headers that pass
+`forecast_park_or_disconnect`. If the dynamo parks before the first `on_roll_forward`
+call (i.e. it parks before the first header), `latest_slot = None` and GDD
+Gate 0 excludes the dynamo entirely — no disconnect. So GDD should not be
+killing the dynamo during the freeze. Can still cause intermittent disconnects
+once a few headers arrive but are below the genesis window.
+
+### B.5 — `chainsel_starvation_ms` semantics incorrect under heavy apply load
+
+**Status: UNLIKELY — edge semantics are correct per code review.**
+
+`chainsel_dequeued` does a CAS from 0 (Ongoing) to EndedAt only once per
+starvation period (`connection_lifecycle.rs:1180`). Long apply times do not
+falsely look like starvation because `chainsel_queue_empty` sets Ongoing only
+when the queue goes EMPTY (apply is blocked waiting). During normal bulk sync
+the queue stays full (multiple blocks fetched per apply cycle), so starvation
+stays EndedAt from the last epoch-boundary apply. The watchdog's condition
+`last_starvation_ms >= since + watchdog_ms` is then false (old EndedAt is in
+the past), so it does NOT fire — the watchdog only fires when the queue is
+actively empty AND has been empty throughout the unproductive window. This is
+exactly the cold-restart scenario.
+
+---
+
+## C — Live-repro diagnostics plan
+
+### Existing metrics to watch (no code change)
+
+On the Prometheus endpoint (port 12798) during cold genesis restart from epoch ~498:
+
+1. **`peers_connected` and `sync_progress_percent`** — should show steady
+   progress if priming works; flatline at ~1 blk/min indicates the wedge.
+2. **Log grep for `rotating (#742)`** — both watchdog paths log at INFO:
+   - `"BlockFetch: dynamo unproductive past watchdog"` (`connection_lifecycle.rs:2469`)
+   - `"BlockFetch: dynamo declined far-ahead ranges past watchdog"` (`connection_lifecycle.rs:2601`)
+   - `"BlockFetch: peer starved ChainSel past grace period — rotating CSJ dynamo"` (`connection_lifecycle.rs:2662`)
+
+   If these appear at ~30 s intervals, the primary root cause is confirmed.
+
+3. **Log grep for `"CSJ: promoted peer re-intersected at frontier"`** 
+   (`sync.rs:4395`) — each re-intersection fires at INFO. On a healthy sync
+   this should appear once per dynamo per many minutes; on the wedge it fires
+   every ~30 s.
+
+4. **Log grep for `"ChainSync: peer has been parked on forecast horizon"`**
+   (`sync.rs:3763`) — WARN at 60 s intervals per parked peer. These will show
+   which dynamo is parked and for how long.
+
+### Temporary debug logs to add (targeted; one cold-restart repro disambiguates)
+
+**File: `crates/dugite-node/src/node/connection_lifecycle.rs`**
+
+At line 2449, just inside the `if fetch_runs.is_empty()` branch, add:
+```rust
+debug!(%addr,
+    unproductive_secs = unproductive_since_ms.map(|s| now_ms.saturating_sub(s) / 1000).unwrap_or(0),
+    watchdog_threshold_secs = 3 * block_fetch_grace_period.as_secs(),
+    chainsel_starved = (chainsel_starvation_ms.load(…) == 0),
+    "BlockFetch: dynamo unproductive — pending_headers empty, checking watchdog"
+);
+```
+
+This fires every 10 ms (BlockFetch poll cadence) while the dynamo is
+unproductive, so gate it on `unproductive_since_ms.is_some()` to reduce
+volume. Watching the `unproductive_secs` field confirms it hits 30 before
+rotating.
+
+**File: `crates/dugite-node/src/node/sync.rs`**
+
+At line 5247, just before the `forecast_park_or_disconnect` call, add:
+```rust
+debug!(%peer_addr, slot, pending_headers_before_park = pending_count,
+    "ChainSync: header approaching forecast check");
+```
+
+This shows whether `pending_headers` is filling before the park. If it reads
+0 every time, the BlockFetch cycle has no headers to work with.
+
+**File: `crates/dugite-node/src/genesis_peer_state.rs`**
+
+The `fragment_snapshot()` function is O(1) (imbl clone). In the GSM actor
+loop, after computing `loe_tip` at `gsm.rs:937`, add a debug log:
+```rust
+debug!(loe_tip_slot = ?loe_tip, dynamo_frag_len = frags.first().map(|(_, f)| f.len()),
+    "GSM: LoE computed");
+```
+
+This confirms whether the LoE tip is advancing between rotations.
+
+**Disambiguation criteria from ONE cold-restart run:**
+- If the `rotating (#742)` log appears at ~30 s intervals → Primary root cause
+  confirmed.
+- If `pending_headers_before_park` is > 0 most of the time but `fetch_runs`
+  is still empty → #735 contiguity guard is blocking BlockFetch; secondary cause.
+- If `dynamo_frag_len` stays at 0 throughout → jumpers never get jump info;
+  LoE pins at snapshot_tip; secondary cause B.1 also active.
+- If none of the above and the node IS making progress → the wedge is not
+  reproducible at this epoch gap; try a larger gap or check for recent fix.
+
+---
+
+## D — Corrected Haskell-faithful fix design
+
+### Rejected approach (oracle-confirmed)
+
+A1 as described in `reports/issue-760-genesis-csj-wedge-design.md` — buffer
+beyond-horizon headers into `pending_headers` and the candidate fragment
+BEFORE `forecast_park_or_disconnect` — is **rejected**. Haskell does NOT put
+beyond-horizon headers into `csCandidate`. The Haskell `checkTime` step BLOCKS
+at the forecast horizon; headers before it fill `csCandidate`; headers at or
+past it park. The candidate never holds beyond-horizon headers.
+
+### Corrected approach: fix the watchdog exemption
+
+**The problem is the watchdog's definition of "unproductive."** A dynamo that
+is legitimately parked on the forecast horizon while BlockFetch drains its
+in-horizon headers is NOT unproductive — it is working exactly as Haskell
+intends. The watchdog should fire only when the dynamo has NO in-horizon headers
+queued AND is parked.
+
+**Fix A: Widen the watchdog exemption in `connection_lifecycle.rs`**
+
+The `fetch_runs.is_empty()` check at `connection_lifecycle.rs:2431` correctly
+detects nothing-dispatchable-from-this-peer, but the watchdog then fires after
+just 30 s. In genesis bulk sync, the correct grace is 3k/f × slot_length =
+129 600 × 1 s ≈ 36 h — effectively unlimited. The watchdog should be
+**disabled for genesis bulk sync**.
+
+Specifically, at line 2464:
+```rust
+// BEFORE (fires in genesis bulk sync):
+if is_genesis_bulk_sync
+    && now_ms.saturating_sub(since) >= watchdog_ms
+    && last_starvation_ms >= since.saturating_add(watchdog_ms)
+{
+    cs.rotate_dynamo(&addr);
+
+// AFTER (exempt in genesis bulk sync):
+if !is_genesis_bulk_sync
+    && now_ms.saturating_sub(since) >= watchdog_ms
+    && last_starvation_ms >= since.saturating_add(watchdog_ms)
+{
+    cs.rotate_dynamo(&addr);
+```
+
+Haskell parity: In Haskell, `checkLastChainSelStarvation` (`BlockFetch/Decision/Genesis.hs`)
+runs only in `GenesisFetchMode` (genesis AND not caught up), firing when
+`lastStarvationTime >= peersOrderStart(p) + gracePeriod`. The
+`peersOrderStart` is the timestamp when the peer was promoted to active; the
+grace period is `bfcBlockFetchGracePeriod` (default 10 s). But Haskell's
+starvation is measured from `ChainSel` being EMPTY, which during genesis bulk
+sync only occurs between block-apply cycles — roughly once per block. A peer
+that causes no blocks to be applied (truly stuck) WILL be rotated; a peer
+whose blocks are being applied fast enough is NOT rotated.
+
+In dugite's current code, `chainsel_starvation_ms = 0` (Ongoing) when the
+apply queue is empty. This is correct. But the `unproductive-claim` watchdog
+at line 2431-2484 fires based on `fetch_runs.is_empty()`, which is TRUE when
+the dynamo is legitimately parked (no headers yet). This second watchdog path
+is NOT in Haskell — it was added as a conservative safeguard for CSJ dynamos
+that are silent without the LoP waking them. But in genesis bulk sync it fires
+on the wrong condition. The fix is to gate this second watchdog on
+`!is_genesis_bulk_sync` (like the Haskell path, which relies on starvation
+NOT on "no ranges to dispatch").
+
+**Fix B: Also widen the "far-ahead" watchdog at line 2592**
+
+The second instance of the watchdog (`connection_lifecycle.rs:2570-2613`) fires
+when BlockFetch has pending headers but they are ALL declined by the #735
+contiguity guard. This IS a real failure mode (post-jump far-ahead headers
+on a just-promoted dynamo). However, the same 30 s threshold is too short for
+genesis bulk sync; it should also be gated on `!is_genesis_bulk_sync`.
+
+```rust
+// Line 2592:
+if !is_genesis_bulk_sync           // <─── add this gate
+    && is_genesis_bulk_sync        // <─── REMOVE the existing is_genesis_bulk_sync check
+```
+
+Wait — actually the existing code at 2592 ALREADY requires `is_genesis_bulk_sync`.
+The "far-ahead" watchdog is intentionally genesis-only, because in Praos mode
+a peer with far-ahead headers would simply be disconnected by the forecast
+timeout (no CSJ). This watchdog is correct for the post-jump case where the
+promoted dynamo serves headers from its jump point. However, after
+`reintersect_promoted_peer`, the dynamo re-anchors at the frontier; headers
+that arrive after reintersect are in-horizon (from the frontier). If the
+watchdog fires here it means `reintersect_promoted_peer` failed to bring the
+dynamo back far enough. This is a secondary concern; Fix A above addresses the
+primary wedge.
+
+**Fix C: Broadcast an initial jump immediately after the first in-horizon batch**
+
+This is the dual fix to ensure the jumpers' fragments advance once the dynamo
+gets its first batch of headers. Currently, `on_roll_forward` (`csj.rs:289-320`)
+only broadcasts when `slot > last_jump_slot + jump_size`. For a freshly-elected
+dynamo, `last_jump_slot = candidate_anchor_slot` (the snapshot tip, set at
+`csj.rs:186`). `jump_size = 4320` (mainnet default, `csj.rs:138`). So the
+first broadcast happens when the dynamo's slot exceeds `snapshot_tip + 4320`.
+At 20 blk/s (rough header throughput on good peers) this takes ~216 s = 3.6 min.
+That is within the first rotation window IF Fix A removes the 30 s limit.
+With Fix A alone, the cycle should self-prime within the first stability_window
+pass. Fix C would reduce the first-jump latency from 4320 headers to a smaller
+configurable threshold, but it is not required for correctness.
+
+### Exact functions to change
+
+**Primary (must change):**
+
+`crates/dugite-node/src/node/connection_lifecycle.rs`
+
+- Line 2464: Change the `if is_genesis_bulk_sync` condition of the
+  "unproductive-claim" watchdog to `if !is_genesis_bulk_sync`. This disables
+  the false-trigger that rotates a legitimately-parked genesis dynamo.
+- The ChainSel-starvation rotation at line 2661 is CORRECT and should remain:
+  it only fires when `last_starvation_ms >= claim_ms + grace_ms`, which in
+  genesis bulk sync means ChainSel has been empty (no blocks applied) for the
+  entire time the peer held the active-fetcher slot. A truly silent dynamo
+  (no blocks flowing at all) will still be rotated via this path. This
+  preserves Haskell's rotation-on-starvation semantics.
+
+**Secondary (consider, not strictly required):**
+
+`crates/dugite-node/src/node/connection_lifecycle.rs`
+
+- Line 2592: The "far-ahead-ranges" watchdog already gates on
+  `is_genesis_bulk_sync`, which is correct — this path is only reached in
+  genesis mode and only when pending_headers exist but are all declined by the
+  contiguity guard (the post-jump far-ahead scenario). Its 30 s threshold could
+  be increased if live testing shows it fires too eagerly, but it is not the
+  primary wedge for the cold-restart scenario.
+
+### Why this is praos-byte-identical
+
+Praos mode: `is_genesis_bulk_sync` is false (GSM is `CaughtUp` in Praos mode,
+or CSJ is disabled entirely). The changed condition `!is_genesis_bulk_sync`
+evaluates to `true` in Praos, preserving the existing behavior for non-genesis
+mode exactly. The condition flip does not touch any data path; it changes only
+the watchdog trigger guard. Zero risk of Praos regression.
+
+### Why this does NOT buffer beyond-horizon headers
+
+This fix changes only the watchdog gate condition in the BlockFetch worker. It
+does not touch `forecast_park_or_disconnect`, `pending_headers`, or the
+candidate fragment at all. The ChainSync task continues to block at the forecast
+horizon exactly as Haskell does. The only change is that the BlockFetch worker
+no longer rotates the dynamo for being parked, allowing the in-horizon headers
+batch to build up, be fetched, advance the ledger, unpark the dynamo, and prime
+the cycle.
+
+---
+
+## Summary table
+
+| Question | Answer | File:line |
+|---|---|---|
+| Does dynamo intersect at snapshot tip? | Yes, via `reintersect_promoted_peer` | `sync.rs:4348-4415` |
+| First headers in-horizon? | Yes (snapshot_tip+1 < snapshot_tip+stability_window) | `forecast_park_or_disconnect` |
+| Does `peer_state` fill before rotation? | Partially — 0 to stability_window headers, then drains and parks | `sync.rs:5396` |
+| LoE pinned? | Yes, secondary — jumpers never receive jump because dynamo's `jump_info = None` | `csj.rs:194-197`, `gsm.rs:923` |
+| Watchdog fires during park? | **YES — primary root cause** — 30 s × `is_genesis_bulk_sync` condition fires on legitimately-parked dynamo | `connection_lifecycle.rs:2464` |
+| GDD kills dynamo? | No — Gate 0 excludes dynamo with `latest_slot = None` | `genesis_governor.rs:224` |
+| GDD reads csLatestSlot? | Yes — `st.as_ref().and_then(|s| s.latest_slot())` | `gsm.rs:1005` |
+| Fix is praos-byte-identical? | Yes — `!is_genesis_bulk_sync` guard preserves praos path | `connection_lifecycle.rs:2464` |

--- a/reports/v2.0.7-notes.md
+++ b/reports/v2.0.7-notes.md
@@ -1,0 +1,96 @@
+# dugite v2.0.7
+
+Byte-exactness release: a cluster of Conway phase-1/phase-2 validation
+divergences found during a from-snapshot mainnet validation sync (epochs
+507–528) are root-caused against the canonical IntersectMBO/cardano-ledger
+source and fixed. Each fix is cross-checked via the cardano-ledger / Haskell
+oracle and pinned to a real on-chain transaction.
+
+## Fixes
+
+- **PlutusV3 cost model seeded at the Conway hard fork + snapshot restore**
+  (`00a1a3ac8b`). The V3 cost model originates from `conway-genesis.json`
+  (`ucppPlutusV3CostModel`), not an on-chain update, so it was never present in
+  Conway ledger state — every PlutusV3 tx got a wrong `script_data_hash`
+  (`ScriptDataHashMismatch`) and default-cost-model budgets. Now seeded as a
+  per-language INSERT at the Babbage→Conway translation (`on_era_transition`)
+  and via a post-snapshot guard (`pv>=9 && plutus_v3.is_none()`), mirroring
+  Haskell `upgradeConwayPParams`. Validated live: `ScriptDataHashMismatch` 23→0.
+
+- **Deposit-bearing `ConwayStakeRegistration` (script cred) requires a Cert
+  redeemer** (`a6639ae520`). Conway `RegDepositTxCert` carries a script witness;
+  dugite previously flagged the supplied redeemer as `ExtraRedeemer` (false
+  rejection). Per `getScriptWitnessConwayTxCert`.
+
+- **`RegDRep` (script cred) requires a Cert redeemer** (`01718b8b88`). All three
+  DRep gov-certs (RegDRep/UnregDRep/UpdateDRep) are symmetric in
+  `getScriptWitnessConwayTxCert.govWitness`; dugite omitted RegDRep → false
+  `ExtraRedeemer` rejection. (cardano-ledger-conway-1.23.0.0, oracle-confirmed.)
+
+- **`VRFKeyHashAlreadyRegistered` gated at PV≥11, not PV≥9** (`0784df61a3`).
+  Haskell `hardforkConwayDisallowDuplicatedVRFKeys = pvMajor pv > natVersion @10`
+  — inactive through the entire Conway bootstrap and current mainnet. dugite
+  rejected a legitimate pool registration (two pools sharing a VRF key) at
+  epoch 523 (PV 9) that cardano-node accepts.
+
+- **Phase-2 divergence checker gets cost models in ApplyOnly mode**
+  (`cb4630efca`). `cost_models_cbor` was computed only for `ValidateAll`, so the
+  always-on parallel divergence checker evaluated V3 scripts with a default cost
+  model and emitted a flood of spurious `budget exhausted` divergences. Diagnostic
+  accuracy only — apply/gating behavior unchanged.
+
+## Carried from the v2.0.6..HEAD range
+
+#760 genesis cold-restart watchdog rotation + bounded SIGTERM watchdog;
+Babbage→Conway eager-validation forecast deferral; Conway reg/dereg certs in the
+V1/V2 script context; `DelegateeDRepNotRegistered` skipped during the PV9
+bootstrap; `#742` ledger-tip watch seeded from the ChainDB tip at startup; live
+pots gauges during bulk sync.
+
+## Adversarial review
+
+A multi-agent adversarial review of v2.0.6..HEAD returned **0 blockers** and 4
+minor findings. Two were addressed in this release (`redeemer_script_version_map`
+cert-set consistency for the PV11 V3 disjointness path; the post-init V3 seed
+gated to PV9 so it cannot inject a stale model at PV10+). The other two concerned
+a dead-work change that was reverted, both verified harmless.
+
+## Known issues (filed, tracked for follow-up in soak)
+
+These are pre-existing phase-1/phase-2 verdict divergences (node trusts on-chain
+consensus — ledger state stays correct) or inherited snapshot state, NOT v2.0.7
+regressions. Each is filed with a full root-cause report and concrete next steps.
+
+- **#761** Conway PlutusV3 ScriptContext Data-shape divergence
+  (`unMapData`/`appendByteString` on rare V3 governance/SOP-script txs). Low-volume.
+- **#762** Restart from a snapshot below the ChainDB tip (gap > stability window)
+  wedges on the forecast horizon; self-heals on a second restart. Liveness only.
+- **#763** Reserves divergence vs Koios (~285K→928K ADA/epoch). Investigated:
+  live reward/reserves formulas verified byte-exact; root cause is a stuck
+  large reward account inherited from the Mithril snapshot, not v2.0.7 code.
+  Node is non-forging.
+- **#764** PlutusV3 budget-exhausted divergence. Investigated: V3 cost model
+  confirmed present (297 entries) and correct (ScriptDataHashMismatch is 0); the
+  overrun is a CEK step/builtin over-count for specific V3 scripts, not a
+  cost-model issue. Needs DUGITE_DUMP differential analysis.
+
+## Gates
+
+- Multi-agent adversarial review of v2.0.6..HEAD: **PASS** (0 blockers; 4 minor
+  findings, 2 addressed in this release, 2 reverted/harmless)
+- `just check` (fmt + clippy + build + test + test-doc): **PASS**
+- `DUGITE_REQUIRE_UPSTREAM=1` upstream conformance: **PASS** (6026/6026 tests,
+  0 skipped — UPLC + ledger-rules ImpSpec + VRF + golden, all byte-exact)
+- `just devnet-validate-extended`: **PASS** (3 rounds; all 5 predicates — forge
+  cross-check 74 canonical blocks, per-bp attribution, tx-inclusion 11/12 with
+  all 3 nodes incl. cardano-node agreeing, tip-parity 36/36 = 100%, tip-age <4s)
+- CI green: pending (post-tag Release workflow)
+
+## Soak note
+
+The from-Mithril-snapshot mainnet validation sync (all-ValidateAll) halted at
+slot 146625164 (epoch 536) on #763 (`MismatchedTreasuryValue`, ~115K ADA). This
+is inherited snapshot state, not a v2.0.7 regression (live reward/reserves
+formulas verified byte-exact; conway.rs:234 is a deliberate ValidateAll strict
+gate, #678). The soak's next priority is #763 (Mithril reward-account artifact
+vs withdrawal misapplication) or a from-genesis full-validation run for clean pots.


### PR DESCRIPTION
## v2.0.7 release

Linear extension of main (deeaf58376) — the #760 genesis-CSJ work plus a tranche of Conway byte-exactness validation fixes found on a from-Mithril-snapshot mainnet ValidateAll sync (epochs 521→536).

### Byte-exact validation fixes (all oracle-verified vs IntersectMBO/cardano-ledger)
- **PlutusV3 cost model seeded at the Conway hard fork + snapshot restore** (`00a1a3ac8b`) — fixed `ScriptDataHashMismatch` 23→0, live-validated. Per `upgradeConwayPParams` (per-language insert).
- **Deposit-bearing `ConwayStakeRegistration` + `RegDRep` (script cred) require a Cert redeemer** (`a6639ae520`, `01718b8b88`) — were false `ExtraRedeemer` rejections. Per `getScriptWitnessConwayTxCert` (conway-1.23.0.0).
- **`VRFKeyHashAlreadyRegistered` gated PV≥11 not PV≥9** (`0784df61a3`) — `hardforkConwayDisallowDuplicatedVRFKeys = pvMajor > 10`. Fixed a false pool-registration rejection at ep523.
- **2 adversarial-review hardening follow-ups** (`34b12eae5f`) — `redeemer_script_version_map` cert-set consistency (PV11 V3 disjointness); post-init V3 seed gated to PV9. Reverted dead-work `cb4630efca`.

### #760 genesis-CSJ wedge (prior commits in range)
SIGTERM watchdog (Part B), genesis dynamo rotation (Part A), eager-validation forecast deferral, Conway reg/dereg certs in V1/V2 script context, DRep PV9 bootstrap, `#742` ledger-tip seed.

### Gates (all green)
- `just check` (fmt + clippy + build + test + test-doc): **PASS**
- Upstream conformance `DUGITE_REQUIRE_UPSTREAM=1`: **PASS** (6026/6026, 0 skipped)
- Multi-agent adversarial review of v2.0.6..HEAD: **0 blockers**
- `devnet-validate-extended`: **PASS** (all 5 predicates; tx-inclusion parity with cardano-node, tip-parity 100%)

### Versions
Workspace 2.0.6→2.0.7; Helm chart 0.5.6→0.5.7, appVersion 2.0.6→2.0.7.

### Known issues filed for soak (#761-764 — pre-existing, non-regressions; node trusts on-chain consensus so ledger state stays correct)
- #761 V3 ScriptContext data-shape divergence (rare V3 gov/SOP txs)
- #762 restart-from-lagging-snapshot forecast-horizon wedge (self-heals on 2nd restart)
- #763 reserves/treasury divergence — inherited Mithril-snapshot reward-account artifact; **chain-halts in ValidateAll at ep536** (`MismatchedTreasuryValue`). Live reward/reserves formulas verified byte-exact. Top soak item.
- #764 PlutusV3 budget CEK over-count — V3 cost model confirmed present (297 entries); needs DUGITE_DUMP differential.