### PR TITLE
ChainSync robustness (ForkTooDeep severity, stale-RollForward recovery) + PlutusV2 PV11 cost shapes

### DIFF
--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -223,6 +223,49 @@ pub(crate) enum PeerFailureKind {
     ProtocolFault,
     /// Timeout / transport failure — reputation only.
     Slow,
+    /// Peer cannot offer a usable chain: its ChainSync intersection resolves
+    /// only at genesis while our local selection is beyond `k` blocks (the peer
+    /// is far behind our immutable tip, or on a disjoint chain). This is the
+    /// dugite equivalent of Haskell's `ChainSyncClientResult::ForkTooDeep` — an
+    /// EXPECTED, routine outcome on public networks (stale / wrong-chain
+    /// registered relays), NOT a fault. Handled identically to `Slow`
+    /// (reputation + teardown + governor re-promote after backoff) but logged
+    /// at INFO, mirroring cardano-node's `Notice` severity for
+    /// `TraceTermination ForkTooDeep`, so it does not drown real warnings.
+    Unsuitable,
+}
+
+/// Marker error returned by `chainsync_client_task` when the peer's ChainSync
+/// intersection resolves only at genesis while our local selection is beyond
+/// `k` blocks. Downstream code downcasts to this to classify the failure as
+/// [`PeerFailureKind::Unsuitable`] (logged at INFO) instead of a generic fault.
+/// See [`classify_chainsync_failure`]. Equivalent to Haskell `ForkTooDeep`.
+#[derive(Debug, Clone)]
+pub(crate) struct PeerUnsuitable {
+    pub(crate) reason: String,
+}
+
+impl std::fmt::Display for PeerUnsuitable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.reason)
+    }
+}
+
+impl std::error::Error for PeerUnsuitable {}
+
+/// Classify a `chainsync_client_task` failure into a [`PeerFailureKind`].
+///
+/// A [`PeerUnsuitable`] marker (ChainSync intersection only at genesis — the
+/// Haskell `ForkTooDeep` equivalent) is an expected, routine peer-quality
+/// outcome and maps to [`PeerFailureKind::Unsuitable`] (logged at INFO).
+/// Everything else (bearer close, decode error, timeout, etc.) maps to
+/// [`PeerFailureKind::Slow`].
+pub(crate) fn classify_chainsync_failure(err: &anyhow::Error) -> PeerFailureKind {
+    if err.downcast_ref::<PeerUnsuitable>().is_some() {
+        PeerFailureKind::Unsuitable
+    } else {
+        PeerFailureKind::Slow
+    }
 }
 
 use tokio::sync::{broadcast, mpsc, RwLock};
@@ -2174,12 +2217,23 @@ impl ConnectionLifecycleManager {
                 // intersection) leaves the TCP connection up but no headers
                 // arriving (#499).  Matches keepalive/blockfetch pattern.
                 if let Err(e) = result {
-                    warn!(%addr, error = %e, "chainsync task failed");
+                    let kind = classify_chainsync_failure(&e);
+                    // `Unsuitable` (ChainSync intersection only at genesis — the
+                    // Haskell `ForkTooDeep` equivalent) is an EXPECTED outcome on
+                    // public networks (stale / wrong-chain relays), so log it at
+                    // INFO (≈ cardano-node `Notice`). Genuine faults stay WARN so
+                    // they are not drowned out.
+                    if kind == PeerFailureKind::Unsuitable {
+                        info!(%addr, error = %e, "chainsync ended: peer unsuitable (intersection only at genesis / ForkTooDeep) — demoting for backoff");
+                    } else {
+                        warn!(%addr, error = %e, "chainsync task failed");
+                    }
                     if !cancel.is_cancelled() {
-                        // Reported as `Slow` (reputation-only) even for decode
-                        // errors: upgrading ChainSync faults to teardown is a
-                        // behavior change beyond #751's BlockFetch scope.
-                        let _ = peer_failure_tx.try_send((addr, PeerFailureKind::Slow));
+                        // Both kinds hit reputation + teardown in the peer-failure
+                        // handler; they differ only in log severity / reputation
+                        // weight. (Reported as `Slow`/`Unsuitable`, not teardown-
+                        // upgraded, for decode errors — that stays #751's scope.)
+                        let _ = peer_failure_tx.try_send((addr, kind));
                     }
                 }
                 debug!(%addr, "chainsync task exiting");
@@ -5154,6 +5208,35 @@ mod tests {
             Err(mpsc::error::TryRecvError::Empty) => { /* expected */ }
             other => panic!("expected no peer_failure when cancelled, got {:?}", other),
         }
+    }
+
+    /// A `PeerUnsuitable` marker (ChainSync intersection only at genesis — the
+    /// Haskell `ForkTooDeep` equivalent) is an EXPECTED, routine peer-quality
+    /// outcome on public networks, not a fault. It must classify as
+    /// `Unsuitable` so it is logged at INFO (≈ cardano-node `Notice`) rather
+    /// than spamming WARN.
+    #[test]
+    fn classify_chainsync_failure_maps_peer_unsuitable_to_unsuitable() {
+        let err = anyhow::Error::new(PeerUnsuitable {
+            reason: "intersection only at genesis (block_no=4394795 > k=432)".to_string(),
+        });
+        assert_eq!(
+            classify_chainsync_failure(&err),
+            PeerFailureKind::Unsuitable,
+            "a PeerUnsuitable (ForkTooDeep) marker must classify as Unsuitable, not a fault"
+        );
+    }
+
+    /// Any other chainsync failure (bearer close, decode error, timeout) is a
+    /// genuine transport/protocol problem and must stay `Slow` (WARN).
+    #[test]
+    fn classify_chainsync_failure_maps_generic_error_to_slow() {
+        let err = anyhow::anyhow!("bearer read error: timeout");
+        assert_eq!(
+            classify_chainsync_failure(&err),
+            PeerFailureKind::Slow,
+            "a generic transport/decode error must classify as Slow"
+        );
     }
 
     // ── PeerFetchStatus / CandidateChainState status tracking ────────────────

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -5309,7 +5309,16 @@ impl Node {
                 // channel without closing TCP).
                 Some((failed_addr, failure_kind)) = peer_failure_rx.recv() => {
                     let mut pm = peer_manager.write().await;
-                    warn!(%failed_addr, kind = ?failure_kind, "peer reported as failed by protocol task");
+                    // `Unsuitable` (ChainSync intersection only at genesis — the
+                    // Haskell `ForkTooDeep` equivalent) is routine on public
+                    // networks, so log at INFO (≈ cardano-node `Notice`). Real
+                    // faults (Slow / ProtocolFault) stay WARN. Demotion + backoff
+                    // below are identical for every kind.
+                    if failure_kind == PeerFailureKind::Unsuitable {
+                        info!(%failed_addr, kind = ?failure_kind, "peer reported unsuitable by protocol task (intersection only at genesis) — demoting for backoff");
+                    } else {
+                        warn!(%failed_addr, kind = ?failure_kind, "peer reported as failed by protocol task");
+                    }
                     pm.peer_failed(&failed_addr);
                     // #sync-eval companion fix: tear the connection down for
                     // BOTH failure kinds, not just `ProtocolFault`. A `Slow`

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -4246,15 +4246,17 @@ pub(crate) fn classify_intersect_response(msg: &ChainSyncMessage) -> IntersectOu
 /// swap time and get routed onto this fresh channel by the ingress task. It is
 /// provably NOT a reply to our `MsgFindIntersect` — the caller never pipelines a
 /// request before intersection — so we discard it and re-read, up to
-/// `MAX_STALE_DISCARD`. Beyond that a genuinely broken peer fails fast and falls
+/// `max_stale_discard` (sized to the pipeline window: a demoted prior session
+/// can leave that many responses in flight). Beyond that a genuinely broken
+/// peer fails fast and falls
 /// back to the pre-existing teardown+reconnect. Mirrors Haskell, whose
 /// typed-protocols codec rejects a next-phase message in StIntersect as a
 /// wire-state violation.
 pub(crate) async fn read_intersect_reply(
     channel: &mut MuxChannel,
     peer_addr: SocketAddr,
+    max_stale_discard: u32,
 ) -> Result<Option<CodecPoint>, anyhow::Error> {
-    const MAX_STALE_DISCARD: u32 = 16;
     let mut discarded: u32 = 0;
     loop {
         let response = channel
@@ -4313,20 +4315,16 @@ pub(crate) async fn read_intersect_reply(
             other => match classify_intersect_response(&other) {
                 IntersectOutcome::StaleNextPhase => {
                     discarded += 1;
-                    if discarded > MAX_STALE_DISCARD {
+                    if discarded > max_stale_discard {
                         return Err(anyhow::anyhow!(
                             "ChainSync: {discarded} stale next-phase responses in StIntersect \
-                             from {peer_addr}; giving up (will reconnect)"
+                             from {peer_addr} (bound {max_stale_discard}); giving up (reconnect)"
                         ));
                     }
-                    // NB: do NOT Debug-format `other` here — MsgRollForward
-                    // carries the full header bytes and would flood the log.
-                    warn!(
-                        %peer_addr,
-                        discarded,
-                        "ChainSync: discarding stale next-phase response in StIntersect \
-                         (reused-mux residue)",
-                    );
+                    // Silently discard prior-session residue; the count is logged
+                    // ONCE on recovery (the Found/NotFound arms) to avoid
+                    // per-frame spam — a deeply-pipelined prior session can leave
+                    // up to ~DUGITE_PIPELINE_DEPTH (default 300) frames in flight.
                     // loop re-reads
                 }
                 _ => {
@@ -4930,7 +4928,15 @@ pub async fn chainsync_client_task(
         // INVARIANT: that tolerance is sound ONLY because we do NOT pipeline any
         // request before this read — do not add a pre-intersection
         // MsgRequestNext without revisiting `read_intersect_reply`.
-        read_intersect_reply(channel, peer_addr).await
+        // Bound the stale-residue discard by the pipeline window + margin: a
+        // demoted prior session can leave up to DUGITE_PIPELINE_DEPTH (default
+        // 300) RollForward responses in flight on a reused mux.
+        let max_stale_discard = std::env::var("DUGITE_PIPELINE_DEPTH")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(300)
+            .saturating_add(16);
+        read_intersect_reply(channel, peer_addr, max_stale_discard).await
     }
 
     // Attempt 1: use the known_points we built above.
@@ -6984,7 +6990,7 @@ mod chainsync_task_tests {
             tip_block_number: 10,
         });
         let mut ch = preload_chainsync_channel(vec![stale_roll_forward(), found]);
-        let res = read_intersect_reply(&mut ch, test_addr()).await;
+        let res = read_intersect_reply(&mut ch, test_addr(), 16).await;
         assert!(
             matches!(res, Ok(Some(_))),
             "stale RollForward must be discarded then IntersectFound returned, got {res:?}"
@@ -7002,7 +7008,7 @@ mod chainsync_task_tests {
         });
         let mut ch = preload_chainsync_channel(vec![found]);
         assert!(matches!(
-            read_intersect_reply(&mut ch, test_addr()).await,
+            read_intersect_reply(&mut ch, test_addr(), 16).await,
             Ok(Some(_))
         ));
 
@@ -7013,7 +7019,7 @@ mod chainsync_task_tests {
         });
         let mut ch = preload_chainsync_channel(vec![not_found]);
         assert!(matches!(
-            read_intersect_reply(&mut ch, test_addr()).await,
+            read_intersect_reply(&mut ch, test_addr(), 16).await,
             Ok(None)
         ));
     }
@@ -7036,18 +7042,18 @@ mod chainsync_task_tests {
         });
         let mut ch = preload_chainsync_channel(vec![rb, await_reply, nf]);
         assert!(matches!(
-            read_intersect_reply(&mut ch, test_addr()).await,
+            read_intersect_reply(&mut ch, test_addr(), 16).await,
             Ok(None)
         ));
     }
 
-    /// Beyond MAX_STALE_DISCARD (16) the reader fails fast (→ reconnect), not
-    /// an infinite spin on a genuinely broken peer.
+    /// Beyond `max_stale_discard` (16 here) the reader fails fast (→ reconnect),
+    /// not an infinite spin on a genuinely broken peer.
     #[tokio::test]
     async fn read_intersect_reply_exceeds_stale_bound_errors() {
         let frames: Vec<Vec<u8>> = (0..17).map(|_| stale_roll_forward()).collect();
         let mut ch = preload_chainsync_channel(frames);
-        let res = read_intersect_reply(&mut ch, test_addr()).await;
+        let res = read_intersect_reply(&mut ch, test_addr(), 16).await;
         let err = res.expect_err("17 stale frames must exceed the bound and error");
         assert!(
             format!("{err:?}").contains("giving up"),
@@ -7060,7 +7066,7 @@ mod chainsync_task_tests {
     #[tokio::test]
     async fn read_intersect_reply_genuine_violation_errors_immediately() {
         let mut ch = preload_chainsync_channel(vec![enc(&ChainSyncMessage::MsgDone)]);
-        let res = read_intersect_reply(&mut ch, test_addr()).await;
+        let res = read_intersect_reply(&mut ch, test_addr(), 16).await;
         let err = res.expect_err("MsgDone in StIntersect is a violation");
         assert!(
             format!("{err:?}").contains("unexpected response"),

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -4903,18 +4903,39 @@ pub async fn chainsync_client_task(
             db.get_tip_info().map(|(_, _, bn)| bn.0).unwrap_or(0)
         };
         if local_block_no > security_param {
-            warn!(
+            // EXPECTED on public networks: the peer shares no history with us
+            // above genesis (it is far behind our immutable tip or on a disjoint
+            // chain), so ChainSync cannot make progress and we end it. This is
+            // the dugite equivalent of Haskell's
+            // `ChainSyncClientResult::ForkTooDeep`, which cardano-node traces at
+            // `Notice` (not `Warning`) — see Consensus tracer + ExitPolicy
+            // (RepromoteDelay 120). We log at INFO and return a `PeerUnsuitable`
+            // marker so `classify_chainsync_failure` maps this to
+            // `PeerFailureKind::Unsuitable` (quiet) instead of a generic fault.
+            //
+            // NOTE — deliberate divergence from Haskell: we tear the whole
+            // connection down here (Bug-A / Bug-E: chain selection cannot operate
+            // across an Origin anchor, and the inbound supervisor cannot re-spawn
+            // a gracefully-ended ChainSync). Haskell ends only the ChainSync
+            // mini-protocol and keeps the mux alive for the other protocols. For
+            // a peer this far behind, block-fetch from it is useless anyway, so
+            // the teardown is harmless; the governor re-promotes after backoff.
+            info!(
                 %peer_addr,
                 local_ledger_tip = %ledger_tip,
                 local_block_no,
                 security_param,
-                "ChainSync intersection at Origin with non-Origin local chain \
-                 beyond k blocks — disconnecting to retry after peer catches up"
+                "ChainSync intersection only at genesis (peer far behind our \
+                 immutable tip / disjoint chain) — ending ChainSync, demoting \
+                 for backoff (Haskell ForkTooDeep equivalent)"
             );
-            return Err(anyhow::anyhow!(
-                "Peer {peer_addr} intersection at Origin with non-Origin local \
-                 ledger tip (block_no={local_block_no} > k={security_param}); \
-                 disconnecting to retry after peer catches up"
+            return Err(anyhow::Error::new(
+                super::connection_lifecycle::PeerUnsuitable {
+                    reason: format!(
+                        "peer {peer_addr} ChainSync intersection only at genesis \
+                         (block_no={local_block_no} > k={security_param})"
+                    ),
+                },
             ));
         }
         info!(

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -4194,6 +4194,151 @@ pub(crate) const VOLATILE_POINTS_DEPTH: usize = 10;
 /// chunks (passed to `ChainDB::get_immutable_historical_points`).
 pub(crate) const DEEP_HISTORICAL_DEPTH: usize = 8;
 
+/// Classification of a server response received while the ChainSync client is
+/// in `StIntersect` — i.e. immediately after sending `MsgFindIntersect`, before
+/// any streaming `MsgRequestNext`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IntersectOutcome {
+    /// Legitimate StIntersect reply: an intersection point was found.
+    Found,
+    /// Legitimate StIntersect reply: no intersection within our offered points.
+    NotFound,
+    /// A server *next-phase* response (`MsgRollForward` / `MsgRollBackward` /
+    /// `MsgAwaitReply`) seen while in StIntersect. On a reused (resubscribed)
+    /// mux this is prior-session residue: the previous ChainSync run pipelined
+    /// `MsgRequestNext` and the server's reply was still in-flight in the kernel
+    /// socket buffer when the peer was demoted+re-promoted without TCP teardown;
+    /// the ingress task then routes it onto this fresh channel. It is provably
+    /// NOT a reply to our `MsgFindIntersect` — the client never pipelines a
+    /// request before intersection (see `try_find_intersect`) — so it is safe to
+    /// discard and re-read. (Haskell typed-protocols treats a next-phase message
+    /// in StIntersect as a wire-state violation and tears the run down; we
+    /// recover in place for this known stale-only case instead.)
+    StaleNextPhase,
+    /// Any other message — client-agency `MsgRequestNext` / `MsgFindIntersect` /
+    /// `MsgDone`, or anything unexpected: a genuine protocol violation.
+    Invalid,
+}
+
+/// Classify a message received while in `StIntersect`. Pure and *total* over
+/// every `ChainSyncMessage` variant (no wildcard arm, so adding a protocol
+/// message forces an update here). See [`IntersectOutcome`] / `try_find_intersect`.
+pub(crate) fn classify_intersect_response(msg: &ChainSyncMessage) -> IntersectOutcome {
+    match msg {
+        ChainSyncMessage::MsgIntersectFound { .. } => IntersectOutcome::Found,
+        ChainSyncMessage::MsgIntersectNotFound { .. } => IntersectOutcome::NotFound,
+        ChainSyncMessage::MsgRollForward { .. }
+        | ChainSyncMessage::MsgRollBackward { .. }
+        | ChainSyncMessage::MsgAwaitReply => IntersectOutcome::StaleNextPhase,
+        ChainSyncMessage::MsgRequestNext
+        | ChainSyncMessage::MsgFindIntersect(_)
+        | ChainSyncMessage::MsgDone => IntersectOutcome::Invalid,
+    }
+}
+
+/// Read the reply to a `MsgFindIntersect` we just sent (the server is in
+/// `StIntersect`), tolerating a bounded number of STALE next-phase responses.
+///
+/// Only `MsgIntersectFound` / `MsgIntersectNotFound` are legitimate here. On a
+/// mux that was resubscribed after a warm demote+re-promote (no TCP teardown), a
+/// next-phase response (`MsgRollForward` / `MsgRollBackward` / `MsgAwaitReply`)
+/// from the PRIOR session can still be in-flight in the kernel socket buffer at
+/// swap time and get routed onto this fresh channel by the ingress task. It is
+/// provably NOT a reply to our `MsgFindIntersect` — the caller never pipelines a
+/// request before intersection — so we discard it and re-read, up to
+/// `MAX_STALE_DISCARD`. Beyond that a genuinely broken peer fails fast and falls
+/// back to the pre-existing teardown+reconnect. Mirrors Haskell, whose
+/// typed-protocols codec rejects a next-phase message in StIntersect as a
+/// wire-state violation.
+pub(crate) async fn read_intersect_reply(
+    channel: &mut MuxChannel,
+    peer_addr: SocketAddr,
+) -> Result<Option<CodecPoint>, anyhow::Error> {
+    const MAX_STALE_DISCARD: u32 = 16;
+    let mut discarded: u32 = 0;
+    loop {
+        let response = channel
+            .recv()
+            .await
+            .map_err(|e| anyhow::anyhow!("ChainSync intersection response recv failed: {e}"))?;
+        let intersect_msg = cs_decode(&response)
+            .map_err(|e| anyhow::anyhow!("ChainSync intersection decode failed: {e}"))?;
+
+        match intersect_msg {
+            ChainSyncMessage::MsgIntersectFound {
+                point,
+                tip_slot,
+                tip_block_number,
+                ..
+            } => {
+                let prim_point = from_codec_point(&point);
+                if discarded > 0 {
+                    warn!(
+                        %peer_addr,
+                        discarded,
+                        "ChainSync intersection found after discarding stale next-phase \
+                         residue (reused-mux)",
+                    );
+                }
+                info!(
+                    %peer_addr,
+                    point = %prim_point,
+                    tip_slot,
+                    tip_block_number,
+                    "ChainSync intersection found",
+                );
+                return Ok(Some(point));
+            }
+            ChainSyncMessage::MsgIntersectNotFound {
+                tip_slot,
+                tip_block_number,
+                ..
+            } => {
+                if discarded > 0 {
+                    warn!(
+                        %peer_addr,
+                        discarded,
+                        "ChainSync no-intersection after discarding stale next-phase \
+                         residue (reused-mux)",
+                    );
+                }
+                info!(
+                    %peer_addr,
+                    tip_slot,
+                    tip_block_number,
+                    "ChainSync MsgIntersectNotFound",
+                );
+                return Ok(None);
+            }
+            other => match classify_intersect_response(&other) {
+                IntersectOutcome::StaleNextPhase => {
+                    discarded += 1;
+                    if discarded > MAX_STALE_DISCARD {
+                        return Err(anyhow::anyhow!(
+                            "ChainSync: {discarded} stale next-phase responses in StIntersect \
+                             from {peer_addr}; giving up (will reconnect)"
+                        ));
+                    }
+                    // NB: do NOT Debug-format `other` here — MsgRollForward
+                    // carries the full header bytes and would flood the log.
+                    warn!(
+                        %peer_addr,
+                        discarded,
+                        "ChainSync: discarding stale next-phase response in StIntersect \
+                         (reused-mux residue)",
+                    );
+                    // loop re-reads
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "ChainSync unexpected response to MsgFindIntersect: {other:?}"
+                    ))
+                }
+            },
+        }
+    }
+}
+
 /// Drop pending headers whose block is already stored in the local ChainDB.
 ///
 /// Use **hash equality** rather than slot comparison: after a peer issues
@@ -4778,47 +4923,14 @@ pub async fn chainsync_client_task(
             .await
             .map_err(|e| anyhow::anyhow!("ChainSync MsgFindIntersect send failed: {e}"))?;
 
-        let response = channel
-            .recv()
-            .await
-            .map_err(|e| anyhow::anyhow!("ChainSync intersection response recv failed: {e}"))?;
-        let intersect_msg = cs_decode(&response)
-            .map_err(|e| anyhow::anyhow!("ChainSync intersection decode failed: {e}"))?;
-
-        match intersect_msg {
-            ChainSyncMessage::MsgIntersectFound {
-                point,
-                tip_slot,
-                tip_block_number,
-                ..
-            } => {
-                let prim_point = from_codec_point(&point);
-                info!(
-                    %peer_addr,
-                    point = %prim_point,
-                    tip_slot,
-                    tip_block_number,
-                    "ChainSync intersection found",
-                );
-                Ok(Some(point))
-            }
-            ChainSyncMessage::MsgIntersectNotFound {
-                tip_slot,
-                tip_block_number,
-                ..
-            } => {
-                info!(
-                    %peer_addr,
-                    tip_slot,
-                    tip_block_number,
-                    "ChainSync MsgIntersectNotFound",
-                );
-                Ok(None)
-            }
-            other => Err(anyhow::anyhow!(
-                "ChainSync unexpected response to MsgFindIntersect: {other:?}"
-            )),
-        }
+        // After MsgFindIntersect the server is in StIntersect; read the reply,
+        // tolerating bounded stale next-phase residue from a reused mux (see
+        // `read_intersect_reply` / `classify_intersect_response`).
+        //
+        // INVARIANT: that tolerance is sound ONLY because we do NOT pipeline any
+        // request before this read — do not add a pre-intersection
+        // MsgRequestNext without revisiting `read_intersect_reply`.
+        read_intersect_reply(channel, peer_addr).await
     }
 
     // Attempt 1: use the known_points we built above.
@@ -6755,6 +6867,206 @@ mod forecast_park_tests {
 #[cfg(test)]
 mod chainsync_task_tests {
     use super::*;
+
+    /// `classify_intersect_response` must map every `ChainSyncMessage` variant
+    /// correctly: only `MsgIntersectFound`/`NotFound` are legitimate replies in
+    /// StIntersect; the three server next-phase responses are stale residue to
+    /// discard; everything else is a protocol violation. (Drives the stale-
+    /// RollForward-on-reused-mux fix.)
+    #[test]
+    fn classify_intersect_response_covers_all_variants() {
+        let found = ChainSyncMessage::MsgIntersectFound {
+            point: CodecPoint::Origin,
+            tip_slot: 1,
+            tip_hash: [0u8; 32],
+            tip_block_number: 1,
+        };
+        let not_found = ChainSyncMessage::MsgIntersectNotFound {
+            tip_slot: 1,
+            tip_hash: [0u8; 32],
+            tip_block_number: 1,
+        };
+        let roll_fwd = ChainSyncMessage::MsgRollForward {
+            header: vec![],
+            tip_slot: 1,
+            tip_hash: [0u8; 32],
+            tip_block_number: 1,
+        };
+        let roll_back = ChainSyncMessage::MsgRollBackward {
+            point: CodecPoint::Origin,
+            tip_slot: 1,
+            tip_hash: [0u8; 32],
+            tip_block_number: 1,
+        };
+        assert_eq!(classify_intersect_response(&found), IntersectOutcome::Found);
+        assert_eq!(
+            classify_intersect_response(&not_found),
+            IntersectOutcome::NotFound
+        );
+        // The three stale next-phase responses (reused-mux residue):
+        assert_eq!(
+            classify_intersect_response(&roll_fwd),
+            IntersectOutcome::StaleNextPhase
+        );
+        assert_eq!(
+            classify_intersect_response(&roll_back),
+            IntersectOutcome::StaleNextPhase
+        );
+        assert_eq!(
+            classify_intersect_response(&ChainSyncMessage::MsgAwaitReply),
+            IntersectOutcome::StaleNextPhase
+        );
+        // Client-agency / terminal messages are genuine violations here:
+        assert_eq!(
+            classify_intersect_response(&ChainSyncMessage::MsgRequestNext),
+            IntersectOutcome::Invalid
+        );
+        assert_eq!(
+            classify_intersect_response(&ChainSyncMessage::MsgFindIntersect(vec![])),
+            IntersectOutcome::Invalid
+        );
+        assert_eq!(
+            classify_intersect_response(&ChainSyncMessage::MsgDone),
+            IntersectOutcome::Invalid
+        );
+    }
+
+    /// Build a `MuxChannel` whose ingress is preloaded with the given complete
+    /// CBOR frames (each a `cs_encode`d `ChainSyncMessage`), then closed. Lets
+    /// `read_intersect_reply` be driven without a live mux/egress.
+    fn preload_chainsync_channel(frames: Vec<Vec<u8>>) -> dugite_network::MuxChannel {
+        use dugite_network::{Direction, MuxChannel};
+        type Bytes = tokio_util::bytes::Bytes;
+        let (egress_tx, _egress_rx) = tokio::sync::mpsc::channel::<(u16, Direction, Bytes)>(8);
+        let (ingress_tx, ingress_rx) = tokio::sync::mpsc::channel::<Bytes>(64);
+        for f in frames {
+            ingress_tx
+                .try_send(Bytes::from(f))
+                .expect("preload ingress");
+        }
+        drop(ingress_tx); // close after preloading; recv yields buffered frames first
+        MuxChannel::new(
+            2,
+            Direction::InitiatorDir,
+            egress_tx,
+            ingress_rx,
+            65_536,
+            std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        )
+    }
+
+    fn test_addr() -> std::net::SocketAddr {
+        "127.0.0.1:3001".parse().unwrap()
+    }
+
+    fn enc(msg: &ChainSyncMessage) -> Vec<u8> {
+        cs_encode(msg)
+    }
+
+    fn stale_roll_forward() -> Vec<u8> {
+        enc(&ChainSyncMessage::MsgRollForward {
+            header: vec![0x80], // any valid CBOR value; content irrelevant (discarded)
+            tip_slot: 9,
+            tip_hash: [1u8; 32],
+            tip_block_number: 9,
+        })
+    }
+
+    /// THE BUG REPRO: a stale `MsgRollForward` (prior-session residue on a
+    /// reused mux) is discarded, then the real `MsgIntersectFound` is returned.
+    /// Pre-fix this hit the `unexpected response` error and tore the peer down.
+    #[tokio::test]
+    async fn read_intersect_reply_discards_one_stale_rollforward_then_found() {
+        let found = enc(&ChainSyncMessage::MsgIntersectFound {
+            point: CodecPoint::Origin,
+            tip_slot: 10,
+            tip_hash: [2u8; 32],
+            tip_block_number: 10,
+        });
+        let mut ch = preload_chainsync_channel(vec![stale_roll_forward(), found]);
+        let res = read_intersect_reply(&mut ch, test_addr()).await;
+        assert!(
+            matches!(res, Ok(Some(_))),
+            "stale RollForward must be discarded then IntersectFound returned, got {res:?}"
+        );
+    }
+
+    /// A clean connection (only the intersect reply) is byte-identical behavior.
+    #[tokio::test]
+    async fn read_intersect_reply_clean_found_and_not_found() {
+        let found = enc(&ChainSyncMessage::MsgIntersectFound {
+            point: CodecPoint::Origin,
+            tip_slot: 5,
+            tip_hash: [0u8; 32],
+            tip_block_number: 5,
+        });
+        let mut ch = preload_chainsync_channel(vec![found]);
+        assert!(matches!(
+            read_intersect_reply(&mut ch, test_addr()).await,
+            Ok(Some(_))
+        ));
+
+        let not_found = enc(&ChainSyncMessage::MsgIntersectNotFound {
+            tip_slot: 5,
+            tip_hash: [0u8; 32],
+            tip_block_number: 5,
+        });
+        let mut ch = preload_chainsync_channel(vec![not_found]);
+        assert!(matches!(
+            read_intersect_reply(&mut ch, test_addr()).await,
+            Ok(None)
+        ));
+    }
+
+    /// Multiple stale next-phase variants (RollBackward + AwaitReply) discarded
+    /// before the real NotFound.
+    #[tokio::test]
+    async fn read_intersect_reply_discards_rollback_and_awaitreply_then_not_found() {
+        let rb = enc(&ChainSyncMessage::MsgRollBackward {
+            point: CodecPoint::Origin,
+            tip_slot: 1,
+            tip_hash: [0u8; 32],
+            tip_block_number: 1,
+        });
+        let await_reply = enc(&ChainSyncMessage::MsgAwaitReply);
+        let nf = enc(&ChainSyncMessage::MsgIntersectNotFound {
+            tip_slot: 2,
+            tip_hash: [0u8; 32],
+            tip_block_number: 2,
+        });
+        let mut ch = preload_chainsync_channel(vec![rb, await_reply, nf]);
+        assert!(matches!(
+            read_intersect_reply(&mut ch, test_addr()).await,
+            Ok(None)
+        ));
+    }
+
+    /// Beyond MAX_STALE_DISCARD (16) the reader fails fast (→ reconnect), not
+    /// an infinite spin on a genuinely broken peer.
+    #[tokio::test]
+    async fn read_intersect_reply_exceeds_stale_bound_errors() {
+        let frames: Vec<Vec<u8>> = (0..17).map(|_| stale_roll_forward()).collect();
+        let mut ch = preload_chainsync_channel(frames);
+        let res = read_intersect_reply(&mut ch, test_addr()).await;
+        let err = res.expect_err("17 stale frames must exceed the bound and error");
+        assert!(
+            format!("{err:?}").contains("giving up"),
+            "expected a give-up error, got: {err:?}"
+        );
+    }
+
+    /// A genuine protocol violation (client-agency/terminal message in
+    /// StIntersect) errors immediately, NOT tolerated.
+    #[tokio::test]
+    async fn read_intersect_reply_genuine_violation_errors_immediately() {
+        let mut ch = preload_chainsync_channel(vec![enc(&ChainSyncMessage::MsgDone)]);
+        let res = read_intersect_reply(&mut ch, test_addr()).await;
+        let err = res.expect_err("MsgDone in StIntersect is a violation");
+        assert!(
+            format!("{err:?}").contains("unexpected response"),
+            "expected the unexpected-response error, got: {err:?}"
+        );
+    }
 
     /// Verify extract_hash_from_header produces a 32-byte array.
     #[test]

--- a/crates/dugite-uplc/src/cost_apply.rs
+++ b/crates/dugite-uplc/src/cost_apply.rs
@@ -181,23 +181,6 @@ fn refill_builtin(
     Ok(())
 }
 
-/// V1 integer-division cpu: `const_above_diagonal` over `multiplied_sizes`,
-/// flat sub-order `constant`, `model-arguments-intercept`,
-/// `model-arguments-slope`. mem: `subtracted_sizes`.
-fn v1_division(cur: &mut Cursor<'_>) -> CostPair {
-    let cpu = CostingFun::ConstAboveDiagonalMul(ConstAboveDiagMulP {
-        constant: cur.next(),
-        intercept: cur.next(),
-        slope: cur.next(),
-    });
-    let mem = CostingFun::SubtractedSizes(SubtractedSizesP {
-        intercept: cur.next(),
-        minimum: cur.next(),
-        slope: cur.next(),
-    });
-    CostPair { cpu, mem }
-}
-
 /// Protocol-version-dependent `BuiltinSemanticsVariant` for PlutusV1/V2.
 ///
 /// Per IntersectMBO/plutus `PlutusLedgerApi.Common.ProtocolVersions`
@@ -208,11 +191,85 @@ fn v1_division(cur: &mut Cursor<'_>) -> CostPair {
 /// flat-array PARAM COUNT is identical across the variants (175 for V2); only
 /// the cost-function SHAPE of two builtins changes — `multiplyInteger` cpu
 /// (`added_sizes` → `multiplied_sizes`) and `verifyEd25519Signature` cpu
-/// (`linear_in_z` → `linear_in_y`). (PV11/van Rossem introduces VariantD with
-/// further text-builtin changes — a future follow-up.)
+/// (`linear_in_z` → `linear_in_y`).
 #[inline]
 fn is_variant_b(major_pv: u32) -> bool {
     major_pv >= 9
+}
+
+/// `DefaultFunSemanticsVariantD` gate for PlutusV1/V2 — the van Rossem hard fork
+/// (`PV11`). Per IntersectMBO/plutus `PlutusLedgerApi.Common.ProtocolVersions`,
+/// PlutusV1 and PlutusV2 move VariantB → VariantD at PV11 (V3 moves C → E).
+///
+/// Beyond the VariantB changes, VariantD changes the cost-function SHAPE of two
+/// integer-division builtins (`builtinCostModelD.json` vs `…B.json`):
+/// `modInteger`/`remainderInteger` MEMORY goes `subtracted_sizes` →
+/// `linear_in_y2` (= `intercept + slope*size_y`, the `minimum` dropped), and
+/// `modInteger`/`divideInteger` CPU goes `const_above_diagonal` →
+/// `above_and_below_diagonal` (always runs the `multiplied_sizes` sub-model over
+/// `(max,min)`, the diagonal `constant` dropped). `quotientInteger` is
+/// unchanged, as are `divideInteger` mem and `remainderInteger` cpu. The flat
+/// param count/order is identical across variants — only the interpretation of
+/// the same coefficients changes.
+#[inline]
+fn is_variant_d(major_pv: u32) -> bool {
+    major_pv >= 11
+}
+
+/// Integer-division (`divideInteger` / `modInteger` / `quotientInteger` /
+/// `remainderInteger`) cost pair, variant-aware. Consumes 6 flat params in
+/// canonical order in EVERY branch — cpu `[constant, intercept, slope]` then mem
+/// `[intercept, minimum, slope]` — so the param cursor stays aligned; only the
+/// cost-function SHAPE differs by semantics variant (see [`is_variant_d`]).
+///
+/// `cpu_variant_d` (set for `modInteger`/`divideInteger` at PV≥11): cpu becomes
+/// `above_and_below_diagonal` over `multiplied_sizes`, which equals
+/// [`CostingFun::MultipliedSizes`] because `max*min == x*y` (the diagonal
+/// `constant` is dropped); otherwise `const_above_diagonal`
+/// ([`CostingFun::ConstAboveDiagonalMul`]).
+///
+/// `mem_variant_d` (set for `modInteger`/`remainderInteger` at PV≥11): mem
+/// becomes `linear_in_y2` = `intercept + slope*size_y` ([`CostingFun::LinearInY`],
+/// the `minimum` dropped); otherwise `subtracted_sizes`
+/// ([`CostingFun::SubtractedSizes`]).
+///
+/// Source: IntersectMBO/plutus `builtinCostModel{B,D}.json` +
+/// `PlutusCore.Evaluation.Machine.CostingFun.Core` (`runTwoArgumentModel`,
+/// `ModelTwoArgumentsLinearInY2` discards the minimum;
+/// `ModelTwoArgumentsAboveAndBelowDiagonal` drops the constant).
+fn divmod_cost(cur: &mut Cursor<'_>, cpu_variant_d: bool, mem_variant_d: bool) -> CostPair {
+    // cpu params: [constant, intercept, slope] (const_above_diagonal / multiplied_sizes).
+    let cpu_constant = cur.next();
+    let cpu_lin = cur.linear(); // intercept, slope
+    let cpu = if cpu_variant_d {
+        // above_and_below_diagonal(multiplied_sizes) ≡ multiplied_sizes, since
+        // max*min == x*y; the diagonal `constant` is dropped at VariantD.
+        CostingFun::MultipliedSizes(cpu_lin)
+    } else {
+        CostingFun::ConstAboveDiagonalMul(ConstAboveDiagMulP {
+            constant: cpu_constant,
+            intercept: cpu_lin.intercept,
+            slope: cpu_lin.slope,
+        })
+    };
+    // mem params: [intercept, minimum, slope] (subtracted_sizes / linear_in_y2).
+    let mem_intercept = cur.next();
+    let mem_minimum = cur.next();
+    let mem_slope = cur.next();
+    let mem = if mem_variant_d {
+        // linear_in_y2 == intercept + slope*size_y; the `minimum` is dropped.
+        CostingFun::LinearInY(Linear1 {
+            intercept: mem_intercept,
+            slope: mem_slope,
+        })
+    } else {
+        CostingFun::SubtractedSizes(SubtractedSizesP {
+            intercept: mem_intercept,
+            minimum: mem_minimum,
+            slope: mem_slope,
+        })
+    };
+    CostPair { cpu, mem }
 }
 
 /// `multiplyInteger` cost pair for the given semantics variant. Consumes 4
@@ -249,6 +306,7 @@ fn verify_ed25519(cur: &mut Cursor<'_>, variant_b: bool) -> CostPair {
 /// `ParamName` order) to a fresh [`AppliedCosts`].
 pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApplyError> {
     let variant_b = is_variant_b(major_pv);
+    let variant_d = is_variant_d(major_pv);
     if p.len() != V1_PARAM_COUNT {
         return Err(CostModelApplyError::WrongLength {
             expected: V1_PARAM_COUNT,
@@ -285,7 +343,7 @@ pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
     refill_builtin(&mut b, ConsByteString, cur)?;
     refill_builtin(&mut b, ConstrData, cur)?;
     refill_builtin(&mut b, DecodeUtf8, cur)?;
-    b.set_cost_pair(DivideInteger, v1_division(cur));
+    b.set_cost_pair(DivideInteger, divmod_cost(cur, variant_d, false));
     refill_builtin(&mut b, EncodeUtf8, cur)?;
     refill_builtin(&mut b, EqualsByteString, cur)?;
     refill_builtin(&mut b, EqualsData, cur)?;
@@ -307,14 +365,14 @@ pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
     refill_builtin(&mut b, MkNilData, cur)?;
     refill_builtin(&mut b, MkNilPairData, cur)?;
     refill_builtin(&mut b, MkPairData, cur)?;
-    b.set_cost_pair(ModInteger, v1_division(cur));
+    b.set_cost_pair(ModInteger, divmod_cost(cur, variant_d, variant_d));
     // multiplyInteger — VariantA cpu `added_sizes`; VariantB (PV9+)
     // `multiplied_sizes`.
     let mul = multiply_integer(cur, variant_b);
     b.set_cost_pair(MultiplyInteger, mul);
     refill_builtin(&mut b, NullList, cur)?;
-    b.set_cost_pair(QuotientInteger, v1_division(cur));
-    b.set_cost_pair(RemainderInteger, v1_division(cur));
+    b.set_cost_pair(QuotientInteger, divmod_cost(cur, false, false));
+    b.set_cost_pair(RemainderInteger, divmod_cost(cur, false, variant_d));
     refill_builtin(&mut b, Sha2_256, cur)?;
     refill_builtin(&mut b, Sha3_256, cur)?;
     refill_builtin(&mut b, SliceByteString, cur)?;
@@ -371,6 +429,7 @@ pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
 /// no-op for any V2 script that does not call a Plomin-era builtin.
 pub fn apply_v2(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApplyError> {
     let variant_b = is_variant_b(major_pv);
+    let variant_d = is_variant_d(major_pv);
     if p.len() < V2_PARAM_COUNT {
         return Err(CostModelApplyError::WrongLength {
             expected: V2_PARAM_COUNT,
@@ -407,7 +466,7 @@ pub fn apply_v2(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
     refill_builtin(&mut b, ConsByteString, cur)?;
     refill_builtin(&mut b, ConstrData, cur)?;
     refill_builtin(&mut b, DecodeUtf8, cur)?;
-    b.set_cost_pair(DivideInteger, v1_division(cur));
+    b.set_cost_pair(DivideInteger, divmod_cost(cur, variant_d, false));
     refill_builtin(&mut b, EncodeUtf8, cur)?;
     refill_builtin(&mut b, EqualsByteString, cur)?;
     refill_builtin(&mut b, EqualsData, cur)?;
@@ -429,15 +488,16 @@ pub fn apply_v2(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
     refill_builtin(&mut b, MkNilData, cur)?;
     refill_builtin(&mut b, MkNilPairData, cur)?;
     refill_builtin(&mut b, MkPairData, cur)?;
-    b.set_cost_pair(ModInteger, v1_division(cur));
+    b.set_cost_pair(ModInteger, divmod_cost(cur, variant_d, variant_d));
     // multiplyInteger — VariantA cpu `added_sizes`; VariantB (PV9+)
-    // `multiplied_sizes`. (Division shapes are unchanged A↔B — only the
-    // coefficients differ — so they stay on `v1_division`.)
+    // `multiplied_sizes`. (The integer-division builtins are handled by the
+    // variant-aware `divmod_cost`, which switches their cost shapes at
+    // VariantD/PV11.)
     let mul = multiply_integer(cur, variant_b);
     b.set_cost_pair(MultiplyInteger, mul);
     refill_builtin(&mut b, NullList, cur)?;
-    b.set_cost_pair(QuotientInteger, v1_division(cur));
-    b.set_cost_pair(RemainderInteger, v1_division(cur));
+    b.set_cost_pair(QuotientInteger, divmod_cost(cur, false, false));
+    b.set_cost_pair(RemainderInteger, divmod_cost(cur, false, variant_d));
     // serialiseData — new in V2, alphabetically before sha2_256.
     refill_builtin(&mut b, SerialiseData, cur)?;
     refill_builtin(&mut b, Sha2_256, cur)?;
@@ -775,6 +835,48 @@ pub fn apply_v3(p: &[i64]) -> Result<AppliedCosts, CostModelApplyError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `divmod_cost` must select the correct cost-function SHAPE per semantics
+    /// variant while consuming the SAME 6 params (cursor alignment), reading the
+    /// coefficients into the right fields. VariantD (PV≥11) switches
+    /// modInteger/divideInteger cpu → multiplied_sizes and
+    /// modInteger/remainderInteger mem → linear_in_y2; VariantB keeps
+    /// const_above_diagonal / subtracted_sizes. (PV11 byte-correctness fix.)
+    #[test]
+    fn divmod_cost_variant_boundary_shapes() {
+        // cpu [constant, intercept, slope], mem [intercept, minimum, slope]
+        // (modInteger D-model coefficients).
+        let p = [85848_i64, 228465, 122, 0, 1, 1];
+
+        // VariantD modInteger: cpu AND mem switch.
+        let mut cur = Cursor { p: &p, i: 0 };
+        let d = divmod_cost(&mut cur, true, true);
+        assert_eq!(cur.i, 6, "divmod_cost must consume exactly 6 params");
+        match d.cpu {
+            CostingFun::MultipliedSizes(l) => assert_eq!((l.intercept, l.slope), (228465, 122)),
+            other => panic!("VariantD cpu must be MultipliedSizes, got {other:?}"),
+        }
+        match d.mem {
+            CostingFun::LinearInY(l) => assert_eq!((l.intercept, l.slope), (0, 1)),
+            other => panic!("VariantD mem must be LinearInY (linear_in_y2), got {other:?}"),
+        }
+
+        // VariantB: cpu const_above_diagonal(mul), mem subtracted_sizes.
+        let mut cur = Cursor { p: &p, i: 0 };
+        let b = divmod_cost(&mut cur, false, false);
+        match b.cpu {
+            CostingFun::ConstAboveDiagonalMul(c) => {
+                assert_eq!((c.constant, c.intercept, c.slope), (85848, 228465, 122))
+            }
+            other => panic!("VariantB cpu must be ConstAboveDiagonalMul, got {other:?}"),
+        }
+        match b.mem {
+            CostingFun::SubtractedSizes(s) => {
+                assert_eq!((s.intercept, s.minimum, s.slope), (0, 1, 1))
+            }
+            other => panic!("VariantB mem must be SubtractedSizes, got {other:?}"),
+        }
+    }
 
     #[test]
     fn wrong_length_is_rejected() {


### PR DESCRIPTION
All three fixes were surfaced during a live preview-testnet block-producer soak and verified against canonical Haskell source (IntersectMBO).

## 1. ForkTooDeep peer severity (`3fe70f09b1`)
Peers far behind us (or on a disjoint chain) whose ChainSync intersection resolves only at genesis are the dugite equivalent of Haskell's `ChainSyncClientResult::ForkTooDeep` — an expected, routine outcome on public networks (stale/wrong-chain registered relays), traced at `Notice` in cardano-node. dugite logged them at WARN ×3/retry and labelled them `kind=Slow`. Now classified as a distinct `PeerFailureKind::Unsuitable` and logged at INFO; disconnect/backoff behaviour is unchanged. Live-verified (120 events at INFO, 0 at WARN).

## 2. Stale ChainSync RollForward on reused mux (`25c32975ac` + `09ec8a6fee`)
On a warm demote→re-promote (no TCP teardown), a `MsgRollForward` the server sent for the prior session's pipelined `MsgRequestNext` can still be in-flight in the kernel socket buffer at mux-resubscribe; the ingress task then routes it onto the fresh channel, where the new task's `MsgFindIntersect` read mistakes it as the reply → "unexpected response" + spurious peer churn. Fix: the StIntersect reader tolerates a bounded number of stale next-phase responses (matching Haskell typed-protocols, which rejects a next-phase message in StIntersect as a wire-state violation). The bound is sized to `DUGITE_PIPELINE_DEPTH` — the live soak showed the initial fixed bound of 16 was too low (a deeply-pipelined peer left >16 residue). Byte-identical on clean connections. Live-verified (0 "unexpected response").

## 3. PlutusV2 PV11 (VariantD) integer-division cost shapes (`c1d0eb7f7a`)
`apply_v1`/`apply_v2` hardcoded the VariantB division cost shapes for **all** protocol versions (only `is_variant_b` existed), mispricing the integer-division builtins at PV11. A live preview (epoch 1332, PV11) PlutusV2 DeFi tx that Haskell accepted over-charged **memory by 109 units** in dugite's evaluator (the node's trust-on-chain valve kept it byte-exact at block level, but phase-2 eval diverged). Per `builtinCostModel{B,D}.json` + `PlutusLedgerApi.Common.ProtocolVersions` + `CostingFun/Core.hs`: at PV11, `modInteger`/`remainderInteger` memory becomes `linear_in_y2` (not `subtracted_sizes`) and `modInteger`/`divideInteger` cpu becomes `above_and_below_diagonal`. dugite's DEFAULT cost table already used these VariantD shapes — only the on-chain-applied path was wrong. Adds `is_variant_d` (pv≥11) + a variant-aware `divmod_cost`. Byte-identical at PV<11.

## Verification
- TDD throughout (exhaustive classifier + 5 loop tests incl. the exact bug repro for #2; variant-boundary shape/coefficient test for #3).
- `just check` green (fmt + clippy `-D warnings` + workspace tests + doc-tests).
- **6027/6027 upstream golden conformance** (cardano-ledger, ledger-rules, plutus, ouroboros-consensus, …) for #3.
- #1 and #2 live-verified on the running BP; #3 deployed live with 0 Plutus divergences since.

## Follow-up
A PV11 V2 `phase2_onchain_budget` regression fixture for #3 (every existing fixture is PV8 — the coverage gap that let this ship). Cleanly capturing it needs a dedicated "re-eval tx from local chain" tool: UTxO-HD snapshots carry no in-memory UTxO and all startup-replay paths use `ApplyOnly` (no phase-2), so the offline capture paths are blocked.
