### PR TITLE
fix(uplc): era-gate validity-range upper-bound closure in ScriptContext (#772)

### DIFF
--- a/crates/dugite-uplc/src/eval_redeemer.rs
+++ b/crates/dugite-uplc/src/eval_redeemer.rs
@@ -91,7 +91,7 @@ pub fn eval_resolved_redeemer(
     let term = program.term;
 
     // 2. Build the per-version ScriptContext as Data.
-    let ctx_data = build_script_context(tx, resolved, r, slot_config)?;
+    let ctx_data = build_script_context(tx, resolved, r, slot_config, major_pv)?;
 
     if std::env::var("DUGITE_DUMP_CTX").is_ok() {
         eprintln!(
@@ -478,7 +478,13 @@ fn build_script_context(
     resolved: &[(PrimTxIn, PrimTxOut, Vec<u8>)],
     r: &ResolvedRedeemer,
     slot_config: &SlotConfig,
+    major_pv: u32,
 ) -> Result<crate::data::Data, PhaseTwoError> {
+    // The validity-range upper-bound closure in the V1/V2 ScriptContext is
+    // era-gated (#772): Conway+ (PV ≥ 9) makes a finite upper bound exclusive
+    // (`strictUpperBound`), while Alonzo/Babbage keep a ttl-only finite upper
+    // bound inclusive (`PV1.to`). See `PosixTimeRange::to_data`.
+    let conway_or_later = major_pv >= 9;
     match r.language {
         ScriptLanguage::PlutusV1 => {
             let tx_info = populate_tx_info_v1(tx, resolved, slot_config)?;
@@ -486,7 +492,7 @@ fn build_script_context(
                 tx_info,
                 purpose: r.purpose.clone(),
             };
-            Ok(ctx.to_data())
+            Ok(ctx.to_data(conway_or_later))
         }
         ScriptLanguage::PlutusV2 => {
             let tx_info = populate_tx_info_v2(tx, resolved, slot_config)?;
@@ -494,7 +500,7 @@ fn build_script_context(
                 tx_info,
                 purpose: r.purpose.clone(),
             };
-            Ok(ctx.to_data())
+            Ok(ctx.to_data(conway_or_later))
         }
         ScriptLanguage::PlutusV3 => {
             let tx_info = populate_tx_info_v3(tx, resolved, slot_config)?;

--- a/crates/dugite-uplc/src/script_context.rs
+++ b/crates/dugite-uplc/src/script_context.rs
@@ -554,7 +554,7 @@ impl TxInInfo {
 }
 
 impl PosixTimeRange {
-    pub fn to_data(&self, v3_semantics: bool) -> Data {
+    pub fn to_data(&self, conway_or_later: bool) -> Data {
         // Plutus `Interval POSIXTime` is encoded as:
         //   Interval (LowerBound (Extended POSIXTime) Bool)
         //            (UpperBound (Extended POSIXTime) Bool)
@@ -611,12 +611,36 @@ impl PosixTimeRange {
             None => data_constr(2, vec![]), // PosInf = Constr 2 []
             Some(t) => data_constr(1, vec![data_i(t.into())]), // Finite t = Constr 1 [I(t)]
         };
+        // Finite upper-bound closure is ERA-GATED (NOT language-gated):
+        //
+        //   * Conway+ (`conway_or_later`): a finite upper bound is ALWAYS
+        //     exclusive (closure False). Conway's `transValidityInterval`
+        //     (`eras/conway/impl/Cardano.Ledger.Conway.TxInfo`) builds BOTH the
+        //     upper-only case and the both-bounds case with `strictUpperBound`.
+        //   * Alonzo/Babbage (pre-Conway): the upper-ONLY case uses `PV1.to`
+        //     (`eras/alonzo/impl/Cardano.Ledger.Alonzo.Plutus.TxInfo`), and
+        //     `PlutusLedgerApi.V1.Interval.to s = Interval (LowerBound NegInf True)
+        //     (upperBound s)` with `upperBound s = UpperBound (Finite s) True` —
+        //     i.e. INCLUSIVE. The both-bounds case still uses `strictUpperBound`
+        //     (exclusive). Conway deliberately unified these to exclusive.
+        //
+        // PosInf upper bound is always closed (True).
+        //
+        // #772: dugite previously gated this on LANGUAGE (V1/V2 ⇒ inclusive),
+        // emitting an inclusive upper bound for a V1/V2 script in the Conway era.
+        // That over-charged a validity-range-reading Reward redeemer by +1453 cpu
+        // vs cardano-node (empirically localised by a leaf-diff of dugite's vs
+        // cardano-ledger's constructed ScriptContext; the closure was the only
+        // differing leaf). The gate is the ERA, not the script language version.
         let upper_closed = match self.upper {
-            None => true, // PosInf upper bound is always closed (True)
-            // Finite upper: CLOSED (True) only for Alonzo/Babbage (V1/V2)
-            // with no lower bound (`PV1.to` path); OPEN (False) for V3
-            // (Conway `strictUpperBound`) and for any both-bounds interval.
-            Some(_) => !v3_semantics && self.lower.is_none(),
+            None => true,
+            Some(_) => {
+                if conway_or_later {
+                    false
+                } else {
+                    self.lower.is_none()
+                }
+            }
         };
         let upper_bound = data_constr(
             0,
@@ -899,7 +923,7 @@ impl ScriptContextV3 {
 }
 
 impl TxInfoV1 {
-    pub fn to_data(&self) -> Data {
+    pub fn to_data(&self, conway_or_later: bool) -> Data {
         // V1 TxInfo (Alonzo-era) field order — 10 fields, Constr 0:
         //   [inputs, outputs, fee, mint, dcert, wdrl, validRange,
         //    signatories, data, id]
@@ -932,9 +956,10 @@ impl TxInfoV1 {
                         })
                         .collect(),
                 ),
-                // txInfoValidRange (V1/Alonzo semantics: a ttl-only finite
-                // upper bound is CLOSED via `PV1.to`).
-                self.valid_range.to_data(false),
+                // txInfoValidRange — closure is ERA-gated (#772): pre-Conway
+                // ttl-only finite upper is CLOSED via `PV1.to`; Conway+ is OPEN
+                // via `strictUpperBound`. See `PosixTimeRange::to_data`.
+                self.valid_range.to_data(conway_or_later),
                 data_list(self.signatories.iter().map(data_bs28).collect()),
                 // V1 data :: [(DatumHash, Datum)] — AssocList, not Map.
                 // Encoded as List[Constr 0 [B32(hash), datum]].
@@ -952,13 +977,19 @@ impl TxInfoV1 {
 }
 
 impl ScriptContextV1 {
-    pub fn to_data(&self) -> Data {
-        data_constr(0, vec![self.tx_info.to_data(), self.purpose.to_data()])
+    pub fn to_data(&self, conway_or_later: bool) -> Data {
+        data_constr(
+            0,
+            vec![
+                self.tx_info.to_data(conway_or_later),
+                self.purpose.to_data(),
+            ],
+        )
     }
 }
 
 impl TxInfoV2 {
-    pub fn to_data(&self) -> Data {
+    pub fn to_data(&self, conway_or_later: bool) -> Data {
         // V2 TxInfo (Babbage-era) field order — 12 fields, Constr 0:
         //   [inputs, refInputs, outputs, fee, mint, dcert, wdrl,
         //    validRange, signatories, redeemers, data, id]
@@ -994,9 +1025,10 @@ impl TxInfoV2 {
                         .map(|(cred, amt)| (cred.to_data(), data_i(amt.clone())))
                         .collect(),
                 ),
-                // txInfoValidRange (V2/Babbage semantics: a ttl-only finite
-                // upper bound is CLOSED via `PV1.to`).
-                self.valid_range.to_data(false),
+                // txInfoValidRange — closure is ERA-gated (#772): pre-Conway
+                // ttl-only finite upper is CLOSED via `PV1.to`; Conway+ is OPEN
+                // via `strictUpperBound`. See `PosixTimeRange::to_data`.
+                self.valid_range.to_data(conway_or_later),
                 data_list(self.signatories.iter().map(data_bs28).collect()),
                 // V2 redeemers :: Map ScriptPurpose Redeemer — Data::Map.
                 data_map(
@@ -1020,8 +1052,14 @@ impl TxInfoV2 {
 }
 
 impl ScriptContextV2 {
-    pub fn to_data(&self) -> Data {
-        data_constr(0, vec![self.tx_info.to_data(), self.purpose.to_data()])
+    pub fn to_data(&self, conway_or_later: bool) -> Data {
+        data_constr(
+            0,
+            vec![
+                self.tx_info.to_data(conway_or_later),
+                self.purpose.to_data(),
+            ],
+        )
     }
 }
 
@@ -1742,7 +1780,7 @@ mod tests {
             data: vec![],
             txid: [0u8; 32],
         };
-        let d = info.to_data();
+        let d = info.to_data(false);
         let cbor = d.to_cbor().unwrap();
         let d2 = Data::from_cbor(&cbor).unwrap();
         assert_eq!(d, d2);
@@ -1767,7 +1805,7 @@ mod tests {
             data: vec![],
             txid: [0u8; 32],
         };
-        let d = info.to_data();
+        let d = info.to_data(false);
         let cbor = d.to_cbor().unwrap();
         let d2 = Data::from_cbor(&cbor).unwrap();
         assert_eq!(d, d2);
@@ -1814,8 +1852,8 @@ mod tests {
             },
             purpose: p,
         };
-        assert!(matches!(v1.to_data(), Data::Constr(0, _)));
-        assert!(matches!(v2.to_data(), Data::Constr(0, _)));
+        assert!(matches!(v1.to_data(false), Data::Constr(0, _)));
+        assert!(matches!(v2.to_data(false), Data::Constr(0, _)));
     }
 
     #[test]

--- a/crates/dugite-uplc/tests/phase2_script_context_regression.rs
+++ b/crates/dugite-uplc/tests/phase2_script_context_regression.rs
@@ -224,6 +224,41 @@ fn posix_time_range_finite_bounds_have_correct_structure() {
     );
 }
 
+/// #772 regression: a ttl-ONLY validity interval (`invalid_hereafter` set, no
+/// `invalid_before`) has an ERA-GATED upper-bound closure. Pre-Conway uses
+/// `PV1.to` (INCLUSIVE, closure True); Conway+ uses `strictUpperBound`
+/// (EXCLUSIVE, closure False). dugite previously gated this on the script
+/// LANGUAGE (always inclusive for V1/V2), over-charging a validity-range-reading
+/// Reward redeemer by +1453 cpu vs cardano-node in the Conway era.
+#[test]
+fn posix_time_range_ttl_only_upper_closure_is_era_gated() {
+    let r = PosixTimeRange {
+        lower: None,
+        upper: Some(1_781_858_645_000i64),
+    };
+    let upper_closure = |conway: bool| -> Data {
+        let Data::Constr(0, outer) = r.to_data(conway) else {
+            panic!("interval must be Constr 0");
+        };
+        let Data::Constr(0, ub) = outer[1].clone() else {
+            panic!("upper bound must be Constr 0");
+        };
+        ub[1].clone()
+    };
+    // Pre-Conway (Alonzo/Babbage): `PV1.to` → UpperBound (Finite t) True.
+    assert_eq!(
+        upper_closure(false),
+        Data::Constr(1, vec![]),
+        "pre-Conway ttl-only upper closure must be True (inclusive, PV1.to)"
+    );
+    // Conway+: `strictUpperBound` → UpperBound (Finite t) False.
+    assert_eq!(
+        upper_closure(true),
+        Data::Constr(0, vec![]),
+        "Conway+ ttl-only upper closure must be False (exclusive, strictUpperBound)"
+    );
+}
+
 /// Regression: before the fix, bounds were flat Constr 1 [val, unit]
 /// without the outer LowerBound/UpperBound Constr 0 wrapper.
 #[test]
@@ -489,7 +524,7 @@ fn txinfo_v1_wdrl_is_data_list_of_constr_pairs() {
     let (sc, amt) = dummy_staking_cred();
     let mut info = minimal_txinfo_v1();
     info.wdrl = vec![(sc, amt)];
-    let d = info.to_data();
+    let d = info.to_data(false);
 
     // V1 TxInfo: Constr 0 [inputs, outputs, fee, mint, dcert, wdrl, ...]
     let Data::Constr(0, ref fields) = d else {
@@ -525,7 +560,7 @@ fn txinfo_v2_wdrl_is_data_map() {
     let (sc, amt) = dummy_staking_cred();
     let mut info = minimal_txinfo_v2();
     info.wdrl = vec![(sc, amt)];
-    let d = info.to_data();
+    let d = info.to_data(false);
 
     let Data::Constr(0, ref fields) = d else {
         panic!("TxInfoV2 must be Constr 0");
@@ -548,7 +583,7 @@ fn txinfo_v2_wdrl_is_data_map() {
 #[test]
 fn txinfo_v1_empty_wdrl_is_empty_list() {
     let info = minimal_txinfo_v1();
-    let d = info.to_data();
+    let d = info.to_data(false);
     let Data::Constr(0, ref fields) = d else {
         panic!("expected Constr 0");
     };
@@ -564,7 +599,7 @@ fn txinfo_v1_empty_wdrl_is_empty_list() {
 #[test]
 fn txinfo_v2_empty_wdrl_is_empty_map() {
     let info = minimal_txinfo_v2();
-    let d = info.to_data();
+    let d = info.to_data(false);
     let Data::Constr(0, ref fields) = d else {
         panic!("expected Constr 0");
     };
@@ -785,7 +820,7 @@ fn txinfo_v1_fee_is_ada_value_map() {
     let lovelace = 177_721u64;
     let mut info = minimal_txinfo_v1();
     info.fee = BigInt::from(lovelace);
-    let d = info.to_data();
+    let d = info.to_data(false);
 
     // V1 TxInfo: Constr 0 [inputs, outputs, fee, ...]  — fee is field 2
     let Data::Constr(0, ref fields) = d else {
@@ -836,7 +871,7 @@ fn txinfo_v1_fee_is_ada_value_map() {
 fn txinfo_v2_fee_is_ada_value_map() {
     let mut info = minimal_txinfo_v2();
     info.fee = BigInt::from(5_000_000u64);
-    let d = info.to_data();
+    let d = info.to_data(false);
     let Data::Constr(0, ref fields) = d else {
         panic!("TxInfoV2 must be Constr 0");
     };
@@ -861,7 +896,7 @@ fn txinfo_v1_data_is_list_of_constr_pairs() {
     let datum_value = Data::I(BigInt::from(99u64));
     let mut info = minimal_txinfo_v1();
     info.data = vec![(datum_hash, datum_value.clone())];
-    let d = info.to_data();
+    let d = info.to_data(false);
 
     // V1 TxInfo: Constr 0 [inputs, outputs, fee, mint, dcert, wdrl, validRange, sigs, data, id]
     // data is field index 8
@@ -903,7 +938,7 @@ fn txinfo_v2_data_is_map() {
     let datum_value = Data::B(vec![0x01, 0x02]);
     let mut info = minimal_txinfo_v2();
     info.data = vec![(datum_hash, datum_value)];
-    let d = info.to_data();
+    let d = info.to_data(false);
 
     // V2: field 10 is data
     let Data::Constr(0, ref fields) = d else {
@@ -925,7 +960,7 @@ fn txinfo_v2_data_is_map() {
 fn txinfo_v1_txid_is_constr_wrapped() {
     let mut info = minimal_txinfo_v1();
     info.txid = [0xfe; 32];
-    let d = info.to_data();
+    let d = info.to_data(false);
 
     // V1 TxInfo field 9 is txid
     let Data::Constr(0, ref fields) = d else {
@@ -947,7 +982,7 @@ fn txinfo_v1_txid_is_constr_wrapped() {
 #[test]
 fn txinfo_v1_txid_is_not_bare_bytes() {
     let info = minimal_txinfo_v1();
-    let d = info.to_data();
+    let d = info.to_data(false);
     let Data::Constr(0, ref fields) = d else {
         panic!("expected Constr 0")
     };
@@ -1062,7 +1097,7 @@ fn script_context_v1_spend_purpose_has_wrapped_txid() {
         tx_info: minimal_txinfo_v1(),
         purpose,
     };
-    let d = ctx.to_data();
+    let d = ctx.to_data(false);
     // ctx = Constr 0 [TxInfo, ScriptPurpose]
     let Data::Constr(0, ref ctx_fields) = d else {
         panic!("ScriptContext must be Constr 0");


### PR DESCRIPTION
## Root cause of the phase-2 +1453 cpu over-charge (#772)

dugite built the `txInfoValidRange` upper-bound **closure** gated on the script **language** (V1/V2 ⇒ inclusive, V3 ⇒ exclusive). cardano-ledger gates it on the **era**:

| Era | ttl-only (`SNothing (SJust j)`) | both-bounds |
|-----|---------------------------------|-------------|
| Alonzo / Babbage | `PV1.to` → **inclusive** (closure True) | `strictUpperBound` → exclusive (False) |
| Conway+ | `strictUpperBound` → **exclusive** (False) | `strictUpperBound` → exclusive (False) |

So a PlutusV1/V2 script in the **Conway era** with a ttl-only validity interval got an inclusive upper bound from dugite but an exclusive one from cardano-node. The Reward (withdraw-0 staking) redeemer reads the validity range and took a different evaluation path → **+1453 cpu**, flipping `is_valid` under restricting mode.

## How it was localised (ground-truth diff)

1. Built cardano-ledger at the pinned conformance SHA `ebed62de` with a small harness (`reports/772-harness/`) that dumps cardano-ledger's *own* constructed `ScriptContext` via `collectPlutusScriptsWithContext`.
2. Leaf-diffed dugite's vs cardano-ledger's context for the dump tx. The **only** differing leaf was this closure (`Constr 1` True vs `Constr 0` False) — at the top-level `validRange` and inside a redeemer embedding a copy of it. The 3 byte-exact non-Reward redeemers validated the harness.
3. Confirmed the semantics with the cardano-haskell-oracle (gate is **era**, not language) and reading `Cardano.Ledger.{Alonzo,Conway}` `transValidityInterval` + `PlutusLedgerApi.V1.Interval.{to,strictUpperBound}`.
4. Empirically: after the fix, `replay_phase2` consumes exactly **774,090,127** on Reward@0 (== declared), +1453 gone.

## Fix

Thread `conway_or_later = major_pv >= 9` through `build_script_context` → `ScriptContext{V1,V2}::to_data` → `TxInfo{V1,V2}::to_data` → `PosixTimeRange::to_data`, and compute the finite upper-bound closure as `if conway_or_later { false } else { lower.is_none() }`.

This is **byte-identical to the previous behaviour** for every pre-Conway V1/V2 context, every V3 context, every both-bounds interval, and every PosInf upper bound. The **only** change is the Conway-era V1/V2 ttl-only case (True → False).

## Verification

- New regression test `posix_time_range_ttl_only_upper_closure_is_era_gated` (asserts both era branches).
- `dugite-uplc` (481), `dugite-ledger`+uplc (2067), `dugite-node` (1053) suites green; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- The db-preview Conway `apply_bench` regression fingerprint (`72a1c983…`) is **unchanged**, so the #763 byte-exact pots verification is unaffected.

Fixes #772.