### PR TITLE
perf+genesis: apply-throughput (registry cache 2.1x, Plutus deferral) + Haskell-faithful genesis-mode sync + fetch instrumentation

### DIFF
--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -440,6 +440,86 @@ pub fn run_phase2_parallel(items: Vec<Phase2WorkItem>) -> Vec<Phase2Outcome> {
     outcomes
 }
 
+/// Cross-block pooled Phase-2 evaluation — the CPU-saturation primitive for
+/// bulk sync.
+///
+/// A single block carries only ~2-3 redeemers on the median preview Conway
+/// block, so its `into_par_iter` cannot fill a 12-core host. This concatenates
+/// the work items of MANY blocks into one rayon batch (all redeemers fan across
+/// every core at once), then regroups the outcomes back per input block,
+/// preserving each block's internal `tx_idx` ordering.
+///
+/// `batches[i]` are block `i`'s [`Phase2WorkItem`]s (from
+/// [`crate::state::LedgerState::apply_block_defer_phase2`]); the returned
+/// `Vec<Vec<Phase2Outcome>>` is aligned 1:1 with `batches` and each inner vec is
+/// sorted by `tx_idx`, so feeding `result[i]` to
+/// [`crate::state::apply_phase2_outcomes`] with block `i` reproduces the exact
+/// per-block fatality decision the serial path would make.
+#[cfg(feature = "parallel-verification")]
+pub fn run_phase2_parallel_pooled(batches: Vec<Vec<Phase2WorkItem>>) -> Vec<Vec<Phase2Outcome>> {
+    use rayon::prelude::*;
+
+    let n_blocks = batches.len();
+
+    // Flatten to (block_idx, item) so every redeemer across every block is a
+    // single rayon work unit — this is what actually fills the cores. Consume
+    // `batches` by value (move, no clone) since items are owned and self-contained.
+    let mut flat: Vec<(usize, Phase2WorkItem)> = Vec::new();
+    for (block_idx, items) in batches.into_iter().enumerate() {
+        for item in items {
+            flat.push((block_idx, item));
+        }
+    }
+
+    let mut tagged: Vec<(usize, Phase2Outcome)> = flat
+        .into_par_iter()
+        .map(|(block_idx, item)| {
+            let dugite_slot_config = dugite_uplc::phase_two::SlotConfig {
+                network_start_unix_seconds: item.slot_config.zero_time / 1_000,
+                slot_zero_offset: item.slot_config.zero_slot,
+                slot_length_ms: item.slot_config.slot_length,
+                safe_zone_horizon_slot: item.slot_config.safe_zone_horizon_slot,
+            };
+            let result = run_single_phase2_eval(
+                &item.tx_cbor,
+                &item.utxo_pairs,
+                item.cost_models_cbor.as_deref(),
+                item.max_ex,
+                dugite_slot_config,
+                item.protocol_major,
+            );
+            if (result.is_ok() && !item.is_valid) || (result.is_err() && item.is_valid) {
+                maybe_dump_phase2_divergence(&item);
+            }
+            (
+                block_idx,
+                Phase2Outcome {
+                    tx_idx: item.tx_idx,
+                    is_valid: item.is_valid,
+                    result,
+                    utxo_complete: item.utxo_complete,
+                },
+            )
+        })
+        .collect();
+
+    // Regroup by block index, one inner vec per input block.
+    let mut grouped: Vec<Vec<Phase2Outcome>> = (0..n_blocks).map(|_| Vec::new()).collect();
+    // Sort by (block_idx, tx_idx) so each block's outcomes land in tx order —
+    // identical to run_phase2_parallel's per-block sort_by_key(tx_idx).
+    tagged.sort_by_key(|(block_idx, o)| (*block_idx, o.tx_idx));
+    for (block_idx, outcome) in tagged {
+        grouped[block_idx].push(outcome);
+    }
+    grouped
+}
+
+/// Sequential fallback (feature gate off).
+#[cfg(not(feature = "parallel-verification"))]
+pub fn run_phase2_parallel_pooled(batches: Vec<Vec<Phase2WorkItem>>) -> Vec<Vec<Phase2Outcome>> {
+    batches.into_iter().map(run_phase2_parallel).collect()
+}
+
 /// Sequential fallback (feature gate off).
 #[cfg(not(feature = "parallel-verification"))]
 pub fn run_phase2_parallel(items: Vec<Phase2WorkItem>) -> Vec<Phase2Outcome> {

--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -440,14 +440,106 @@ pub fn run_phase2_parallel(items: Vec<Phase2WorkItem>) -> Vec<Phase2Outcome> {
     outcomes
 }
 
+/// Evaluate one pooled Phase-2 work item into its `(block_idx, outcome)`.
+///
+/// Pure and self-contained (reads only the borrowed item), so it is safe to run
+/// on any rayon worker or sequentially. Shared by the parallel and sequential
+/// pooled paths so the per-item logic — including the divergence dump — lives in
+/// exactly one place.
+fn eval_phase2_item(block_idx: usize, item: &Phase2WorkItem) -> (usize, Phase2Outcome) {
+    let dugite_slot_config = dugite_uplc::phase_two::SlotConfig {
+        network_start_unix_seconds: item.slot_config.zero_time / 1_000,
+        slot_zero_offset: item.slot_config.zero_slot,
+        slot_length_ms: item.slot_config.slot_length,
+        safe_zone_horizon_slot: item.slot_config.safe_zone_horizon_slot,
+    };
+    let result = run_single_phase2_eval(
+        &item.tx_cbor,
+        &item.utxo_pairs,
+        item.cost_models_cbor.as_deref(),
+        item.max_ex,
+        dugite_slot_config,
+        item.protocol_major,
+    );
+    if (result.is_ok() && !item.is_valid) || (result.is_err() && item.is_valid) {
+        maybe_dump_phase2_divergence(item);
+    }
+    (
+        block_idx,
+        Phase2Outcome {
+            tx_idx: item.tx_idx,
+            is_valid: item.is_valid,
+            result,
+            utxo_complete: item.utxo_complete,
+        },
+    )
+}
+
+/// Default cap on CONCURRENT Plutus evaluations in the cross-block pooled flush.
+///
+/// Each in-flight CEK evaluation can hold up to roughly its declared
+/// `maxTxExUnits` mem budget worth of live term/environment data (hundreds of MB
+/// for a max-budget script), so peak RSS during a pooled flush is
+/// ≈ concurrency × per-eval peak. The original pooled path ran ONE rayon batch
+/// across EVERY core (`into_par_iter` on the global pool); in a dense-Plutus
+/// region that produced an ~11-core × ~1.2 GB ≈ 13.5 GB runaway that froze block
+/// apply (the deferral-soak wedge). Capping concurrency bounds peak RSS while
+/// still filling several cores. Tunable via `DUGITE_PHASE2_POOL_THREADS`;
+/// default = min(cores − 2, this).
+const PHASE2_POOL_DEFAULT_MAX_THREADS: usize = 6;
+
+/// Per-chunk work-item multiple (× pool width). Chunking gives the pooled flush
+/// a cancellation checkpoint between chunks and bounds the live outcome buffer,
+/// without starving the pool's work-stealing depth.
+const PHASE2_POOL_CHUNK_FACTOR: usize = 4;
+
+/// Resolve the pooled-flush concurrency cap (see [`PHASE2_POOL_DEFAULT_MAX_THREADS`]).
+fn phase2_pool_max_threads() -> usize {
+    if let Ok(v) = std::env::var("DUGITE_PHASE2_POOL_THREADS") {
+        if let Ok(n) = v.parse::<usize>() {
+            if n >= 1 {
+                return n;
+            }
+        }
+    }
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    cores
+        .saturating_sub(2)
+        .clamp(1, PHASE2_POOL_DEFAULT_MAX_THREADS)
+}
+
+/// Process-wide bounded rayon pool for the cross-block pooled flush. Built once
+/// (its width is fixed by [`phase2_pool_max_threads`] at first use); `None` only
+/// if the pool cannot be created (resource exhaustion), in which case the caller
+/// runs the chunks sequentially.
+#[cfg(feature = "parallel-verification")]
+fn phase2_pool() -> Option<&'static rayon::ThreadPool> {
+    static POOL: std::sync::OnceLock<Option<rayon::ThreadPool>> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(phase2_pool_max_threads())
+            .thread_name(|i| format!("phase2-pool-{i}"))
+            .build()
+            .ok()
+    })
+    .as_ref()
+}
+
 /// Cross-block pooled Phase-2 evaluation — the CPU-saturation primitive for
 /// bulk sync.
 ///
 /// A single block carries only ~2-3 redeemers on the median preview Conway
 /// block, so its `into_par_iter` cannot fill a 12-core host. This concatenates
-/// the work items of MANY blocks into one rayon batch (all redeemers fan across
-/// every core at once), then regroups the outcomes back per input block,
-/// preserving each block's internal `tx_idx` ordering.
+/// the work items of MANY blocks (all redeemers fan across the pool at once),
+/// then regroups the outcomes back per input block, preserving each block's
+/// internal `tx_idx` ordering.
+///
+/// **Memory-bounded.** Rather than fanning every redeemer across the global
+/// rayon pool at once (which produced the deferral-soak RSS runaway), this runs
+/// on a dedicated pool capped at [`phase2_pool_max_threads`] and processes the
+/// flattened items in chunks, so peak concurrent CEK memory stays bounded.
 ///
 /// `batches[i]` are block `i`'s [`Phase2WorkItem`]s (from
 /// [`crate::state::LedgerState::apply_block_defer_phase2`]); the returned
@@ -457,13 +549,36 @@ pub fn run_phase2_parallel(items: Vec<Phase2WorkItem>) -> Vec<Phase2Outcome> {
 /// per-block fatality decision the serial path would make.
 #[cfg(feature = "parallel-verification")]
 pub fn run_phase2_parallel_pooled(batches: Vec<Vec<Phase2WorkItem>>) -> Vec<Vec<Phase2Outcome>> {
+    // Never-cancel: the offline / bench path always runs to completion.
+    run_phase2_pooled_inner(batches, &|| false)
+        .expect("pooled phase-2 eval cannot be cancelled with a never-cancel token")
+}
+
+/// Cancellable + memory-bounded variant for the live deferral flush.
+///
+/// Returns `None` if `cancel()` observed `true` between chunks (shutdown in
+/// progress) before all items were evaluated — the caller MUST treat the window
+/// as NOT confirmed (roll back / retry) and never apply a partial result. On
+/// success returns per-block outcomes aligned 1:1 with `batches`.
+#[cfg(feature = "parallel-verification")]
+pub fn run_phase2_parallel_pooled_cancellable(
+    batches: Vec<Vec<Phase2WorkItem>>,
+    cancel: &dyn Fn() -> bool,
+) -> Option<Vec<Vec<Phase2Outcome>>> {
+    run_phase2_pooled_inner(batches, cancel)
+}
+
+#[cfg(feature = "parallel-verification")]
+fn run_phase2_pooled_inner(
+    batches: Vec<Vec<Phase2WorkItem>>,
+    cancel: &dyn Fn() -> bool,
+) -> Option<Vec<Vec<Phase2Outcome>>> {
     use rayon::prelude::*;
 
     let n_blocks = batches.len();
 
-    // Flatten to (block_idx, item) so every redeemer across every block is a
-    // single rayon work unit — this is what actually fills the cores. Consume
-    // `batches` by value (move, no clone) since items are owned and self-contained.
+    // Flatten to (block_idx, item) so every redeemer is a single work unit.
+    // Consume `batches` by value (move, no clone) since items are self-contained.
     let mut flat: Vec<(usize, Phase2WorkItem)> = Vec::new();
     for (block_idx, items) in batches.into_iter().enumerate() {
         for item in items {
@@ -471,53 +586,71 @@ pub fn run_phase2_parallel_pooled(batches: Vec<Vec<Phase2WorkItem>>) -> Vec<Vec<
         }
     }
 
-    let mut tagged: Vec<(usize, Phase2Outcome)> = flat
-        .into_par_iter()
-        .map(|(block_idx, item)| {
-            let dugite_slot_config = dugite_uplc::phase_two::SlotConfig {
-                network_start_unix_seconds: item.slot_config.zero_time / 1_000,
-                slot_zero_offset: item.slot_config.zero_slot,
-                slot_length_ms: item.slot_config.slot_length,
-                safe_zone_horizon_slot: item.slot_config.safe_zone_horizon_slot,
-            };
-            let result = run_single_phase2_eval(
-                &item.tx_cbor,
-                &item.utxo_pairs,
-                item.cost_models_cbor.as_deref(),
-                item.max_ex,
-                dugite_slot_config,
-                item.protocol_major,
-            );
-            if (result.is_ok() && !item.is_valid) || (result.is_err() && item.is_valid) {
-                maybe_dump_phase2_divergence(&item);
-            }
-            (
-                block_idx,
-                Phase2Outcome {
-                    tx_idx: item.tx_idx,
-                    is_valid: item.is_valid,
-                    result,
-                    utxo_complete: item.utxo_complete,
-                },
-            )
-        })
-        .collect();
+    let pool = phase2_pool();
+    let chunk_items = phase2_pool_max_threads()
+        .saturating_mul(PHASE2_POOL_CHUNK_FACTOR)
+        .max(1);
 
-    // Regroup by block index, one inner vec per input block.
+    // Process in bounded chunks: a cancellation checkpoint between chunks (one
+    // chunk = bounded latency) and a bounded live outcome buffer. Concurrency
+    // within a chunk is capped by the dedicated pool, which is what bounds RSS.
+    let mut tagged: Vec<(usize, Phase2Outcome)> = Vec::with_capacity(flat.len());
+    let mut start = 0usize;
+    while start < flat.len() {
+        if cancel() {
+            return None;
+        }
+        let end = (start + chunk_items).min(flat.len());
+        let chunk = &flat[start..end];
+        let mut chunk_out: Vec<(usize, Phase2Outcome)> = match pool {
+            Some(p) => p.install(|| {
+                chunk
+                    .par_iter()
+                    .map(|(block_idx, item)| eval_phase2_item(*block_idx, item))
+                    .collect()
+            }),
+            // Pool unavailable (build failed): sequential, still cancellable
+            // per chunk.
+            None => chunk
+                .iter()
+                .map(|(block_idx, item)| eval_phase2_item(*block_idx, item))
+                .collect(),
+        };
+        tagged.append(&mut chunk_out);
+        start = end;
+    }
+
+    // Regroup by block index, one inner vec per input block, sorted by
+    // (block_idx, tx_idx) so each block's outcomes land in tx order — identical
+    // to run_phase2_parallel's per-block sort_by_key(tx_idx).
     let mut grouped: Vec<Vec<Phase2Outcome>> = (0..n_blocks).map(|_| Vec::new()).collect();
-    // Sort by (block_idx, tx_idx) so each block's outcomes land in tx order —
-    // identical to run_phase2_parallel's per-block sort_by_key(tx_idx).
     tagged.sort_by_key(|(block_idx, o)| (*block_idx, o.tx_idx));
     for (block_idx, outcome) in tagged {
         grouped[block_idx].push(outcome);
     }
-    grouped
+    Some(grouped)
 }
 
 /// Sequential fallback (feature gate off).
 #[cfg(not(feature = "parallel-verification"))]
 pub fn run_phase2_parallel_pooled(batches: Vec<Vec<Phase2WorkItem>>) -> Vec<Vec<Phase2Outcome>> {
     batches.into_iter().map(run_phase2_parallel).collect()
+}
+
+/// Cancellable sequential fallback (feature gate off).
+#[cfg(not(feature = "parallel-verification"))]
+pub fn run_phase2_parallel_pooled_cancellable(
+    batches: Vec<Vec<Phase2WorkItem>>,
+    cancel: &dyn Fn() -> bool,
+) -> Option<Vec<Vec<Phase2Outcome>>> {
+    let mut grouped: Vec<Vec<Phase2Outcome>> = Vec::with_capacity(batches.len());
+    for items in batches {
+        if cancel() {
+            return None;
+        }
+        grouped.push(run_phase2_parallel(items));
+    }
+    Some(grouped)
 }
 
 /// Sequential fallback (feature gate off).
@@ -919,6 +1052,92 @@ mod tests {
         assert!(
             !datum_present(&dugite_serialization::encode_transaction(&tx)),
             "encode_transaction must mangle the non-canonical datum (proves the bug)"
+        );
+    }
+
+    /// The memory-bounded + chunked pooled flush must be byte-for-byte
+    /// equivalent to the established per-block sequential-parallel path: each
+    /// item's evaluation is independent, and the regroup re-sorts by
+    /// `(block_idx, tx_idx)`, so the dedicated capped pool + chunking changes
+    /// only WHEN/WHERE an eval runs, never its outcome. This pins that invariant
+    /// (the deferral byte-exactness guarantee) and the cancellation contract.
+    #[test]
+    fn pooled_phase2_equals_sequential_reference_and_honours_cancel() {
+        let tx_cbor = hexd(include_str!("../test_data/phase2_datum_tag102_tx.hex"));
+        let mk_item = |tx_idx: usize, is_valid: bool| Phase2WorkItem {
+            tx_idx,
+            is_valid,
+            tx_cbor: tx_cbor.clone(),
+            // No resolved inputs: every eval fails fast + deterministically. We
+            // are testing scheduling-invariance, which holds for ANY deterministic
+            // per-item function regardless of the Ok/Err verdict.
+            utxo_pairs: Vec::new(),
+            cost_models_cbor: None,
+            max_ex: (10_000_000_000, 14_000_000),
+            slot_config: SlotConfig {
+                zero_time: 1_596_059_091_000,
+                zero_slot: 4_492_800,
+                slot_length: 1_000,
+                safe_zone_horizon_slot: None,
+            },
+            protocol_major: 9,
+            utxo_complete: false,
+        };
+        // Fresh blocks each call (Phase2WorkItem is not Clone). Includes an empty
+        // block and a block larger than a chunk so flatten/regroup + the chunk
+        // boundary are exercised.
+        let mk_blocks = || -> Vec<Vec<Phase2WorkItem>> {
+            vec![
+                vec![mk_item(0, true), mk_item(1, false)],
+                Vec::new(),
+                vec![mk_item(0, true)],
+                (0..40).map(|i| mk_item(i, i % 2 == 0)).collect(),
+            ]
+        };
+        let proj = |groups: Vec<Vec<Phase2Outcome>>| -> Vec<Vec<(usize, bool, bool, bool)>> {
+            groups
+                .into_iter()
+                .map(|g| {
+                    g.into_iter()
+                        .map(|o| (o.tx_idx, o.is_valid, o.result.is_ok(), o.utxo_complete))
+                        .collect()
+                })
+                .collect()
+        };
+
+        // Reference: per-block sequential-parallel (the path the pooled flush
+        // must reproduce).
+        let reference: Vec<Vec<(usize, bool, bool, bool)>> = mk_blocks()
+            .into_iter()
+            .map(|b| {
+                run_phase2_parallel(b)
+                    .into_iter()
+                    .map(|o| (o.tx_idx, o.is_valid, o.result.is_ok(), o.utxo_complete))
+                    .collect()
+            })
+            .collect();
+
+        // Pooled (memory-bounded, chunked) must align 1:1 and match exactly.
+        let pooled = run_phase2_parallel_pooled(mk_blocks());
+        assert_eq!(
+            pooled.len(),
+            4,
+            "outcome groups align 1:1 with input blocks"
+        );
+        assert_eq!(
+            proj(pooled),
+            reference,
+            "pooled outcomes must equal the sequential reference exactly"
+        );
+
+        // Cancellable: never-cancel == reference; always-cancel == None (the
+        // window is NOT confirmed, never partially applied).
+        let never = run_phase2_parallel_pooled_cancellable(mk_blocks(), &|| false)
+            .expect("never-cancel returns Some");
+        assert_eq!(proj(never), reference, "never-cancel matches the reference");
+        assert!(
+            run_phase2_parallel_pooled_cancellable(mk_blocks(), &|| true).is_none(),
+            "always-cancel returns None so the caller cannot apply a partial window"
         );
     }
 

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -59,6 +59,102 @@ fn phase2_collect_fatal_enabled() -> bool {
     })
 }
 
+/// Apply the result of a block's Phase-2 (Plutus) evaluation: convert the
+/// per-tx [`Phase2Outcome`]s into the block-fatal rejection decision (Babbage+
+/// collection error) or a divergence warning, exactly as Step 8d does inline.
+///
+/// Extracted so the deferred bulk-sync path can reproduce the identical
+/// fatality decision after pooling+evaluating work items across many blocks
+/// (see [`LedgerState::apply_block_defer_phase2`]). It is a **pure function of
+/// `(block, outcomes)`** — it mutates no ledger state (state is already applied
+/// in Step 8b), so deferring *when* it runs cannot change *what* it decides.
+///
+/// Returns `Err(Phase2CollectErrors)` for a block-fatal collection error and
+/// `Ok(())` otherwise (logging is_valid divergences warn-and-trust).
+#[cfg(feature = "parallel-verification")]
+pub fn apply_phase2_outcomes(
+    block: &Block,
+    outcomes: Vec<crate::plutus::Phase2Outcome>,
+) -> Result<(), LedgerError> {
+    for outcome in outcomes {
+        // Look up the transaction by index. Duplicate txs were skipped during
+        // the loop (not added to work_items), so every outcome.tx_idx is valid.
+        let tx = match block.transactions.get(outcome.tx_idx) {
+            Some(t) => t,
+            None => continue,
+        };
+        // #733: a phase-2 COLLECTION error is block-fatal in Babbage+ regardless
+        // of the is_valid tag — Haskell raises `UtxosFailure (CollectErrors …)`
+        // before any script runs, so every honest node rejects this block.
+        // Carve-outs: CEK panics (not a Haskell error class — correction 3) and
+        // UTxO-gap work items (inputs unresolved during best-effort partial
+        // replay — correction 4) stay warn-and-trust. Alonzo blocks never arm
+        // the time-translation horizon (correction 2) and keep warn-only
+        // semantics for the remaining collect classes (no false fatality).
+        if let Err(e) = &outcome.result {
+            if e.is_eval_panic() {
+                warn!(
+                    tx_hash = %tx.hash.to_hex(),
+                    slot = block.slot().0,
+                    error = %e,
+                    "Phase-2 evaluator PANIC on confirmed block — trusting \
+                     on-chain consensus (dugite CEK robustness gap; never \
+                     block-fatal at apply)"
+                );
+                continue;
+            }
+            if e.is_collect_error()
+                && block.era >= Era::Babbage
+                && outcome.utxo_complete
+                && phase2_collect_fatal_enabled()
+            {
+                return Err(LedgerError::Phase2CollectErrors {
+                    slot: block.slot().0,
+                    tx_hash: tx.hash.to_hex(),
+                    error: e.to_string(),
+                });
+            }
+        }
+        if outcome.is_valid {
+            // is_valid=true: phase-2 failure is a ScriptFailed on a confirmed
+            // block — log a warning and trust on-chain consensus.
+            if let Err(e) = outcome.result {
+                warn!(
+                    tx_hash = %tx.hash.to_hex(),
+                    slot = block.slot().0,
+                    error = %e,
+                    "Plutus evaluation divergence (parallel): uplc says scripts fail \
+                     but block is_valid=true on-chain — trusting on-chain consensus"
+                );
+            }
+        } else {
+            // is_valid=false: the producer's scripts failed on-chain (collateral
+            // consumed). dugite's CEK says they pass — a Phase-2 evaluation
+            // divergence. On a block received via ChainSync the is_valid flag is
+            // CONSENSUS TRUTH: honest (Haskell) nodes enforce it with a correct
+            // CEK, so any block on the selected chain carries a genuine flag and
+            // the divergence is a dugite-CEK bug, not collateral theft. The tx
+            // was ALREADY applied as invalid (collateral consumed, no outputs) in
+            // Step 8b, so the ledger state is byte-exact regardless. Trust the
+            // on-chain flag and log the divergence (symmetric with the
+            // is_valid=true branch above) instead of hard-halting the whole sync.
+            // The DUGITE_PHASE2_DUMP_DIR repro was captured in
+            // run_phase2_parallel for offline CEK root-causing.
+            if outcome.result.is_ok() {
+                warn!(
+                    tx_hash = %tx.hash.to_hex(),
+                    slot = block.slot().0,
+                    "Plutus evaluation divergence (parallel): uplc says scripts PASS \
+                     but block is_valid=false on-chain — trusting on-chain consensus \
+                     (tx applied as invalid; dugite CEK over-permissive — see \
+                     DUGITE_PHASE2_DUMP_DIR)"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl LedgerState {
     /// Build a read-only rule context for era rule dispatch.
     ///
@@ -106,6 +202,46 @@ impl LedgerState {
         block: &Block,
         mode: BlockValidationMode,
     ) -> Result<(), LedgerError> {
+        // Default path: apply state AND drain Phase-2 inline (byte-identical to
+        // the historic behaviour). The returned work-item vec is always empty.
+        self.apply_block_impl(block, mode, false)?;
+        Ok(())
+    }
+
+    /// Apply a block's STATE in-order but **defer** the Phase-2 (Plutus) drain,
+    /// returning the captured [`Phase2WorkItem`]s instead of evaluating them.
+    ///
+    /// Bulk-sync CPU-saturation lever: each [`Phase2WorkItem`] is fully
+    /// self-contained (resolved UTxO CBOR + script + per-block `cost_models_cbor`
+    /// / `slot_config` / `protocol_major`), so items captured here can be pooled
+    /// across many blocks and evaluated together on a rayon pool to fill all
+    /// cores — a single block's ~2-3 redeemers can never saturate a 12-core host.
+    ///
+    /// **Byte-exact contract:** ledger STATE is mutated identically to
+    /// [`apply_block`] (Plutus never writes state — it only gates acceptance), so
+    /// the caller MUST later run [`apply_phase2_outcomes`] on the drained outcomes
+    /// to reproduce the exact block-fatal rejection decision before the block is
+    /// exposed. Deferring *when* Plutus runs cannot change *what* it decides
+    /// (the fatality verdict is a pure function of the self-contained outcomes).
+    pub fn apply_block_defer_phase2(
+        &mut self,
+        block: &Block,
+        mode: BlockValidationMode,
+    ) -> Result<Vec<Phase2WorkItem>, LedgerError> {
+        self.apply_block_impl(block, mode, true)
+    }
+
+    /// Implementation shared by [`apply_block`] (inline drain) and
+    /// [`apply_block_defer_phase2`] (deferred drain). When `defer_phase2` is
+    /// `true`, Step 8d's `run_phase2_parallel` + fatality loop is skipped and the
+    /// captured `phase2_work_items` are returned for later pooled evaluation;
+    /// when `false`, the drain runs inline and an empty vec is returned.
+    fn apply_block_impl(
+        &mut self,
+        block: &Block,
+        mode: BlockValidationMode,
+        defer_phase2: bool,
+    ) -> Result<Vec<Phase2WorkItem>, LedgerError> {
         trace!(
             slot = block.slot().0,
             block_no = block.block_number().0,
@@ -535,7 +671,8 @@ impl LedgerState {
                 epoch = self.epoch.0,
                 "Ledger: Byron block applied successfully"
             );
-            return Ok(());
+            // Byron has no Phase-2; nothing to defer.
+            return Ok(Vec::new());
         }
 
         // ══════════════════════════════════════════════════════════════════
@@ -1515,98 +1652,26 @@ impl LedgerState {
         #[cfg(feature = "parallel-verification")]
         {
             crate::validation::restore_phase2_eval(_phase2_skip_guard);
-            if mode == BlockValidationMode::ValidateAll && !phase2_work_items.is_empty() {
+            // When deferring (bulk-sync pooling), DO NOT drain here — the
+            // captured `phase2_work_items` are returned to the caller, which
+            // pools them across blocks, evaluates on a rayon pool, and runs
+            // `apply_phase2_outcomes` to reproduce the exact fatality decision
+            // before exposing the block. The inline path drains immediately so
+            // its behaviour (and the apply_bench fingerprint) is unchanged.
+            if !defer_phase2
+                && mode == BlockValidationMode::ValidateAll
+                && !phase2_work_items.is_empty()
+            {
                 let t_phase2_start = if timing_enabled {
                     Some(std::time::Instant::now())
                 } else {
                     None
                 };
-                let outcomes = run_phase2_parallel(phase2_work_items);
+                let outcomes = run_phase2_parallel(std::mem::take(&mut phase2_work_items));
                 if let Some(start) = t_phase2_start {
                     t_phase2 += start.elapsed();
                 }
-                for outcome in outcomes {
-                    // Look up the transaction by index. Duplicate txs were
-                    // skipped during the loop (not added to work_items), so
-                    // every outcome.tx_idx is a valid index.
-                    let tx = match block.transactions.get(outcome.tx_idx) {
-                        Some(t) => t,
-                        None => continue,
-                    };
-                    // #733: a phase-2 COLLECTION error is block-fatal in
-                    // Babbage+ regardless of the is_valid tag — Haskell
-                    // raises `UtxosFailure (CollectErrors …)` before any
-                    // script runs, so every honest node rejects this block.
-                    // Carve-outs: CEK panics (not a Haskell error class —
-                    // correction 3) and UTxO-gap work items (inputs
-                    // unresolved during best-effort partial replay —
-                    // correction 4) stay warn-and-trust. Alonzo blocks never
-                    // arm the time-translation horizon (correction 2) and
-                    // keep warn-only semantics for the remaining collect
-                    // classes (conservative: no false fatality).
-                    if let Err(e) = &outcome.result {
-                        if e.is_eval_panic() {
-                            warn!(
-                                tx_hash = %tx.hash.to_hex(),
-                                slot = block.slot().0,
-                                error = %e,
-                                "Phase-2 evaluator PANIC on confirmed block — trusting \
-                                 on-chain consensus (dugite CEK robustness gap; never \
-                                 block-fatal at apply)"
-                            );
-                            continue;
-                        }
-                        if e.is_collect_error()
-                            && block.era >= Era::Babbage
-                            && outcome.utxo_complete
-                            && phase2_collect_fatal_enabled()
-                        {
-                            return Err(LedgerError::Phase2CollectErrors {
-                                slot: block.slot().0,
-                                tx_hash: tx.hash.to_hex(),
-                                error: e.to_string(),
-                            });
-                        }
-                    }
-                    if outcome.is_valid {
-                        // is_valid=true: phase-2 failure is a ScriptFailed on a
-                        // confirmed block — log a warning and trust on-chain consensus.
-                        if let Err(e) = outcome.result {
-                            warn!(
-                                tx_hash = %tx.hash.to_hex(),
-                                slot = block.slot().0,
-                                error = %e,
-                                "Plutus evaluation divergence (parallel): uplc says scripts fail \
-                                 but block is_valid=true on-chain — trusting on-chain consensus"
-                            );
-                        }
-                    } else {
-                        // is_valid=false: the producer's scripts failed on-chain
-                        // (collateral consumed). dugite's CEK says they pass — a
-                        // Phase-2 evaluation divergence. On a block received via
-                        // ChainSync the is_valid flag is CONSENSUS TRUTH: honest
-                        // (Haskell) nodes enforce it with a correct CEK, so any
-                        // block on the selected chain carries a genuine flag and
-                        // the divergence is a dugite-CEK bug, not collateral
-                        // theft. The tx was ALREADY applied as invalid (collateral
-                        // consumed, no outputs) in Step 8b, so the ledger state is
-                        // byte-exact regardless. Trust the on-chain flag and log
-                        // the divergence (symmetric with the is_valid=true branch
-                        // above) instead of hard-halting the whole sync. The
-                        // DUGITE_PHASE2_DUMP_DIR repro was captured in
-                        // run_phase2_parallel for offline CEK root-causing.
-                        if outcome.result.is_ok() {
-                            warn!(
-                                tx_hash = %tx.hash.to_hex(),
-                                slot = block.slot().0,
-                                "Plutus evaluation divergence (parallel): uplc says scripts PASS \
-                                 but block is_valid=false on-chain — trusting on-chain consensus \
-                                 (tx applied as invalid; dugite CEK over-permissive — see \
-                                 DUGITE_PHASE2_DUMP_DIR)"
-                            );
-                        }
-                    }
-                }
+                apply_phase2_outcomes(block, outcomes)?;
             }
         }
 
@@ -1707,7 +1772,14 @@ impl LedgerState {
             );
         }
 
-        Ok(())
+        // In deferred mode return the captured Phase-2 work items (possibly
+        // empty for ApplyOnly / Byron / script-free blocks); the inline path
+        // already drained them above and returns an empty vec.
+        Ok(if defer_phase2 {
+            std::mem::take(&mut phase2_work_items)
+        } else {
+            Vec::new()
+        })
     }
 
     /// Apply a block and produce a [`LedgerDelta`] capturing all state changes.

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -1798,6 +1798,31 @@ impl LedgerState {
         block: &Block,
         mode: BlockValidationMode,
     ) -> Result<LedgerDelta, LedgerError> {
+        let (delta, _items) = self.apply_block_with_delta_impl(block, mode, false)?;
+        Ok(delta)
+    }
+
+    /// Like [`apply_block_with_delta`] but **defers** the Phase-2 (Plutus) drain,
+    /// returning the captured [`Phase2WorkItem`]s alongside the delta for later
+    /// cross-block pooled evaluation (bulk-sync CPU-saturation; see
+    /// [`apply_block_defer_phase2`]). The state mutations and the `LedgerDelta`
+    /// are byte-identical to [`apply_block_with_delta`]; the caller MUST run
+    /// [`apply_phase2_outcomes`] on the drained outcomes before exposing the block
+    /// to reproduce the exact block-fatal rejection decision.
+    pub fn apply_block_with_delta_defer(
+        &mut self,
+        block: &Block,
+        mode: BlockValidationMode,
+    ) -> Result<(LedgerDelta, Vec<Phase2WorkItem>), LedgerError> {
+        self.apply_block_with_delta_impl(block, mode, true)
+    }
+
+    fn apply_block_with_delta_impl(
+        &mut self,
+        block: &Block,
+        mode: BlockValidationMode,
+        defer_phase2: bool,
+    ) -> Result<(LedgerDelta, Vec<Phase2WorkItem>), LedgerError> {
         let mut delta = LedgerDelta::new(block.slot(), *block.hash(), block.block_number());
 
         // Snapshot pre-block epoch to detect epoch transitions.
@@ -1817,8 +1842,9 @@ impl LedgerState {
         let pending_retirements_len_before = self.certs.pending_retirements.len();
         let future_pool_params_len_before = self.certs.future_pool_params.len();
 
-        // Apply the block (all state mutations happen here).
-        self.apply_block(block, mode)?;
+        // Apply the block (all state mutations happen here). In deferred mode
+        // this returns the captured Phase-2 work items without draining them.
+        let deferred_items = self.apply_block_impl(block, mode, defer_phase2)?;
 
         // Capture the post-block `imbl` cert maps so state reconstruction
         // (rollback_via_seq / state_at_index / anchor advance) restores them
@@ -1974,7 +2000,7 @@ impl LedgerState {
             epoch_fees: self.utxo.epoch_fees,
         };
 
-        Ok(delta)
+        Ok((delta, deferred_items))
     }
 }
 

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -645,6 +645,7 @@ impl LedgerState {
         };
         let mut t_registry_build = std::time::Duration::ZERO;
         let mut t_validate = std::time::Duration::ZERO;
+        let mut t_phase2 = std::time::Duration::ZERO;
         let mut t_apply = std::time::Duration::ZERO;
         let mut t_diff_merge = std::time::Duration::ZERO;
         let mut t_ctx_build = std::time::Duration::ZERO;
@@ -1522,7 +1523,7 @@ impl LedgerState {
                 };
                 let outcomes = run_phase2_parallel(phase2_work_items);
                 if let Some(start) = t_phase2_start {
-                    t_validate += start.elapsed();
+                    t_phase2 += start.elapsed();
                 }
                 for outcome in outcomes {
                     // Look up the transaction by index. Duplicate txs were
@@ -1679,7 +1680,8 @@ impl LedgerState {
 
         if let Some(start) = block_start {
             let total = start.elapsed();
-            let accounted = t_registry_build + t_ctx_build + t_validate + t_apply + t_diff_merge;
+            let accounted =
+                t_registry_build + t_ctx_build + t_validate + t_phase2 + t_apply + t_diff_merge;
             let other = total.saturating_sub(accounted);
             tracing::info!(
                 target: "dugite_ledger::apply::timing",
@@ -1696,6 +1698,7 @@ impl LedgerState {
                 registry_us = t_registry_build.as_micros() as u64,
                 ctx_build_us = t_ctx_build.as_micros() as u64,
                 validate_us = t_validate.as_micros() as u64,
+                phase2_us = t_phase2.as_micros() as u64,
                 apply_us = t_apply.as_micros() as u64,
                 merge_us = t_diff_merge.as_micros() as u64,
                 other_us = other.as_micros() as u64,

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -722,67 +722,130 @@ impl LedgerState {
         ) = if mode == BlockValidationMode::ValidateAll {
             use std::collections::{HashMap, HashSet};
             use std::sync::Arc;
-            let pools: HashSet<dugite_primitives::hash::Hash28> =
-                self.certs.pool_params.keys().copied().collect();
-            let dreps: HashSet<dugite_primitives::hash::Hash32> =
-                self.gov.governance.dreps.keys().copied().collect();
-            let vrf_keys: HashMap<
-                dugite_primitives::hash::Hash32,
-                dugite_primitives::hash::Hash28,
-            > = self
-                .certs
-                .pool_params
-                .values()
-                .map(|reg| (reg.vrf_keyhash, reg.pool_id))
-                .collect();
+
+            // ── Per-source registry cache (bulk-sync apply-ceiling fix) ───────
+            //
+            // Rebuilding these derived registries from scratch every block was
+            // ~51% of apply wall time on preview Conway blocks.  The THREE
+            // expensive registries are memoized, each keyed on the structural
+            // identity of its OWN source map (see `CachedValidationRegistry`):
+            //   • `pools` + `vrf_keys` ← `certs.pool_params`  (Arc::ptr_eq)
+            //   • `dreps`              ← `gov.dreps`           (imbl ptr_eq)
+            //   • `vote_delegations`   ← `gov.vote_delegations`(imbl ptr_eq)
+            // Per-source keying means a vote/proposal block (which bumps the
+            // `governance` Arc + `proposals` map but leaves `dreps` /
+            // `vote_delegations` structurally identical) still hits both big
+            // caches.  The small registries below are cheap and rebuilt fresh.
+            //
+            // Byte-exact: identical source pointer ⟹ identical contents ⟹
+            // identical registry; any mutation copy-on-writes a fresh root.
+            let cached = self.cached_validation_registry.take();
+
+            // `pools` + `vrf_keys` ← `certs.pool_params` (Arc ptr-eq).
+            let pp_hit = cached
+                .as_ref()
+                .is_some_and(|c| Arc::ptr_eq(&c.pool_params_src, &self.certs.pool_params));
+            let (pools, vrf_keys) = if pp_hit {
+                let c = cached.as_ref().expect("pp_hit implies Some");
+                (Arc::clone(&c.pools), Arc::clone(&c.vrf_keys))
+            } else {
+                let pools: Arc<HashSet<dugite_primitives::hash::Hash28>> =
+                    Arc::new(self.certs.pool_params.keys().copied().collect());
+                let vrf_keys: Arc<
+                    HashMap<dugite_primitives::hash::Hash32, dugite_primitives::hash::Hash28>,
+                > = Arc::new(
+                    self.certs
+                        .pool_params
+                        .values()
+                        .map(|reg| (reg.vrf_keyhash, reg.pool_id))
+                        .collect(),
+                );
+                (pools, vrf_keys)
+            };
+
+            // `dreps` ← `gov.dreps` (imbl ptr-eq).
+            let dreps_hit = cached
+                .as_ref()
+                .is_some_and(|c| c.dreps_src.ptr_eq(&self.gov.governance.dreps));
+            let dreps: Arc<HashSet<dugite_primitives::hash::Hash32>> = if dreps_hit {
+                Arc::clone(&cached.as_ref().expect("dreps_hit implies Some").dreps)
+            } else {
+                Arc::new(self.gov.governance.dreps.keys().copied().collect())
+            };
+
+            // `vote_delegations` ← `gov.vote_delegations` (imbl ptr-eq).
+            let vd_hit = cached.as_ref().is_some_and(|c| {
+                c.vote_delegations_src
+                    .ptr_eq(&self.gov.governance.vote_delegations)
+            });
+            let vote_delegations: Arc<HashSet<dugite_primitives::hash::Hash32>> = if vd_hit {
+                Arc::clone(
+                    &cached
+                        .as_ref()
+                        .expect("vd_hit implies Some")
+                        .vote_delegations,
+                )
+            } else {
+                Arc::new(
+                    self.gov
+                        .governance
+                        .vote_delegations
+                        .keys()
+                        .copied()
+                        .collect(),
+                )
+            };
+
+            // ── Small registries — cheap, always rebuilt fresh ────────────────
             // Current members ∪ `members_to_add` of live UpdateCommittee
             // proposals — Haskell GOVCERT accepts a CommitteeHotAuth from a
             // potential FUTURE member too (`isPotentialFutureMember`).
-            let committee_members: HashSet<dugite_primitives::hash::Hash32> =
-                self.gov.governance.committee_auth_eligible_members();
-            let committee_resigned: HashSet<dugite_primitives::hash::Hash32> = self
-                .gov
-                .governance
-                .committee_resigned
-                .keys()
-                .copied()
-                .collect();
-            let vote_delegations: HashSet<dugite_primitives::hash::Hash32> = self
-                .gov
-                .governance
-                .vote_delegations
-                .keys()
-                .copied()
-                .collect();
-            let active_proposals: HashMap<
-                dugite_primitives::transaction::GovActionId,
-                crate::validation::ActiveProposal,
-            > = self
-                .gov
-                .governance
-                .proposals
-                .iter()
-                .map(|(id, state)| {
-                    (
-                        id.clone(),
-                        crate::validation::ActiveProposal {
-                            gov_action: state.procedure.gov_action.clone(),
-                            return_addr: state.procedure.return_addr.clone(),
-                            deposit: state.procedure.deposit,
-                            expires_after_epoch: state.expires_epoch,
-                            proposed_in_epoch: state.proposed_epoch,
-                        },
-                    )
-                })
-                .collect();
-            let committee_authorized_hot_keys: HashSet<dugite_primitives::hash::Hash32> = self
-                .gov
-                .governance
-                .committee_hot_keys
-                .values()
-                .copied()
-                .collect();
-            let committee_authorized_elected_hot_keys: HashSet<dugite_primitives::hash::Hash32> =
+            let committee_members: Arc<HashSet<dugite_primitives::hash::Hash32>> =
+                Arc::new(self.gov.governance.committee_auth_eligible_members());
+            let committee_resigned: Arc<HashSet<dugite_primitives::hash::Hash32>> = Arc::new(
+                self.gov
+                    .governance
+                    .committee_resigned
+                    .keys()
+                    .copied()
+                    .collect(),
+            );
+            let active_proposals: Arc<
+                HashMap<
+                    dugite_primitives::transaction::GovActionId,
+                    crate::validation::ActiveProposal,
+                >,
+            > = Arc::new(
+                self.gov
+                    .governance
+                    .proposals
+                    .iter()
+                    .map(|(id, state)| {
+                        (
+                            id.clone(),
+                            crate::validation::ActiveProposal {
+                                gov_action: state.procedure.gov_action.clone(),
+                                return_addr: state.procedure.return_addr.clone(),
+                                deposit: state.procedure.deposit,
+                                expires_after_epoch: state.expires_epoch,
+                                proposed_in_epoch: state.proposed_epoch,
+                            },
+                        )
+                    })
+                    .collect(),
+            );
+            let committee_authorized_hot_keys: Arc<HashSet<dugite_primitives::hash::Hash32>> =
+                Arc::new(
+                    self.gov
+                        .governance
+                        .committee_hot_keys
+                        .values()
+                        .copied()
+                        .collect(),
+                );
+            let committee_authorized_elected_hot_keys: Arc<
+                HashSet<dugite_primitives::hash::Hash32>,
+            > = Arc::new(
                 self.gov
                     .governance
                     .committee_hot_keys
@@ -791,23 +854,38 @@ impl LedgerState {
                         self.gov.governance.committee_expiration.contains_key(*cold)
                     })
                     .map(|(_, hot)| *hot)
-                    .collect();
+                    .collect(),
+            );
             let constitution_script_hash = self
                 .gov
                 .governance
                 .constitution
                 .as_ref()
                 .and_then(|c| c.script_hash);
+
+            // Refresh the cache with the (possibly rebuilt) large registries and
+            // their current source keys.  RHS reads only `&self` immutably and
+            // local Arcs; the assignment target is a disjoint field.
+            self.cached_validation_registry = Some(crate::state::CachedValidationRegistry {
+                pool_params_src: Arc::clone(&self.certs.pool_params),
+                pools: Arc::clone(&pools),
+                vrf_keys: Arc::clone(&vrf_keys),
+                dreps_src: self.gov.governance.dreps.clone(),
+                dreps: Arc::clone(&dreps),
+                vote_delegations_src: self.gov.governance.vote_delegations.clone(),
+                vote_delegations: Arc::clone(&vote_delegations),
+            });
+
             (
-                Arc::new(pools),
-                Arc::new(dreps),
-                Arc::new(vrf_keys),
-                Arc::new(committee_members),
-                Arc::new(committee_resigned),
-                Arc::new(vote_delegations),
-                Arc::new(active_proposals),
-                Arc::new(committee_authorized_hot_keys),
-                Arc::new(committee_authorized_elected_hot_keys),
+                pools,
+                dreps,
+                vrf_keys,
+                committee_members,
+                committee_resigned,
+                vote_delegations,
+                active_proposals,
+                committee_authorized_hot_keys,
+                committee_authorized_elected_hot_keys,
                 // O(1) imbl structural clone — pre-block snapshot for stake_key_deposits validation.
                 self.certs.stake_key_deposits.clone(),
                 constitution_script_hash,

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -2852,4 +2852,73 @@ mod tests {
             "Bogus body-size approximation must not be present; got: {result:?}"
         );
     }
+
+    /// Deferred Phase-2 fatality decision — the consensus-critical verdict shared
+    /// by the inline drain (Step 8d) and the cross-block deferred/pooled path
+    /// (`apply_block_defer_phase2` → `run_phase2_parallel_pooled` →
+    /// `apply_phase2_outcomes`). Deferring *when* Plutus runs must not change
+    /// *what* it decides, so this locks the exact per-outcome semantics: only a
+    /// Babbage+ CollectError with all inputs resolved is block-fatal; panics,
+    /// partial-replay gaps, the Alonzo era, and genuine script failures all
+    /// warn-and-trust. (#733 carve-outs.)
+    #[cfg(feature = "parallel-verification")]
+    #[test]
+    fn deferred_phase2_fatality_decision_matches_semantics() {
+        use crate::plutus::{Phase2Outcome, PlutusError};
+
+        // Only block.era / block.slot / block.transactions[tx_idx].hash are read.
+        let tx = make_simple_tx(0x11, vec![], vec![make_output(1_000_000)], 0);
+        let conway = make_test_block(Era::Conway, 100, 1, 10, 0, vec![tx.clone()]);
+        let alonzo = make_test_block(Era::Alonzo, 100, 1, 6, 0, vec![tx.clone()]);
+        let oc = |result, utxo_complete| Phase2Outcome {
+            tx_idx: 0,
+            is_valid: true,
+            result,
+            utxo_complete,
+        };
+
+        // (1) Babbage+ CollectError with complete UTxOs → BLOCK-FATAL (the only
+        // case that rejects; mirrors the synchronous Err return, one window later).
+        assert!(
+            matches!(
+                apply_phase2_outcomes(
+                    &conway,
+                    vec![oc(Err(PlutusError::CollectError("x".into())), true)]
+                ),
+                Err(LedgerError::Phase2CollectErrors { .. })
+            ),
+            "Conway CollectError(utxo_complete) must be block-fatal"
+        );
+
+        // (2) CEK panic → NOT fatal (dugite robustness gap, warn-and-trust; #733 c3).
+        assert!(apply_phase2_outcomes(
+            &conway,
+            vec![oc(Err(PlutusError::EvalPanic("x".into())), true)]
+        )
+        .is_ok());
+
+        // (3) CollectError with an unresolved UTxO gap → NOT fatal (#733 c4).
+        assert!(apply_phase2_outcomes(
+            &conway,
+            vec![oc(Err(PlutusError::CollectError("x".into())), false)]
+        )
+        .is_ok());
+
+        // (4) Alonzo never arms the horizon → CollectError NOT fatal (#733 c2).
+        assert!(apply_phase2_outcomes(
+            &alonzo,
+            vec![oc(Err(PlutusError::CollectError("x".into())), true)]
+        )
+        .is_ok());
+
+        // (5) Genuine script failure on is_valid=true → warn-and-trust, NOT fatal.
+        assert!(apply_phase2_outcomes(
+            &conway,
+            vec![oc(Err(PlutusError::EvalFailed("x".into())), true)]
+        )
+        .is_ok());
+
+        // (6) All scripts pass → Ok.
+        assert!(apply_phase2_outcomes(&conway, vec![oc(Ok(()), true)]).is_ok());
+    }
 }

--- a/crates/dugite-ledger/src/state/mod.rs
+++ b/crates/dugite-ledger/src/state/mod.rs
@@ -12,6 +12,11 @@ mod snapshot;
 pub mod snapshot_format;
 pub mod substates;
 
+// Re-export the deferred Phase-2 fatality applier for the bulk-sync pooling
+// path (apply_bench / node). Gated identically to its definition.
+#[cfg(feature = "parallel-verification")]
+pub use apply::apply_phase2_outcomes;
+
 // Re-export governance free functions and types for use by tests
 #[cfg(test)]
 pub(crate) use governance::{

--- a/crates/dugite-ledger/src/state/mod.rs
+++ b/crates/dugite-ledger/src/state/mod.rs
@@ -88,6 +88,45 @@ fn default_update_quorum() -> u64 {
 /// it only bumps reference counts instead of deep-copying megabytes of
 /// data.  Mutations go through `Arc::make_mut()`, which clones the inner
 /// collection only when there are other outstanding references.
+/// Memoized large validation registries — bulk-sync apply-ceiling fix.
+///
+/// Phase-1/Phase-2 validation needs read-only derived views of
+/// `certs.pool_params` and `gov.governance`.  Rebuilding all of them from
+/// scratch on EVERY block (one `.keys().collect()` / `.values().collect()` per
+/// registry) measured ~51% of `apply_block` wall time on preview Conway blocks
+/// (`apply_bench --restore-lsm` + `DUGITE_BLOCK_APPLY_TIMING=1`).
+///
+/// This memoizes the THREE expensive registries — the registered pool-id set,
+/// the VRF-key→pool map (both derived from `pool_params`), the DRep set, and the
+/// vote-delegation set — each keyed on the structural identity of its OWN source
+/// map, not on the whole `governance` Arc.  `pools`/`vrf_keys` use
+/// `Arc::ptr_eq` on `certs.pool_params`; `dreps`/`vote_delegations` use
+/// `imbl::HashMap::ptr_eq` on `gov.governance.{dreps,vote_delegations}`.  Keying
+/// per-source means a block that merely casts a vote or advances a proposal
+/// (which bumps the `governance` Arc and the `proposals` map but leaves `dreps`
+/// and `vote_delegations` structurally identical) still HITS both big caches.
+/// The remaining registries (committee sets, active proposals, constitution)
+/// are small and rebuilt fresh every block.
+///
+/// Soundness: identical source pointer ⟹ identical contents ⟹ byte-exact reuse.
+/// `Arc` and `imbl` collections copy-on-write on mutation, so any change
+/// allocates a fresh root and the next block detects the miss.  Purely
+/// transient — never serialized (snapshots use the separate
+/// `LedgerStateSnapshot`) and never part of the ledger fingerprint.
+#[derive(Debug, Clone)]
+pub(crate) struct CachedValidationRegistry {
+    /// `certs.pool_params` Arc the pool registries were derived from (ptr-eq key).
+    pub pool_params_src: std::sync::Arc<std::collections::HashMap<Hash28, PoolRegistration>>,
+    pub pools: std::sync::Arc<std::collections::HashSet<Hash28>>,
+    pub vrf_keys: std::sync::Arc<std::collections::HashMap<Hash32, Hash28>>,
+    /// `gov.governance.dreps` imbl map the DRep set was derived from (ptr-eq key).
+    pub dreps_src: ImblHashMap<Hash32, DRepRegistration>,
+    pub dreps: std::sync::Arc<std::collections::HashSet<Hash32>>,
+    /// `gov.governance.vote_delegations` imbl map the set was derived from (ptr-eq key).
+    pub vote_delegations_src: ImblHashMap<Hash32, DRep>,
+    pub vote_delegations: std::sync::Arc<std::collections::HashSet<Hash32>>,
+}
+
 #[derive(Debug, Clone)]
 pub struct LedgerState {
     // ── Component sub-states (independently borrowable) ──────────────
@@ -164,6 +203,15 @@ pub struct LedgerState {
     /// apply-time horizon check is skipped (warn-only) — never a false
     /// fatality. Not persisted in snapshots (per-block transient).
     pub phase2_apply_horizon: Option<u64>,
+
+    /// Memoized per-block validation registries — see
+    /// [`CachedValidationRegistry`].  Reused across blocks while
+    /// `certs.pool_params` and `gov.governance` stay pointer-identical, which
+    /// eliminates the ~51%-of-apply registry rebuild on the ~95% of blocks that
+    /// carry no pool/DRep/committee/governance certificate.  Transient: `None`
+    /// on a freshly (re)constructed state forces a one-off rebuild; never
+    /// serialized and never part of the fingerprint.
+    pub(crate) cached_validation_registry: Option<CachedValidationRegistry>,
 }
 
 /// Pending reward update matching Haskell's RUPD structure.
@@ -730,6 +778,7 @@ impl LedgerState {
             conway_genesis_init: None,
             max_lovelace_supply: MAX_LOVELACE_SUPPLY,
             phase2_apply_horizon: None,
+            cached_validation_registry: None,
         }
     }
 
@@ -1219,6 +1268,7 @@ impl LedgerState {
             conway_genesis_init: None, // Will be set by caller
             max_lovelace_supply: MAX_LOVELACE_SUPPLY,
             phase2_apply_horizon: None,
+            cached_validation_registry: None,
         }
     }
 
@@ -1267,6 +1317,7 @@ impl LedgerState {
             conway_genesis_init: self.conway_genesis_init.clone(),
             max_lovelace_supply: self.max_lovelace_supply,
             phase2_apply_horizon: None,
+            cached_validation_registry: None,
         }
     }
 

--- a/crates/dugite-ledger/src/state/snapshot_format.rs
+++ b/crates/dugite-ledger/src/state/snapshot_format.rs
@@ -421,6 +421,7 @@ impl From<LedgerStateSnapshot> for super::LedgerState {
             conway_genesis_init: None, // Set from genesis config at startup
             max_lovelace_supply: super::MAX_LOVELACE_SUPPLY,
             phase2_apply_horizon: None,
+            cached_validation_registry: None,
         }
     }
 }

--- a/crates/dugite-network/src/bearer/tcp.rs
+++ b/crates/dugite-network/src/bearer/tcp.rs
@@ -60,6 +60,32 @@ impl TcpBearer {
 
         socket.set_tcp_nodelay(true).map_err(BearerError::Io)?;
 
+        // SO_RCVBUF / SO_SNDBUF — lift the single-stream BDP ceiling.
+        //
+        // A single TCP stream's throughput is bounded by `window / RTT`. Public
+        // Cardano relays sit at 250–500 ms RTT, where the OS default receive
+        // window (macOS `net.inet.tcp.recvspace` = 128 KiB, auto-tuning to
+        // `autorcvbufmax` = 4 MiB but in practice settling near ~1 MiB) caps a
+        // BlockFetch stream at ~1–3 MB/s. Once apply is no longer the bottleneck
+        // (registry cache + Plutus pooling), this single-peer BDP cap — not CPU
+        // — is the bulk-sync ceiling, and the bfcMaxConcurrencyBulkSync=1
+        // single-fetcher means the other hot peers can't pick up the slack.
+        //
+        // Setting SO_RCVBUF explicitly bypasses conservative auto-tuning and
+        // takes the window up to the OS hard cap (`kern.ipc.maxsockbuf`, 8 MiB
+        // default on macOS) → ~20 MB/s at 400 ms RTT. Best-effort: the kernel
+        // silently clamps to its max, and some platforms ignore it — never fatal.
+        // Tunable via `DUGITE_TCP_BUFFER_BYTES`; for windows beyond the OS cap,
+        // raise `kern.ipc.maxsockbuf` / `net.core.rmem_max` first.
+        let buf_bytes: usize = std::env::var("DUGITE_TCP_BUFFER_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8 * 1024 * 1024);
+        if buf_bytes > 0 {
+            let _ = socket.set_recv_buffer_size(buf_bytes);
+            let _ = socket.set_send_buffer_size(buf_bytes);
+        }
+
         let keepalive = TcpKeepalive::new().with_time(KEEPALIVE_INTERVAL);
         socket
             .set_tcp_keepalive(&keepalive)
@@ -125,6 +151,19 @@ impl TcpBearer {
         let _ = socket.set_reuseaddr(true);
         #[cfg(unix)]
         let _ = socket.set_reuseport(true);
+
+        // Size the receive/send buffers BEFORE connect so the TCP window scale
+        // factor is negotiated for the large window (see `new()` for the BDP
+        // rationale). `new()` also sets them post-connect as a backstop for the
+        // ephemeral-port fallback and the inbound-accept path.
+        let buf_bytes: u32 = std::env::var("DUGITE_TCP_BUFFER_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(8 * 1024 * 1024);
+        if buf_bytes > 0 {
+            let _ = socket.set_recv_buffer_size(buf_bytes);
+            let _ = socket.set_send_buffer_size(buf_bytes);
+        }
 
         if socket.bind(local_addr).is_err() {
             // Bind to listen-port may fail (already in use without REUSEPORT

--- a/crates/dugite-network/src/peer/manager.rs
+++ b/crates/dugite-network/src/peer/manager.rs
@@ -56,6 +56,12 @@ impl PeerState {
 /// EWMA smoothing factor (0-1). Higher = more weight on recent measurements.
 const EWMA_ALPHA: f64 = 0.3;
 
+/// GSV fetch-bandwidth sample is considered STALE after this long. A gated-out
+/// peer whose last sample is older re-qualifies for the fetch slot so it can be
+/// re-measured — the explore step that stops the gate latching onto a peer that
+/// has since degraded (or missing a peer that has since become faster).
+const STALE_FETCH_SAMPLE: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Failure count decay interval — halves every 5 minutes.
 const FAILURE_DECAY_INTERVAL: Duration = Duration::from_secs(300);
 
@@ -93,6 +99,16 @@ pub struct PeerInfo {
     pub state: PeerState,
     /// EWMA round-trip latency in milliseconds (None if no measurement yet).
     pub latency_ms: Option<f64>,
+    /// EWMA block-fetch throughput in bytes/second (None until this peer has
+    /// served at least one fetch range). The bandwidth half of the GSV estimate
+    /// (`G`=latency, `S`=1/bandwidth) that cardano-node's `prioritisePeerChains`
+    /// uses to prefer the fastest-serving peer for the single bulk-sync fetcher.
+    pub fetch_bandwidth_bps: Option<f64>,
+    /// When `fetch_bandwidth_bps` was last updated. Drives the GSV gate's
+    /// explore step: a peer whose sample is stale re-qualifies, so gated-out
+    /// peers periodically re-measure and the gate can never latch onto a peer
+    /// that has since degraded. `None` until the first sample.
+    pub fetch_sample_at: Option<Instant>,
     /// Reputation score (0.0 = worst, 1.0 = best).
     pub reputation: f64,
     /// Number of failures since last decay.
@@ -133,6 +149,8 @@ impl PeerInfo {
         Self {
             state: PeerState::Cold,
             latency_ms: None,
+            fetch_bandwidth_bps: None,
+            fetch_sample_at: None,
             reputation: INITIAL_REPUTATION,
             failure_count: 0,
             last_failure_decay: now,
@@ -149,6 +167,19 @@ impl PeerInfo {
             Some(prev) => prev * (1.0 - EWMA_ALPHA) + rtt_ms * EWMA_ALPHA,
             None => rtt_ms,
         });
+    }
+
+    /// Update fetch throughput with a new measurement (EWMA), in bytes/second.
+    /// Measured per completed BlockFetch range as `seen_bytes / fetch_seconds`.
+    pub fn update_fetch_bandwidth(&mut self, bytes_per_sec: f64) {
+        if !bytes_per_sec.is_finite() || bytes_per_sec <= 0.0 {
+            return;
+        }
+        self.fetch_bandwidth_bps = Some(match self.fetch_bandwidth_bps {
+            Some(prev) => prev * (1.0 - EWMA_ALPHA) + bytes_per_sec * EWMA_ALPHA,
+            None => bytes_per_sec,
+        });
+        self.fetch_sample_at = Some(Instant::now());
     }
 
     /// Record a failure — increments failure count, reduces reputation, and
@@ -385,6 +416,78 @@ impl PeerManager {
     pub fn get_latency_ms(&self, addr: &SocketAddr) -> Option<f64> {
         self.peers.get(addr).and_then(|p| p.latency_ms)
     }
+
+    /// Record a measured BlockFetch throughput sample (bytes/second) for a peer.
+    pub fn update_fetch_bandwidth(&mut self, addr: &SocketAddr, bytes_per_sec: f64) {
+        if let Some(p) = self.peers.get_mut(addr) {
+            p.update_fetch_bandwidth(bytes_per_sec);
+        }
+    }
+
+    /// EWMA fetch throughput (bytes/second) for a peer, or `None` if it has not
+    /// served a range yet.
+    pub fn get_fetch_bandwidth_bps(&self, addr: &SocketAddr) -> Option<f64> {
+        self.peers.get(addr).and_then(|p| p.fetch_bandwidth_bps)
+    }
+
+    /// GSV peer prioritisation for the single bulk-sync fetcher — should `addr`
+    /// be allowed to claim the fetch slot right now?
+    ///
+    /// Mirrors cardano-node's `prioritisePeerChains`: prefer the fastest-serving
+    /// peers. `addr` is preferred iff its measured fetch bandwidth ranks in the
+    /// top `top_k` among the `candidates` (the currently fetch-eligible / hot
+    /// peers). To stay wedge-safe and avoid a measurement chicken-and-egg:
+    ///
+    /// * a peer with NO bandwidth sample yet is always preferred (so every
+    ///   peer gets at least one range and a measurement);
+    /// * if fewer than `top_k` candidates have samples, all are preferred;
+    /// * if `addr` isn't among `candidates` (race vs a just-changed set), it
+    ///   is preferred (fail-open — never block progress).
+    ///
+    /// `top_k = 1` matches Haskell's `nPreferedPeers = maxConcurrencyBulkSync`;
+    /// using a small k > 1 keeps a hot standby so a momentarily-busy best peer
+    /// can't stall the slot.
+    pub fn is_preferred_fetch_peer(
+        &self,
+        addr: &SocketAddr,
+        candidates: &[SocketAddr],
+        top_k: usize,
+    ) -> bool {
+        // Fail-open if the caller's peer isn't in the candidate set.
+        if !candidates.contains(addr) {
+            return true;
+        }
+        let info = match self.peers.get(addr) {
+            Some(i) => i,
+            None => return true,
+        };
+        // This peer has no measurement yet → let it fetch once to bootstrap.
+        let my_bw = match info.fetch_bandwidth_bps {
+            Some(b) => b,
+            None => return true,
+        };
+        // Explore: a peer whose sample has gone stale re-qualifies so it gets
+        // re-measured (prevents latching onto a now-degraded peer).
+        if info
+            .fetch_sample_at
+            .map(|t| t.elapsed() >= STALE_FETCH_SAMPLE)
+            .unwrap_or(true)
+        {
+            return true;
+        }
+        // Rank candidates that HAVE a measurement by bandwidth (desc).
+        let mut measured: Vec<f64> = candidates
+            .iter()
+            .filter_map(|a| self.get_fetch_bandwidth_bps(a))
+            .collect();
+        if measured.len() <= top_k.max(1) {
+            return true;
+        }
+        measured.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+        // `addr` is preferred iff its bandwidth is >= the k-th best.
+        let threshold = measured[top_k.max(1) - 1];
+        my_bw >= threshold
+    }
 }
 
 impl Default for PeerManager {
@@ -400,6 +503,62 @@ mod tests {
 
     fn test_addr(port: u16) -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), port)
+    }
+
+    #[test]
+    fn fetch_bandwidth_ewma_and_gsv_preference() {
+        let mut pm = PeerManager::new();
+        let fast = test_addr(3001);
+        let mid = test_addr(3002);
+        let slow = test_addr(3003);
+        let fresh = test_addr(3004);
+        for a in [fast, mid, slow, fresh] {
+            pm.add_peer(a, PeerSource::Topology);
+        }
+        let cands = vec![fast, mid, slow, fresh];
+
+        // Cold start: nobody measured → everyone preferred (no wedge).
+        assert!(pm.is_preferred_fetch_peer(&fast, &cands, 1));
+        assert!(pm.is_preferred_fetch_peer(&slow, &cands, 1));
+
+        // EWMA: first sample seeds, second blends (alpha=0.3).
+        pm.update_fetch_bandwidth(&fast, 10_000_000.0);
+        assert_eq!(pm.get_fetch_bandwidth_bps(&fast), Some(10_000_000.0));
+        pm.update_fetch_bandwidth(&fast, 20_000_000.0);
+        assert_eq!(pm.get_fetch_bandwidth_bps(&fast), Some(13_000_000.0)); // 10M*.7 + 20M*.3
+        pm.update_fetch_bandwidth(&mid, 5_000_000.0);
+        pm.update_fetch_bandwidth(&slow, 1_000_000.0);
+
+        // top_k=1: only the fastest measured peer is preferred...
+        assert!(pm.is_preferred_fetch_peer(&fast, &cands, 1));
+        assert!(!pm.is_preferred_fetch_peer(&mid, &cands, 1));
+        assert!(!pm.is_preferred_fetch_peer(&slow, &cands, 1));
+        // ...but an UNMEASURED peer is always preferred (bootstrap its sample).
+        assert!(pm.is_preferred_fetch_peer(&fresh, &cands, 1));
+
+        // top_k=2: the two fastest measured peers are preferred.
+        assert!(pm.is_preferred_fetch_peer(&fast, &cands, 2));
+        assert!(pm.is_preferred_fetch_peer(&mid, &cands, 2));
+        assert!(!pm.is_preferred_fetch_peer(&slow, &cands, 2));
+
+        // Fail-open: a peer not in the candidate set is never blocked.
+        assert!(pm.is_preferred_fetch_peer(&test_addr(9999), &cands, 1));
+
+        // Explore: ageing a gated (slow) peer's sample past STALE_FETCH_SAMPLE
+        // re-qualifies it, so the gate can never latch out a peer forever.
+        assert!(!pm.is_preferred_fetch_peer(&slow, &cands, 1)); // fresh + slow → gated
+        if let Some(info) = pm.peers.get_mut(&slow) {
+            info.fetch_sample_at = Some(Instant::now() - std::time::Duration::from_secs(20));
+        }
+        assert!(
+            pm.is_preferred_fetch_peer(&slow, &cands, 1),
+            "a stale-sample peer must re-qualify for exploration"
+        );
+
+        // Non-finite / non-positive samples are ignored (no NaN poisoning).
+        pm.update_fetch_bandwidth(&slow, f64::NAN);
+        pm.update_fetch_bandwidth(&slow, -1.0);
+        assert_eq!(pm.get_fetch_bandwidth_bps(&slow), Some(1_000_000.0));
     }
 
     #[test]

--- a/crates/dugite-node/src/bin/apply_bench.rs
+++ b/crates/dugite-node/src/bin/apply_bench.rs
@@ -64,9 +64,16 @@ use std::sync::Arc;
 
 struct Args {
     snapshot: PathBuf,
-    #[allow(dead_code)] // reserved for future LSM-path profiling
     utxo_store: PathBuf,
     immutable_dir: PathBuf,
+    /// Restore the on-disk LSM UTxO store (`--utxo-store`) and attach it to the
+    /// loaded ledger before applying blocks.  Required for v23+ (LSM/UTxO-HD)
+    /// snapshots whose `.bin` no longer embeds the UTxO set (`utxo_count: 0`) —
+    /// without it every input misses and the run falls through the
+    /// "trusting on-chain consensus" divergence path, making the timing
+    /// unrepresentative.  NOTE: applying MUTATES the store, so point
+    /// `--utxo-store` at a COW clone, never the live store.
+    restore_lsm: bool,
     /// First slot to include in the benchmark slice.
     start_slot: u64,
     /// Number of blocks to apply (0 = apply all available).
@@ -95,6 +102,7 @@ impl Args {
         let mut alonzo_preset = false;
         let mut alonzo_ep300_preset = false;
         let mut save_snapshot: Option<PathBuf> = None;
+        let mut restore_lsm = false;
 
         let mut i = 1;
         while i < args.len() {
@@ -132,6 +140,9 @@ impl Args {
                     i += 1;
                     save_snapshot = Some(PathBuf::from(&args[i]));
                 }
+                "--restore-lsm" => {
+                    restore_lsm = true;
+                }
                 "--help" | "-h" => {
                     eprintln!("{USAGE}");
                     std::process::exit(0);
@@ -168,6 +179,7 @@ impl Args {
                 verbose,
                 preset_name: "Alonzo-ep290",
                 save_snapshot,
+                restore_lsm,
             }
         } else if alonzo_ep300_preset {
             // ── Alonzo/Plutus ep300 preset ──────────────────────────────────
@@ -190,6 +202,7 @@ impl Args {
                 verbose,
                 preset_name: "Alonzo-ep300",
                 save_snapshot,
+                restore_lsm,
             }
         } else {
             // ── Mary-era default preset ─────────────────────────────────────
@@ -206,6 +219,7 @@ impl Args {
                 verbose,
                 preset_name: "Mary-ep286",
                 save_snapshot,
+                restore_lsm,
             }
         }
     }
@@ -226,6 +240,8 @@ OPTIONS:
   --alonzo                Use the Alonzo/Plutus preset (ep290 snapshot, /tmp/alonzo-bench-*)
   --alonzo-ep300          Use the Alonzo ep300 preset (ep300 snapshot, /tmp/alonzo-bench-*)
   --save-snapshot <path>  Save the final ledger state to this path (for checkpoint generation)
+  --restore-lsm           Open --utxo-store (LSM) and attach it before applying. Required for
+                          v23+ LSM snapshots (utxo_count:0). MUTATES the store — use a COW clone.
   --help / -h             This message
 
 PRESETS:
@@ -380,6 +396,44 @@ fn main() {
         "[apply_bench] UTxO set: {} entries (in-memory UtxoStore)",
         ledger.utxo.utxo_set.len()
     );
+
+    // ── Optional: restore the on-disk LSM UTxO store ─────────────────────
+    // v23+ (LSM/UTxO-HD) snapshots no longer embed the UTxO set in the `.bin`
+    // (`utxo_count: 0`); the live set lives in `utxo-store/`.  Without
+    // restoring it, every tx input misses → the apply path short-circuits
+    // through the "trusting on-chain consensus" divergence branch and the
+    // timing is NOT representative of real validation.  Mirrors the live
+    // node's `UtxoStore::open` + `attach_utxo_store` wiring (mod.rs:1784).
+    //
+    // WARNING: applying blocks MUTATES the store (memtable inserts/deletes).
+    // Always point `--utxo-store` at a COW clone (e.g. `cp -c -R`), never the
+    // live store, or the benchmark will corrupt it.
+    if args.restore_lsm {
+        eprintln!(
+            "[apply_bench] Restoring LSM UTxO store: {}",
+            args.utxo_store.display()
+        );
+        let t_store = Instant::now();
+        match dugite_ledger::utxo_store::UtxoStore::open(&args.utxo_store) {
+            Ok(mut store) => {
+                // Disable the WAL so per-UTxO inserts/deletes don't fsync to the
+                // (clone) store during the run — we only care about the in-memory
+                // apply cost, not LSM durability. Mirrors the catch-up path.
+                store.set_wal_enabled(false);
+                ledger.attach_utxo_store(store);
+                eprintln!(
+                    "[apply_bench] LSM store attached in {:.1}s — UTxO set: {} entries",
+                    t_store.elapsed().as_secs_f64(),
+                    ledger.utxo.utxo_set.len()
+                );
+            }
+            Err(e) => {
+                eprintln!("[apply_bench] ERROR opening LSM UTxO store: {e}");
+                eprintln!("             Point --utxo-store at a COW clone of db-*/utxo-store.");
+                std::process::exit(1);
+            }
+        }
+    }
 
     // Diagnostic probe (issue: epoch-boundary reward-pots divergence).
     // When DUGITE_DUMP_LEDGER_PROBE is set, print the reward-update inputs and

--- a/crates/dugite-node/src/bin/apply_bench.rs
+++ b/crates/dugite-node/src/bin/apply_bench.rs
@@ -49,7 +49,9 @@
 //! - `DUGITE_BLOCK_APPLY_TIMING=1` activates per-phase breakdown logging.
 //! - `RUST_LOG=warn` suppresses verbose ledger trace during profiling runs.
 
-use dugite_ledger::state::{BlockValidationMode, LedgerState};
+use dugite_ledger::plutus::{run_phase2_parallel_pooled, Phase2WorkItem};
+use dugite_ledger::state::{apply_phase2_outcomes, BlockValidationMode, LedgerState};
+use dugite_primitives::block::Block;
 use dugite_primitives::hash::blake2b_256;
 use dugite_serialization::decode_block_with_byron_epoch_length;
 use dugite_storage::ImmutableDB;
@@ -74,6 +76,13 @@ struct Args {
     /// unrepresentative.  NOTE: applying MUTATES the store, so point
     /// `--utxo-store` at a COW clone, never the live store.
     restore_lsm: bool,
+    /// Cross-block Plutus pooling window (0 = disabled / serial inline drain).
+    /// When > 0, apply each block's STATE in-order via `apply_block_defer_phase2`,
+    /// pool `W` blocks' Phase-2 work items, and evaluate them together on rayon
+    /// (filling all cores) on a background thread that OVERLAPS the next window's
+    /// state apply — the bulk-sync CPU-saturation path. Ledger state (and thus
+    /// the fingerprint) is unchanged; only when/where Plutus runs moves.
+    defer_phase2: usize,
     /// First slot to include in the benchmark slice.
     start_slot: u64,
     /// Number of blocks to apply (0 = apply all available).
@@ -103,6 +112,7 @@ impl Args {
         let mut alonzo_ep300_preset = false;
         let mut save_snapshot: Option<PathBuf> = None;
         let mut restore_lsm = false;
+        let mut defer_phase2 = 0usize;
 
         let mut i = 1;
         while i < args.len() {
@@ -143,6 +153,10 @@ impl Args {
                 "--restore-lsm" => {
                     restore_lsm = true;
                 }
+                "--defer-phase2" => {
+                    i += 1;
+                    defer_phase2 = args[i].parse().expect("--defer-phase2 must be a usize");
+                }
                 "--help" | "-h" => {
                     eprintln!("{USAGE}");
                     std::process::exit(0);
@@ -180,6 +194,7 @@ impl Args {
                 preset_name: "Alonzo-ep290",
                 save_snapshot,
                 restore_lsm,
+                defer_phase2,
             }
         } else if alonzo_ep300_preset {
             // ── Alonzo/Plutus ep300 preset ──────────────────────────────────
@@ -203,6 +218,7 @@ impl Args {
                 preset_name: "Alonzo-ep300",
                 save_snapshot,
                 restore_lsm,
+                defer_phase2,
             }
         } else {
             // ── Mary-era default preset ─────────────────────────────────────
@@ -220,6 +236,7 @@ impl Args {
                 preset_name: "Mary-ep286",
                 save_snapshot,
                 restore_lsm,
+                defer_phase2,
             }
         }
     }
@@ -557,46 +574,144 @@ fn main() {
 
     let t_apply_start = Instant::now();
 
-    for raw in raw_blocks.iter().take(apply_count) {
-        // Decode block CBOR → in-memory Block
-        let block = match decode_block_with_byron_epoch_length(raw, BYRON_EPOCH_LENGTH) {
-            Ok(b) => b,
-            Err(e) => {
-                if args.verbose {
-                    eprintln!("[apply_bench] WARN decode error: {e}");
+    if args.defer_phase2 == 0 {
+        // ── Serial path: apply state + drain Phase-2 inline, per block ────────
+        for raw in raw_blocks.iter().take(apply_count) {
+            // Decode block CBOR → in-memory Block
+            let block = match decode_block_with_byron_epoch_length(raw, BYRON_EPOCH_LENGTH) {
+                Ok(b) => b,
+                Err(e) => {
+                    if args.verbose {
+                        eprintln!("[apply_bench] WARN decode error: {e}");
+                    }
+                    decode_errors += 1;
+                    continue;
                 }
-                decode_errors += 1;
-                continue;
-            }
-        };
+            };
 
-        let slot = block.slot().0;
-        let tx_count = block.transactions.len();
+            let slot = block.slot().0;
+            let tx_count = block.transactions.len();
 
-        // ── THE HOT PATH ──────────────────────────────────────────────
-        // Includes apply_block + publish_ledger_view simulation so we measure
-        // the full per-block cost the live node incurs at tip.
-        let t_block = Instant::now();
-        match ledger.apply_block(&block, BlockValidationMode::ValidateAll) {
-            Ok(()) => {
-                // Replicate publish_ledger_view cost INSIDE the timing window.
-                // This is the fix: iteration-2 had an O(784K) iterate+collect
-                // here that the original apply_bench never measured.
-                simulate_publish_ledger_view(&ledger);
-                let elapsed_us = t_block.elapsed().as_micros() as u64;
-                timings_us.push(elapsed_us);
-                total_txs += tx_count;
-                if args.verbose {
-                    eprintln!(
-                        "[apply_bench] slot={slot} era={:?} txs={tx_count} {:.1}ms",
-                        block.era,
-                        elapsed_us as f64 / 1000.0,
-                    );
+            // ── THE HOT PATH ──────────────────────────────────────────────
+            // Includes apply_block + publish_ledger_view simulation so we measure
+            // the full per-block cost the live node incurs at tip.
+            let t_block = Instant::now();
+            match ledger.apply_block(&block, BlockValidationMode::ValidateAll) {
+                Ok(()) => {
+                    // Replicate publish_ledger_view cost INSIDE the timing window.
+                    // This is the fix: iteration-2 had an O(784K) iterate+collect
+                    // here that the original apply_bench never measured.
+                    simulate_publish_ledger_view(&ledger);
+                    let elapsed_us = t_block.elapsed().as_micros() as u64;
+                    timings_us.push(elapsed_us);
+                    total_txs += tx_count;
+                    if args.verbose {
+                        eprintln!(
+                            "[apply_bench] slot={slot} era={:?} txs={tx_count} {:.1}ms",
+                            block.era,
+                            elapsed_us as f64 / 1000.0,
+                        );
+                    }
+                }
+                Err(e) => {
+                    if args.verbose {
+                        eprintln!("[apply_bench] WARN slot={slot}: {e}");
+                    }
+                    apply_errors += 1;
                 }
             }
-            Err(e) => {
+        }
+    } else {
+        // ── Cross-block Plutus pooling + overlap (CPU-saturation path) ────────
+        // Apply each block's STATE in-order on this (main) thread, pool W blocks'
+        // Phase-2 work items, and evaluate them together on rayon (all cores) on
+        // a background thread that OVERLAPS the next window's state apply. State
+        // mutation is byte-identical to the serial path, so the fingerprint is
+        // unchanged; only when/where Plutus runs moves.
+        let window_size = args.defer_phase2;
+
+        // Drain one window: pooled rayon eval (fills cores) + per-block fatality.
+        // Self-contained (reads only the moved-in blocks + items), so it is safe
+        // to run on a separate thread concurrently with main-thread state apply.
+        fn drain_window(batch: Vec<(Block, Vec<Phase2WorkItem>)>) -> Result<(), String> {
+            let n = batch.len();
+            let mut blocks: Vec<Block> = Vec::with_capacity(n);
+            let mut items: Vec<Vec<Phase2WorkItem>> = Vec::with_capacity(n);
+            for (b, it) in batch {
+                blocks.push(b);
+                items.push(it);
+            }
+            let outcomes = run_phase2_parallel_pooled(items);
+            for (block, oc) in blocks.iter().zip(outcomes) {
+                apply_phase2_outcomes(block, oc)
+                    .map_err(|e| format!("slot {}: {e}", block.slot().0))?;
+            }
+            Ok(())
+        }
+
+        let mut window: Vec<(Block, Vec<Phase2WorkItem>)> = Vec::with_capacity(window_size);
+        let mut pending: Option<std::thread::JoinHandle<Result<(), String>>> = None;
+
+        for raw in raw_blocks.iter().take(apply_count) {
+            let block = match decode_block_with_byron_epoch_length(raw, BYRON_EPOCH_LENGTH) {
+                Ok(b) => b,
+                Err(e) => {
+                    if args.verbose {
+                        eprintln!("[apply_bench] WARN decode error: {e}");
+                    }
+                    decode_errors += 1;
+                    continue;
+                }
+            };
+            let tx_count = block.transactions.len();
+
+            // STATE apply on the main thread (deferred Plutus drain).
+            let t_block = Instant::now();
+            match ledger.apply_block_defer_phase2(&block, BlockValidationMode::ValidateAll) {
+                Ok(items) => {
+                    simulate_publish_ledger_view(&ledger);
+                    timings_us.push(t_block.elapsed().as_micros() as u64);
+                    total_txs += tx_count;
+                    window.push((block, items));
+                    if window.len() >= window_size {
+                        // Join the PREVIOUS window's drain (it overlapped this
+                        // window's state apply), then spawn this one.
+                        if let Some(h) = pending.take() {
+                            if let Err(e) = h.join().expect("drain thread panicked") {
+                                if args.verbose {
+                                    eprintln!("[apply_bench] WARN deferred phase-2: {e}");
+                                }
+                                apply_errors += 1;
+                            }
+                        }
+                        let batch = std::mem::take(&mut window);
+                        pending = Some(std::thread::spawn(move || drain_window(batch)));
+                    }
+                }
+                Err(e) => {
+                    if args.verbose {
+                        eprintln!(
+                            "[apply_bench] WARN state-apply slot={}: {e}",
+                            block.slot().0
+                        );
+                    }
+                    apply_errors += 1;
+                }
+            }
+        }
+        // Flush: join the last in-flight drain, then drain any remainder.
+        if let Some(h) = pending.take() {
+            if let Err(e) = h.join().expect("drain thread panicked") {
                 if args.verbose {
-                    eprintln!("[apply_bench] WARN slot={slot}: {e}");
+                    eprintln!("[apply_bench] WARN deferred phase-2: {e}");
+                }
+                apply_errors += 1;
+            }
+        }
+        if !window.is_empty() {
+            if let Err(e) = drain_window(window) {
+                if args.verbose {
+                    eprintln!("[apply_bench] WARN deferred phase-2 (flush): {e}");
                 }
                 apply_errors += 1;
             }

--- a/crates/dugite-node/src/gsm.rs
+++ b/crates/dugite-node/src/gsm.rs
@@ -299,6 +299,30 @@ pub struct GenesisStateMachine {
     last_loe_tip_slot: u64,
 }
 
+/// Operator opt-in (`DUGITE_GENESIS_BOOTSTRAP_SYNCING=1`): start a from-genesis /
+/// far-behind genesis-mode node directly in `Syncing` instead of `PreSyncing`.
+///
+/// Default OFF. With it OFF (and no Mithril/recent-tip #757 fast-path applying), a
+/// node with no `peerSnapshotFile` whose tip is below `useLedgerAfterSlot` can
+/// never satisfy the Honest-Availability-Assumption gate — no big-ledger-peers are
+/// ever classified — so it stalls permanently in `PreSyncing` with the LoE frozen
+/// at the immutable tip (the genesis bulk-sync stall: ledger wedged ~k blocks past
+/// origin). Setting this flag bypasses that gate so the live GDD/LoE-advance path
+/// runs and the ledger can progress.
+///
+/// SECURITY TRADEOFF: this trusts the bootstrap/public peers' density-selected
+/// chain WITHOUT the honest-availability assumption — unlike the #757 recent-tip
+/// path, which is backed by a Mithril certificate or a prior caught-up run. It is
+/// intended for trusted-bootstrap from-genesis sync (e.g. testnet soak); the
+/// faithful production fix is to seed big-ledger-peers via a `peerSnapshotFile`.
+/// Kept OFF by default so mainnet / default genesis behaviour is unchanged.
+pub fn bootstrap_syncing_override() -> bool {
+    matches!(
+        std::env::var("DUGITE_GENESIS_BOOTSTRAP_SYNCING").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes")
+    )
+}
+
 impl GenesisStateMachine {
     /// Create a new GSM. If not enabled, it immediately enters CaughtUp
     /// and all constraints are disabled.
@@ -372,6 +396,21 @@ impl GenesisStateMachine {
                         threshold_secs = config.syncing_startup_threshold_secs,
                         "Genesis: tip is recent (no marker) — starting in \
                          Syncing (Mithril snapshot / fast-restart path, issue #757)"
+                    );
+                    GenesisSyncState::Syncing
+                } else if bootstrap_syncing_override() {
+                    // From-genesis / far-behind bootstrap with no peerSnapshotFile:
+                    // the HAA gate (>= min_active_blp BLPs) can never fire (no BLPs
+                    // are classified before useLedgerAfterSlot, which the stalled
+                    // ledger never reaches), so PreSyncing would freeze the LoE at
+                    // the immutable tip forever. This explicit opt-in starts in
+                    // Syncing so the live GDD/LoE-advance path runs. See
+                    // `bootstrap_syncing_override` for the security tradeoff.
+                    info!(
+                        tip_age_secs = initial_tip_age_secs,
+                        "Genesis: DUGITE_GENESIS_BOOTSTRAP_SYNCING set — starting in \
+                         Syncing (bootstrap HAA bypass; trusts peer-density chain \
+                         selection without the honest-availability assumption)"
                     );
                     GenesisSyncState::Syncing
                 } else {
@@ -1322,6 +1361,67 @@ mod tests {
         // Unknown age: trust the marker.
         let gsm = GenesisStateMachine::new(config, true, PeerStateRegistry::new(), None);
         assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
+        let _ = std::fs::remove_file(marker);
+    }
+
+    #[test]
+    fn test_bootstrap_syncing_override() {
+        // From-genesis / far-behind, no marker, OLD tip (age >> threshold so the
+        // #757 recent-tip path does NOT fire): default = PreSyncing (the stall);
+        // with DUGITE_GENESIS_BOOTSTRAP_SYNCING set = Syncing (bootstrap bypass).
+        let marker = "/tmp/gsm_bootstrap_override.marker";
+        let _ = std::fs::remove_file(marker);
+        let config = GsmConfig {
+            syncing_startup_threshold_secs: 100,
+            marker_path: PathBuf::from(marker),
+            ..Default::default()
+        };
+
+        std::env::remove_var("DUGITE_GENESIS_BOOTSTRAP_SYNCING");
+        assert!(!bootstrap_syncing_override());
+        let gsm = GenesisStateMachine::new(
+            config.clone(),
+            true,
+            PeerStateRegistry::new(),
+            Some(1_000_000),
+        );
+        assert_eq!(
+            gsm.state(),
+            GenesisSyncState::PreSyncing,
+            "default (env unset): far-behind from-genesis stalls in PreSyncing"
+        );
+
+        std::env::set_var("DUGITE_GENESIS_BOOTSTRAP_SYNCING", "1");
+        assert!(bootstrap_syncing_override());
+        let gsm = GenesisStateMachine::new(
+            config.clone(),
+            true,
+            PeerStateRegistry::new(),
+            Some(1_000_000),
+        );
+        assert_eq!(
+            gsm.state(),
+            GenesisSyncState::Syncing,
+            "opt-in: starts in Syncing (bootstrap HAA bypass)"
+        );
+
+        // The override lives ONLY in the no-marker branch: a caught_up marker must
+        // still win (the bypass must never downgrade a caught-up node).
+        std::fs::write(marker, "caught_up").unwrap();
+        let config2 = GsmConfig {
+            max_caught_up_age_secs: 10_000_000,
+            syncing_startup_threshold_secs: 100,
+            marker_path: PathBuf::from(marker),
+            ..Default::default()
+        };
+        let gsm = GenesisStateMachine::new(config2, true, PeerStateRegistry::new(), Some(10));
+        assert_eq!(
+            gsm.state(),
+            GenesisSyncState::CaughtUp,
+            "caught_up marker still wins over the override"
+        );
+
+        std::env::remove_var("DUGITE_GENESIS_BOOTSTRAP_SYNCING");
         let _ = std::fs::remove_file(marker);
     }
 

--- a/crates/dugite-node/src/gsm.rs
+++ b/crates/dugite-node/src/gsm.rs
@@ -299,30 +299,6 @@ pub struct GenesisStateMachine {
     last_loe_tip_slot: u64,
 }
 
-/// Operator opt-in (`DUGITE_GENESIS_BOOTSTRAP_SYNCING=1`): start a from-genesis /
-/// far-behind genesis-mode node directly in `Syncing` instead of `PreSyncing`.
-///
-/// Default OFF. With it OFF (and no Mithril/recent-tip #757 fast-path applying), a
-/// node with no `peerSnapshotFile` whose tip is below `useLedgerAfterSlot` can
-/// never satisfy the Honest-Availability-Assumption gate — no big-ledger-peers are
-/// ever classified — so it stalls permanently in `PreSyncing` with the LoE frozen
-/// at the immutable tip (the genesis bulk-sync stall: ledger wedged ~k blocks past
-/// origin). Setting this flag bypasses that gate so the live GDD/LoE-advance path
-/// runs and the ledger can progress.
-///
-/// SECURITY TRADEOFF: this trusts the bootstrap/public peers' density-selected
-/// chain WITHOUT the honest-availability assumption — unlike the #757 recent-tip
-/// path, which is backed by a Mithril certificate or a prior caught-up run. It is
-/// intended for trusted-bootstrap from-genesis sync (e.g. testnet soak); the
-/// faithful production fix is to seed big-ledger-peers via a `peerSnapshotFile`.
-/// Kept OFF by default so mainnet / default genesis behaviour is unchanged.
-pub fn bootstrap_syncing_override() -> bool {
-    matches!(
-        std::env::var("DUGITE_GENESIS_BOOTSTRAP_SYNCING").as_deref(),
-        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes")
-    )
-}
-
 impl GenesisStateMachine {
     /// Create a new GSM. If not enabled, it immediately enters CaughtUp
     /// and all constraints are disabled.
@@ -396,21 +372,6 @@ impl GenesisStateMachine {
                         threshold_secs = config.syncing_startup_threshold_secs,
                         "Genesis: tip is recent (no marker) — starting in \
                          Syncing (Mithril snapshot / fast-restart path, issue #757)"
-                    );
-                    GenesisSyncState::Syncing
-                } else if bootstrap_syncing_override() {
-                    // From-genesis / far-behind bootstrap with no peerSnapshotFile:
-                    // the HAA gate (>= min_active_blp BLPs) can never fire (no BLPs
-                    // are classified before useLedgerAfterSlot, which the stalled
-                    // ledger never reaches), so PreSyncing would freeze the LoE at
-                    // the immutable tip forever. This explicit opt-in starts in
-                    // Syncing so the live GDD/LoE-advance path runs. See
-                    // `bootstrap_syncing_override` for the security tradeoff.
-                    info!(
-                        tip_age_secs = initial_tip_age_secs,
-                        "Genesis: DUGITE_GENESIS_BOOTSTRAP_SYNCING set — starting in \
-                         Syncing (bootstrap HAA bypass; trusts peer-density chain \
-                         selection without the honest-availability assumption)"
                     );
                     GenesisSyncState::Syncing
                 } else {
@@ -1361,67 +1322,6 @@ mod tests {
         // Unknown age: trust the marker.
         let gsm = GenesisStateMachine::new(config, true, PeerStateRegistry::new(), None);
         assert_eq!(gsm.state(), GenesisSyncState::CaughtUp);
-        let _ = std::fs::remove_file(marker);
-    }
-
-    #[test]
-    fn test_bootstrap_syncing_override() {
-        // From-genesis / far-behind, no marker, OLD tip (age >> threshold so the
-        // #757 recent-tip path does NOT fire): default = PreSyncing (the stall);
-        // with DUGITE_GENESIS_BOOTSTRAP_SYNCING set = Syncing (bootstrap bypass).
-        let marker = "/tmp/gsm_bootstrap_override.marker";
-        let _ = std::fs::remove_file(marker);
-        let config = GsmConfig {
-            syncing_startup_threshold_secs: 100,
-            marker_path: PathBuf::from(marker),
-            ..Default::default()
-        };
-
-        std::env::remove_var("DUGITE_GENESIS_BOOTSTRAP_SYNCING");
-        assert!(!bootstrap_syncing_override());
-        let gsm = GenesisStateMachine::new(
-            config.clone(),
-            true,
-            PeerStateRegistry::new(),
-            Some(1_000_000),
-        );
-        assert_eq!(
-            gsm.state(),
-            GenesisSyncState::PreSyncing,
-            "default (env unset): far-behind from-genesis stalls in PreSyncing"
-        );
-
-        std::env::set_var("DUGITE_GENESIS_BOOTSTRAP_SYNCING", "1");
-        assert!(bootstrap_syncing_override());
-        let gsm = GenesisStateMachine::new(
-            config.clone(),
-            true,
-            PeerStateRegistry::new(),
-            Some(1_000_000),
-        );
-        assert_eq!(
-            gsm.state(),
-            GenesisSyncState::Syncing,
-            "opt-in: starts in Syncing (bootstrap HAA bypass)"
-        );
-
-        // The override lives ONLY in the no-marker branch: a caught_up marker must
-        // still win (the bypass must never downgrade a caught-up node).
-        std::fs::write(marker, "caught_up").unwrap();
-        let config2 = GsmConfig {
-            max_caught_up_age_secs: 10_000_000,
-            syncing_startup_threshold_secs: 100,
-            marker_path: PathBuf::from(marker),
-            ..Default::default()
-        };
-        let gsm = GenesisStateMachine::new(config2, true, PeerStateRegistry::new(), Some(10));
-        assert_eq!(
-            gsm.state(),
-            GenesisSyncState::CaughtUp,
-            "caught_up marker still wins over the override"
-        );
-
-        std::env::remove_var("DUGITE_GENESIS_BOOTSTRAP_SYNCING");
         let _ = std::fs::remove_file(marker);
     }
 

--- a/crates/dugite-node/src/metrics.rs
+++ b/crates/dugite-node/src/metrics.rs
@@ -556,6 +556,22 @@ pub struct NodeMetrics {
     /// the real fetch concurrency once multi-peer parallel fetch is active —
     /// the headline signal for whether the single-fetcher gate is lifted.
     pub blockfetch_active_peers: AtomicU64,
+    /// Cumulative microseconds the single fetch slot was HELD by some worker
+    /// (counter). Fetcher utilization = rate(busy_us)/1e6; (1 - utilization) is
+    /// the fraction of wall-time NO peer is fetching (idle-wait). The headline
+    /// "are we fetching as fast as the network allows" signal: ~1.0 = network/
+    /// peer-bound, well below 1.0 = idle-blocked (header-supply or backpressure).
+    pub blockfetch_busy_us_total: AtomicU64,
+    /// Cumulative microseconds a fetch worker was BLOCKED on `fetched_blocks`
+    /// channel send (counter) — i.e. the apply consumer could not keep up and
+    /// backpressured the fetcher (slot held but no bytes downloaded). A nonzero
+    /// rate means idle is apply-bound, NOT network-bound (#767 cascade class).
+    pub blockfetch_send_blocked_us_total: AtomicU64,
+    /// Cumulative count of fetch ticks where the slot was claimable but there
+    /// were NO pending headers ahead to fetch (counter). A rising rate means the
+    /// fetcher has drained the header supply and is waiting on ChainSync — the
+    /// idle is header-supply-bound (ChainSync/forecast-paced), not the network.
+    pub blockfetch_idle_no_headers_total: AtomicU64,
     /// Current average RTT across connected peers (milliseconds, gauge).
     /// Updated on each KeepAlive pong from the PeerManager's EWMA values.
     pub peer_rtt_avg_ms: AtomicU64,
@@ -870,6 +886,9 @@ impl NodeMetrics {
             peer_block_fetch_range_ms: Histogram::new(),
             blockfetch_rx_bytes_total: AtomicU64::new(0),
             blockfetch_active_peers: AtomicU64::new(0),
+            blockfetch_busy_us_total: AtomicU64::new(0),
+            blockfetch_send_blocked_us_total: AtomicU64::new(0),
+            blockfetch_idle_no_headers_total: AtomicU64::new(0),
             peer_rtt_avg_ms: AtomicU64::new(0),
             peer_rtt_min_ms: AtomicU64::new(0),
             peer_rtt_max_ms: AtomicU64::new(0),
@@ -1020,6 +1039,28 @@ impl NodeMetrics {
     pub fn inc_blockfetch_rx_bytes(&self, n: u64) {
         self.blockfetch_rx_bytes_total
             .fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Add `us` microseconds the fetch slot was held (busy). See
+    /// [`Self::blockfetch_busy_us_total`].
+    pub fn inc_blockfetch_busy_us(&self, us: u64) {
+        self.blockfetch_busy_us_total
+            .fetch_add(us, Ordering::Relaxed);
+    }
+
+    /// Add `us` microseconds blocked on the `fetched_blocks` channel send
+    /// (apply backpressure). See [`Self::blockfetch_send_blocked_us_total`].
+    pub fn inc_blockfetch_send_blocked_us(&self, us: u64) {
+        self.blockfetch_send_blocked_us_total
+            .fetch_add(us, Ordering::Relaxed);
+    }
+
+    /// Record one fetch tick that found the slot claimable but no headers ahead
+    /// to fetch (header-supply-bound idle). See
+    /// [`Self::blockfetch_idle_no_headers_total`].
+    pub fn inc_blockfetch_idle_no_headers(&self) {
+        self.blockfetch_idle_no_headers_total
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// Mark a peer as having begun streaming blocks (gauge +1).
@@ -1708,6 +1749,24 @@ impl NodeMetrics {
                  Phase-1 + Phase-2 Plutus evaluation run; equivalent to \
                  Haskell updateChainDepState",
                 &self.apply_mode_validate_all_total,
+            ),
+            (
+                "dugite_blockfetch_busy_us_total",
+                "Microseconds the single fetch slot was held by some worker; \
+                 fetcher utilization = rate(busy_us)/1e6, (1-util) = idle-wait fraction",
+                &self.blockfetch_busy_us_total,
+            ),
+            (
+                "dugite_blockfetch_send_blocked_us_total",
+                "Microseconds a fetch worker was blocked on the fetched_blocks channel \
+                 send (apply backpressure) — nonzero rate = apply-bound, not network-bound",
+                &self.blockfetch_send_blocked_us_total,
+            ),
+            (
+                "dugite_blockfetch_idle_no_headers_total",
+                "Fetch ticks with the slot claimable but no headers ahead to fetch \
+                 (header-supply-bound idle: waiting on ChainSync, not the network)",
+                &self.blockfetch_idle_no_headers_total,
             ),
             (
                 "dugite_snapshot_enqueued_total",

--- a/crates/dugite-node/src/metrics.rs
+++ b/crates/dugite-node/src/metrics.rs
@@ -617,6 +617,16 @@ pub struct NodeMetrics {
     /// (0 = Praos, 1 = Ouroboros Genesis).  Set once at startup so dugite-monitor
     /// can show whether the node is running with Genesis (LoE/GDD) protection.
     pub consensus_mode_genesis: AtomicU64,
+    /// Cumulative count of deferred Phase-2 (cross-block Plutus) window flushes
+    /// (`dugite_deferred_phase2_flushes_total`). Only moves when the experimental
+    /// `DUGITE_DEFER_PHASE2_WINDOW` deferral is enabled; a non-zero, rising value
+    /// confirms the deferral path actually engaged during catch-up (vs staying
+    /// inert), so a soak can tell it exercised the pooled-flush code.
+    pub deferred_phase2_flushes: AtomicU64,
+    /// Cumulative count of blocks confirmed through the deferred Phase-2 pooled
+    /// flush (`dugite_deferred_phase2_blocks_total`). Paired with the flush
+    /// counter to show the window fill size over the run.
+    pub deferred_phase2_blocks: AtomicU64,
     /// Genesis State Machine state: 0=PreSyncing, 1=Syncing, 2=CaughtUp.
     /// `dugite_gsm_state`.
     pub gsm_state: AtomicU64,
@@ -882,6 +892,8 @@ impl NodeMetrics {
             epoch_length_slots: AtomicU64::new(0),
             slot_in_epoch: AtomicU64::new(0),
             consensus_mode_genesis: AtomicU64::new(0),
+            deferred_phase2_flushes: AtomicU64::new(0),
+            deferred_phase2_blocks: AtomicU64::new(0),
             gsm_state: AtomicU64::new(0),
             loe_tip_slot: AtomicU64::new(0),
             gdd_disconnects_total: AtomicU64::new(0),
@@ -1412,6 +1424,13 @@ impl NodeMetrics {
     /// Increment the GDD disconnect counter.
     pub fn record_gdd_disconnect(&self) {
         self.gdd_disconnects_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one completed deferred Phase-2 pooled flush over `blocks` blocks.
+    pub fn record_deferred_phase2_flush(&self, blocks: u64) {
+        self.deferred_phase2_flushes.fetch_add(1, Ordering::Relaxed);
+        self.deferred_phase2_blocks
+            .fetch_add(blocks, Ordering::Relaxed);
     }
 
     pub fn set_consensus_mode_genesis(&self, genesis: bool) {
@@ -2040,6 +2059,16 @@ impl NodeMetrics {
                 "dugite_gsm_state",
                 "Genesis State Machine state: 0=PreSyncing, 1=Syncing, 2=CaughtUp",
                 &self.gsm_state,
+            ),
+            (
+                "dugite_deferred_phase2_flushes_total",
+                "Cumulative cross-block deferred Phase-2 (Plutus) window flushes",
+                &self.deferred_phase2_flushes,
+            ),
+            (
+                "dugite_deferred_phase2_blocks_total",
+                "Cumulative blocks confirmed via the deferred Phase-2 pooled flush",
+                &self.deferred_phase2_blocks,
             ),
             (
                 "dugite_loe_tip_slot",

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -2312,9 +2312,15 @@ impl ConnectionLifecycleManager {
                     /// (≈1 under the single-fetcher mutex; rises with multi-peer
                     /// fetch). Decremented on any drop (release / cancel / unwind).
                     metrics: std::sync::Arc<crate::metrics::NodeMetrics>,
+                    /// When the slot was claimed — on drop, the held duration is
+                    /// added to `blockfetch_busy_us_total` so utilization
+                    /// (busy / wall) can be computed (idle-vs-network-bound).
+                    claim_at: std::time::Instant,
                 }
                 impl Drop for ActiveFetcherGuard {
                     fn drop(&mut self) {
+                        self.metrics
+                            .inc_blockfetch_busy_us(self.claim_at.elapsed().as_micros() as u64);
                         let swapped = self.fetcher.compare_exchange(
                             self.id,
                             0,
@@ -2505,6 +2511,7 @@ impl ConnectionLifecycleManager {
                                 id: my_id,
                                 peer_slot: active_fetch_peer.clone(),
                                 metrics: metrics_clone.clone(),
+                                claim_at: std::time::Instant::now(),
                             };
 
                             // Build the list of headers to fetch from this peer.
@@ -2570,6 +2577,11 @@ impl ConnectionLifecycleManager {
                             };
 
                             if fetch_runs.is_empty() {
+                                // Header-supply-bound idle signal: the slot was
+                                // claimable but there are no headers ahead to
+                                // fetch — the fetcher has drained ChainSync's
+                                // supply and is waiting (NOT network-bound).
+                                metrics_clone.inc_blockfetch_idle_no_headers();
                                 // #742 watchdog (unproductive claim): the slot
                                 // was claimed but there is NOTHING dispatchable
                                 // from this peer. Haskell's rotation cannot
@@ -3303,6 +3315,13 @@ impl ConnectionLifecycleManager {
                                     // blockfetch task un-cancellable for an unbounded
                                     // duration — blocking demote_to_warm past the 5s
                                     // spsDeactivateTimeout and forcing a TCP teardown.
+                                    // Measure time blocked here: when the apply
+                                    // consumer is slow the channel fills and this
+                                    // send parks the fetcher (slot held, no bytes
+                                    // downloaded) — apply-backpressure, NOT a
+                                    // network limit. Surfaced as
+                                    // blockfetch_send_blocked_us_total.
+                                    let send_started = std::time::Instant::now();
                                     let send_result = tokio::select! {
                                         biased;
                                         _ = cancel.cancelled() => {
@@ -3311,6 +3330,9 @@ impl ConnectionLifecycleManager {
                                         }
                                         r = fetched_blocks_tx.send(fetched) => r
                                     };
+                                    metrics_clone.inc_blockfetch_send_blocked_us(
+                                        send_started.elapsed().as_micros() as u64,
+                                    );
                                     if let Err(e) = send_result {
                                         warn!(%addr, slot, "send to run loop failed (channel closed): {e}");
                                         // Channel closed means the run loop

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -146,6 +146,13 @@ const BLOCKFETCH_INIT_AVG_BLOCK_BYTES: usize = 65_536;
 /// Real RTT-hiding throughput work is concurrent multi-peer fetch (deferred).
 const BLOCKFETCH_PIPELINE_WINDOW: usize = 2;
 
+/// GSV fetch-peer preference width (cardano-node `nPreferedPeers`). The single
+/// bulk-sync fetch slot is contested only by the top-K peers ranked by measured
+/// fetch bandwidth. Haskell uses `maxConcurrencyBulkSync = 1`; dugite keeps a
+/// hot standby (K=2) so a momentarily-busy best peer cannot stall the slot,
+/// while still concentrating fetching on the fastest peers.
+const GSV_FETCH_TOP_K: usize = 2;
+
 // Issue #747: compile-time invariant, referencing the REAL mux constant
 // directly (no hand-mirrored copy that could drift).
 // The total pipelined in-flight bytes (PIPELINE_WINDOW × RANGE_BYTE_BUDGET)
@@ -2273,6 +2280,11 @@ impl ConnectionLifecycleManager {
         let block_fetch_grace_period = self.block_fetch_grace_period;
         // GSM state for genesis-mode gate (only rotate in genesis bulk sync).
         let gsm_snapshot_rx_for_starv = self.gsm_snapshot_rx.clone();
+        // GSV peer prioritisation: rank fetch peers by measured bandwidth so the
+        // single bulk-sync fetch slot goes to the fastest-serving peer (matching
+        // cardano-node's prioritisePeerChains). Read in the claim gate; updated
+        // after each range. `None` when no peer manager (unit tests) → gate off.
+        let peer_manager_for_fetch = self.peer_manager_for_servers.clone();
 
         Box::new(move |mut channel, cancel| {
             Box::pin(async move {
@@ -2435,6 +2447,22 @@ impl ConnectionLifecycleManager {
                                 addr.hash(&mut hasher);
                                 hasher.finish() | 1
                             };
+                            // GSV gate (cardano-node prioritisePeerChains): when the
+                            // slot is FREE, only the fastest-serving peers contest it,
+                            // so the single fetcher converges on the best peer rather
+                            // than a fair race. A peer that already holds the slot
+                            // keeps it (re-claim) — the gate only filters NEW claims.
+                            // Wedge-safe: unmeasured / cold-start peers stay eligible
+                            // and the existing starvation rotation frees a stuck peer.
+                            if active_fetcher.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                                let preferred = peer_manager_for_fetch
+                                    .read()
+                                    .await
+                                    .should_claim_fetch_slot(&addr, GSV_FETCH_TOP_K);
+                                if !preferred {
+                                    continue;
+                                }
+                            }
                             let claimed = active_fetcher.compare_exchange(
                                 0,
                                 my_id,
@@ -3089,6 +3117,19 @@ impl ConnectionLifecycleManager {
                                         // bytes this range delivered (rate = rx B/s).
                                         metrics_clone
                                             .inc_blockfetch_rx_bytes(range_abort.seen_bytes() as u64);
+                                        // GSV: record this peer's measured fetch
+                                        // bandwidth (bytes/sec) so the claim gate can
+                                        // prefer the fastest-serving peers. Only count
+                                        // ranges with a meaningful sample (>0 bytes,
+                                        // >1 ms) so tiny/instant ranges don't skew it.
+                                        if range_abort.seen_bytes() > 0 && fetch_ms > 1.0 {
+                                            let bps = range_abort.seen_bytes() as f64
+                                                / (fetch_ms / 1000.0);
+                                            peer_manager_for_fetch
+                                                .write()
+                                                .await
+                                                .update_peer_fetch_bandwidth(&addr, bps);
+                                        }
                                         // Refresh the average block size for the
                                         // next range's byte-budget sizing.
                                         if let Some(avg) = range_abort.seen_bytes().checked_div(count) {
@@ -3166,6 +3207,16 @@ impl ConnectionLifecycleManager {
                                             timeout_secs = FETCH_RANGE_TIMEOUT.as_secs(),
                                             "BlockFetch range timed out, releasing fetcher",
                                         );
+                                        // GSV: a timed-out peer is effectively zero
+                                        // throughput right now — collapse its measured
+                                        // bandwidth so the claim gate de-prefers it and
+                                        // the slot converges on a healthy fast peer
+                                        // (rather than re-picking the stalled one from a
+                                        // stale-but-high EWMA).
+                                        peer_manager_for_fetch
+                                            .write()
+                                            .await
+                                            .update_peer_fetch_bandwidth(&addr, 1.0);
                                         // CSJ: a peer starving BlockFetch is
                                         // rotated out of the dynamo role so a
                                         // different peer drives the jumps

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -6719,6 +6719,17 @@ impl Node {
         // ValidateAll: at-tip we keep the exact synchronous path so served/forged
         // tips carry zero deferral. `at_tip` here uses the same predicate as the
         // publish gate below (peer_tip==0 ⇒ no peer yet ⇒ treat as at-tip).
+        //
+        // **Fork-in-window is structurally impossible under this gate.** Deferral
+        // engages only when `peer_tip − block_slot > stability_window = ⌈3k/f⌉`
+        // slots (≈129 600 = 36 h on mainnet/preview). Ouroboros k-finality bounds
+        // ANY fork rollback to ≤ k blocks ≈ k/f slots. A deferred block therefore
+        // sits ~3k blocks deep — 3× beyond the deepest reachable fork — so no fork
+        // can ever roll back a block whose Plutus is still pending. The window is
+        // flushed the moment `at_tip` flips (well before blocks enter the
+        // fork-reachable k window), so a deferred block is always settled/final.
+        // (This is why the deferral needs no fork-in-window handling: the gate
+        // keeps the un-confirmed prefix strictly below the finality horizon.)
         let defer_pre_at_tip = {
             let peer_tip = self.metrics.get_peer_tip();
             let sw = dugite_consensus::stability_window_slots(

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -708,6 +708,29 @@ pub struct Node {
     /// Receiver for blocks fetched by per-peer BlockFetch workers.
     /// The main run loop consumes these and applies them to the ledger.
     fetched_blocks_rx: Option<mpsc::Receiver<FetchedBlock>>,
+    /// Cross-block Phase-2 (Plutus) pooling window for bulk-sync CPU saturation
+    /// (`DUGITE_DEFER_PHASE2_WINDOW`, default 0 = OFF). When > 0, during catch-up
+    /// (`!at_tip`) `apply_fetched_block` applies each block's STATE inline but
+    /// DEFERS the Plutus drain, stashing `(block, work_items)` here; the run loop
+    /// flushes the window via [`Self::flush_pending_phase2`] — pooling many
+    /// blocks' redeemers into one rayon batch to fill all cores. State is
+    /// byte-identical; only when/where Plutus runs moves. Default OFF: the live
+    /// apply path is unchanged until an operator opts in (the exposure-gating /
+    /// fork-in-window gauntlet is the prerequisite for default-on).
+    defer_phase2_window: usize,
+    /// The deferred (block, Phase-2 work items) accumulated under
+    /// `defer_phase2_window`, drained by [`Self::flush_pending_phase2`].
+    pending_phase2: Vec<(
+        Box<dugite_primitives::block::Block>,
+        Vec<dugite_ledger::plutus::Phase2WorkItem>,
+    )>,
+    /// Exact ledger tip point immediately BEFORE the first block of the current
+    /// deferred window was applied (the parent of `pending_phase2[0]`). On a
+    /// deferred block-fatal at window index 0 this is the precise rollback
+    /// target; for i>0 the target is block i-1's own point. Slots are sparse in
+    /// Cardano, so the rollback must land on a real on-chain point, not a
+    /// `slot-1` guess (`handle_ledger_rollback` classifies by slot).
+    pending_phase2_anchor: Option<dugite_primitives::block::Point>,
     /// Receiver for peer failure reports from protocol tasks (e.g. fetch timeout).
     /// The main run loop drains this to call `peer_failed()` for reputation scoring.
     peer_failure_rx: Option<mpsc::Receiver<(SocketAddr, PeerFailureKind)>>,
@@ -2568,6 +2591,12 @@ impl Node {
             connection_lifecycle: None,
             block_fetch_task: None,
             fetched_blocks_rx: None,
+            defer_phase2_window: std::env::var("DUGITE_DEFER_PHASE2_WINDOW")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0),
+            pending_phase2: Vec::new(),
+            pending_phase2_anchor: None,
             peer_failure_rx: None,
             keepalive_rtt_rx: None,
             query_handler,
@@ -4948,6 +4977,9 @@ impl Node {
                 // ── Shutdown ────────────────────────────────────────────
                 _ = shutdown_rx.changed() => {
                     info!("Shutdown signal received");
+                    // Confirm any deferred Plutus before the shutdown snapshot so
+                    // the persisted state reflects only Plutus-confirmed blocks.
+                    self.flush_pending_phase2().await;
                     break;
                 }
 
@@ -4988,6 +5020,17 @@ impl Node {
                         lc.chainsel_dequeued();
                     }
                     self.apply_fetched_block(fetched).await;
+                    // Cross-block Phase-2 pooling flush: drain the deferred window
+                    // when it reaches the configured size, or when the fetch queue
+                    // has drained (we've caught up to the buffered blocks, so flush
+                    // before idling / before any at-tip transition). No-op when the
+                    // window is empty (deferral off / at-tip).
+                    if !self.pending_phase2.is_empty()
+                        && (self.pending_phase2.len() >= self.defer_phase2_window
+                            || fetched_blocks_rx.is_empty())
+                    {
+                        self.flush_pending_phase2().await;
+                    }
                     // After the apply, if the queue is empty we are about to
                     // block waiting → starvation Ongoing. A FULL queue during
                     // a long apply (epoch boundary, snapshot) keeps the old
@@ -5006,6 +5049,9 @@ impl Node {
                     blocks_since_maintenance += 1;
                     if blocks_since_maintenance >= MAINTENANCE_FORCE_BLOCKS {
                         blocks_since_maintenance = 0;
+                        // Confirm all deferred Plutus before maintenance flushes
+                        // volatile→immutable so nothing un-confirmed is finalised.
+                        self.flush_pending_phase2().await;
                         self.run_background_maintenance().await;
                     }
                 }
@@ -5017,6 +5063,8 @@ impl Node {
                 // for why this is the from-genesis apply-rate fix.
                 _ = maintenance_ticker.tick() => {
                     blocks_since_maintenance = 0;
+                    // Confirm deferred Plutus before the volatile→immutable flush.
+                    self.flush_pending_phase2().await;
                     self.run_background_maintenance().await;
                 }
 
@@ -6666,6 +6714,23 @@ impl Node {
             BlockValidationMode::ValidateAll => self.metrics.inc_apply_mode_validate_all(),
         }
 
+        // Cross-block Phase-2 pooling gate (DUGITE_DEFER_PHASE2_WINDOW, default
+        // OFF). Defer the Plutus drain ONLY during catch-up (`!at_tip`) under
+        // ValidateAll: at-tip we keep the exact synchronous path so served/forged
+        // tips carry zero deferral. `at_tip` here uses the same predicate as the
+        // publish gate below (peer_tip==0 ⇒ no peer yet ⇒ treat as at-tip).
+        let defer_pre_at_tip = {
+            let peer_tip = self.metrics.get_peer_tip();
+            let sw = dugite_consensus::stability_window_slots(
+                self.consensus.security_param,
+                self.consensus.active_slot_coeff,
+            );
+            peer_tip == 0 || block_slot.0.saturating_add(sw) >= peer_tip
+        };
+        let should_defer_phase2 = self.defer_phase2_window > 0
+            && matches!(validation_mode, BlockValidationMode::ValidateAll)
+            && !defer_pre_at_tip;
+
         // Apply to ledger state and collect the delta for LedgerSeq.
         //
         // Fix A (Bug B, 2026-05-16): use apply_block_with_delta so that every
@@ -6685,7 +6750,14 @@ impl Node {
         // NOTE: apply_fetched_block and process_blocks_bulk are mutually
         // exclusive code paths (bulk sync runs to completion, then live sync
         // starts), so there is no risk of double-pushing the same block.
-        let delta = {
+        // If this block opens a new deferred window, record the pre-apply ledger
+        // tip as the window anchor (the exact rollback target should the window's
+        // first block later prove block-fatal under pooled Plutus).
+        if should_defer_phase2 && self.pending_phase2.is_empty() {
+            let pre_tip = self.ledger_state.read().await.tip.point.clone();
+            self.pending_phase2_anchor = Some(pre_tip);
+        }
+        let (delta, deferred_items) = {
             let mut ls = self.ledger_state.write().await;
             // #733: per-block apply horizon snapshot at the pre-block
             // ledger tip (one-shot, conservative — sound across HF windows).
@@ -6706,10 +6778,19 @@ impl Node {
             // one worker for the full Phase-1/Phase-2 validation and
             // UTxO/cert/gov update window, leaving the work-stealing
             // pool unable to fan out runnable tasks elsewhere.
-            let apply_result =
-                tokio::task::block_in_place(|| ls.apply_block_with_delta(&block, validation_mode));
+            // Deferred path returns the captured Phase-2 work items (drained
+            // later by the run loop's pooled flush); inline path drains Plutus
+            // now and yields no items. Both produce a byte-identical delta.
+            let apply_result = if should_defer_phase2 {
+                tokio::task::block_in_place(|| {
+                    ls.apply_block_with_delta_defer(&block, validation_mode)
+                })
+            } else {
+                tokio::task::block_in_place(|| ls.apply_block_with_delta(&block, validation_mode))
+                    .map(|delta| (delta, Vec::new()))
+            };
             match apply_result {
-                Ok(delta) => {
+                Ok((delta, items)) => {
                     // Publish the lock-free read view (issue #651 P2 / #652 P0)
                     // — readers see the new tip without acquiring the ledger
                     // lock.
@@ -6816,7 +6897,7 @@ impl Node {
                             );
                         }
                     }
-                    delta
+                    (delta, items)
                 }
                 Err(e) => {
                     // Issue #669 — surface this as a hard operator-actionable
@@ -6931,6 +7012,85 @@ impl Node {
         // per block would replace the old O(N²) `get_all_fork_tips` cost with a
         // per-block O(k) WAL rewrite.  Batching it on the 250 ms ticker keeps
         // WAL rewrites to ~4/s while still bounding VolatileDB to the k window.
+
+        // Cross-block Phase-2 pooling: stash this block + its deferred Plutus
+        // work items for the run loop's pooled flush. `block` is moved here
+        // after its last borrow (the announce above), so no clone is needed.
+        if should_defer_phase2 {
+            self.pending_phase2.push((Box::new(block), deferred_items));
+        }
+    }
+
+    /// Drain the deferred Phase-2 (Plutus) window: evaluate every pooled block's
+    /// work items in ONE rayon batch (filling all cores), then apply each block's
+    /// fatality verdict in order. On a block-fatal collection error, roll the
+    /// ledger back to before that block and stop (mirrors the synchronous
+    /// per-block `Err` path, just deferred). A no-op when the window is empty.
+    ///
+    /// Byte-exact: state was already applied in-order by `apply_fetched_block`;
+    /// this only runs the deferred read-only fatality check whose decision is a
+    /// pure function of each block's self-contained work items.
+    async fn flush_pending_phase2(&mut self) {
+        if self.pending_phase2.is_empty() {
+            return;
+        }
+        let batch = std::mem::take(&mut self.pending_phase2);
+        let anchor = self.pending_phase2_anchor.take();
+        let n_blocks = batch.len();
+        let (blocks, items): (Vec<_>, Vec<_>) = batch.into_iter().unzip();
+
+        // Pooled rayon evaluation (CPU-bound) under block_in_place so the
+        // multi-thread runtime spawns relief workers for the duration.
+        let outcomes_per_block = tokio::task::block_in_place(|| {
+            dugite_ledger::plutus::run_phase2_parallel_pooled(items)
+        });
+
+        // Apply each block's fatality verdict in chain order. `prev_confirmed`
+        // tracks the last block that drained non-fatal (starting at the window
+        // anchor = parent of block[0]). The FIRST block with a block-fatal
+        // CollectError is the rejection point — identical to the block the
+        // synchronous path would have rejected.
+        let mut prev_confirmed: Option<dugite_primitives::block::Point> = anchor;
+        for (block, outcomes) in blocks.into_iter().zip(outcomes_per_block) {
+            if let Err(e) = dugite_ledger::state::apply_phase2_outcomes(&block, outcomes) {
+                let fatal_slot = block.slot().0;
+                self.metrics
+                    .block_apply_failures
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                error!(
+                    slot = fatal_slot,
+                    pooled_blocks = n_blocks,
+                    "Deferred Phase-2 (pooled) found a block-fatal error: {e} — rolling \
+                     the ledger back to the last confirmed block and disabling deferral. \
+                     The rejected block (and any later un-confirmed window blocks) are \
+                     undone; they are re-fetched and re-validated synchronously."
+                );
+                // Roll back to the last confirmed on-chain point (real slot+hash,
+                // never a slot-1 guess). This undoes the fatal block AND every
+                // later un-confirmed block in the window via the LedgerSeq path.
+                match prev_confirmed {
+                    Some(rb) => {
+                        let _ = self.handle_ledger_rollback(&rb).await;
+                    }
+                    None => {
+                        // No anchor (should not happen) — halt deferral; the
+                        // serial re-validation on restart/refetch is the backstop.
+                        error!(
+                            "Deferred Phase-2 fatal at window head with no anchor — \
+                             cannot roll back precisely; halting deferral."
+                        );
+                    }
+                }
+                // Disable further deferral for the remainder of this run so the
+                // re-fetched blocks are validated synchronously (conservative).
+                self.defer_phase2_window = 0;
+                return;
+            }
+            prev_confirmed = Some(dugite_primitives::block::Point::Specific(
+                block.slot(),
+                *block.hash(),
+            ));
+        }
     }
 
     // ─── run_background_maintenance() ────────────────────────────────────────

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -731,6 +731,21 @@ pub struct Node {
     /// Cardano, so the rollback must land on a real on-chain point, not a
     /// `slot-1` guess (`handle_ledger_rollback` classifies by slot).
     pending_phase2_anchor: Option<dugite_primitives::block::Point>,
+    /// Running Σ of Phase-2 work items (redeemers) buffered in `pending_phase2`.
+    /// The pooled flush is triggered by THIS, not block count, so a dense-Plutus
+    /// region (many redeemers per block) flushes before the pooled eval's peak
+    /// memory grows unbounded. The deferral-soak wedge was a 64-block window
+    /// whose redeemer count — not block count — drove a multi-GB pooled eval.
+    pending_phase2_items: usize,
+    /// Work-item cap that forces a [`Self::flush_pending_phase2`] even before the
+    /// block window (`defer_phase2_window`) fills (`DUGITE_DEFER_PHASE2_MAX_ITEMS`,
+    /// default 256). Bounds the pooled flush's peak memory + wall time.
+    defer_phase2_max_items: usize,
+    /// Clone of the run loop's shutdown watch, observed by the pooled flush
+    /// between chunks so a SIGTERM during a long flush aborts the remaining
+    /// chunks instead of being swallowed (the original `block_in_place` flush was
+    /// not cancel-aware → SIGTERM was ignored during the soak wedge).
+    shutdown_rx_for_flush: Option<tokio::sync::watch::Receiver<bool>>,
     /// Receiver for peer failure reports from protocol tasks (e.g. fetch timeout).
     /// The main run loop drains this to call `peer_failed()` for reputation scoring.
     peer_failure_rx: Option<mpsc::Receiver<(SocketAddr, PeerFailureKind)>>,
@@ -2597,6 +2612,13 @@ impl Node {
                 .unwrap_or(0),
             pending_phase2: Vec::new(),
             pending_phase2_anchor: None,
+            pending_phase2_items: 0,
+            defer_phase2_max_items: std::env::var("DUGITE_DEFER_PHASE2_MAX_ITEMS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|n| *n > 0)
+                .unwrap_or(256),
+            shutdown_rx_for_flush: None,
             peer_failure_rx: None,
             keepalive_rtt_rx: None,
             query_handler,
@@ -2815,6 +2837,9 @@ impl Node {
         // Setup shutdown signal (SIGINT + SIGTERM) early so the node can be
         // gracefully stopped during replay (which can take 30+ minutes).
         let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        // Let the pooled Phase-2 deferral flush observe shutdown between chunks
+        // (cancel-aware flush; see `flush_pending_phase2`).
+        self.shutdown_rx_for_flush = Some(shutdown_rx.clone());
         // #760: set true the instant the main run loop breaks, so the
         // shutdown watchdog can tell "loop wedged, never broke" (force-exit)
         // from "loop broke, draining cleanly" (the post-loop block has its own
@@ -4979,7 +5004,10 @@ impl Node {
                     info!("Shutdown signal received");
                     // Confirm any deferred Plutus before the shutdown snapshot so
                     // the persisted state reflects only Plutus-confirmed blocks.
-                    self.flush_pending_phase2().await;
+                    // allow_cancel = false: this flush must COMPLETE (the window
+                    // is small + memory-bounded), never observe its own shutdown
+                    // signal and bail before persisting confirmed state.
+                    self.flush_pending_phase2(false).await;
                     break;
                 }
 
@@ -5021,15 +5049,19 @@ impl Node {
                     }
                     self.apply_fetched_block(fetched).await;
                     // Cross-block Phase-2 pooling flush: drain the deferred window
-                    // when it reaches the configured size, or when the fetch queue
-                    // has drained (we've caught up to the buffered blocks, so flush
-                    // before idling / before any at-tip transition). No-op when the
-                    // window is empty (deferral off / at-tip).
+                    // when its REDEEMER count reaches the memory-safety cap
+                    // (`defer_phase2_max_items` — the primary trigger, since a
+                    // dense-Plutus region fills memory by redeemer count, not
+                    // block count), or the block window fills, or the fetch queue
+                    // has drained (we've caught up to the buffered blocks, so
+                    // flush before idling / before any at-tip transition). No-op
+                    // when the window is empty (deferral off / at-tip).
                     if !self.pending_phase2.is_empty()
-                        && (self.pending_phase2.len() >= self.defer_phase2_window
+                        && (self.pending_phase2_items >= self.defer_phase2_max_items
+                            || self.pending_phase2.len() >= self.defer_phase2_window
                             || fetched_blocks_rx.is_empty())
                     {
-                        self.flush_pending_phase2().await;
+                        self.flush_pending_phase2(true).await;
                     }
                     // After the apply, if the queue is empty we are about to
                     // block waiting → starvation Ongoing. A FULL queue during
@@ -5051,7 +5083,7 @@ impl Node {
                         blocks_since_maintenance = 0;
                         // Confirm all deferred Plutus before maintenance flushes
                         // volatile→immutable so nothing un-confirmed is finalised.
-                        self.flush_pending_phase2().await;
+                        self.flush_pending_phase2(true).await;
                         self.run_background_maintenance().await;
                     }
                 }
@@ -5064,7 +5096,7 @@ impl Node {
                 _ = maintenance_ticker.tick() => {
                     blocks_since_maintenance = 0;
                     // Confirm deferred Plutus before the volatile→immutable flush.
-                    self.flush_pending_phase2().await;
+                    self.flush_pending_phase2(true).await;
                     self.run_background_maintenance().await;
                 }
 
@@ -7028,33 +7060,81 @@ impl Node {
         // work items for the run loop's pooled flush. `block` is moved here
         // after its last borrow (the announce above), so no clone is needed.
         if should_defer_phase2 {
+            // Track the running redeemer count so the run loop flushes by
+            // work-item count (memory) before the block window fills.
+            self.pending_phase2_items += deferred_items.len();
             self.pending_phase2.push((Box::new(block), deferred_items));
         }
     }
 
     /// Drain the deferred Phase-2 (Plutus) window: evaluate every pooled block's
-    /// work items in ONE rayon batch (filling all cores), then apply each block's
-    /// fatality verdict in order. On a block-fatal collection error, roll the
-    /// ledger back to before that block and stop (mirrors the synchronous
-    /// per-block `Err` path, just deferred). A no-op when the window is empty.
+    /// work items on the memory-bounded pool, then apply each block's fatality
+    /// verdict in order. On a block-fatal collection error, roll the ledger back
+    /// to before that block and stop (mirrors the synchronous per-block `Err`
+    /// path, just deferred). A no-op when the window is empty.
+    ///
+    /// Memory + cancel safety: the pooled eval is concurrency-capped and chunked
+    /// (see [`dugite_ledger::plutus::run_phase2_parallel_pooled_cancellable`]) so
+    /// it cannot reproduce the deferral-soak RSS runaway, and — when
+    /// `allow_cancel` is true — it observes the shutdown watch between chunks so
+    /// a SIGTERM during a long flush aborts the remaining work instead of being
+    /// swallowed by `block_in_place`. The shutdown-arm flush passes
+    /// `allow_cancel = false` so it always confirms the (small, bounded) window
+    /// before the persisted snapshot.
     ///
     /// Byte-exact: state was already applied in-order by `apply_fetched_block`;
     /// this only runs the deferred read-only fatality check whose decision is a
     /// pure function of each block's self-contained work items.
-    async fn flush_pending_phase2(&mut self) {
+    async fn flush_pending_phase2(&mut self, allow_cancel: bool) {
         if self.pending_phase2.is_empty() {
             return;
         }
         let batch = std::mem::take(&mut self.pending_phase2);
         let anchor = self.pending_phase2_anchor.take();
+        self.pending_phase2_items = 0;
         let n_blocks = batch.len();
         let (blocks, items): (Vec<_>, Vec<_>) = batch.into_iter().unzip();
+        let n_items: usize = items.iter().map(Vec::len).sum();
+        let t_flush = std::time::Instant::now();
 
-        // Pooled rayon evaluation (CPU-bound) under block_in_place so the
-        // multi-thread runtime spawns relief workers for the duration.
+        // Cancellation token: observe the shutdown watch between chunks so a
+        // SIGTERM during a long flush aborts the remaining work. The shutdown-arm
+        // flush passes allow_cancel = false (None token) so it always completes.
+        let sd_rx = if allow_cancel {
+            self.shutdown_rx_for_flush.clone()
+        } else {
+            None
+        };
+        let cancel = move || sd_rx.as_ref().is_some_and(|rx| *rx.borrow());
+
+        // Pooled rayon evaluation (CPU-bound, memory-bounded) under
+        // block_in_place so the multi-thread runtime spawns relief workers.
         let outcomes_per_block = tokio::task::block_in_place(|| {
-            dugite_ledger::plutus::run_phase2_parallel_pooled(items)
+            dugite_ledger::plutus::run_phase2_parallel_pooled_cancellable(items, &cancel)
         });
+
+        let outcomes_per_block = match outcomes_per_block {
+            Some(o) => o,
+            None => {
+                // Cancelled mid-flush (shutdown in progress). Nothing was applied
+                // yet — the deferred blocks' STATE is in the in-memory ledger but
+                // their Plutus is unconfirmed, so we must NOT let them reach a
+                // persisted snapshot. Roll the ledger back to the window anchor
+                // (undoing the whole un-confirmed window) and disable deferral;
+                // the blocks are re-fetched + validated synchronously on restart.
+                warn!(
+                    pooled_blocks = n_blocks,
+                    pooled_items = n_items,
+                    "Deferred Phase-2 flush cancelled by shutdown — rolling the \
+                     ledger back to the last confirmed block and disabling deferral."
+                );
+                if let Some(rb) = anchor {
+                    let _ = self.handle_ledger_rollback(&rb).await;
+                }
+                self.defer_phase2_window = 0;
+                return;
+            }
+        };
 
         // Apply each block's fatality verdict in chain order. `prev_confirmed`
         // tracks the last block that drained non-fatal (starting at the window
@@ -7102,6 +7182,12 @@ impl Node {
                 *block.hash(),
             ));
         }
+        debug!(
+            pooled_blocks = n_blocks,
+            pooled_items = n_items,
+            elapsed_ms = t_flush.elapsed().as_millis() as u64,
+            "Deferred Phase-2 window flushed (pooled, memory-bounded)"
+        );
     }
 
     // ─── run_background_maintenance() ────────────────────────────────────────

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -7209,6 +7209,7 @@ impl Node {
                 *block.hash(),
             ));
         }
+        self.metrics.record_deferred_phase2_flush(n_blocks as u64);
         debug!(
             pooled_blocks = n_blocks,
             pooled_items = n_items,

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -5914,6 +5914,33 @@ impl Node {
         rollback: Vec<dugite_primitives::hash::Hash32>,
         apply: Vec<dugite_primitives::hash::Hash32>,
     ) -> ForkSwitchOutcome {
+        // ── Phase-2 deferral safety: flush BEFORE the ledger rolls back ──────
+        //
+        // A fork switch rolls the ledger backward through the volatile window,
+        // which can include blocks whose deferred Plutus is still pending. This
+        // is the SOLE ledger-rollback path that can orphan a pending block: it
+        // is reached both inline (an arriving block triggers the fork) and from
+        // the run-loop LoE arm (a GDD/LoE advance unlocks a candidate). In
+        // GENESIS mode especially, LoE/GDD makes such switches reachable while
+        // the deferral window is non-empty — the Praos "fork-in-window is
+        // structurally impossible" argument (deferred blocks ~3k deep, below the
+        // k-finality horizon) does NOT hold under LoE selection, whose switches
+        // can intersect anywhere down to the immutable tip, inside the volatile
+        // window where the pending blocks live.
+        //
+        // Flush the window FIRST so every pending block's Plutus is validated
+        // against the exact ledger it was applied to, BEFORE the rollback/replay
+        // — mirroring the existing flush-before-maintenance/snapshot/shutdown
+        // ordering. Without this, a post-switch flush would run Plutus against
+        // (or roll back to a stale anchor on) a chain the deferred blocks are no
+        // longer on. `allow_cancel = false`: complete it (the window is
+        // memory-bounded) so the ledger is deterministic before the switch.
+        // No-op when the window is empty (deferral off, or already flushed by
+        // the run loop). Cannot recurse: flush_pending_phase2 calls
+        // handle_ledger_rollback, never apply_fork_switch_plan, and it empties
+        // pending_phase2 before that call.
+        self.flush_pending_phase2(false).await;
+
         // Chain selection determined a competing fork is strictly
         // preferred.  The VolatileDB chain switch is already
         // committed — selected_chain now points at the new fork.

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2461,9 +2461,8 @@ impl Node {
                         && age < gsm_config.syncing_startup_threshold_secs
                 );
                 // MUST mirror GenesisStateMachine::new()'s no-marker branch so the
-                // seed snapshot's state/LoE matches the GSM actor's internal state
-                // (DUGITE_GENESIS_BOOTSTRAP_SYNCING bootstrap HAA bypass).
-                if recent || crate::gsm::bootstrap_syncing_override() {
+                // seed snapshot's state matches the GSM actor's internal state.
+                if recent {
                     crate::gsm::GenesisSyncState::Syncing
                 } else {
                     crate::gsm::GenesisSyncState::PreSyncing
@@ -3615,6 +3614,12 @@ impl Node {
             };
 
             let mut resolved_peers: Vec<std::net::SocketAddr> = Vec::new();
+            // Bootstrap / trustable peers' resolved addresses, registered with
+            // the PeerManager so haa_satisfied() can recognise them as the
+            // trusted external set (Haskell UseBootstrapPeers HAA path). A
+            // `trustable` topology entry is a bootstrap peer or a trustable
+            // local root — exactly Haskell's trusted-peer set.
+            let mut resolved_bootstrap: Vec<std::net::SocketAddr> = Vec::new();
             for peer in &detailed_peers {
                 let addrs = resolve_with_srv(dns_resolver.as_ref(), &peer.address, peer.port).await;
                 if addrs.is_empty() {
@@ -3624,6 +3629,9 @@ impl Node {
                         "Failed to resolve peer address (SRV + A/AAAA both failed)"
                     );
                 } else {
+                    if peer.trustable {
+                        resolved_bootstrap.extend(addrs.iter().copied());
+                    }
                     resolved_peers.extend(addrs);
                 }
             }
@@ -3675,6 +3683,11 @@ impl Node {
             let mut pm = peer_manager.write().await;
             for socket_addr in resolved_peers {
                 pm.add_config_peer(socket_addr);
+            }
+            // Register bootstrap/trustable peers for the UseBootstrapPeers HAA
+            // path (must be AFTER add_config_peer so the peer table has them).
+            for socket_addr in resolved_bootstrap {
+                pm.add_bootstrap_peer(socket_addr);
             }
             // Register per-group valency targets.  This must happen AFTER
             // add_config_peer() calls so the peer table contains the members.

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2460,7 +2460,10 @@ impl Node {
                     Some(age) if gsm_config.syncing_startup_threshold_secs > 0
                         && age < gsm_config.syncing_startup_threshold_secs
                 );
-                if recent {
+                // MUST mirror GenesisStateMachine::new()'s no-marker branch so the
+                // seed snapshot's state/LoE matches the GSM actor's internal state
+                // (DUGITE_GENESIS_BOOTSTRAP_SYNCING bootstrap HAA bypass).
+                if recent || crate::gsm::bootstrap_syncing_override() {
                     crate::gsm::GenesisSyncState::Syncing
                 } else {
                     crate::gsm::GenesisSyncState::PreSyncing

--- a/crates/dugite-node/src/node/networking.rs
+++ b/crates/dugite-node/src/node/networking.rs
@@ -774,6 +774,21 @@ impl NodePeerManager {
         self.inner.get_latency_ms(addr)
     }
 
+    /// Record a measured BlockFetch throughput sample (bytes/second) for a peer
+    /// — the bandwidth half of the GSV estimate used to pick the fetch peer.
+    pub fn update_peer_fetch_bandwidth(&mut self, addr: &SocketAddr, bytes_per_sec: f64) {
+        self.inner.update_fetch_bandwidth(addr, bytes_per_sec);
+    }
+
+    /// Whether `addr` should contest the single fetch slot right now, ranking it
+    /// against the current HOT peers by GSV (fetch bandwidth). Self-contained
+    /// candidate derivation for the BlockFetch worker's claim loop.
+    pub fn should_claim_fetch_slot(&self, addr: &SocketAddr, top_k: usize) -> bool {
+        use dugite_network::peer::PeerState;
+        let candidates = self.inner.peers_in_state(PeerState::Hot);
+        self.inner.is_preferred_fetch_peer(addr, &candidates, top_k)
+    }
+
     /// Record blocks fetched from a peer.
     #[allow(dead_code)] // used by networking rewrite
     pub fn record_block_fetch(&mut self, addr: &SocketAddr, blocks: usize) {

--- a/crates/dugite-node/src/node/networking.rs
+++ b/crates/dugite-node/src/node/networking.rs
@@ -310,6 +310,14 @@ pub struct NodePeerManager {
     local_root_groups: Vec<LocalRootGroupInfo>,
     /// Set of big ledger peer addresses.
     big_ledger_peers: std::collections::HashSet<SocketAddr>,
+    /// Set of bootstrap peer addresses (topology `bootstrapPeers`, always
+    /// trustable). Mirrors Haskell's bootstrap-peer set used by
+    /// `outboundConnectionsState`: in `UseBootstrapPeers` mode the
+    /// Honest-Availability-Assumption is satisfied by >=1 active (hot) bootstrap
+    /// peer (plus the "all established peers are trusted" invariant). Without
+    /// this, a from-genesis node with only bootstrap peers and no
+    /// `peerSnapshotFile` can never satisfy the HAA and stalls in PreSyncing.
+    bootstrap_peer_addrs: std::collections::HashSet<SocketAddr>,
     /// Inbound-duplex peers awaiting `inboundMaturePeerDelay`.
     ///
     /// Mirrors Haskell's `freshDuplexPeers` (OrdPSQ keyed by `(SocketAddr,
@@ -354,6 +362,7 @@ impl NodePeerManager {
             local_addr: None,
             local_root_groups: Vec::new(),
             big_ledger_peers: std::collections::HashSet::new(),
+            bootstrap_peer_addrs: std::collections::HashSet::new(),
             fresh_inbound: HashMap::new(),
             rollback_below_immutable_witnesses: HashMap::new(),
             gsm_event_tx: None,
@@ -565,6 +574,13 @@ impl NodePeerManager {
     /// Mark a peer as a big ledger peer.
     pub fn add_big_ledger_peer(&mut self, addr: SocketAddr) {
         self.big_ledger_peers.insert(addr);
+    }
+
+    /// Mark a peer as a bootstrap peer (topology `bootstrapPeers`). Bootstrap
+    /// peers are always trustable and satisfy the `UseBootstrapPeers` HAA path
+    /// (see [`Self::haa_satisfied`]).
+    pub fn add_bootstrap_peer(&mut self, addr: SocketAddr) {
+        self.bootstrap_peer_addrs.insert(addr);
     }
 
     /// Read-only view of all known big-ledger peers.
@@ -894,20 +910,28 @@ impl NodePeerManager {
     /// Honest-Availability-Assumption satisfaction (Haskell
     /// `outboundConnectionsState` → `TrustedStateWithExternalPeers`).
     ///
-    /// Two independent ways to be trusted, matching the Haskell case split:
-    /// - **Local-roots trust** (`LocalRootsOnly`): there is at least one
-    ///   active (hot) peer AND every established (warm/hot) peer is a
-    ///   trusted local root. This is how a devnet — and a mainnet node early
-    ///   in boot before ledger big-ledger peers are established — satisfies
-    ///   the HAA.
+    /// Two independent ways to be trusted, matching the Haskell
+    /// `(associationMode, bootstrapPeersFlag, consensusMode)` case split:
     /// - **Big-ledger trust** (Genesis mode, `DontUseBootstrapPeers`): at
     ///   least `min_active_blp` ACTIVE big-ledger peers.
+    /// - **Trusted-external trust** (`UseBootstrapPeers` / `LocalRootsOnly`):
+    ///   there is at least one active (hot) peer in the trusted set AND every
+    ///   established (warm/hot) outbound peer is in the trusted set, where the
+    ///   trusted set is `bootstrap peers ∪ trustable local roots`. This is how
+    ///   a from-genesis node (whose ledger has not reached `useLedgerAfterSlot`
+    ///   so no big-ledger peers are classified) satisfies the HAA via its
+    ///   bootstrap relays — mirroring Haskell `outboundConnectionsState →
+    ///   TrustedStateWithExternalPeers`. Without the bootstrap-peer term such a
+    ///   node would stall permanently in PreSyncing.
     pub fn haa_satisfied(&self, min_active_blp: usize) -> bool {
         if self.active_big_ledger_peer_count() >= min_active_blp {
             return true;
         }
-        let local_roots = self.local_root_addrs();
-        if local_roots.is_empty() {
+        // Trusted external set = bootstrap peers ∪ trustable local roots
+        // (Haskell `viewEstablishedBootstrapPeers ∪ trustableLocalRootSet`).
+        let mut trusted = self.local_root_addrs();
+        trusted.extend(self.bootstrap_peer_addrs.iter().copied());
+        if trusted.is_empty() {
             return false;
         }
         // Haskell `outboundConnectionsState` assesses only OUTBOUND-initiated
@@ -925,23 +949,24 @@ impl NodePeerManager {
                 )
             )
         };
-        // At least one ACTIVE (hot) outbound trusted local root.
-        let any_hot_root = self
+        // At least one ACTIVE (hot) outbound trusted peer (Haskell
+        // `not (Set.null viewActiveBootstrapPeers)`).
+        let any_hot_trusted = self
             .inner
             .peers_in_state(PeerState::Hot)
             .into_iter()
-            .any(|a| is_outbound(&a) && local_roots.contains(&a));
-        if !any_hot_root {
+            .any(|a| is_outbound(&a) && trusted.contains(&a));
+        if !any_hot_trusted {
             return false;
         }
-        // Every OUTBOUND established (warm + hot) peer must be a trusted
-        // local root.
+        // Every OUTBOUND established (warm + hot) peer must be trusted (Haskell
+        // `viewEstablishedPeers ⊆ viewEstablishedBootstrapPeers ∪ trustableLocalRootSet`).
         let mut established = self.inner.peers_in_state(PeerState::Warm);
         established.extend(self.inner.peers_in_state(PeerState::Hot));
         established
             .iter()
             .filter(|a| is_outbound(a))
-            .all(|a| local_roots.contains(a))
+            .all(|a| trusted.contains(a))
     }
 
     /// Get connected peer addresses.
@@ -1145,6 +1170,37 @@ mod tests {
         pm2.peer_connected(&public, ConnectionDirection::Outbound);
         pm2.inner.promote_to_hot(&public);
         assert!(!pm2.haa_satisfied(5));
+    }
+
+    #[test]
+    fn test_haa_satisfied_via_bootstrap_peers() {
+        // From-genesis genesis-mode path (Haskell UseBootstrapPeers →
+        // TrustedStateWithExternalPeers): HAA holds when there is ≥1 hot
+        // bootstrap peer AND every established outbound peer is trusted, with
+        // ZERO big-ledger peers and NO local roots. This is exactly what a
+        // from-genesis node needs to leave PreSyncing; without the bootstrap
+        // term in the trusted set it stalls forever (the genesis bulk-sync bug).
+        let mut pm = NodePeerManager::new(PeerManagerConfig::default());
+        let boot: SocketAddr = "3.74.40.92:3001".parse().unwrap();
+        pm.add_bootstrap_peer(boot);
+        // Warm only → not satisfied (Haskell needs an ACTIVE/hot peer).
+        pm.peer_connected(&boot, ConnectionDirection::Outbound);
+        assert!(!pm.haa_satisfied(5));
+        // Hot outbound bootstrap peer → satisfied (no BLPs, no local roots).
+        pm.inner.promote_to_hot(&boot);
+        assert!(
+            pm.haa_satisfied(5),
+            "a hot bootstrap peer satisfies the UseBootstrapPeers HAA path"
+        );
+        // Condition 2 (established ⊆ trusted): an untrusted outbound hot peer
+        // must break the HAA, mirroring Haskell outboundConnectionsState.
+        let public: SocketAddr = "8.8.8.8:3001".parse().unwrap();
+        pm.peer_connected(&public, ConnectionDirection::Outbound);
+        pm.inner.promote_to_hot(&public);
+        assert!(
+            !pm.haa_satisfied(5),
+            "an established untrusted outbound peer must break the HAA"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Apply-throughput + genesis-mode sync work, accumulated on this branch. All changes are either default-ON perf wins (validated byte-exact), default-OFF experimental features, or pure observability — and the full `just check` gate (fmt + clippy + build + test + doc) is green.

### Apply throughput (default-ON, byte-exact)
- **Registry cache (2.1×)** — memoize per-block validation registries keyed on Arc/imbl `ptr_eq` (`6e97431895`). 190→402 blk/s, hit-rate 99.8%, fingerprint unchanged.
- **GSV fetch-peer selection** (`e03f1e2ba8`) + **TCP BDP socket buffers** (`bd225b91d1`) — match cardano-node's single-peer bulk-sync behaviour.

### Cross-block Plutus deferral (default-OFF: `DUGITE_DEFER_PHASE2_WINDOW`)
- Foundation (`cb0ff17aff`, `1dd68c490e`) + fatality-semantics tests + fork-in-window impossibility proof (`70f2ed984c`).
- **Memory-bound + cancel-aware pooled flush** (`599bf69d5a`) — fixes a soak-discovered CPU/RSS runaway: dedicated capped rayon pool, chunked + cancellable, redeemer-count flush trigger.
- **Flush-before-fork-switch** (`f1372ffd7c`) — a fork switch (esp. genesis LoE/GDD) can roll the ledger back through pending-Plutus blocks; flush at the sole rollback choke point so the window is validated against the ledger it was applied to. Strengthens both praos and genesis.
- Flush counters (`d43e784371`) for soak validity.

### Genesis-mode from-genesis sync (Haskell-faithful)
- **Bootstrap-peer HAA** (`d0dd252e08`) — `haa_satisfied()` now recognizes active trusted bootstrap peers, mirroring cardano-node's `outboundConnectionsState` `UseBootstrapPeers` branch (≥1 hot bootstrap peer AND all established ⊆ trusted). Fixes a permanent PreSyncing stall at the first LoE window (~slot 8620); the GSM now transitions PreSyncing→Syncing legitimately and the LoE/GDD advance path runs. (Supersedes a reverted env-bypass shortcut, which was non-faithful — cardano-node never starts in Syncing.) Live-verified: from-genesis preview reaches Babbage (slot 5.5M+), `gsm=1`, 0 fatals.

### Fetch-path instrumentation (default-ON, observability)
- `blockfetch_busy_us_total` (utilization), `blockfetch_send_blocked_us_total` (apply backpressure), `blockfetch_idle_no_headers_total` (header-supply) — split fetcher idle into its causes (`f12bcab484`). Plus `apply_bench` tooling (`bfdf0d3c9b`, `3043f3522b`) and apply timing split (`7d0d91f750`).

## Validation
`just check` green. Per-area: 1054 node tests, ledger/plutus/conformance suites, clippy `-D warnings`, fmt all clean. Live: registry cache byte-exact; genesis from-genesis sync advancing to Babbage with the faithful HAA; deferral clean on every block it processed.

## Known follow-ups (non-blocking)
- Deferral remains **default-OFF** pending a full re-soak through the dense-Plutus region.
- `blockfetch_busy_us_total` over-counts by the worker hand-off overlap (util can read slightly >100%); cosmetic, doesn't affect drop-detection — to be tightened to account at the CAS release point.
- Full genesis faithfulness for arbitrary topologies would also restrict outbound connections to bootstrap peers while PreSyncing (the cardano-node governor behaviour).
