### PR TITLE
chore(release): bump version to 2.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-cli"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-config"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-conformance"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "cddl",
  "dugite-crypto",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-consensus"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-crypto"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "criterion",
  "curve25519-dalek 3.2.0 (git+https://github.com/iquerejeta/curve25519-dalek?branch=ietf03_vrf_compat_ell2)",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-golden-tests"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "dugite-crypto",
  "dugite-network",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-integration-tests"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "dugite-consensus",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-ledger"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "bincode 1.3.3",
  "criterion",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-lsm"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-mempool"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-monitor"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-network"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-node"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-primitives"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "bech32",
  "blake2 0.10.6",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-rpc"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-serialization"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-storage"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-uplc"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "amaru-uplc",
  "blake2 0.10.6",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.0.12"
+version = "2.0.13"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.12"
+version = "2.0.13"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/michaeljfazio/dugite"

--- a/charts/dugite-node/Chart.yaml
+++ b/charts/dugite-node/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dugite-node
 description: A Helm chart for deploying Dugite, a Rust implementation of the Cardano node
 type: application
-version: 0.5.12
-appVersion: "2.0.12"
+version: 0.5.13
+appVersion: "2.0.13"
 kubeVersion: ">= 1.27.0-0"
 keywords:
   - cardano


### PR DESCRIPTION
Patch release for two consensus-critical ledger fixes already merged to `main`:

- **#763** (PR #776) — reconstruct `epoch_blocks_by_pool` from an absolute per-delta snapshot. Fixes the live `BlocksMade` counter drift (gap-bridge/no-delta reconstruction) that skewed reserves/treasury and per-account rewards. **Confirmed no-drift by a live preview soak** across a 41-restart epoch boundary (`bprev_block_count` 2502 == Koios; reserves/treasury byte-exact).
- **#772** (PR #777) — era-gate the validity-range upper-bound closure in the PlutusV1/V2 ScriptContext (Conway = exclusive `strictUpperBound`). Fixes the +1453 phase-2 cpu over-charge on validity-range-reading redeemers.

## Bump

- workspace version `2.0.12` → `2.0.13`
- Helm chart `version 0.5.12` → `0.5.13`, `appVersion 2.0.12` → `2.0.13` (required by the `release.yml` chart-guard)

Snapshot format unchanged — no re-sync needed. `just check` green locally. Tagging `v2.0.13` after merge triggers the release pipeline (binaries + container + chart + GitHub release).