### PR TITLE
config-wiring audit + fixes (v2.0.12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-cli"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-config"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-conformance"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "cddl",
  "dugite-crypto",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-consensus"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-crypto"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "criterion",
  "curve25519-dalek 3.2.0 (git+https://github.com/iquerejeta/curve25519-dalek?branch=ietf03_vrf_compat_ell2)",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-golden-tests"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "dugite-crypto",
  "dugite-network",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-integration-tests"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "dugite-consensus",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-ledger"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "bincode 1.3.3",
  "criterion",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-lsm"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-mempool"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-monitor"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-network"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-node"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-primitives"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "bech32",
  "blake2 0.10.6",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-rpc"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-serialization"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-storage"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-uplc"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "amaru-uplc",
  "blake2 0.10.6",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.11"
+version = "2.0.12"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/michaeljfazio/dugite"

--- a/charts/dugite-node/Chart.yaml
+++ b/charts/dugite-node/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dugite-node
 description: A Helm chart for deploying Dugite, a Rust implementation of the Cardano node
 type: application
-version: 0.5.11
-appVersion: "2.0.11"
+version: 0.5.12
+appVersion: "2.0.12"
 kubeVersion: ">= 1.27.0-0"
 keywords:
   - cardano

--- a/config/mainnet/config.json
+++ b/config/mainnet/config.json
@@ -1,38 +1,29 @@
 {
+  "AlonzoGenesisFile": "alonzo-genesis.json",
+  "ByronGenesisFile": "byron-genesis.json",
+  "ByronGenesisHash": "dbbdaeab0ea4ea58225892d8b1294f178b417f4a9d1ed3bbf629c40d8f74e86b",
+  "ConsensusMode": "Genesis",
+  "ConwayGenesisFile": "conway-genesis.json",
+  "DiffusionMode": "InitiatorAndResponder",
+  "LowLevelGenesisOptions": {
+    "EnableCSJ": true,
+    "EnableLoEAndGDD": true,
+    "EnableLoP": true
+  },
+  "MetricsPort": 12800,
+  "MinSeverity": "Info",
   "Network": "Mainnet",
   "NetworkMagic": 764824073,
   "Protocol": {
     "RequiresNetworkMagic": "RequiresMagic"
   },
-  "DiffusionMode": "InitiatorAndResponder",
-  "TargetNumberOfRootPeers": 60,
-  "TargetNumberOfActivePeers": 15,
-  "TargetNumberOfEstablishedPeers": 40,
-  "TargetNumberOfKnownPeers": 85,
-  "TargetNumberOfActiveBigLedgerPeers": 5,
-  "TargetNumberOfEstablishedBigLedgerPeers": 10,
-  "TargetNumberOfKnownBigLedgerPeers": 15,
-  "ByronGenesisFile": "byron-genesis.json",
-  "ByronGenesisHash": "dbbdaeab0ea4ea58225892d8b1294f178b417f4a9d1ed3bbf629c40d8f74e86b",
   "ShelleyGenesisFile": "shelley-genesis.json",
   "ShelleyGenesisHash": "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
-  "AlonzoGenesisFile": "alonzo-genesis.json",
-  "ConwayGenesisFile": "conway-genesis.json",
-  "TraceOptions": {
-    "TraceBlockFetchClient": false,
-    "TraceBlockFetchServer": false,
-    "TraceChainDb": true,
-    "TraceChainSyncClient": true,
-    "TraceChainSyncServer": false,
-    "TraceForge": true,
-    "TraceMempool": true
-  },
-  "MinSeverity": "Info",
-  "MetricsPort": 12800,
-  "ConsensusMode": "Genesis",
-  "LowLevelGenesisOptions": {
-    "EnableCSJ": true,
-    "EnableLoEAndGDD": true,
-    "EnableLoP": true
-  }
+  "TargetNumberOfActiveBigLedgerPeers": 5,
+  "TargetNumberOfActivePeers": 15,
+  "TargetNumberOfEstablishedBigLedgerPeers": 10,
+  "TargetNumberOfEstablishedPeers": 40,
+  "TargetNumberOfKnownBigLedgerPeers": 15,
+  "TargetNumberOfKnownPeers": 85,
+  "TargetNumberOfRootPeers": 60
 }

--- a/crates/dugite-config/src/schema.rs
+++ b/crates/dugite-config/src/schema.rs
@@ -396,6 +396,129 @@ const RPC_FIELDS: &[SubParamDef] = &[
     },
 ];
 
+/// Sub-fields for LowLevelGenesisOptions.
+///
+/// These match cardano-node's `LowLevelGenesisOptions` / `GenesisConfigFlags`
+/// exactly (field renames verified against `dugite-node/src/config.rs`).
+const LOW_LEVEL_GENESIS_OPTIONS_FIELDS: &[SubParamDef] = &[
+    SubParamDef {
+        key: "EnableCSJ",
+        param_type: ParamType::Bool,
+        default: "true",
+        description: "Enable ChainSync Jumping (CSJ). Allows the genesis sync protocol \
+                      to jump ahead using checkpoints rather than streaming every header.",
+        tuning_hint: "Keep enabled (default). Disabling forces header-by-header sync \
+                      which is much slower during Genesis bulk sync.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "EnableLoEAndGDD",
+        param_type: ParamType::Bool,
+        default: "true",
+        description: "Enable Limit on Eagerness (LoE) and Genesis Density Disconnection \
+                      (GDD). These enforce the core Genesis safety property: the node will \
+                      not adopt a chain that outpaces the density guarantee.",
+        tuning_hint: "Keep enabled (default). Disabling removes the primary Genesis \
+                      safety mechanism and allows eclipse attacks during sync.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "EnableLoP",
+        param_type: ParamType::Bool,
+        default: "true",
+        description: "Enable Limit on Patience (LoP) leaky bucket. Tracks per-peer \
+                      block-serving capacity and disconnects peers that serve too slowly.",
+        tuning_hint: "Keep enabled (default). Disabling allows stalled peers to block \
+                      the sync pipeline indefinitely.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "CSJJumpSize",
+        param_type: ParamType::U64 {
+            min: 1,
+            max: 100_000,
+        },
+        default: "4320",
+        description: "ChainSync Jump size in slots (default 4320 = 2 × Byron k=2160). \
+                      Controls how far ahead a CSJ dynamo peer can jump at once.",
+        tuning_hint: "4320 is the cardano-node default (twice the Byron security parameter). \
+                      Only change for private networks with different epoch/slot parameters.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "GDDRateLimit",
+        param_type: ParamType::F64 {
+            min: 0.0,
+            max: 3600.0,
+        },
+        default: "1.0",
+        description: "Minimum seconds between GDD (Genesis Density Disconnection) \
+                      evaluations. Controls how frequently the node checks whether \
+                      peers satisfy the density guarantee.",
+        tuning_hint: "1.0 s (default) matches cardano-node. Increasing reduces CPU at \
+                      the cost of slower detection of density-violating peers.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "BlockFetchGracePeriod",
+        param_type: ParamType::F64 {
+            min: 0.0,
+            max: 300.0,
+        },
+        default: "10.0",
+        description: "Seconds of block-fetch inactivity before rotating to the next \
+                      peer during Genesis bulk sync. Prevents a stalled fetcher from \
+                      blocking sync indefinitely.",
+        tuning_hint: "10 s (default) matches cardano-node. Lower values rotate peers \
+                      faster but may cause unnecessary churn on slow connections.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "BucketCapacity",
+        param_type: ParamType::U64 {
+            min: 1,
+            max: 10_000_000,
+        },
+        default: "100000",
+        description: "LoP leaky bucket capacity in tokens. Each peer starts with a full \
+                      bucket; tokens are consumed when the peer fails to deliver blocks \
+                      promptly and replenish over time at BucketRate.",
+        tuning_hint: "100000 (default) matches cardano-node. Lower values disconnect \
+                      slow peers sooner; higher values give more tolerance.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "BucketRate",
+        param_type: ParamType::U64 {
+            min: 1,
+            max: 1_000_000,
+        },
+        default: "500",
+        description: "LoP bucket replenishment rate in tokens per second. Higher values \
+                      give peers more forgiveness for occasional slow responses.",
+        tuning_hint: "500 (default) matches cardano-node. Adjust in proportion to \
+                      BucketCapacity when tuning patience.",
+        reloadability: Reloadability::Restart,
+    },
+    SubParamDef {
+        key: "SnapshotMinIntervalBulkSync",
+        param_type: ParamType::F64 {
+            min: 0.0,
+            max: 86_400.0,
+        },
+        default: "1800.0",
+        description: "Minimum wall-clock seconds between epoch-boundary ledger snapshots \
+                      during Genesis bulk sync. Raising this reduces snapshot I/O \
+                      pressure during fast catch-up at the cost of a longer rollback \
+                      blast radius on unclean shutdown. Dugite-specific (not a \
+                      cardano-node key).",
+        tuning_hint: "1800 s (30 min, default) balances snapshot overhead against \
+                      restart recovery time. Lower to 300 s on fast NVMe hosts where \
+                      snapshot I/O is cheap.",
+        reloadability: Reloadability::Restart,
+    },
+];
+
 const STORAGE_FIELDS: &[SubParamDef] = &[
     SubParamDef {
         key: "profile",
@@ -503,9 +626,13 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
             values: &["RequiresNoMagic", "RequiresMagic"],
         },
         default: "RequiresMagic",
-        description: "Controls whether the network magic is enforced on peer handshakes. \
-                      Use 'RequiresMagic' for all non-mainnet deployments.",
-        tuning_hint: "Use 'RequiresMagic' for all testnets, 'RequiresNoMagic' for mainnet.",
+        description: "Accepted for cardano-node config-file compatibility; has NO runtime \
+                      effect in dugite (magic enforcement always uses the NetworkMagic field \
+                      directly). Use 'RequiresMagic' for testnets and 'RequiresNoMagic' \
+                      for mainnet to match the official config format.",
+        tuning_hint: "Use 'RequiresMagic' for all testnets, 'RequiresNoMagic' for mainnet. \
+                      This field is accepted but ignored by the dugite runtime — NetworkMagic \
+                      is the authoritative source for magic enforcement.",
         reloadability: Reloadability::Restart,
     },
     ParamDef {
@@ -547,14 +674,14 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
         section: "Network",
         param_type: ParamType::Bool,
         default: "false",
-        description: "Enable peer sharing mini-protocol. When true, this node \
-                      advertises known peers to requesting peers. Automatically \
-                      disabled for block producers (when KES/VRF keys are provided) \
-                      and enabled for relays when not set explicitly. Setting this \
-                      field overrides the automatic detection.",
-        tuning_hint: "Leave unset to use the automatic default (enabled for relays, \
-                      disabled for block producers). Only set explicitly if you need \
-                      to override the detection.",
+        description: "Enable peer sharing mini-protocol. The real default is automatic: \
+                      enabled for relays, disabled for block producers (when KES/VRF keys \
+                      are provided). The schema default of 'false' is only used for display \
+                      purposes; omitting this key from the config file gives the auto \
+                      behaviour. Setting it explicitly overrides auto-detection.",
+        tuning_hint: "Leave this key absent from the config file to use auto-detection \
+                      (enabled for relays, disabled for block producers). Only set explicitly \
+                      when you need to force a specific value regardless of node role.",
         reloadability: Reloadability::Restart,
     },
     ParamDef {
@@ -733,6 +860,18 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
                       Only relevant when ConsensusMode is GenesisMode.",
         reloadability: Reloadability::Restart,
     },
+    ParamDef {
+        key: "MaxN2cConnections",
+        section: "Network",
+        param_type: ParamType::U64 { min: 1, max: 1024 },
+        default: "16",
+        description: "Maximum concurrent N2C (Unix socket) connections. Prevents a local \
+                      attacker or misbehaving wallet from accumulating unbounded connections \
+                      in the N2C accept loop.",
+        tuning_hint: "16 (default) is sufficient for almost all operators. Raise only if \
+                      many local tools (wallet backends, CLI scripts) connect simultaneously.",
+        reloadability: Reloadability::Restart,
+    },
     // --- Genesis section ---------------------------------------------------
     ParamDef {
         key: "ByronGenesisFile",
@@ -835,6 +974,63 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
         tuning_hint: "Must exactly match the hash of the file at DijkstraGenesisFile.",
         reloadability: Reloadability::Restart,
     },
+    ParamDef {
+        key: "LowLevelGenesisOptions",
+        section: "Genesis",
+        param_type: ParamType::Object {
+            fields: LOW_LEVEL_GENESIS_OPTIONS_FIELDS,
+        },
+        default: "",
+        description: "Low-level Ouroboros Genesis tuning knobs (cardano-node \
+                      LowLevelGenesisOptions / GenesisConfigFlags). Only consulted \
+                      when ConsensusMode is 'Genesis'; in Praos mode all sub-fields \
+                      are ignored. Sub-fields: \
+                      'EnableCSJ' (bool, default true): ChainSync Jumping; \
+                      'EnableLoEAndGDD' (bool, default true): Limit on Eagerness + GDD; \
+                      'EnableLoP' (bool, default true): Limit on Patience leaky bucket; \
+                      'CSJJumpSize' (u64, default 4320): CSJ ahead-jump in slots; \
+                      'GDDRateLimit' (f64, default 1.0 s): GDD evaluation interval; \
+                      'BlockFetchGracePeriod' (f64, default 10.0 s): peer rotation timeout; \
+                      'BucketCapacity' (u64, default 100000): LoP bucket size in tokens; \
+                      'BucketRate' (u64, default 500): LoP refill rate (tokens/s); \
+                      'SnapshotMinIntervalBulkSync' (f64, default 1800.0 s): \
+                        minimum seconds between ledger snapshots during bulk sync (dugite-specific).",
+        tuning_hint: "Leave at defaults unless you are tuning Genesis sync performance. \
+                      The most impactful knob is SnapshotMinIntervalBulkSync: set to 300 s \
+                      on fast NVMe hosts to recover faster after unclean shutdown. \
+                      GDDRateLimit and BlockFetchGracePeriod control peer rotation \
+                      aggressiveness.",
+        reloadability: Reloadability::Restart,
+    },
+    ParamDef {
+        key: "CheckpointsFile",
+        section: "Genesis",
+        param_type: ParamType::Path,
+        default: "",
+        description: "Path to a lightweight-checkpoints JSON file \
+                      ({\"checkpoints\":[{\"blockNo\":N,\"hash\":hex},...]}). \
+                      Resolved relative to the config file's directory. When present, \
+                      the node enforces every listed checkpoint on header validation in \
+                      both Praos and Genesis consensus modes — a mismatch is fatal. \
+                      A hash mismatch with CheckpointsFileHash is also a fatal startup error.",
+        tuning_hint: "Leave empty unless you are using a known-good checkpoint list to \
+                      speed up or harden initial sync. A wrong checkpoint will prevent \
+                      the node from following the canonical chain.",
+        reloadability: Reloadability::Restart,
+    },
+    ParamDef {
+        key: "CheckpointsFileHash",
+        section: "Genesis",
+        param_type: ParamType::String,
+        default: "",
+        description: "Optional Blake2b-256 hex digest of the checkpoints file bytes. \
+                      If present, the node verifies this on startup and aborts if the \
+                      digest does not match — preventing accidental use of a corrupted \
+                      or wrong checkpoints file.",
+        tuning_hint: "Set alongside CheckpointsFile to get tamper-detection. Leave empty \
+                      when you do not want digest verification.",
+        reloadability: Reloadability::Restart,
+    },
     // --- Protocol section --------------------------------------------------
     ParamDef {
         key: "Protocol",
@@ -843,105 +1039,13 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
             values: &["Cardano", "TPraos", "Praos"],
         },
         default: "Cardano",
-        description: "Consensus protocol. 'Cardano' runs the full Hard Fork Combinator \
-                      covering all eras from Byron to Conway. 'TPraos' and 'Praos' are \
-                      single-era modes used only for isolated test networks.",
-        tuning_hint: "Always use 'Cardano' for mainnet and public testnets. \
-                      'TPraos'/'Praos' are for private devnet experiments only.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceBlockFetchClient",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit detailed block-fetch client trace events. Useful for \
-                      diagnosing slow block propagation but very verbose at high sync rates.",
-        tuning_hint: "Enable only for debugging slow block propagation. \
-                      Increases log volume significantly; disable in production.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceBlockFetchServer",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit detailed block-fetch server trace events (blocks served \
-                      to downstream peers).",
-        tuning_hint: "Enable only for debugging. Increases log volume significantly.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceChainSyncClient",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit chain-sync client trace events (header fetch from upstream).",
-        tuning_hint: "Enable only for debugging chain-sync issues. \
-                      Very verbose during initial sync; keep off in production.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceChainSyncHeaderServer",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit chain-sync header server trace events (headers served to \
-                      downstream peers).",
-        tuning_hint: "Enable only for debugging. Increases log volume significantly.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceChainSyncBlockServer",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit chain-sync block server trace events.",
-        tuning_hint: "Enable only for debugging. Increases log volume significantly.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceChainDb",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit ChainDB trace events (block storage, volatile/immutable flush, \
-                      rollback operations). Useful for diagnosing storage-layer issues.",
-        tuning_hint: "Enable to debug block storage problems or unexpected rollbacks. \
-                      Moderate log volume; safe to leave enabled in production if needed.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceChainSyncServer",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit chain-sync server trace events (both header and block serving \
-                      to downstream N2N peers).",
-        tuning_hint: "Enable only for debugging downstream sync issues. \
-                      Increases log volume significantly under heavy peer load.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceForge",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit block forging trace events (VRF leader check, block construction, \
-                      KES signing, block announcement). Essential for block producer debugging.",
-        tuning_hint: "Enable on block producers to diagnose missed slots or forging failures. \
-                      Low volume (one event per slot check); safe for production.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TraceMempool",
-        section: "Protocol",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Emit mempool trace events (transaction admission, rejection, removal \
-                      on block application, TTL expiry).",
-        tuning_hint: "Enable to debug transaction flow or mempool capacity issues. \
-                      Volume depends on transaction rate; moderate on mainnet.",
+        description: "Accepted for cardano-node config-file compatibility; has NO runtime \
+                      effect in dugite (dugite always runs the full Hard Fork Combinator \
+                      from Byron to Conway regardless of this value). Set to 'Cardano' \
+                      for mainnet/testnet compatibility with official node configs.",
+        tuning_hint: "Set to 'Cardano' to match official cardano-node configs. \
+                      This field is parsed but ignored by the dugite runtime — it exists \
+                      only to prevent JSON parse errors when loading official config files.",
         reloadability: Reloadability::Restart,
     },
     // --- Logging section ---------------------------------------------------
@@ -1000,76 +1104,29 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
         section: "Logging",
         param_type: ParamType::Bool,
         default: "true",
-        description: "Enable the EKG / Prometheus metrics endpoint. When true, metrics \
-                      are published on port 12798 and can be scraped by Prometheus.",
+        description: "Enable the Prometheus metrics endpoint. When true, metrics \
+                      are published on MetricsPort and can be scraped by Prometheus. \
+                      Setting to false suppresses the endpoint regardless of MetricsPort.",
         tuning_hint: "Keep enabled. Disabling removes Prometheus scraping capability \
                       and breaks monitoring dashboards.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "TurnOnScripting",
-        section: "Logging",
-        param_type: ParamType::Bool,
-        default: "false",
-        description: "Enable scripted log routing (cardano-node legacy logging system). \
-                      Not applicable to Dugite's tracing-subscriber backend.",
-        tuning_hint: "Leave disabled for Dugite. This setting is a legacy flag \
-                      that has no effect on Dugite's tracing-subscriber backend.",
         reloadability: Reloadability::Restart,
     },
     ParamDef {
         key: "MetricsPort",
         section: "Logging",
         param_type: ParamType::U64 { min: 0, max: 65535 },
-        default: "12798",
-        description: "TCP port for the Prometheus metrics endpoint. Set to 0 to disable \
-                      the metrics server entirely. The CLI flag --metrics-port takes \
-                      precedence over this config value; --no-metrics forces port to 0.",
-        tuning_hint: "12798 (default) matches cardano-node. Change only if the port \
-                      conflicts with another service. Set to 0 in hardened environments \
-                      where metrics scraping is not needed.",
+        default: "12796",
+        description: "TCP port for the Prometheus metrics endpoint. Dugite's default is \
+                      12796 (deliberately offset from cardano-node's 12798 so both can \
+                      run side-by-side without a port clash). Set to 0 to disable the \
+                      metrics server entirely. The CLI flag --metrics-port takes \
+                      precedence; --no-metrics forces port to 0.",
+        tuning_hint: "12796 is the dugite default (not 12798). Change only if the port \
+                      conflicts with another service or to match cardano-node's 12798 for \
+                      a unified Prometheus scrape config. Set to 0 in hardened environments.",
         reloadability: Reloadability::Restart,
     },
     // --- Advanced section --------------------------------------------------
-    ParamDef {
-        key: "MaxConcurrencyBulkSync",
-        section: "Advanced",
-        param_type: ParamType::U64 { min: 1, max: 64 },
-        default: "2",
-        description: "Maximum number of parallel block-fetch workers during bulk \
-                      (catch-up) sync. Higher values saturate bandwidth faster at the \
-                      cost of higher memory usage.",
-        tuning_hint: "4-8 on fast hardware/NVMe with ample RAM. \
-                      Lower to 2 if memory is constrained below 8 GB.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "MaxConcurrencyDeadline",
-        section: "Advanced",
-        param_type: ParamType::U64 { min: 1, max: 32 },
-        default: "4",
-        description: "Maximum number of parallel block-fetch workers when near the tip \
-                      (deadline mode). Lower than bulk to reduce latency jitter.",
-        tuning_hint: "Keep lower than MaxConcurrencyBulkSync. \
-                      2-4 is optimal; higher values add latency jitter near tip.",
-        reloadability: Reloadability::Restart,
-    },
-    ParamDef {
-        key: "SnapshotInterval",
-        section: "Advanced",
-        param_type: ParamType::U64 {
-            min: 0,
-            max: 86_400,
-        },
-        default: "72",
-        description: "Interval in minutes between ledger state snapshots. \
-                      Snapshots allow faster restart after an unclean shutdown. \
-                      0 disables periodic snapshotting (not recommended).",
-        tuning_hint: "72 minutes (default) matches the Haskell node. \
-                      Never set to 0 in production — recovery from an unclean \
-                      shutdown will require a full replay from genesis.",
-        reloadability: Reloadability::Restart,
-    },
     ParamDef {
         key: "ExperimentalHardForksEnabled",
         section: "Advanced",
@@ -1112,30 +1169,6 @@ pub static KNOWN_PARAMS: &[ParamDef] = &[
                       unresponsive peers. Default 900 s (15 minutes) matches cardano-node.",
         tuning_hint: "Keep below 15 minutes to shed unresponsive peers during catch-up. \
                       Lower values improve sync speed at the cost of more connection churn.",
-        reloadability: Reloadability::Hot,
-    },
-    ParamDef {
-        key: "StallDemotionCycles",
-        section: "Advanced",
-        param_type: ParamType::U64 { min: 1, max: 100 },
-        default: "6",
-        description: "Number of consecutive governor evaluation cycles (each ~30 s) in \
-                      which a hot peer must serve zero new blocks before it is demoted \
-                      back to warm. Default of 6 cycles = 3 minutes of inactivity.",
-        tuning_hint: "Increase if hot peers legitimately produce zero blocks for extended \
-                      periods (e.g., low-stake pools). Decrease for aggressive stall detection.",
-        reloadability: Reloadability::Hot,
-    },
-    ParamDef {
-        key: "ErrorDemotionThreshold",
-        section: "Advanced",
-        param_type: ParamType::U64 { min: 1, max: 100 },
-        default: "5",
-        description: "Failure count threshold above which a hot peer is unconditionally \
-                      demoted to warm during each governor evaluation cycle. Local root \
-                      peers are exempt from this check.",
-        tuning_hint: "Lower to aggressively shed failing peers. Raise if peers are being \
-                      demoted too frequently due to transient network issues.",
         reloadability: Reloadability::Hot,
     },
     ParamDef {
@@ -1439,32 +1472,18 @@ pub fn network_defaults(network: Network) -> serde_json::Map<String, serde_json:
 
     // Protocol.
     map.insert("Protocol".into(), json!("Cardano"));
-    map.insert("TraceBlockFetchClient".into(), json!(false));
-    map.insert("TraceBlockFetchServer".into(), json!(false));
-    map.insert("TraceChainSyncClient".into(), json!(false));
-    map.insert("TraceChainSyncHeaderServer".into(), json!(false));
-    map.insert("TraceChainSyncBlockServer".into(), json!(false));
-    map.insert("TraceChainDb".into(), json!(false));
-    map.insert("TraceChainSyncServer".into(), json!(false));
-    map.insert("TraceForge".into(), json!(false));
-    map.insert("TraceMempool".into(), json!(false));
 
     // Logging.
     map.insert("MinSeverity".into(), json!("Info"));
     // LogDirective is optional — omit from defaults so SIGHUP is a no-op unless set.
     map.insert("TurnOnLogMetrics".into(), json!(true));
-    map.insert("TurnOnScripting".into(), json!(false));
-    map.insert("MetricsPort".into(), json!(12798));
+    // MetricsPort: dugite default is 12796 (offset from cardano-node's 12798 to avoid clash).
+    map.insert("MetricsPort".into(), json!(12796));
 
     // Advanced.
-    map.insert("MaxConcurrencyBulkSync".into(), json!(2));
-    map.insert("MaxConcurrencyDeadline".into(), json!(4));
-    map.insert("SnapshotInterval".into(), json!(72));
     map.insert("ExperimentalHardForksEnabled".into(), json!(false));
     map.insert("ChurnIntervalNormalSecs".into(), json!(3300));
     map.insert("ChurnIntervalSyncSecs".into(), json!(900));
-    map.insert("StallDemotionCycles".into(), json!(6));
-    map.insert("ErrorDemotionThreshold".into(), json!(5));
 
     // Connection management (fractional seconds, matching Haskell DiffTime).
     map.insert("ProtocolIdleTimeout".into(), json!(5));
@@ -1579,11 +1598,11 @@ mod tests {
 
         // U64 default parses to JSON number.
         let v = lookup
-            .get("MaxConcurrencyBulkSync")
+            .get("TargetNumberOfActivePeers")
             .unwrap()
             .default_as_json()
             .unwrap();
-        assert_eq!(v, Value::Number(2.into()));
+        assert_eq!(v, Value::Number(20.into()));
 
         // String default parses to JSON string (even when empty).
         let v = lookup
@@ -1949,11 +1968,16 @@ mod tests {
 
     #[test]
     fn test_known_params_count() {
-        // We expect at least 45 known parameters (audit baseline: 43 before
-        // this change; +3 new: LogDirective, AcceptedConnectionsLimit, Storage).
+        // Baseline after config-wiring audit (2026-06-21):
+        //   removed 15 orphan/dead keys (9 Trace*, TurnOnScripting,
+        //   MaxConcurrencyBulkSync, MaxConcurrencyDeadline, SnapshotInterval,
+        //   StallDemotionCycles, ErrorDemotionThreshold)
+        //   added 4 wired keys (MaxN2cConnections, LowLevelGenesisOptions,
+        //   CheckpointsFile, CheckpointsFileHash)
+        // net: 62 - 15 + 4 = 51
         assert!(
-            KNOWN_PARAMS.len() >= 45,
-            "Expected >= 45 known params, got {}",
+            KNOWN_PARAMS.len() >= 48,
+            "Expected >= 48 known params, got {}",
             KNOWN_PARAMS.len()
         );
     }

--- a/crates/dugite-config/tests/config_coverage.rs
+++ b/crates/dugite-config/tests/config_coverage.rs
@@ -156,14 +156,6 @@ mod roundtrip {
             d.churn_interval_sync_secs, 900,
             "churn_interval_sync_secs default changed — update schema"
         );
-        assert_eq!(
-            d.stall_demotion_cycles, 6,
-            "stall_demotion_cycles default changed — update schema"
-        );
-        assert_eq!(
-            d.error_demotion_threshold, 5,
-            "error_demotion_threshold default changed — update schema"
-        );
         assert!(
             d.log_directive.is_none(),
             "log_directive default changed — update schema"

--- a/crates/dugite-network/src/peer/governor.rs
+++ b/crates/dugite-network/src/peer/governor.rs
@@ -69,8 +69,19 @@ impl Default for PeerTargets {
 pub struct GovernorConfig {
     /// Peer count targets.
     pub targets: PeerTargets,
-    /// Minimum interval between hot churn rotations (demote worst hot, promote best warm).
+    /// Minimum interval between hot churn rotations (demote worst hot, promote
+    /// best warm) while the node is caught up — the *deadline* churn cadence.
+    ///
+    /// Maps to Haskell `defaultDeadlineChurnInterval = 3300 s` (55 min). Used
+    /// whenever the governor is not in bulk-sync mode (see [`Governor::set_bulk_sync_mode`]).
     pub hot_churn_interval: Duration,
+    /// Minimum interval between hot churn rotations while the node is bulk
+    /// syncing (behind the network tip) — the faster *bulk-sync* churn cadence
+    /// that sheds slow peers quickly during catch-up.
+    ///
+    /// Maps to Haskell `defaultBulkChurnInterval = 900 s` (15 min). Selected
+    /// over [`hot_churn_interval`] only while [`Governor::bulk_sync_mode`] is set.
+    pub bulk_sync_churn_interval: Duration,
     /// Minimum interval between cold churn sweeps (forget lowest-reputation cold peers).
     pub cold_churn_interval: Duration,
     /// Minimum interval between warm churn rotations (demote worst warm, promote best cold).
@@ -97,7 +108,8 @@ impl Default for GovernorConfig {
             // determinism; #703 fix B adds jitter via inbound maturation.
             // Previously this was 600 s — 5.5× more aggressive than Haskell,
             // contributing to the demote-promote-demote loop in #703.
-            hot_churn_interval: Duration::from_secs(3300), // 55 minutes (Haskell default)
+            hot_churn_interval: Duration::from_secs(3300), // 55 minutes (Haskell deadline default)
+            bulk_sync_churn_interval: Duration::from_secs(900), // 15 minutes (Haskell bulk-sync default)
             cold_churn_interval: Duration::from_secs(900),
             warm_churn_interval: Duration::from_secs(600),
             // 5 minutes — matches Haskell's `policyPeerShareActivationDelay`.
@@ -185,6 +197,12 @@ pub struct Governor {
     /// the Cold→Warm reconnect path that the `#516` single-use-channel
     /// workaround forces.
     recently_demoted: HashMap<SocketAddr, Instant>,
+    /// When `true`, hot churn uses [`GovernorConfig::bulk_sync_churn_interval`]
+    /// (faster) instead of [`GovernorConfig::hot_churn_interval`]. Set by the
+    /// node from its at-tip signal: bulk-syncing (behind tip) → `true`,
+    /// caught-up → `false`. Mirrors the Haskell `FetchMode` BulkSync/Deadline
+    /// churn-cadence split.
+    bulk_sync_mode: bool,
 }
 
 impl Governor {
@@ -199,6 +217,7 @@ impl Governor {
             in_progress_promote_cold: HashSet::new(),
             in_progress_promote_warm: HashSet::new(),
             recently_demoted: HashMap::new(),
+            bulk_sync_mode: false,
         }
     }
 
@@ -238,6 +257,34 @@ impl Governor {
     /// retroactive effect on in-flight promotions.
     pub fn update_targets(&mut self, new_targets: PeerTargets) {
         self.config.targets = new_targets;
+    }
+
+    /// Update the hot-churn cadences from a live config reload (SIGHUP).
+    ///
+    /// `deadline` is the caught-up cadence (`ChurnIntervalNormalSecs`,
+    /// Haskell `defaultDeadlineChurnInterval`); `bulk_sync` is the catch-up
+    /// cadence (`ChurnIntervalSyncSecs`, Haskell `defaultBulkChurnInterval`).
+    /// Takes effect on the next churn evaluation; in-flight timers are not reset.
+    pub fn update_churn_intervals(&mut self, deadline: Duration, bulk_sync: Duration) {
+        self.config.hot_churn_interval = deadline;
+        self.config.bulk_sync_churn_interval = bulk_sync;
+    }
+
+    /// Switch the hot-churn cadence between bulk-sync (catch-up) and deadline
+    /// (caught-up). The node drives this from its at-tip signal so that, while
+    /// catching up, slow hot peers are rotated out faster — matching the
+    /// Haskell `FetchMode` BulkSync/Deadline churn split.
+    pub fn set_bulk_sync_mode(&mut self, on: bool) {
+        self.bulk_sync_mode = on;
+    }
+
+    /// The hot-churn interval currently in effect (bulk-sync vs deadline).
+    fn effective_hot_churn_interval(&self) -> Duration {
+        if self.bulk_sync_mode {
+            self.config.bulk_sync_churn_interval
+        } else {
+            self.config.hot_churn_interval
+        }
     }
 
     /// Signal that a cold→warm promotion has completed (succeeded or failed).
@@ -735,7 +782,9 @@ impl Governor {
         // ── Hot churn ───────────────────────────────────────────────────
         // Periodically rotate one hot peer to keep the active set fresh.
         // Uses scoring to demote the worst hot peer and promote the best warm.
-        if self.last_hot_churn.elapsed() >= self.config.hot_churn_interval && hot_count > 1 {
+        // The cadence is faster while bulk-syncing (catch-up) than when caught
+        // up, mirroring Haskell's BulkSync vs Deadline churn intervals.
+        if self.last_hot_churn.elapsed() >= self.effective_hot_churn_interval() && hot_count > 1 {
             if let Some(churn_out) = select_worst_hot(peer_manager) {
                 actions.push(GovernorAction::DemoteToWarm(churn_out));
                 self.record_demote(churn_out, now);
@@ -834,6 +883,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -874,6 +924,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -911,6 +962,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -923,6 +975,38 @@ mod tests {
             .filter(|a| matches!(a, GovernorAction::PromoteToHot(_)))
             .count();
         assert_eq!(promote_hot_count, 3);
+    }
+
+    /// Bulk-sync mode must select the faster bulk churn cadence; deadline mode
+    /// the slower one. SIGHUP `update_churn_intervals` must update both.
+    /// Mirrors Haskell's `defaultBulkChurnInterval` / `defaultDeadlineChurnInterval`.
+    #[test]
+    fn bulk_sync_mode_selects_bulk_churn_interval() {
+        let config = GovernorConfig {
+            hot_churn_interval: Duration::from_secs(3300),
+            bulk_sync_churn_interval: Duration::from_secs(900),
+            ..Default::default()
+        };
+        let mut gov = Governor::new(config);
+        // Default = caught-up → deadline cadence.
+        assert_eq!(
+            gov.effective_hot_churn_interval(),
+            Duration::from_secs(3300)
+        );
+        // Bulk-syncing → faster cadence.
+        gov.set_bulk_sync_mode(true);
+        assert_eq!(gov.effective_hot_churn_interval(), Duration::from_secs(900));
+        // Back to caught-up.
+        gov.set_bulk_sync_mode(false);
+        assert_eq!(
+            gov.effective_hot_churn_interval(),
+            Duration::from_secs(3300)
+        );
+        // SIGHUP reload updates both cadences.
+        gov.update_churn_intervals(Duration::from_secs(100), Duration::from_secs(50));
+        assert_eq!(gov.effective_hot_churn_interval(), Duration::from_secs(100));
+        gov.set_bulk_sync_mode(true);
+        assert_eq!(gov.effective_hot_churn_interval(), Duration::from_secs(50));
     }
 
     /// #703 fix C: production defaults must match Haskell
@@ -963,6 +1047,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -989,6 +1074,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1026,6 +1112,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             // Trigger cold churn immediately.
             cold_churn_interval: Duration::ZERO,
             warm_churn_interval: Duration::from_secs(3600),
@@ -1075,6 +1162,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             // Trigger warm churn immediately.
             warm_churn_interval: Duration::ZERO,
@@ -1114,6 +1202,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::ZERO,
             demote_cooldown: Duration::from_secs(3600),
@@ -1148,6 +1237,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1180,6 +1270,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1224,6 +1315,7 @@ mod tests {
             },
             // Trigger hot churn immediately.
             hot_churn_interval: Duration::ZERO,
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1277,6 +1369,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1321,6 +1414,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1360,6 +1454,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::ZERO,
             demote_cooldown: Duration::from_secs(3600),
@@ -1419,6 +1514,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1473,6 +1569,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1534,6 +1631,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1587,6 +1685,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1657,6 +1756,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1741,6 +1841,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1797,6 +1898,7 @@ mod tests {
                 target_hot_big_ledger: 0,
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1851,6 +1953,7 @@ mod tests {
                 target_hot_big_ledger: 2,
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1900,6 +2003,7 @@ mod tests {
                 target_hot_big_ledger: 5,
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -1994,6 +2098,7 @@ mod tests {
             },
             // Long intervals so timer-gated churn doesn't fire mid-test.
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -2060,6 +2165,7 @@ mod tests {
                 target_hot_big_ledger: 5,
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             // Cooldown is what stops the flap.
@@ -2180,6 +2286,7 @@ mod tests {
                 target_hot_big_ledger: 5,
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -2245,6 +2352,7 @@ mod tests {
                 target_hot_big_ledger: 0,
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(300),
@@ -2343,6 +2451,7 @@ mod tests {
             },
             // Long enough that timer-gated churn never fires in this test.
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(300),
@@ -2427,6 +2536,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -2479,6 +2589,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -2532,6 +2643,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),

--- a/crates/dugite-node/src/config.rs
+++ b/crates/dugite-node/src/config.rs
@@ -587,9 +587,8 @@ pub struct NodeConfig {
     /// `connectionRateLimit`.  Prevents a single source IP from exhausting all
     /// inbound connection slots with stalled half-open connections.
     ///
-    /// Note: this config field was previously defined in `ConnectionManagerConfig`
-    /// in `dugite-network` but was never wired into the accept loop.  This is the
-    /// authoritative config field going forward.
+    /// Wired into the N2N accept loop as the per-IP concurrent-connection limit
+    /// (the `ConnectionManager` `per_ip_rate_limit`).
     #[serde(default = "default_per_ip_rate_limit_n2n")]
     pub per_ip_rate_limit_n2n: usize,
 

--- a/crates/dugite-node/src/config.rs
+++ b/crates/dugite-node/src/config.rs
@@ -493,20 +493,6 @@ pub struct NodeConfig {
     #[serde(default = "default_churn_interval_sync_secs")]
     pub churn_interval_sync_secs: u64,
 
-    /// Number of consecutive governor evaluation cycles in which a hot peer
-    /// must serve zero new blocks before it is demoted back to warm (stall
-    /// detection).  A cycle runs every 30 seconds, so the default of 6 cycles
-    /// corresponds to a 3-minute stall window.
-    #[serde(default = "default_stall_demotion_cycles")]
-    pub stall_demotion_cycles: u32,
-
-    /// Failure count threshold above which a hot peer is unconditionally
-    /// demoted to warm during each governor evaluation cycle.  Local root
-    /// peers are exempt from this check and will never be demoted by the
-    /// governor.  Default: 5 failures.
-    #[serde(default = "default_error_demotion_threshold")]
-    pub error_demotion_threshold: u32,
-
     /// Enable experimental hard fork transitions (default: false).
     ///
     /// When true, the node signals `ProtVer 11 0` in forged block headers,
@@ -737,14 +723,6 @@ fn default_churn_interval_normal_secs() -> u64 {
 
 fn default_churn_interval_sync_secs() -> u64 {
     900 // 15 minutes, matching cardano-node
-}
-
-fn default_stall_demotion_cycles() -> u32 {
-    6 // 6 × 30 s = 3 minutes of inactivity triggers demotion
-}
-
-fn default_error_demotion_threshold() -> u32 {
-    5 // 5 accumulated failures triggers demotion
 }
 
 fn default_hard_limit() -> u32 {
@@ -1144,8 +1122,6 @@ impl Default for NodeConfig {
             rpc: None,
             churn_interval_normal_secs: default_churn_interval_normal_secs(),
             churn_interval_sync_secs: default_churn_interval_sync_secs(),
-            stall_demotion_cycles: default_stall_demotion_cycles(),
-            error_demotion_threshold: default_error_demotion_threshold(),
             experimental_hard_forks_enabled: false,
             consensus_mode: ConsensusMode::default(),
             low_level_genesis_options: None,

--- a/crates/dugite-node/src/config.rs
+++ b/crates/dugite-node/src/config.rs
@@ -449,9 +449,21 @@ pub struct NodeConfig {
     /// `--metrics-port` takes precedence over this field; the CLI flag
     /// `--no-metrics` forces the port to 0 regardless of this value.
     /// If neither the CLI flag nor this field is present the node falls back
-    /// to 12798, matching cardano-node's default.
+    /// to 12796 (deliberately offset from cardano-node's 12798 so a dugite
+    /// node can run alongside a cardano-node without a Prometheus port clash).
     #[serde(default)]
     pub metrics_port: Option<u16>,
+
+    /// Master switch for the Prometheus metrics endpoint, matching
+    /// cardano-node's `TurnOnLogMetrics`.
+    ///
+    /// When `false`, the metrics server is not started regardless of
+    /// `MetricsPort` — equivalent to setting the port to 0. An explicit
+    /// `--metrics-port` CLI flag still wins (operator override), but the
+    /// config-file `MetricsPort` does not re-enable a server disabled here.
+    /// Defaults to `true` so existing configs keep metrics on.
+    #[serde(default = "default_turn_on_log_metrics")]
+    pub turn_on_log_metrics: bool,
 
     /// Storage configuration (optional overrides for storage profiles)
     #[serde(default)]
@@ -792,6 +804,12 @@ fn default_min_severity() -> String {
     "Info".to_string()
 }
 
+/// Metrics are enabled by default (matches the prior behaviour where the
+/// endpoint was gated only by the port).
+fn default_turn_on_log_metrics() -> bool {
+    true
+}
+
 fn default_requires_network_magic() -> String {
     "RequiresMagic".to_string()
 }
@@ -1121,6 +1139,7 @@ impl Default for NodeConfig {
             min_severity: "Info".to_string(),
             log_directive: None,
             metrics_port: None,
+            turn_on_log_metrics: default_turn_on_log_metrics(),
             storage: None,
             rpc: None,
             churn_interval_normal_secs: default_churn_interval_normal_secs(),

--- a/crates/dugite-node/src/config.rs
+++ b/crates/dugite-node/src/config.rs
@@ -393,7 +393,13 @@ pub struct NodeConfig {
     #[serde(default)]
     pub peer_sharing: Option<bool>,
 
-    /// Target number of root peers (default: 60, matching cardano-node)
+    /// Target number of root peers (default: 60, matching cardano-node).
+    ///
+    /// Validated at startup and exported as a Prometheus gauge. Note: dugite's
+    /// governor maintains root-peer connectivity via per-local-root-group
+    /// warm/hot valency (`LocalRootGroupTarget`) rather than this aggregate
+    /// target, so changing it affects validation/metrics, not the per-group
+    /// connection policy.
     #[serde(default = "default_root_peers")]
     pub target_number_of_root_peers: usize,
 
@@ -417,7 +423,12 @@ pub struct NodeConfig {
     #[serde(default = "default_established_big_ledger_peers")]
     pub target_number_of_established_big_ledger_peers: usize,
 
-    /// Target number of known big ledger peers (default: 15, matching cardano-node)
+    /// Target number of known big ledger peers (default: 15, matching cardano-node).
+    ///
+    /// Validated at startup and exported as a Prometheus gauge. Note: dugite
+    /// caps the known peer set as a whole via `target_number_of_known_peers`
+    /// (`max_cold`) and does not enforce a separate known-big-ledger-peer cap —
+    /// BLPs are scarce and selectively forgetting them would harm Genesis sync.
     #[serde(default = "default_known_big_ledger_peers")]
     pub target_number_of_known_big_ledger_peers: usize,
 
@@ -557,25 +568,32 @@ pub struct NodeConfig {
     /// Inbound connection limits (hard/soft/delay).
     #[serde(default)]
     pub accepted_connections_limit: Option<AcceptedConnectionsLimit>,
-    /// Time before idle mini-protocol connection is pruned (seconds, default: 5).
+    /// Idle mini-protocol prune timeout (seconds).
     ///
-    /// Accepts fractional seconds, matching Haskell's `DiffTime` type.
+    /// Accepted for cardano-node config-file compatibility but NOT currently
+    /// enforced: dugite prunes idle connections via the connection manager's
+    /// own tuned `INBOUND_IDLE_TIMEOUT` (300 s), and mini-protocol lifetimes
+    /// are governed by the per-protocol drivers. Reserved for a future release.
     #[serde(default = "default_protocol_idle_timeout")]
     pub protocol_idle_timeout: f64,
-    /// Connection TIME_WAIT duration after close (seconds, default: 60).
+    /// Connection TIME_WAIT duration after close (seconds).
     ///
-    /// Accepts fractional seconds, matching Haskell's `DiffTime` type.
+    /// Accepted for cardano-node config-file compatibility but NOT currently
+    /// enforced (dugite relies on the OS TCP TIME_WAIT). Reserved.
     #[serde(default = "default_time_wait_timeout")]
     pub time_wait_timeout: f64,
-    /// Outbound governor poll interval (seconds, default: 0).
+    /// Outbound governor poll interval (seconds).
     ///
-    /// 0 means the governor runs as fast as events arrive (Haskell default).
-    /// Accepts fractional seconds, matching Haskell's `DiffTime` type.
+    /// Accepted for cardano-node config-file compatibility but NOT currently
+    /// enforced: the governor runs on a fixed, tuned 2 s tick. Reserved.
     #[serde(default = "default_egress_poll_interval")]
     pub egress_poll_interval: f64,
-    /// ChainSync-specific idle timeout (seconds, 0 = no timeout).
+    /// ChainSync-specific idle timeout (seconds).
     ///
-    /// Accepts fractional seconds, matching Haskell's `DiffTime` type.
+    /// Accepted for cardano-node config-file compatibility but NOT currently
+    /// enforced: dugite uses a randomized timeout between Haskell's
+    /// `minChainSyncTimeout` / `maxChainSyncTimeout` bounds (a fixed override
+    /// would defeat that). Reserved for a future release.
     #[serde(default)]
     pub chain_sync_idle_timeout: Option<f64>,
 

--- a/crates/dugite-node/src/config_reload.rs
+++ b/crates/dugite-node/src/config_reload.rs
@@ -199,6 +199,7 @@ pub fn reload_partition(old: &NodeConfig, new: &NodeConfig) -> ReloadPlan {
     check_restart_required!(conway_genesis_hash);
     check_restart_required!(dijkstra_genesis_hash);
     check_restart_required!(metrics_port);
+    check_restart_required!(turn_on_log_metrics);
     check_restart_required!(diffusion_mode);
     check_restart_required!(experimental_hard_forks_enabled);
     check_restart_required!(consensus_mode);

--- a/crates/dugite-node/src/config_reload.rs
+++ b/crates/dugite-node/src/config_reload.rs
@@ -26,8 +26,6 @@
 //! | `log_directive` / `min_severity`             | Tracing filter (existing) |
 //! | `churn_interval_normal_secs`                 | Peer governor churn       |
 //! | `churn_interval_sync_secs`                   | Peer governor churn       |
-//! | `stall_demotion_cycles`                      | Peer governor stall       |
-//! | `error_demotion_threshold`                   | Peer governor errors      |
 //!
 //! # Restart-required fields
 //!
@@ -75,10 +73,6 @@ pub struct RuntimeConfig {
     pub churn_interval_normal_secs: u64,
     /// Governor churn interval during syncing (seconds).
     pub churn_interval_sync_secs: u64,
-    /// Consecutive zero-block cycles before a hot peer is demoted to warm.
-    pub stall_demotion_cycles: u32,
-    /// Accumulated failure threshold above which a hot peer is demoted.
-    pub error_demotion_threshold: u32,
 
     // ── Logging ─────────────────────────────────────────────────────────────
     /// Optional `tracing_subscriber::EnvFilter` directive, applied on SIGHUP.
@@ -101,8 +95,6 @@ impl RuntimeConfig {
             target_number_of_known_big_ledger_peers: cfg.target_number_of_known_big_ledger_peers,
             churn_interval_normal_secs: cfg.churn_interval_normal_secs,
             churn_interval_sync_secs: cfg.churn_interval_sync_secs,
-            stall_demotion_cycles: cfg.stall_demotion_cycles,
-            error_demotion_threshold: cfg.error_demotion_threshold,
             log_directive: cfg.log_directive.clone(),
             min_severity: cfg.min_severity.clone(),
         }
@@ -172,8 +164,6 @@ pub fn reload_partition(old: &NodeConfig, new: &NodeConfig) -> ReloadPlan {
     check_reloadable!(target_number_of_known_big_ledger_peers);
     check_reloadable!(churn_interval_normal_secs);
     check_reloadable!(churn_interval_sync_secs);
-    check_reloadable!(stall_demotion_cycles);
-    check_reloadable!(error_demotion_threshold);
     check_reloadable!(log_directive);
     check_reloadable!(min_severity);
 
@@ -331,28 +321,6 @@ mod tests {
     }
 
     #[test]
-    fn test_partition_stall_demotion_cycles_is_applied() {
-        let old = default_config();
-        let mut new = default_config();
-        new.stall_demotion_cycles = 10;
-
-        let plan = reload_partition(&old, &new);
-        assert!(plan.applied.contains(&"stall_demotion_cycles"));
-        assert!(plan.ignored.is_empty());
-    }
-
-    #[test]
-    fn test_partition_error_demotion_threshold_is_applied() {
-        let old = default_config();
-        let mut new = default_config();
-        new.error_demotion_threshold = 8;
-
-        let plan = reload_partition(&old, &new);
-        assert!(plan.applied.contains(&"error_demotion_threshold"));
-        assert!(plan.ignored.is_empty());
-    }
-
-    #[test]
     fn test_partition_log_directive_is_applied() {
         let old = default_config();
         let mut new = default_config();
@@ -505,11 +473,6 @@ mod tests {
             runtime.churn_interval_sync_secs,
             cfg.churn_interval_sync_secs
         );
-        assert_eq!(runtime.stall_demotion_cycles, cfg.stall_demotion_cycles);
-        assert_eq!(
-            runtime.error_demotion_threshold,
-            cfg.error_demotion_threshold
-        );
         assert_eq!(runtime.log_directive, cfg.log_directive);
         assert_eq!(runtime.min_severity, cfg.min_severity);
     }
@@ -533,8 +496,6 @@ mod tests {
             target_number_of_known_big_ledger_peers: 18,
             churn_interval_normal_secs: 1800,
             churn_interval_sync_secs: 600,
-            stall_demotion_cycles: 8,
-            error_demotion_threshold: 3,
             log_directive: Some("info,dugite_network=debug".to_string()),
             min_severity: "Debug".to_string(),
             ..NodeConfig::default()
@@ -575,11 +536,6 @@ mod tests {
         assert_eq!(
             restored.churn_interval_sync_secs,
             cfg.churn_interval_sync_secs
-        );
-        assert_eq!(restored.stall_demotion_cycles, cfg.stall_demotion_cycles);
-        assert_eq!(
-            restored.error_demotion_threshold,
-            cfg.error_demotion_threshold
         );
         assert_eq!(restored.log_directive, cfg.log_directive);
         assert_eq!(restored.min_severity, cfg.min_severity);

--- a/crates/dugite-node/src/logging.rs
+++ b/crates/dugite-node/src/logging.rs
@@ -322,6 +322,39 @@ fn build_filter(level: &str) -> EnvFilter {
     EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level))
 }
 
+/// Translate a cardano-node syslog-style `MinSeverity` value into the bare
+/// `tracing_subscriber::EnvFilter` level token it corresponds to.
+///
+/// cardano-node's `MinSeverity` vocabulary is the `iohk-monitoring` `Severity`
+/// enum — `Debug`/`Info`/`Notice`/`Warning`/`Error`/`Critical`/`Alert`/
+/// `Emergency`. `tracing` only has `trace`/`debug`/`info`/`warn`/`error`, so
+/// the finer syslog levels collapse: `Notice → info`, and
+/// `Critical`/`Alert`/`Emergency → error`.
+///
+/// **Why this exists:** `MinSeverity` values were previously handed verbatim to
+/// `EnvFilter`. Only `Debug`/`Info`/`Error` happen to coincide with EnvFilter
+/// level tokens; `Notice`/`Warning`/`Critical`/`Alert`/`Emergency` are *not*
+/// valid level tokens, so EnvFilter silently reinterpreted e.g. `"Warning"` as
+/// a per-target directive `Warning=trace` — the *opposite* of the operator's
+/// intent. This helper maps every `MinSeverity` value to a valid global level.
+///
+/// Values that are already valid `tracing` tokens (`trace`/`debug`/`info`/
+/// `warn`/`error`/`off`) pass through (case-insensitively). Anything
+/// unrecognised falls back to `info`. Operators needing per-target control
+/// (e.g. `dugite_network=debug`) should use `LogDirective`, which is passed to
+/// `EnvFilter` unchanged.
+pub fn min_severity_to_directive(value: &str) -> &'static str {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "trace" => "trace",
+        "debug" => "debug",
+        "info" | "notice" => "info",
+        "warn" | "warning" => "warn",
+        "error" | "critical" | "alert" | "emergency" => "error",
+        "off" => "off",
+        _ => "info",
+    }
+}
+
 /// Check if stdout is a terminal (for auto-detecting color support).
 fn atty_stdout() -> bool {
     std::io::IsTerminal::is_terminal(&std::io::stdout())
@@ -708,5 +741,47 @@ mod tests {
             err.to_string().contains("Invalid log directive"),
             "expected 'Invalid log directive' wrapper, got: {err}"
         );
+    }
+
+    /// Every cardano-node `MinSeverity` value must translate to a bare,
+    /// *global* EnvFilter level — never a per-target directive. Before the fix,
+    /// `Warning`/`Notice`/`Critical`/`Alert`/`Emergency` were silently parsed
+    /// by EnvFilter as a bogus target at TRACE level, inverting the operator's
+    /// intent. This asserts the translation collapses every syslog value to a
+    /// valid global level whose `max_level_hint` matches expectations.
+    #[test]
+    fn test_min_severity_to_directive_maps_all_syslog_values() {
+        use tracing::level_filters::LevelFilter;
+        // (MinSeverity input, expected translated token, expected global level)
+        let cases = [
+            ("Debug", "debug", LevelFilter::DEBUG),
+            ("Info", "info", LevelFilter::INFO),
+            ("Notice", "info", LevelFilter::INFO),
+            ("Warning", "warn", LevelFilter::WARN),
+            ("Error", "error", LevelFilter::ERROR),
+            ("Critical", "error", LevelFilter::ERROR),
+            ("Alert", "error", LevelFilter::ERROR),
+            ("Emergency", "error", LevelFilter::ERROR),
+            // Case-insensitivity + already-valid tracing tokens pass through.
+            ("warning", "warn", LevelFilter::WARN),
+            ("TRACE", "trace", LevelFilter::TRACE),
+            ("off", "off", LevelFilter::OFF),
+            // Unrecognised → safe default.
+            ("nonsense", "info", LevelFilter::INFO),
+        ];
+        for (input, expected_token, expected_level) in cases {
+            let token = min_severity_to_directive(input);
+            assert_eq!(token, expected_token, "translation of {input:?}");
+            // The translated token must parse as a *global* level: EnvFilter's
+            // max_level_hint equals the level, not TRACE-via-bogus-target.
+            let filter = EnvFilter::try_new(token)
+                .unwrap_or_else(|e| panic!("{input:?}→{token:?} must be valid EnvFilter: {e}"));
+            assert_eq!(
+                filter.max_level_hint(),
+                Some(expected_level),
+                "{input:?}→{token:?} should set global level {expected_level:?}, \
+                 not be reinterpreted as a per-target TRACE directive"
+            );
+        }
     }
 }

--- a/crates/dugite-node/src/main.rs
+++ b/crates/dugite-node/src/main.rs
@@ -1663,16 +1663,21 @@ async fn run_node(args: RunArgs, log_handle: Option<logging::LogHandle>) -> Resu
         }
     }
 
-    // Resolve effective metrics port using a three-level priority:
-    //   1. --no-metrics flag → 0 (disabled), takes highest precedence
-    //   2. --metrics-port <PORT> CLI arg → explicit operator override
-    //   3. MetricsPort field in config JSON → site-wide default from config file
-    //   4. Dugite default: 12796 (avoids collision with cardano-node's 12798)
+    // Resolve effective metrics port using priority (highest first):
+    //   1. --no-metrics flag → 0 (disabled)
+    //   2. --metrics-port <PORT> CLI arg → explicit operator override (wins
+    //      even over TurnOnLogMetrics=false)
+    //   3. TurnOnLogMetrics=false in config JSON → 0 (master off-switch,
+    //      matching cardano-node)
+    //   4. MetricsPort field in config JSON → site-wide default from config file
+    //   5. Dugite default: 12796 (avoids collision with cardano-node's 12798)
     const DEFAULT_METRICS_PORT: u16 = 12796;
     let effective_metrics_port: u16 = if args.no_metrics {
         0
     } else if let Some(cli_port) = args.metrics_port {
         cli_port
+    } else if !node_config.turn_on_log_metrics {
+        0
     } else {
         node_config.metrics_port.unwrap_or(DEFAULT_METRICS_PORT)
     };

--- a/crates/dugite-node/src/main.rs
+++ b/crates/dugite-node/src/main.rs
@@ -1632,6 +1632,37 @@ async fn run_node(args: RunArgs, log_handle: Option<logging::LogHandle>) -> Resu
 
     node_config.validate(&config_dir)?;
 
+    // Apply config-file log verbosity at startup.
+    //
+    // `logging::init` runs in `main()` *before* the config file is parsed, so
+    // the initial filter is seeded only from `--log-level`/`RUST_LOG` (default
+    // `info`). Without this step the config's `MinSeverity`/`LogDirective`
+    // would have no effect until a SIGHUP reload — an operator who sets
+    // `MinSeverity: Debug` in config.json and starts the node would silently
+    // get INFO. Now that the config is loaded, apply it via the live reload
+    // handle, matching cardano-node (where MinSeverity drives startup
+    // verbosity).
+    //
+    // Precedence (highest first): `RUST_LOG` env > explicit `--log-level` CLI >
+    // config `LogDirective` > config `MinSeverity`. An explicit CLI/env
+    // override is therefore never clobbered by the config file.
+    if let Some(handle) = log_handle.as_ref() {
+        let cli_or_env_override =
+            args.log.log_level.is_some() || std::env::var_os("RUST_LOG").is_some();
+        if !cli_or_env_override {
+            let directive = node_config.log_directive.clone().unwrap_or_else(|| {
+                logging::min_severity_to_directive(&node_config.min_severity).to_string()
+            });
+            match handle.reload(&directive) {
+                Ok(()) => info!(directive = %directive, "Applied config-file log verbosity at startup"),
+                Err(e) => tracing::warn!(
+                    directive = %directive,
+                    "Failed to apply config-file log verbosity: {e}"
+                ),
+            }
+        }
+    }
+
     // Resolve effective metrics port using a three-level priority:
     //   1. --no-metrics flag → 0 (disabled), takes highest precedence
     //   2. --metrics-port <PORT> CLI arg → explicit operator override

--- a/crates/dugite-node/src/main.rs
+++ b/crates/dugite-node/src/main.rs
@@ -1654,7 +1654,9 @@ async fn run_node(args: RunArgs, log_handle: Option<logging::LogHandle>) -> Resu
                 logging::min_severity_to_directive(&node_config.min_severity).to_string()
             });
             match handle.reload(&directive) {
-                Ok(()) => info!(directive = %directive, "Applied config-file log verbosity at startup"),
+                Ok(()) => {
+                    info!(directive = %directive, "Applied config-file log verbosity at startup")
+                }
                 Err(e) => tracing::warn!(
                     directive = %directive,
                     "Failed to apply config-file log verbosity: {e}"

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -5498,6 +5498,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),
@@ -5542,6 +5543,7 @@ mod tests {
                 ..Default::default()
             },
             hot_churn_interval: Duration::from_secs(3600),
+            bulk_sync_churn_interval: Duration::from_secs(3600),
             cold_churn_interval: Duration::from_secs(3600),
             warm_churn_interval: Duration::from_secs(3600),
             demote_cooldown: Duration::from_secs(3600),

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -3929,19 +3929,28 @@ impl Node {
 
                             // ── Step 4: apply hot-reloadable fields ───────────────
                             //
-                            // Log directive / min severity (preserves existing #473 behaviour)
+                            // Log directive / min severity (preserves existing #473 behaviour).
+                            //
+                            // `LogDirective` is full EnvFilter syntax and is applied verbatim.
+                            // `MinSeverity` is a cardano-node syslog severity and MUST be
+                            // translated to a valid tracing level — handing it raw to EnvFilter
+                            // silently mis-parses Notice/Warning/Critical/Alert/Emergency into a
+                            // bogus per-target TRACE directive.
                             if let Some(handle) = log_handle.as_ref() {
-                                let directive = new_config
-                                    .log_directive
-                                    .as_deref()
-                                    .unwrap_or(&new_config.min_severity);
-                                match handle.reload(directive) {
+                                let directive: String =
+                                    new_config.log_directive.clone().unwrap_or_else(|| {
+                                        crate::logging::min_severity_to_directive(
+                                            &new_config.min_severity,
+                                        )
+                                        .to_string()
+                                    });
+                                match handle.reload(&directive) {
                                     Ok(()) => info!(
-                                        directive,
+                                        directive = %directive,
                                         "config_reload: log directive applied"
                                     ),
                                     Err(e) => warn!(
-                                        directive,
+                                        directive = %directive,
                                         "config_reload: failed to apply log directive: {e}"
                                     ),
                                 }

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -4201,12 +4201,17 @@ impl Node {
             // Haskell `cardano-node` enforces limits in `Server.run` via
             // `ConnectionLimits` (maxAcceptedConnections + maxAcceptedConnectionsPerHost)
             // acquired before the TCP fd enters the handshake pipeline.
-            let n2n_max_inbound = self
-                .config
-                .accepted_connections_limit
-                .unwrap_or_default()
-                .hard_limit as usize;
-            let n2n_per_ip_limit: usize = 5; // matches Haskell maxAcceptedConnectionsPerHost default
+            let n2n_acl = self.config.accepted_connections_limit.unwrap_or_default();
+            let n2n_max_inbound = n2n_acl.hard_limit as usize;
+            // Graduated admission band: below soft_limit accept immediately;
+            // between soft and hard apply a delay ramping linearly to `delay`
+            // seconds. Matches Haskell AcceptedConnectionsLimit.
+            let n2n_soft_limit = (n2n_acl.soft_limit as usize).min(n2n_max_inbound);
+            let n2n_accept_delay = n2n_acl.delay.max(0.0);
+            // Per-IP concurrent-connection limit, now driven by the
+            // `PerIpRateLimitN2n` config field (default 5, matching Haskell
+            // maxAcceptedConnectionsPerHost) instead of a hardcoded constant.
+            let n2n_per_ip_limit: usize = self.config.per_ip_rate_limit_n2n;
 
             // The semaphore doubles as a backpressure signal: when all permits
             // are taken the accept() call still proceeds (we don't want to stop
@@ -4314,6 +4319,27 @@ impl Node {
                                             continue;
                                         }
                                     };
+
+                                    // Graduated admission delay (Haskell
+                                    // AcceptedConnectionsLimit / Ouroboros.Network.Server
+                                    // .RateLimiting): once the inbound count is in the
+                                    // [soft_limit, hard_limit) band, throttle the accept
+                                    // rate with a delay that ramps linearly from 0 (at soft)
+                                    // to `delay` seconds (at hard). hard_limit itself is
+                                    // still a hard cap (semaphore + ConnectionManager above).
+                                    if n2n_accept_delay > 0.0 && n2n_max_inbound > n2n_soft_limit {
+                                        let used = n2n_max_inbound
+                                            .saturating_sub(n2n_conn_semaphore.available_permits());
+                                        if used > n2n_soft_limit {
+                                            let frac = (used - n2n_soft_limit) as f64
+                                                / (n2n_max_inbound - n2n_soft_limit) as f64;
+                                            let delay_secs = n2n_accept_delay * frac.min(1.0);
+                                            tokio::time::sleep(
+                                                std::time::Duration::from_secs_f64(delay_secs),
+                                            )
+                                            .await;
+                                        }
+                                    }
 
                                     // A-007 (security audit 2026-05-19): downgrade to debug.
                                     // One INFO log per TCP SYN at 100 conn/s = ~50 KB/s of

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1108,26 +1108,6 @@ impl Node {
                 Vec::new()
             };
 
-        // Validate Byron genesis hash if configured (parity with
-        // Alonzo/Conway/Dijkstra, which already bail on mismatch). Previously
-        // the configured ByronGenesisHash silently overrode the computed file
-        // hash with no comparison, so pointing ByronGenesisFile at the wrong
-        // file went undetected.
-        if let Some(ref expected_hex) = args.config.byron_genesis_hash {
-            if let Ok(expected) = dugite_primitives::hash::Hash32::from_hex(expected_hex) {
-                if let Some(ref actual) = byron_genesis_file_hash {
-                    if *actual != expected {
-                        anyhow::bail!(
-                            "Byron genesis hash mismatch: expected {}, got {}",
-                            expected.to_hex(),
-                            actual.to_hex()
-                        );
-                    }
-                    debug!("Byron genesis hash validated: {}", expected.to_hex());
-                }
-            }
-        }
-
         // Open ChainDB with the security parameter k from Byron genesis.
         // Uses default epoch parameters (epoch 0, length 432000) since era_history
         // isn't built yet. The active chunk gets correctly named at the first
@@ -1161,24 +1141,6 @@ impl Node {
             } else {
                 (None, None)
             };
-
-        // Validate Shelley genesis hash if configured (parity with
-        // Alonzo/Conway/Dijkstra). Previously the configured ShelleyGenesisHash
-        // silently overrode the computed file hash with no comparison.
-        if let Some(ref expected_hex) = args.config.shelley_genesis_hash {
-            if let Ok(expected) = dugite_primitives::hash::Hash32::from_hex(expected_hex) {
-                if let Some(ref actual) = shelley_genesis_hash {
-                    if *actual != expected {
-                        anyhow::bail!(
-                            "Shelley genesis hash mismatch: expected {}, got {}",
-                            expected.to_hex(),
-                            actual.to_hex()
-                        );
-                    }
-                    debug!("Shelley genesis hash validated: {}", expected.to_hex());
-                }
-            }
-        }
 
         // Load Alonzo genesis if configured (with hash validation)
         let mut alonzo_genesis_file_hash: Option<dugite_primitives::hash::Hash32> = None;
@@ -5158,32 +5120,6 @@ impl Node {
                     // exactly like Haskell.
                     if let Some(ref lc) = self.connection_lifecycle {
                         lc.chainsel_dequeued();
-                    }
-                    // Genesis-block validation (wrong-network guard).
-                    //
-                    // When syncing from genesis (empty DB → genesis_validated is
-                    // false), the first block must match the configured
-                    // Byron/Shelley genesis hash. A mismatch means the peer is
-                    // serving a different chain — abort rather than build on it.
-                    // `validate_genesis_blocks` no-ops for non-genesis blocks, and
-                    // genesis_validated is already true when resuming from an
-                    // existing DB / Mithril snapshot, so this only bites a real
-                    // from-genesis mismatch. NetworkMagic guards at the handshake;
-                    // this is the in-band defence-in-depth that was previously
-                    // dead (only the unreachable process_forward_blocks called it).
-                    if !self.genesis_validated {
-                        if let Err(e) =
-                            self.validate_genesis_blocks(std::slice::from_ref(&fetched.block))
-                        {
-                            tracing::error!(
-                                peer = %fetched.peer,
-                                "GENESIS BLOCK MISMATCH — refusing to sync a chain that \
-                                 does not match the configured genesis. Verify you are \
-                                 connecting to the correct network. {e}"
-                            );
-                            return Err(e);
-                        }
-                        self.genesis_validated = true;
                     }
                     self.apply_fetched_block(fetched).await;
                     // Cross-block Phase-2 pooling flush: drain the deferred window

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2393,11 +2393,18 @@ impl Node {
             syncing_startup_threshold_secs,
             ..Default::default()
         };
+        // LoE/GDD master switch (LowLevelGenesisOptions.EnableLoEAndGDD,
+        // default true). Genesis mode normally runs LoE (Limit on Eagerness)
+        // + GDD (Genesis Density Disconnect); an operator may explicitly
+        // disable both via EnableLoEAndGDD=false, in which case chain
+        // selection is unconstrained by LoE and no density disconnects fire
+        // (CSJ / LoP / GSM state tracking remain active). Default-neutral.
+        let loe_gdd_enabled = genesis_enabled && genesis_params.options.enable_loe_and_gdd;
         // The LoE handed to chain selection. Initial value mirrors Haskell's
         // pre-setGetLoEFragment conservative default: in genesis mode an
         // empty fragment anchored at the current immutable tip (≤ k blocks
-        // of selection freedom); in praos mode Disabled (identity).
-        let initial_loe = if genesis_enabled {
+        // of selection freedom); in praos mode (or LoE/GDD disabled) Disabled.
+        let initial_loe = if loe_gdd_enabled {
             let db = chain_db
                 .try_read()
                 .expect("ChainDB lock available during startup");
@@ -2450,7 +2457,7 @@ impl Node {
                 .try_write()
                 .expect("ChainDB lock available during startup");
             db.set_loe_handle(loe_out.clone());
-            if genesis_enabled {
+            if loe_gdd_enabled {
                 // Haskell initial-chain-selection k-cap (LoE enabled): never
                 // boot onto a >k-deep selection rebuilt from the volatile WAL
                 // — it may contain an adversarial chain the LoE was deferring
@@ -4784,6 +4791,16 @@ impl Node {
 
         // ─── GSM (Genesis State Machine) ─────────────────────────────────
         let genesis_enabled = self.consensus_mode == "genesis";
+        // LoE/GDD master switch (LowLevelGenesisOptions.EnableLoEAndGDD,
+        // default true). Mirrors the construction-time gate so LoE enforcement
+        // and GDD disconnects are skipped when an operator disables them.
+        let loe_gdd_enabled = genesis_enabled
+            && self
+                .config
+                .low_level_genesis_options
+                .as_ref()
+                .map(|o| o.enable_loe_and_gdd)
+                .unwrap_or(true);
         if genesis_enabled {
             let gsm_state = self.gsm_snapshot_rx.borrow().state;
             info!(
@@ -5596,7 +5613,7 @@ impl Node {
                         Some(rx) => rx.recv().await,
                         None => std::future::pending().await,
                     }
-                } => {
+                }, if loe_gdd_enabled => {
                     warn!(%addr, "GDD: density too low — disconnecting peer");
                     self.metrics.record_gdd_disconnect();
                     let mut pm = peer_manager.write().await;
@@ -5658,7 +5675,7 @@ impl Node {
                             governor.update_targets(targets);
                         }
                     }
-                    if snap.loe_slot != last_seen_loe_slot {
+                    if loe_gdd_enabled && snap.loe_slot != last_seen_loe_slot {
                         last_seen_loe_slot = snap.loe_slot;
                         let handle = self.chain_sel_handle.clone();
                         if let Some(handle) = handle {

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -4892,6 +4892,12 @@ impl Node {
                     target_warm_big_ledger: cfg.target_number_of_established_big_ledger_peers,
                     target_hot_big_ledger: cfg.target_number_of_active_big_ledger_peers,
                 },
+                // ChurnIntervalNormalSecs → deadline churn, ChurnIntervalSyncSecs
+                // → bulk-sync churn (selected by the governor's bulk-sync mode,
+                // driven from the at-tip signal below). Defaults 3300/900 match
+                // Haskell's deadline/bulk churn intervals.
+                hot_churn_interval: Duration::from_secs(cfg.churn_interval_normal_secs),
+                bulk_sync_churn_interval: Duration::from_secs(cfg.churn_interval_sync_secs),
                 ..Default::default()
             }
         };
@@ -5199,6 +5205,13 @@ impl Node {
                             target_warm_big_ledger: rt.target_number_of_established_big_ledger_peers,
                             target_hot_big_ledger: rt.target_number_of_active_big_ledger_peers,
                         });
+                        // Apply reloaded churn cadences (ChurnIntervalNormalSecs
+                        // / ChurnIntervalSyncSecs) so SIGHUP genuinely changes
+                        // governor behaviour rather than only reporting success.
+                        governor.update_churn_intervals(
+                            Duration::from_secs(rt.churn_interval_normal_secs),
+                            Duration::from_secs(rt.churn_interval_sync_secs),
+                        );
                         debug!(
                             active = rt.target_number_of_active_peers,
                             established = rt.target_number_of_established_peers,
@@ -5232,6 +5245,15 @@ impl Node {
                             .connection_lifecycle
                             .as_ref()
                             .and_then(|lc| lc.get_active_fetch_peer());
+                        // Drive hot-churn cadence from the catch-up signal:
+                        // bulk-syncing (behind tip) churns faster
+                        // (ChurnIntervalSyncSecs); caught-up uses
+                        // ChurnIntervalNormalSecs. Mirrors Haskell's
+                        // BulkSync/Deadline churn split.
+                        let at_tip = self
+                            .volatile_wal_sync_at_tip
+                            .load(std::sync::atomic::Ordering::Relaxed);
+                        governor.set_bulk_sync_mode(!at_tip);
                         governor.compute_actions_with_blp(
                             &pm.inner,
                             &local_root_targets,

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1108,6 +1108,26 @@ impl Node {
                 Vec::new()
             };
 
+        // Validate Byron genesis hash if configured (parity with
+        // Alonzo/Conway/Dijkstra, which already bail on mismatch). Previously
+        // the configured ByronGenesisHash silently overrode the computed file
+        // hash with no comparison, so pointing ByronGenesisFile at the wrong
+        // file went undetected.
+        if let Some(ref expected_hex) = args.config.byron_genesis_hash {
+            if let Ok(expected) = dugite_primitives::hash::Hash32::from_hex(expected_hex) {
+                if let Some(ref actual) = byron_genesis_file_hash {
+                    if *actual != expected {
+                        anyhow::bail!(
+                            "Byron genesis hash mismatch: expected {}, got {}",
+                            expected.to_hex(),
+                            actual.to_hex()
+                        );
+                    }
+                    debug!("Byron genesis hash validated: {}", expected.to_hex());
+                }
+            }
+        }
+
         // Open ChainDB with the security parameter k from Byron genesis.
         // Uses default epoch parameters (epoch 0, length 432000) since era_history
         // isn't built yet. The active chunk gets correctly named at the first
@@ -1141,6 +1161,24 @@ impl Node {
             } else {
                 (None, None)
             };
+
+        // Validate Shelley genesis hash if configured (parity with
+        // Alonzo/Conway/Dijkstra). Previously the configured ShelleyGenesisHash
+        // silently overrode the computed file hash with no comparison.
+        if let Some(ref expected_hex) = args.config.shelley_genesis_hash {
+            if let Ok(expected) = dugite_primitives::hash::Hash32::from_hex(expected_hex) {
+                if let Some(ref actual) = shelley_genesis_hash {
+                    if *actual != expected {
+                        anyhow::bail!(
+                            "Shelley genesis hash mismatch: expected {}, got {}",
+                            expected.to_hex(),
+                            actual.to_hex()
+                        );
+                    }
+                    debug!("Shelley genesis hash validated: {}", expected.to_hex());
+                }
+            }
+        }
 
         // Load Alonzo genesis if configured (with hash validation)
         let mut alonzo_genesis_file_hash: Option<dugite_primitives::hash::Hash32> = None;
@@ -5077,6 +5115,32 @@ impl Node {
                     // exactly like Haskell.
                     if let Some(ref lc) = self.connection_lifecycle {
                         lc.chainsel_dequeued();
+                    }
+                    // Genesis-block validation (wrong-network guard).
+                    //
+                    // When syncing from genesis (empty DB → genesis_validated is
+                    // false), the first block must match the configured
+                    // Byron/Shelley genesis hash. A mismatch means the peer is
+                    // serving a different chain — abort rather than build on it.
+                    // `validate_genesis_blocks` no-ops for non-genesis blocks, and
+                    // genesis_validated is already true when resuming from an
+                    // existing DB / Mithril snapshot, so this only bites a real
+                    // from-genesis mismatch. NetworkMagic guards at the handshake;
+                    // this is the in-band defence-in-depth that was previously
+                    // dead (only the unreachable process_forward_blocks called it).
+                    if !self.genesis_validated {
+                        if let Err(e) =
+                            self.validate_genesis_blocks(std::slice::from_ref(&fetched.block))
+                        {
+                            tracing::error!(
+                                peer = %fetched.peer,
+                                "GENESIS BLOCK MISMATCH — refusing to sync a chain that \
+                                 does not match the configured genesis. Verify you are \
+                                 connecting to the correct network. {e}"
+                            );
+                            return Err(e);
+                        }
+                        self.genesis_validated = true;
                     }
                     self.apply_fetched_block(fetched).await;
                     // Cross-block Phase-2 pooling flush: drain the deferred window

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -110,7 +110,9 @@ pub fn validate_genesis_blocks(
 
 impl Node {
     /// Validate genesis blocks against expected hashes from the configuration.
-    #[allow(dead_code)] // retained for networking rewrite
+    ///
+    /// Called from the block-ingestion path on the first block of a
+    /// from-genesis sync (see `genesis_validated` in the run loop).
     pub(crate) fn validate_genesis_blocks(
         &self,
         blocks: &[dugite_primitives::block::Block],

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -110,9 +110,7 @@ pub fn validate_genesis_blocks(
 
 impl Node {
     /// Validate genesis blocks against expected hashes from the configuration.
-    ///
-    /// Called from the block-ingestion path on the first block of a
-    /// from-genesis sync (see `genesis_validated` in the run loop).
+    #[allow(dead_code)] // retained for networking rewrite
     pub(crate) fn validate_genesis_blocks(
         &self,
         blocks: &[dugite_primitives::block::Block],

--- a/crates/dugite-rpc/src/server.rs
+++ b/crates/dugite-rpc/src/server.rs
@@ -157,6 +157,13 @@ async fn run_server(
 
     let mut builder = TonicServer::builder();
 
+    // Apply the HTTP/2 max-concurrent-streams cap (0 = unlimited). Previously
+    // `MaxConcurrentStreams` flowed into RpcConfig but was never applied to the
+    // tonic server, so the limit was silently ignored.
+    if config.max_concurrent_streams > 0 {
+        builder = builder.max_concurrent_streams(Some(config.max_concurrent_streams));
+    }
+
     if let Some(identity) = tls_identity {
         builder = builder.tls_config(ServerTlsConfig::new().identity(identity))?;
     }

--- a/reports/devnet-validate/v2.0.12.json
+++ b/reports/devnet-validate/v2.0.12.json
@@ -1,0 +1,210 @@
+{
+  "schema_version": 1,
+  "timestamp": "2026-06-22T05:13:18Z",
+  "git_rev": "f20581844f11784b6a2aecb652c0483896005c13",
+  "release_tag": "v2.0.12",
+  "preset": "standard",
+  "cardano_node_version": "11.0.1",
+  "cardano_cli_version": "11.0.0.0",
+  "rounds": [
+    {
+      "name": "baseline",
+      "pass": true,
+      "evidence_dir": "evidence/20260622T044101Z",
+      "duration_seconds": 120,
+      "git_rev": "f20581844f11784b6a2aecb652c0483896005c13",
+      "cardano_node_version": "11.0.1",
+      "cardano_cli_version": "11.0.0.0",
+      "blocks": {
+        "total_forges": 71,
+        "canonical": 61,
+        "orphans": 10,
+        "orphan_rate": 0.1408
+      },
+      "tip_age": {
+        "avg_seconds": 1.48,
+        "p99_seconds": 4.0
+      },
+      "chain_density": 0.592,
+      "tx_zoo": {
+        "pass": 81,
+        "fail": 0,
+        "skip": 3,
+        "total": 84
+      },
+      "predicates": {
+        "p1_forge_cross_check": true,
+        "p2_per_bp_attribution": true,
+        "p3_tx_inclusion": null,
+        "p4_tip_parity": true,
+        "p5_tip_age": true
+      },
+      "log_errors": {
+        "dugite-bp": {"errors": 0, "warns": 2},
+        "dugite-relay": {"errors": 0, "warns": 37},
+        "cardano-bp": {"errors": 0, "warns": 0}
+      },
+      "anomalies": [],
+      "epoch_transitions_observed": 0,
+      "bidirectional_parity": {
+        "offdiag_rows": 0,
+        "scripts_tested": 19,
+        "pass": true
+      },
+      "n2n_adversarial": {
+        "pass": 0,
+        "fail": 0,
+        "panic": 0,
+        "silent_skip": 0
+      },
+      "cli_parity": {
+        "equal": 0,
+        "divergent": 0,
+        "skip": 0,
+        "error": 0
+      },
+      "cardano_bp_invalid_blocks": 0,
+      "health_probe": "HEALTHY",
+      "notes": "tx-zoo 81/84 PASS (3 SKIP: no-rewards, cli-dedupes-inputs, socat-not-found). bidirectional-parity: 0 OFFDIAG. health-probe HEALTHY both probes. analyze-evidence NO ANOMALIES."
+    },
+    {
+      "name": "epoch-boundary",
+      "pass": true,
+      "evidence_dir": "evidence/20260622T044742Z",
+      "duration_seconds": 900,
+      "git_rev": "f20581844f11784b6a2aecb652c0483896005c13",
+      "cardano_node_version": "11.0.1",
+      "cardano_cli_version": "11.0.0.0",
+      "blocks": {
+        "total_forges": 410,
+        "canonical": 393,
+        "orphans": 17,
+        "orphan_rate": 0.0415
+      },
+      "tip_age": {
+        "avg_seconds": 1.02,
+        "p99_seconds": 5.0
+      },
+      "chain_density": 0.507,
+      "tx_zoo": {
+        "pass": 0,
+        "fail": 0,
+        "skip": 0,
+        "total": 0
+      },
+      "predicates": {
+        "p1_forge_cross_check": true,
+        "p2_per_bp_attribution": true,
+        "p3_tx_inclusion": true,
+        "p4_tip_parity": true,
+        "p5_tip_age": true
+      },
+      "log_errors": {
+        "dugite-bp": {"errors": 0, "warns": 0},
+        "dugite-relay": {"errors": 0, "warns": 0},
+        "cardano-bp": {"errors": 0, "warns": 0}
+      },
+      "anomalies": [],
+      "epoch_transitions_observed": 2,
+      "pot_parity": {
+        "epoch": 2,
+        "dugite_treasury_lovelace": 3563997508658,
+        "dugite_reserves_lovelace": 5996430007854633,
+        "haskell_treasury_lovelace": 3563997508658,
+        "haskell_reserves_lovelace": 5996430007854633,
+        "byte_exact_match": true,
+        "rupd_applied": true
+      },
+      "n2n_adversarial": {
+        "pass": 0,
+        "fail": 0,
+        "panic": 0,
+        "silent_skip": 0
+      },
+      "cli_parity": {
+        "equal": 0,
+        "divergent": 0,
+        "skip": 0,
+        "error": 0
+      },
+      "cardano_bp_invalid_blocks": 0,
+      "health_probe": "HEALTHY",
+      "notes": "Boundaries 0->1 and 1->2 both crossed (epoch=2 at slot 824). treasury=3563997508658 reserves=5996430007854633 BYTE-EXACT vs Haskell. RUPD applied (treasury>0). 30 txs submitted, 23 accepted/7 rejected, all 3 nodes agree. chain density=0.507 (target 0.5). NO ANOMALIES."
+    },
+    {
+      "name": "restart",
+      "pass": true,
+      "evidence_dir": "evidence/20260622T050927Z",
+      "duration_seconds": 60,
+      "git_rev": "f20581844f11784b6a2aecb652c0483896005c13",
+      "cardano_node_version": "11.0.1",
+      "cardano_cli_version": "11.0.0.0",
+      "blocks": {
+        "total_forges": 26,
+        "canonical": 16,
+        "orphans": 10,
+        "orphan_rate": 0.3846
+      },
+      "tip_age": {
+        "avg_seconds": 1.08,
+        "p99_seconds": 3.0
+      },
+      "chain_density": 0.448,
+      "tx_zoo": {
+        "pass": 0,
+        "fail": 0,
+        "skip": 0,
+        "total": 0
+      },
+      "predicates": {
+        "p1_forge_cross_check": true,
+        "p2_per_bp_attribution": true,
+        "p3_tx_inclusion": null,
+        "p4_tip_parity": true,
+        "p5_tip_age": null
+      },
+      "log_errors": {
+        "dugite-bp": {"errors": 0, "warns": 5},
+        "dugite-relay": {"errors": 0, "warns": 3},
+        "cardano-bp": {"errors": 0, "warns": 0}
+      },
+      "anomalies": [],
+      "epoch_transitions_observed": 2,
+      "restart_resilience": {
+        "tip_before": 46,
+        "tip_after": 138,
+        "tip_advanced": true,
+        "tip_delta": 92,
+        "stale_intersection_warnings": 0,
+        "tip_age_seconds_post_restart": 0,
+        "health_probe_60s_post_restart": "HEALTHY"
+      },
+      "n2n_adversarial": {
+        "pass": 0,
+        "fail": 0,
+        "panic": 0,
+        "silent_skip": 0
+      },
+      "cli_parity": {
+        "equal": 0,
+        "divergent": 0,
+        "skip": 0,
+        "error": 0
+      },
+      "cardano_bp_invalid_blocks": 0,
+      "health_probe": "HEALTHY",
+      "notes": "TIP_BEFORE=46 TIP_AFTER=138 (advanced +92 blocks). tip_age_seconds=0 immediately after restart. 0 stale-intersection warnings. p1/p2/p4 PASS; p3/p5 SKIP (soak too short). Chain density=0.448 (within ±0.2 of 0.5). NO ANOMALIES."
+    }
+  ],
+  "summary": {
+    "pass": true,
+    "rounds_pass": 3,
+    "rounds_fail": 0,
+    "total_canonical_blocks": 470,
+    "total_tx_zoo_pass": 81,
+    "total_tx_zoo_fail": 0,
+    "invalid_forges_detected": 0,
+    "critical_anomalies": 0
+  },
+  "trend": null
+}


### PR DESCRIPTION
## Summary

Comprehensive audit of **dugite-node** ↔ **dugite-config** wiring (every config key cross-referenced: config.json → NodeConfig field → real runtime consumer → editor schema), with adversarial verification, then fixes for every confirmed problem. Motivated by `MinSeverity: Debug` having no effect at startup.

Version bump **2.0.11 → 2.0.12** (Helm chart 0.5.11 → 0.5.12).

## Fixes (10 commits)

- **Logging (headline bug):** config `MinSeverity`/`LogDirective` had **zero startup effect** — `logging::init` ran before the config was parsed; startup verbosity came only from `--log-level` (default info). Now applied at startup via the live reload handle (precedence `RUST_LOG` > `--log-level` > `LogDirective` > `MinSeverity`). Added `min_severity_to_directive` so syslog values (`Notice/Warning/Critical/Alert/Emergency`) map to valid tracing levels instead of silently mis-parsing into bogus per-target TRACE filters. Same translation applied on SIGHUP.
- **Metrics:** wired `TurnOnLogMetrics` (was an orphan schema key) as the metrics master-switch; corrected the metrics-port doc (node default is 12796).
- **Governor:** wired `ChurnIntervalNormalSecs`/`ChurnIntervalSyncSecs` into the governor (deadline vs bulk-sync churn, selected by at-tip state — per ouroboros-network's churn model); **removed** `StallDemotionCycles`/`ErrorDemotionThreshold` (no Haskell analogue — they were inert but reported "applied" on SIGHUP).
- **dugite-config schema:** removed 15 orphan/dead keys (the 9 flat `Trace*` keys, `TraceOptions`, `TurnOnScripting`, `MaxConcurrency*`, `SnapshotInterval`, stall/error); added 4 wired-but-uneditable keys (`LowLevelGenesisOptions` object, `CheckpointsFile`/`Hash`, `MaxN2cConnections`); fixed `MetricsPort`/`PeerSharing` defaults and `Protocol`/`RequiresNetworkMagic` (compat-only) descriptions. Cleaned the dead, self-contradictory trace block from `config/mainnet/config.json`.
- **RPC:** applied `Rpc.MaxConcurrentStreams` to the gRPC HTTP/2 server (was ignored).
- **N2N accept loop:** implemented the Haskell `AcceptedConnectionsLimit` graduated admission delay (soft/hard/delay band); wired `PerIpRateLimitN2n` (was a hardcoded 5).
- **Consensus:** `EnableLoEAndGDD` now actually gates LoE/GDD (was tied to genesis-mode only).
- **Docs:** the 4 deep-timing knobs (`ProtocolIdleTimeout`/`TimeWaitTimeout`/`EgressPollInterval`/`ChainSyncIdleTimeout`) and the aggregate root/known-BLP targets documented as compat/not-enforced rather than risk-wired into tuned timing.

## Reverted in this PR

- **Genesis-hash validation** (Byron/Shelley file + block check) was implemented then **fully reverted**: the Byron file-hash check compared the config's CBOR-method `ByronGenesisHash` against dugite's raw-JSON blake2b — always mismatched, crashing every node at startup. **devnet-validate Round 1 caught it.** Deferred to a follow-up using the canonical CBOR Byron hash + a from-genesis soak. Wrong-network is already guarded by NetworkMagic.

## Verification

- `just check`: clippy clean (`-D warnings`), **7128 tests pass**, fmt clean.
- Live preprod (Genesis-mode) soak: ~185k blocks, no divergence, clean shutdown.
- **devnet-validate standard: PASS 3/3** (baseline / epoch-boundary / restart). Pot-parity **byte-exact** vs cardano-node 11.0.1; 470 canonical blocks; **0 invalid blocks** on the Haskell side; tx-zoo 81/84 (0 fail); 0 bidirectional-parity OFFDIAG. Report: `reports/devnet-validate/v2.0.12.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)