### PR TITLE
Backlog sweep: byte-exact ledger/serialization fixes (#857 #798 #858 #812 #862 #826 #860.4)

### DIFF
--- a/crates/dugite-ledger/src/eras/conway.rs
+++ b/crates/dugite-ledger/src/eras/conway.rs
@@ -51,8 +51,8 @@ use super::{EraRules, RuleContext};
 use crate::state::governance::{
     capture_governance_snapshots, expire_committee_members, forest_add_proposal,
     genesis_root_is_valid, gov_action_purpose_tag, gov_action_raw_prev_id,
-    prev_action_matches_enacted_root, ratify_proposals_impl, update_dormant_epochs,
-    update_drep_activity,
+    hardfork_proposal_cant_follow, prev_action_matches_enacted_root, ratify_proposals_impl,
+    update_dormant_epochs, update_drep_activity,
 };
 use crate::state::substates::*;
 use crate::state::{
@@ -1839,6 +1839,26 @@ fn process_governance_votes_and_proposals(
                  neither a genesis root, the last enacted root, nor an active in-flight proposal"
             );
             continue;
+        }
+
+        // #858: pvCanFollow gate for HardForkInitiation on the LIVE block-apply GOV
+        // rule (previously absent — a skip-minor / skip-major target was admitted).
+        // Uses the shared `preceedingHardFork` + `pvCanFollow` reachability check
+        // (single source of truth with the dead-path processors, #812).
+        {
+            let cur_major = epochs.protocol_params.protocol_version_major;
+            let cur_minor = epochs.protocol_params.protocol_version_minor;
+            if hardfork_proposal_cant_follow(&proposal.gov_action, governance, cur_major, cur_minor)
+            {
+                debug!(
+                    tx = %tx.hash.to_hex(),
+                    action_index = idx,
+                    cur_version = %format!("{cur_major}.{cur_minor}"),
+                    "ProposalCantFollow (GOV rule): HardForkInitiation target does not follow \
+                     the base protocol version — proposal dropped (#858)"
+                );
+                continue;
+            }
         }
 
         let gov_action_lifetime = epochs.protocol_params.gov_action_lifetime;
@@ -5439,6 +5459,70 @@ mod tests {
             "proposal with stale prev_action_id must be rejected (InvalidPrevGovActionId) \
              via the GOV rule block-apply path; proposals={:?}",
             gov.governance.proposals.keys().collect::<Vec<_>>(),
+        );
+    }
+
+    /// #858: the LIVE block-apply GOV rule must drop a HardForkInitiation whose
+    /// target version does not `pvCanFollow` the current version (skip-minor), and
+    /// admit one that does (exact +1 minor). Previously the live path ran NO
+    /// pvCanFollow check, so a skip-minor target was silently admitted at block apply.
+    #[test]
+    fn test_hardfork_pvcanfollow_enforced_via_apply_path_858() {
+        use dugite_primitives::transaction::{GovAction, GovActionId};
+
+        let params = ProtocolParameters::mainnet_defaults();
+        let ctx = make_conway_ctx(&params);
+        let rules = ConwayRules::new();
+
+        let run = |seed: u8, ver: (u64, u64)| -> bool {
+            let mut utxo = make_utxo_sub(vec![]);
+            let mut certs = make_cert_sub();
+            let mut gov = make_gov_sub();
+            let mut epochs = make_epoch_sub();
+            epochs.protocol_params = params.clone();
+            epochs.protocol_params.protocol_version_major = 10;
+            epochs.protocol_params.protocol_version_minor = 0;
+
+            let proposal = ProposalProcedure {
+                deposit: Lovelace(100_000_000_000),
+                return_addr: vec![0u8; 29],
+                gov_action: GovAction::HardForkInitiation {
+                    prev_action_id: None,
+                    protocol_version: ver,
+                },
+                anchor: Anchor {
+                    url: "https://test".to_string(),
+                    data_hash: Hash32::ZERO,
+                },
+            };
+            let mut tx = make_tx(seed, vec![], vec![], 0);
+            tx.body.proposal_procedures = vec![proposal];
+
+            rules
+                .apply_valid_tx(
+                    &tx,
+                    BlockValidationMode::ApplyOnly,
+                    &ctx,
+                    &mut utxo,
+                    &mut certs,
+                    &mut gov,
+                    &mut epochs,
+                )
+                .expect("apply_valid_tx must not error — GOV rule silently drops bad proposals");
+            let id = GovActionId {
+                transaction_id: tx.hash,
+                action_index: 0,
+            };
+            gov.governance.proposals.contains_key(&id)
+        };
+
+        assert!(
+            !run(0x60, (10, 2)),
+            "skip-minor HardForkInitiation (10,0)->(10,2) must be dropped by the live GOV rule (#858)"
+        );
+        assert!(
+            run(0x61, (10, 1)),
+            "exact +1 minor HardForkInitiation (10,0)->(10,1) must be admitted by the live GOV rule"
         );
     }
 

--- a/crates/dugite-ledger/src/eras/dijkstra.rs
+++ b/crates/dugite-ledger/src/eras/dijkstra.rs
@@ -575,13 +575,22 @@ fn check_guard_witnesses(tx: &Transaction, _ctx: &RuleContext) -> Result<(), Led
     }
     let mut plutus_script_hashes: HashSet<Hash28> = HashSet::new();
     for s in &ws.plutus_v1_scripts {
-        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV1(s.clone()), None));
+        plutus_script_hashes.insert(compute_script_ref_hash(
+            &ScriptRef::PlutusV1(s.clone()),
+            None,
+        ));
     }
     for s in &ws.plutus_v2_scripts {
-        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV2(s.clone()), None));
+        plutus_script_hashes.insert(compute_script_ref_hash(
+            &ScriptRef::PlutusV2(s.clone()),
+            None,
+        ));
     }
     for s in &ws.plutus_v3_scripts {
-        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV3(s.clone()), None));
+        plutus_script_hashes.insert(compute_script_ref_hash(
+            &ScriptRef::PlutusV3(s.clone()),
+            None,
+        ));
     }
 
     // The declared-guards set: a `RequireGuard(c)` native script node
@@ -2896,8 +2905,10 @@ mod tests {
             let guard_native_script = NativeScript::ScriptAll(vec![NativeScript::RequireGuard(
                 Credential::VerificationKey(inner_vk_kh),
             )]);
-            let script_hash: Hash28 =
-                compute_script_ref_hash(&ScriptRef::NativeScript(guard_native_script.clone()), None);
+            let script_hash: Hash28 = compute_script_ref_hash(
+                &ScriptRef::NativeScript(guard_native_script.clone()),
+                None,
+            );
             let script_cred = Credential::Script(script_hash);
 
             // Tx skeleton: one input, one output, both at a key-locked

--- a/crates/dugite-ledger/src/eras/dijkstra.rs
+++ b/crates/dugite-ledger/src/eras/dijkstra.rs
@@ -3224,11 +3224,11 @@ mod tests {
             // ──────────────────────────────────────────────────────────────
             let term = Term::Const(Constant::Integer(42.into()));
             let v4_program = Program {
-                version: (1, 2, 0),
+                version: dugite_uplc::program::Program::version_triple(1, 2, 0),
                 term: term.clone(),
             };
             let v3_program = Program {
-                version: (1, 1, 0),
+                version: dugite_uplc::program::Program::version_triple(1, 1, 0),
                 term: term.clone(),
             };
             let v4_cbor_wrapped = v4_program

--- a/crates/dugite-ledger/src/eras/dijkstra.rs
+++ b/crates/dugite-ledger/src/eras/dijkstra.rs
@@ -571,17 +571,17 @@ fn check_guard_witnesses(tx: &Transaction, _ctx: &RuleContext) -> Result<(), Led
     let mut native_scripts_by_hash: HashMap<Hash28, &NativeScript> = HashMap::new();
     for ns in &ws.native_scripts {
         let sr = ScriptRef::NativeScript(ns.clone());
-        native_scripts_by_hash.insert(compute_script_ref_hash(&sr), ns);
+        native_scripts_by_hash.insert(compute_script_ref_hash(&sr, None), ns);
     }
     let mut plutus_script_hashes: HashSet<Hash28> = HashSet::new();
     for s in &ws.plutus_v1_scripts {
-        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV1(s.clone())));
+        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV1(s.clone()), None));
     }
     for s in &ws.plutus_v2_scripts {
-        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV2(s.clone())));
+        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV2(s.clone()), None));
     }
     for s in &ws.plutus_v3_scripts {
-        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV3(s.clone())));
+        plutus_script_hashes.insert(compute_script_ref_hash(&ScriptRef::PlutusV3(s.clone()), None));
     }
 
     // The declared-guards set: a `RequireGuard(c)` native script node
@@ -2897,7 +2897,7 @@ mod tests {
                 Credential::VerificationKey(inner_vk_kh),
             )]);
             let script_hash: Hash28 =
-                compute_script_ref_hash(&ScriptRef::NativeScript(guard_native_script.clone()));
+                compute_script_ref_hash(&ScriptRef::NativeScript(guard_native_script.clone()), None);
             let script_cred = Credential::Script(script_hash);
 
             // Tx skeleton: one input, one output, both at a key-locked

--- a/crates/dugite-ledger/src/eras/shelley.rs
+++ b/crates/dugite-ledger/src/eras/shelley.rs
@@ -88,6 +88,44 @@ impl ShelleyRules {
 /// the Byron-era burned transaction fees (removed from the UTxO, credited
 /// nowhere) are reflected — the bootstrap path's `max − Σ(genesis avvmDistr)`
 /// init misses them. At the fork treasury/rewards/deposits are all 0.
+/// Byron→Shelley: drop every UTxO entry whose coin value is zero, matching the
+/// `coinTxOutL /= zero` filter in Haskell `translateUTxOByronToShelley`
+/// (`Cardano.Ledger.Shelley.API.ByronTranslation`). At this boundary every live
+/// UTxO entry is a Byron-era output, so this scans the whole set. A zero-value
+/// Byron output that survived into Shelley would let dugite accept a spend that
+/// cardano-node rejects with `BadInputsUTxO` — a permanent membership divergence.
+/// See issue #798.
+fn drop_zero_value_byron_txouts(utxo: &mut UtxoSubState) {
+    // scan-collect-remove (cannot mutate the set mid-scan), mirroring
+    // `return_redeem_addrs_to_reserves`.
+    let mut zero_inputs: Vec<TransactionInput> = Vec::new();
+    let scan_failures = utxo.utxo_set.scan_all(|input, output| {
+        if output.value.coin.0 == 0 {
+            zero_inputs.push(input.clone());
+        }
+    });
+    // A partial scan could miss zero-value entries, leaving spend-able ghosts in
+    // the live set — a consensus divergence. Crash rather than diverge on a
+    // corrupt on-disk store (#806).
+    assert_eq!(
+        scan_failures, 0,
+        "Byron->Shelley zero-value TxOut purge: {scan_failures} UTxO entries failed to \
+         decode during the scan — the on-disk UTxO store is corrupt; refusing to purge \
+         from a partial scan. Wipe `<database-path>/utxo-store` and restart."
+    );
+    let dropped = zero_inputs.len();
+    for input in &zero_inputs {
+        utxo.utxo_set.remove(input);
+    }
+    if dropped > 0 {
+        info!(
+            dropped,
+            "Byron->Shelley: purged zero-value Byron TxOuts (translateUTxOByronToShelley \
+             coinTxOutL /= zero filter, #798)"
+        );
+    }
+}
+
 fn recompute_shelley_initial_reserves(
     utxo: &mut UtxoSubState,
     epochs: &mut EpochSubState,
@@ -974,6 +1012,18 @@ impl EraRules for ShelleyRules {
         // reserves now. On the Mithril-import path this branch never fires (the
         // node starts post-Byron with Haskell-correct reserves).
         if from_era == Era::Byron && ctx.era == Era::Shelley {
+            // Haskell `translateUTxOByronToShelley`
+            // (Cardano.Ledger.Shelley.API.ByronTranslation) filters the translated
+            // UTxO with the guard `txOutShelley ^. coinTxOutL /= zero`:
+            //   "In some testnets there are a few TxOuts with zero values injected at
+            //    initialization of Byron. We do not allow zero values in TxOuts in
+            //    Shelley."
+            // Drop them BEFORE recomputing reserves so the live Shelley UTxO membership
+            // matches Haskell exactly. (Zero-coin entries contribute 0 to sumCoinUTxO,
+            // so reserves is unaffected; the divergence this prevents is a later spend
+            // of a zero-value Byron output that Haskell would reject as BadInputsUTxO.)
+            // See issue #798.
+            drop_zero_value_byron_txouts(utxo);
             recompute_shelley_initial_reserves(utxo, epochs, ctx.max_lovelace_supply);
             // Byron fees are burned, not carried forward: Haskell's
             // `translateToShelleyLedgerStateFromUtxo` constructs a brand-new
@@ -2248,6 +2298,48 @@ mod tests {
         ]);
         let mut epochs = make_epoch_sub();
         recompute_shelley_initial_reserves(&mut utxo, &mut epochs, max);
+    }
+
+    /// #798: the Byron→Shelley translation drops zero-value TxOuts
+    /// (`translateUTxOByronToShelley` guard `coinTxOutL /= zero`). A zero-value
+    /// entry must be removed from the live UTxO set; a non-zero entry must remain.
+    #[test]
+    fn byron_to_shelley_drops_zero_value_txouts_798() {
+        let zero_in = make_redeem_input(0x0a, 0);
+        let live_in = make_redeem_input(0x0b, 0);
+        let mut utxo = make_utxo_sub(vec![
+            (zero_in.clone(), make_byron_output(0, 0)), // zero-value — must be dropped
+            (live_in.clone(), make_byron_output(0, 5_000_000)), // must survive
+        ]);
+        drop_zero_value_byron_txouts(&mut utxo);
+        assert!(
+            utxo.utxo_set.lookup(&zero_in).is_none(),
+            "zero-value Byron TxOut must be purged at the Byron->Shelley boundary (#798)"
+        );
+        assert!(
+            utxo.utxo_set.lookup(&live_in).is_some(),
+            "non-zero Byron TxOut must survive the purge"
+        );
+    }
+
+    /// Reserves are identical whether or not zero-value entries are purged (they
+    /// contribute 0 to sumCoinUTxO), so the #798 filter must not perturb the
+    /// reserves recomputation — only UTxO-set membership.
+    #[test]
+    fn byron_to_shelley_zero_purge_does_not_change_reserves_798() {
+        let max = 45_000_000_000_000_000u64;
+        let mut utxo = make_utxo_sub(vec![
+            (make_redeem_input(0x01, 0), make_byron_output(0, 10_000_000)),
+            (make_redeem_input(0x02, 0), make_byron_output(0, 0)),
+        ]);
+        let mut epochs = make_epoch_sub();
+        drop_zero_value_byron_txouts(&mut utxo);
+        recompute_shelley_initial_reserves(&mut utxo, &mut epochs, max);
+        assert_eq!(
+            epochs.reserves.0,
+            max - 10_000_000,
+            "reserves must equal maxLovelaceSupply minus the non-zero UTxO sum"
+        );
     }
 
     /// Shelley → Allegra transition purges AVVM (redeem) UTxOs from the UTxO

--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -1260,36 +1260,39 @@ mod tests {
         let (version, term) = match uplc_src {
             // V1/V2 always-succeeds: 3 lambdas around a Unit constant.
             "(program 1.0.0 (lam _ (lam _ (lam _ (con unit ())))))" => (
-                (1, 0, 0),
+                dugite_uplc::program::Program::version_triple(1, 0, 0),
                 Term::Lam(Rc::new(Term::Lam(Rc::new(Term::Lam(Rc::new(
                     Term::Const(Constant::Unit),
                 )))))),
             ),
             // V3 always-succeeds: 1 lambda around a Unit constant.
             "(program 1.1.0 (lam _ (con unit ())))" => {
-                ((1, 1, 0), Term::Lam(Rc::new(Term::Const(Constant::Unit))))
+                (
+                    dugite_uplc::program::Program::version_triple(1, 1, 0),
+                    Term::Lam(Rc::new(Term::Const(Constant::Unit))),
+                )
             }
             // V2 single-arg "always-succeeds" (used by tests that confirm
             // the V3 Unit-check doesn't bleed into V2 evaluation).
             "(program 1.0.0 (lam _ (con unit ())))" => {
-                ((1, 0, 0), Term::Lam(Rc::new(Term::Const(Constant::Unit))))
+                (dugite_uplc::program::Program::version_triple(1, 0, 0), Term::Lam(Rc::new(Term::Const(Constant::Unit))))
             }
             // V3 returns integer 42 — used by tests that verify the V3
             // non-Unit-return rejection path.
             "(program 1.1.0 (lam _ (con integer 42)))" => (
-                (1, 1, 0),
+                dugite_uplc::program::Program::version_triple(1, 1, 0),
                 Term::Lam(Rc::new(Term::Const(Constant::Integer(42.into())))),
             ),
             // V1/V2 returns integer 42 — used by tests that verify
             // non-Error returns are accepted for V1/V2.
             "(program 1.0.0 (lam _ (lam _ (lam _ (con integer 42)))))" => (
-                (1, 0, 0),
+                dugite_uplc::program::Program::version_triple(1, 0, 0),
                 Term::Lam(Rc::new(Term::Lam(Rc::new(Term::Lam(Rc::new(
                     Term::Const(Constant::Integer(42.into())),
                 )))))),
             ),
             // V1/V2 always-fails.
-            "(program 1.0.0 (error))" => ((1, 0, 0), Term::Error),
+            "(program 1.0.0 (error))" => (dugite_uplc::program::Program::version_triple(1, 0, 0), Term::Error),
             other => panic!("build_script_cbor: unsupported test script: {other:?}"),
         };
         let program = Program { version, term };

--- a/crates/dugite-ledger/src/plutus.rs
+++ b/crates/dugite-ledger/src/plutus.rs
@@ -1266,17 +1266,16 @@ mod tests {
                 )))))),
             ),
             // V3 always-succeeds: 1 lambda around a Unit constant.
-            "(program 1.1.0 (lam _ (con unit ())))" => {
-                (
-                    dugite_uplc::program::Program::version_triple(1, 1, 0),
-                    Term::Lam(Rc::new(Term::Const(Constant::Unit))),
-                )
-            }
+            "(program 1.1.0 (lam _ (con unit ())))" => (
+                dugite_uplc::program::Program::version_triple(1, 1, 0),
+                Term::Lam(Rc::new(Term::Const(Constant::Unit))),
+            ),
             // V2 single-arg "always-succeeds" (used by tests that confirm
             // the V3 Unit-check doesn't bleed into V2 evaluation).
-            "(program 1.0.0 (lam _ (con unit ())))" => {
-                (dugite_uplc::program::Program::version_triple(1, 0, 0), Term::Lam(Rc::new(Term::Const(Constant::Unit))))
-            }
+            "(program 1.0.0 (lam _ (con unit ())))" => (
+                dugite_uplc::program::Program::version_triple(1, 0, 0),
+                Term::Lam(Rc::new(Term::Const(Constant::Unit))),
+            ),
             // V3 returns integer 42 — used by tests that verify the V3
             // non-Unit-return rejection path.
             "(program 1.1.0 (lam _ (con integer 42)))" => (
@@ -1292,7 +1291,10 @@ mod tests {
                 )))))),
             ),
             // V1/V2 always-fails.
-            "(program 1.0.0 (error))" => (dugite_uplc::program::Program::version_triple(1, 0, 0), Term::Error),
+            "(program 1.0.0 (error))" => (
+                dugite_uplc::program::Program::version_triple(1, 0, 0),
+                Term::Error,
+            ),
             other => panic!("build_script_cbor: unsupported test script: {other:?}"),
         };
         let program = Program { version, term };

--- a/crates/dugite-ledger/src/state/governance.rs
+++ b/crates/dugite-ledger/src/state/governance.rs
@@ -3625,7 +3625,12 @@ fn update_enacted_root_local(
 /// `succVersion curMajor = curMajor + 1`. A new version follows iff it is exactly a
 /// major bump (`curMajor+1`, minor reset to 0) or exactly the next minor
 /// (`curMinor+1`, same major). Any larger gap is illegal.
-pub(crate) fn pv_can_follow(cur_major: u64, cur_minor: u64, new_major: u64, new_minor: u64) -> bool {
+pub(crate) fn pv_can_follow(
+    cur_major: u64,
+    cur_minor: u64,
+    new_major: u64,
+    new_minor: u64,
+) -> bool {
     (new_major == cur_major + 1 && new_minor == 0)
         || (new_major == cur_major && new_minor == cur_minor + 1)
 }

--- a/crates/dugite-ledger/src/state/governance.rs
+++ b/crates/dugite-ledger/src/state/governance.rs
@@ -76,31 +76,26 @@ impl LedgerState {
 
         // --- Check 2: pvCanFollow for HardForkInitiation ---
         //
-        // The target protocol version must be reachable from the current version.
-        // Per Haskell `pvCanFollow cur target`:
-        //   (major+1, 0)  — major bump
-        //   (major, minor+1)  — minor bump
-        //
-        // Reject with ProposalCantFollow if neither condition is met.
-        if let GovAction::HardForkInitiation {
-            protocol_version: (tgt_major, tgt_minor),
-            ..
-        } = &proposal.gov_action
+        // The target protocol version must be reachable from the base version, with
+        // the Haskell `preceedingHardFork` three-way base resolution (chaining against
+        // an in-flight parent HardForkInitiation's target when present). Shared with
+        // the live GOV rule via `hardfork_proposal_cant_follow` — single source of
+        // truth (#812 Defect B / #858).
         {
             let cur_major = self.epochs.protocol_params.protocol_version_major;
             let cur_minor = self.epochs.protocol_params.protocol_version_minor;
-            // #812: minor bump must be EXACTLY curMinor+1 (Haskell `pvCanFollow`
-            // requires `(curMajor, curMinor+1) == (newMajor, newMinor)`), not
-            // merely any higher minor. Matches `validation/ppup.rs:225`.
-            let can_follow = (*tgt_major == cur_major + 1 && *tgt_minor == 0)
-                || (*tgt_major == cur_major && *tgt_minor == cur_minor + 1);
-            if !can_follow {
+            if hardfork_proposal_cant_follow(
+                &proposal.gov_action,
+                &self.gov.governance,
+                cur_major,
+                cur_minor,
+            ) {
                 debug!(
                     tx = %tx_hash.to_hex(),
                     action_index,
                     cur_version = %format!("{cur_major}.{cur_minor}"),
-                    target_version = %format!("{tgt_major}.{tgt_minor}"),
-                    "ProposalCantFollow: HardForkInitiation target version does not follow current version"
+                    "ProposalCantFollow: HardForkInitiation target does not follow the base \
+                     protocol version — proposal dropped (#812)"
                 );
                 // Drop proposal — do not insert into active proposals
                 return;
@@ -404,29 +399,24 @@ impl LedgerState {
 
         // --- Check 2: pvCanFollow for HardForkInitiation ---
         //
-        // Target version must be reachable from the current version.
-        // Per Haskell `pvCanFollow cur target`:
-        //   (major+1, 0)  — major bump
-        //   (major, minor+1)  — minor bump
-        if let GovAction::HardForkInitiation {
-            protocol_version: (tgt_major, tgt_minor),
-            ..
-        } = &proposal.gov_action
+        // Shared `preceedingHardFork` + `pvCanFollow` reachability check (chains
+        // against an in-flight parent HardForkInitiation's target when present).
+        // Single source of truth with the live GOV rule (#812 Defect B / #858).
         {
             let cur_major = self.epochs.protocol_params.protocol_version_major;
             let cur_minor = self.epochs.protocol_params.protocol_version_minor;
-            // #812: minor bump must be EXACTLY curMinor+1 (Haskell `pvCanFollow`
-            // requires `(curMajor, curMinor+1) == (newMajor, newMinor)`), not
-            // merely any higher minor. Matches `validation/ppup.rs:225`.
-            let can_follow = (*tgt_major == cur_major + 1 && *tgt_minor == 0)
-                || (*tgt_major == cur_major && *tgt_minor == cur_minor + 1);
-            if !can_follow {
+            if hardfork_proposal_cant_follow(
+                &proposal.gov_action,
+                &self.gov.governance,
+                cur_major,
+                cur_minor,
+            ) {
                 debug!(
                     tx = %tx_hash.to_hex(),
                     action_index,
                     cur_version = %format!("{cur_major}.{cur_minor}"),
-                    target_version = %format!("{tgt_major}.{tgt_minor}"),
-                    "ProposalCantFollow: HardForkInitiation target version does not follow current version"
+                    "ProposalCantFollow: HardForkInitiation target does not follow the base \
+                     protocol version — proposal dropped (#812)"
                 );
                 return;
             }
@@ -3624,6 +3614,75 @@ fn update_enacted_root_local(
 /// Returns `false` (invalid, must reject) when the enacted root is `Some(...)`.
 ///
 /// `TreasuryWithdrawals` and `InfoAction` have no chain requirement — always `true`.
+/// Haskell `pvCanFollow` (`Cardano.Ledger.Shelley.PParams`):
+///
+/// ```haskell
+/// pvCanFollow (ProtVer curMajor curMinor) (ProtVer newMajor newMinor) =
+///   (succVersion curMajor, 0) == (Just newMajor, newMinor)
+///     || (curMajor, curMinor + 1) == (newMajor, newMinor)
+/// ```
+///
+/// `succVersion curMajor = curMajor + 1`. A new version follows iff it is exactly a
+/// major bump (`curMajor+1`, minor reset to 0) or exactly the next minor
+/// (`curMinor+1`, same major). Any larger gap is illegal.
+pub(crate) fn pv_can_follow(cur_major: u64, cur_minor: u64, new_major: u64, new_minor: u64) -> bool {
+    (new_major == cur_major + 1 && new_minor == 0)
+        || (new_major == cur_major && new_minor == cur_minor + 1)
+}
+
+/// Returns `true` when `gov_action` is a `HardForkInitiation` whose target ProtVer
+/// does NOT `pvCanFollow` its resolved base version — i.e. the proposal must be
+/// dropped with `ProposalCantFollow`. Returns `false` for any non-HardFork action,
+/// or a HardForkInitiation whose base is unresolved or whose target legally follows.
+///
+/// Implements Haskell `preceedingHardFork` (`Cardano.Ledger.Conway.Rules.Gov`,
+/// Gov.hs:673-694) three-way base resolution followed by [`pv_can_follow`]:
+///  1. base = current on-chain PV — when the proposal's prev pointer equals the
+///     enacted HardFork root, OR the target major exceeds `succVersion(curMajor)`
+///     (the short-circuit that forbids compounding two major bumps in one epoch);
+///  2. base = an in-flight parent HardForkInitiation's target PV — when the prev
+///     pointer resolves to one already in the live proposal set (including
+///     same-transaction earlier proposals, which are inserted as they are folded);
+///  3. base unresolved (prev missing / not a HardFork) — no `ProposalCantFollow`
+///     (the structural `InvalidPrevGovActionId` check owns that case).
+///
+/// Shared by the live block-apply GOV rule (`eras::conway`, #858) and the
+/// test/dead-path proposal processors here (#812) so the reachability rule has a
+/// single source of truth.
+pub(crate) fn hardfork_proposal_cant_follow(
+    gov_action: &GovAction,
+    governance: &GovernanceState,
+    cur_major: u64,
+    cur_minor: u64,
+) -> bool {
+    let GovAction::HardForkInitiation {
+        prev_action_id: hf_prev,
+        protocol_version: (tgt_major, tgt_minor),
+    } = gov_action
+    else {
+        return false;
+    };
+    let base = if hf_prev == &governance.enacted_hard_fork || *tgt_major > cur_major + 1 {
+        Some((cur_major, cur_minor))
+    } else {
+        match hf_prev
+            .as_ref()
+            .and_then(|p| governance.proposals.get(p))
+            .map(|ps| &ps.procedure.gov_action)
+        {
+            Some(GovAction::HardForkInitiation {
+                protocol_version: (pm, pn),
+                ..
+            }) => Some((*pm, *pn)),
+            _ => None,
+        }
+    };
+    match base {
+        Some((bm, bn)) => !pv_can_follow(bm, bn, *tgt_major, *tgt_minor),
+        None => false,
+    }
+}
+
 pub(crate) fn genesis_root_is_valid(action: &GovAction, governance: &GovernanceState) -> bool {
     let enacted_root = match action {
         GovAction::ParameterChange { .. } => governance.enacted_pparam_update.as_ref(),
@@ -5441,6 +5500,102 @@ mod tests {
             state.gov.governance.proposals.contains_key(&action_id2),
             "HardForkInitiation with an exact +1 minor bump must be accepted"
         );
+    }
+
+    /// #812 Defect B / #858: a HardForkInitiation that chains to an IN-FLIGHT parent
+    /// HardForkInitiation must be checked with `pvCanFollow` against the PARENT's
+    /// target version (`preceedingHardFork`), not the current on-chain version.
+    #[test]
+    fn test_process_proposal_hardfork_chains_to_in_flight_parent_812() {
+        let mut state = gov_test_state(0, 0); // PV (10,0), enacted_hard_fork = None
+        let hf = |prev: Option<GovActionId>, ver: (u64, u64)| ProposalProcedure {
+            deposit: Lovelace(100_000_000_000),
+            return_addr: vec![0u8; 29],
+            gov_action: GovAction::HardForkInitiation {
+                prev_action_id: prev,
+                protocol_version: ver,
+            },
+            anchor: make_anchor(),
+        };
+        let submit = |state: &mut LedgerState, seed: u8, p: &ProposalProcedure| {
+            let h = Hash32::from_bytes([seed; 32]);
+            state.process_proposal(&h, 0, p);
+            GovActionId {
+                transaction_id: h,
+                action_index: 0,
+            }
+        };
+
+        // Parent: (10,0) -> (11,0) major bump, genesis-root (prev=None). Accepted.
+        let parent = submit(&mut state, 70, &hf(None, (11, 0)));
+        assert!(
+            state.gov.governance.proposals.contains_key(&parent),
+            "parent major-bump HardForkInitiation (11,0) must be accepted"
+        );
+
+        // Child chaining to the in-flight parent, target (11,1) = minor+1 off the
+        // parent's (11,0). Under the OLD (base=current-PV) logic this checked
+        // pvCanFollow((10,0),(11,1)) = false and was wrongly dropped; with the
+        // preceedingHardFork chaining it checks pvCanFollow((11,0),(11,1)) = true.
+        let child_ok = submit(&mut state, 71, &hf(Some(parent.clone()), (11, 1)));
+        assert!(
+            state.gov.governance.proposals.contains_key(&child_ok),
+            "child (11,1) chaining off in-flight parent (11,0) must be ACCEPTED (#812 Defect B)"
+        );
+
+        // Child chaining to the in-flight parent but skipping a minor: (11,3) does
+        // not follow (11,0). Dropped.
+        let child_skip = submit(&mut state, 72, &hf(Some(parent.clone()), (11, 3)));
+        assert!(
+            !state.gov.governance.proposals.contains_key(&child_skip),
+            "child (11,3) skip-minor off in-flight parent must be dropped (ProposalCantFollow)"
+        );
+
+        // succVersion short-circuit: a child targeting (12,0) — two major bumps
+        // compounded in one epoch — is checked against CURRENT (10,0), not the
+        // parent, and dropped.
+        let child_double = submit(&mut state, 73, &hf(Some(parent.clone()), (12, 0)));
+        assert!(
+            !state.gov.governance.proposals.contains_key(&child_double),
+            "child (12,0) compounding two major bumps must be dropped (succVersion short-circuit)"
+        );
+    }
+
+    /// Direct unit coverage of the shared `hardfork_proposal_cant_follow` helper for
+    /// the non-HardFork and unresolved-base branches.
+    #[test]
+    fn test_hardfork_proposal_cant_follow_edge_cases() {
+        let state = gov_test_state(0, 0); // PV (10,0)
+        let gov = &state.gov.governance;
+
+        // Non-HardFork action → never a ProposalCantFollow.
+        assert!(!hardfork_proposal_cant_follow(
+            &GovAction::InfoAction,
+            gov,
+            10,
+            0
+        ));
+
+        // HardFork whose prev points at a NON-existent proposal (and not the enacted
+        // root, target not above succVersion) → base unresolved → false (the
+        // structural InvalidPrevGovActionId check owns that case, not pvCanFollow).
+        let dangling = GovActionId {
+            transaction_id: Hash32::from_bytes([0xEE; 32]),
+            action_index: 7,
+        };
+        let hf_dangling = GovAction::HardForkInitiation {
+            prev_action_id: Some(dangling),
+            protocol_version: (10, 1),
+        };
+        assert!(!hardfork_proposal_cant_follow(&hf_dangling, gov, 10, 0));
+
+        // HardFork at genesis root (prev = None = enacted_hard_fork), skip-minor
+        // target (10,2) → base = current (10,0) → cant follow → true.
+        let hf_skip = GovAction::HardForkInitiation {
+            prev_action_id: None,
+            protocol_version: (10, 2),
+        };
+        assert!(hardfork_proposal_cant_follow(&hf_skip, gov, 10, 0));
     }
 
     // ========================================================================

--- a/crates/dugite-ledger/src/validation/collateral.rs
+++ b/crates/dugite-ledger/src/validation/collateral.rs
@@ -918,7 +918,8 @@ fn collect_plutus_script_hashes(tx: &Transaction, utxo_set: &dyn UtxoLookup) -> 
                     | ScriptRef::PlutusV4(_) => {
                         // V4 (Dijkstra) requires a redeemer like V1/V2/V3
                         // (issue #475 Phase 5; full validator integration TBD).
-                        hashes.insert(compute_script_ref_hash(script_ref));
+                        // Plutus refs only (native excluded above) — no native_original.
+                        hashes.insert(compute_script_ref_hash(script_ref, None));
                     }
                     // Native scripts do not require redeemers.
                     ScriptRef::NativeScript(_) => {}
@@ -960,7 +961,8 @@ pub(crate) fn plutus_script_version_map(
                     ScriptRef::PlutusV4(_) => 4,
                     ScriptRef::NativeScript(_) => continue,
                 };
-                map.insert(compute_script_ref_hash(script_ref), tag);
+                // Plutus refs only (native `continue`d above) — no native_original.
+                map.insert(compute_script_ref_hash(script_ref, None), tag);
             }
         }
     }

--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -2101,14 +2101,12 @@ pub(crate) fn missing_cost_model_languages(
         .into_iter()
         .collect::<std::collections::BTreeSet<u8>>()
         .into_iter()
-        .filter(|&lang| {
-            !match lang {
-                1 => cost_models.plutus_v1.is_some(),
-                2 => cost_models.plutus_v2.is_some(),
-                3 => cost_models.plutus_v3.is_some(),
-                4 => cost_models.plutus_v4.is_some(),
-                _ => true,
-            }
+        .filter(|&lang| !match lang {
+            1 => cost_models.plutus_v1.is_some(),
+            2 => cost_models.plutus_v2.is_some(),
+            3 => cost_models.plutus_v3.is_some(),
+            4 => cost_models.plutus_v4.is_some(),
+            _ => true,
         })
         .collect()
 }

--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -2085,6 +2085,34 @@ pub(crate) fn phase2_admission_error(
     }
 }
 
+/// The sorted set of executed Plutus language tags (1=V1, 2=V2, 3=V3, 4=V4) that
+/// have NO cost model in `cost_models`. A non-empty result corresponds to Haskell
+/// `collectPlutusScriptsWithContext` failing with `CollectErrors [NoCostModel lang]`
+/// — the transaction must be rejected regardless of `isValid`, before any script is
+/// evaluated. The lookup is keyed per-executed-script's own language (a tx with only
+/// V2 scripts never observes a missing V1 cost model); native scripts and unknown
+/// tags never need a cost model. Only TOTAL absence counts (a present-but-short cost
+/// model is `maxBound`-padded upstream, not a `NoCostModel`). See #826 / #860.3.
+pub(crate) fn missing_cost_model_languages(
+    executed_langs: impl IntoIterator<Item = u8>,
+    cost_models: &dugite_primitives::transaction::CostModels,
+) -> Vec<u8> {
+    executed_langs
+        .into_iter()
+        .collect::<std::collections::BTreeSet<u8>>()
+        .into_iter()
+        .filter(|&lang| {
+            !match lang {
+                1 => cost_models.plutus_v1.is_some(),
+                2 => cost_models.plutus_v2.is_some(),
+                3 => cost_models.plutus_v3.is_some(),
+                4 => cost_models.plutus_v4.is_some(),
+                _ => true,
+            }
+        })
+        .collect()
+}
+
 pub fn validate_transaction(
     tx: &Transaction,
     utxo_set: &dyn UtxoLookup,
@@ -3931,6 +3959,30 @@ pub fn validate_transaction_with_pools(
         }
 
         if errors.is_empty() && has_redeemers {
+            // ── #826 / #860.3: NoCostModel collection check ───────────────
+            //
+            // Haskell `collectPlutusScriptsWithContext` fails with
+            // `CollectErrors [NoCostModel lang]` — rejecting the transaction
+            // REGARDLESS of `isValid`, before any script is evaluated — when a
+            // Plutus script that is actually EXECUTED (has a matching redeemer)
+            // uses a language that has no cost model in the protocol parameters.
+            // dugite previously fell back silently to the uplc-side reference
+            // cost model, accepting a transaction cardano-node rejects. This is a
+            // *collection* error, so it runs before the (possibly-skipped) eval.
+            {
+                let version_map = crate::validation::plutus_script_version_map(tx, utxo_set);
+                let executed =
+                    crate::validation::redeemer_script_version_map(tx, utxo_set, &version_map);
+                let missing =
+                    missing_cost_model_languages(executed.values().copied(), &params.cost_models);
+                if !missing.is_empty() {
+                    errors.push(ValidationError::Phase2CollectError(format!(
+                        "NoCostModel: executed Plutus language(s) {missing:?} have no cost model \
+                         in the protocol parameters"
+                    )));
+                }
+            }
+
             // ── Parallel-phase-2 gate ─────────────────────────────────────
             //
             // When the block-apply path uses deferred-parallel Phase-2

--- a/crates/dugite-ledger/src/validation/phase1.rs
+++ b/crates/dugite-ledger/src/validation/phase1.rs
@@ -5277,7 +5277,7 @@ mod tests {
 
     fn minimal_plutus_program_flat() -> Vec<u8> {
         let p = dugite_uplc::program::Program {
-            version: (1, 0, 0),
+            version: dugite_uplc::program::Program::version_triple(1, 0, 0),
             term: dugite_uplc::term::Term::Const(dugite_uplc::term::Constant::Integer(
                 num_bigint::BigInt::from(0),
             )),
@@ -5296,7 +5296,7 @@ mod tests {
     /// `ScriptRef` tests.
     fn minimal_plutus_program_cbor() -> Vec<u8> {
         let p = dugite_uplc::program::Program {
-            version: (1, 0, 0),
+            version: dugite_uplc::program::Program::version_triple(1, 0, 0),
             term: dugite_uplc::term::Term::Const(dugite_uplc::term::Constant::Integer(
                 num_bigint::BigInt::from(0),
             )),

--- a/crates/dugite-ledger/src/validation/phase1.rs
+++ b/crates/dugite-ledger/src/validation/phase1.rs
@@ -1161,12 +1161,14 @@ pub(super) fn run_phase1_rules(
     if !body.mint.is_empty() {
         let mut available_script_hashes: HashSet<Hash28> = HashSet::new();
 
-        for script in &tx.witness_set.native_scripts {
-            let script_cbor = dugite_serialization::encode_native_script(script);
-            let mut tagged = Vec::with_capacity(1 + script_cbor.len());
-            tagged.push(0x00);
-            tagged.extend_from_slice(&script_cbor);
-            available_script_hashes.insert(dugite_primitives::hash::blake2b_224(&tagged));
+        // Native scripts hash over their ORIGINAL wire bytes (#862).
+        let witness_native_raws = super::scripts::witness_native_original_bytes(tx);
+        for (i, script) in tx.witness_set.native_scripts.iter().enumerate() {
+            let original = witness_native_raws
+                .as_ref()
+                .and_then(|v| v.get(i))
+                .map(Vec::as_slice);
+            available_script_hashes.insert(super::scripts::native_script_hash(script, original));
         }
         for s in &tx.witness_set.plutus_v1_scripts {
             let mut tagged = Vec::with_capacity(1 + s.len());
@@ -1192,7 +1194,11 @@ pub(super) fn run_phase1_rules(
         for inp in body.inputs.iter().chain(body.reference_inputs.iter()) {
             if let Some(utxo) = utxo_set.lookup(inp) {
                 if let Some(script_ref) = &utxo.script_ref {
-                    let hash = super::scripts::compute_script_ref_hash(script_ref);
+                    let native_original = super::scripts::reference_native_original_bytes(&utxo);
+                    let hash = super::scripts::compute_script_ref_hash(
+                        script_ref,
+                        native_original.as_deref(),
+                    );
                     available_script_hashes.insert(hash);
                 }
             }
@@ -1802,13 +1808,15 @@ pub(super) fn run_phase1_rules(
         let invalid_before = body.validity_interval_start;
         let invalid_hereafter = body.ttl;
 
-        for script in &tx.witness_set.native_scripts {
-            // Compute this script's hash: blake2b_224(0x00 || cbor(script))
-            let script_cbor = dugite_serialization::encode_native_script(script);
-            let mut tagged = Vec::with_capacity(1 + script_cbor.len());
-            tagged.push(0x00);
-            tagged.extend_from_slice(&script_cbor);
-            let script_hash = dugite_primitives::hash::blake2b_224(&tagged);
+        // Native scripts hash over their ORIGINAL wire bytes (#862) so the hash
+        // matches the on-chain `scripts_needed` entry for a non-canonical script.
+        let witness_native_raws = super::scripts::witness_native_original_bytes(tx);
+        for (i, script) in tx.witness_set.native_scripts.iter().enumerate() {
+            let original = witness_native_raws
+                .as_ref()
+                .and_then(|v| v.get(i))
+                .map(Vec::as_slice);
+            let script_hash = super::scripts::native_script_hash(script, original);
 
             // Only evaluate scripts that are actually needed
             if scripts_needed.contains(&script_hash)

--- a/crates/dugite-ledger/src/validation/scripts.rs
+++ b/crates/dugite-ledger/src/validation/scripts.rs
@@ -139,16 +139,52 @@ pub fn evaluate_native_script_with_guards(
 // Script hash utilities
 // ---------------------------------------------------------------------------
 
-/// Compute the witness-set / native-script hash: `blake2b_224(0x00 || cbor(script))`.
+/// Compute the native-script hash: `blake2b_224(0x00 || original_bytes)`.
 ///
-/// Shared by [`compute_script_ref_hash`]'s `NativeScript` arm, Phase-1
-/// Rule 13 (`phase1.rs`), and [`check_extraneous_script_witnesses`]'s
-/// native-witness `received` set (issue #791).
-fn native_script_hash(ns: &NativeScript) -> Hash28 {
-    let script_cbor = dugite_serialization::encode_native_script(ns);
+/// Haskell `hashScript` hashes over the script's ORIGINAL wire bytes (the Timelock
+/// `MemoBytes`), never a canonical re-encode — so a non-canonically-but-validly
+/// encoded native script (indefinite-length outer array, non-minimal integer field)
+/// hashes differently from `encode_native_script(decoded)`. When `original` is
+/// available (decoded transactions), hash over it; fall back to a re-encode only for
+/// locally-constructed scripts whose wire bytes we never had. See issue #862.
+///
+/// Shared by [`compute_script_ref_hash`]'s `NativeScript` arm, Phase-1 Rule 13
+/// (`phase1.rs`), and [`check_extraneous_script_witnesses`]'s native-witness
+/// `received` set (issue #791).
+/// Original wire bytes of every witness native script, indexed, recovered from the
+/// transaction's raw witness-set CBOR. `None` when the raw CBOR is absent (locally
+/// constructed tx) — callers then fall back to a re-encode via [`native_script_hash`].
+/// Every site that hashes a witness native script for matching must use this so the
+/// hash is byte-identical across the whole tx (only non-canonically-encoded scripts
+/// actually differ from a re-encode). See issue #862.
+pub(crate) fn witness_native_original_bytes(tx: &Transaction) -> Option<Vec<Vec<u8>>> {
+    tx.raw_witness_cbor
+        .as_deref()
+        .and_then(dugite_serialization::witness_native_script_original_bytes)
+}
+
+/// Original inner bytes of a reference NATIVE script carried in `utxo`, recovered
+/// from the output's raw CBOR. `None` for Plutus refs / legacy outputs / absent raw.
+pub(crate) fn reference_native_original_bytes(
+    utxo: &dugite_primitives::transaction::TransactionOutput,
+) -> Option<Vec<u8>> {
+    utxo.raw_cbor
+        .as_deref()
+        .and_then(dugite_serialization::reference_native_script_original_bytes)
+}
+
+pub(crate) fn native_script_hash(ns: &NativeScript, original: Option<&[u8]>) -> Hash28 {
+    let reencoded;
+    let script_cbor: &[u8] = match original {
+        Some(bytes) => bytes,
+        None => {
+            reencoded = dugite_serialization::encode_native_script(ns);
+            &reencoded
+        }
+    };
     let mut tagged = Vec::with_capacity(1 + script_cbor.len());
     tagged.push(0x00);
-    tagged.extend_from_slice(&script_cbor);
+    tagged.extend_from_slice(script_cbor);
     dugite_primitives::hash::blake2b_224(&tagged)
 }
 
@@ -160,9 +196,12 @@ fn native_script_hash(ns: &NativeScript) -> Hash28 {
 /// - `0x02` — Plutus V2
 /// - `0x03` — Plutus V3
 /// - `0x04` — Plutus V4 (Dijkstra, issue #475 Phase 5)
-pub(crate) fn compute_script_ref_hash(script_ref: &ScriptRef) -> Hash28 {
+pub(crate) fn compute_script_ref_hash(
+    script_ref: &ScriptRef,
+    native_original: Option<&[u8]>,
+) -> Hash28 {
     match script_ref {
-        ScriptRef::NativeScript(ns) => native_script_hash(ns),
+        ScriptRef::NativeScript(ns) => native_script_hash(ns, native_original),
         ScriptRef::PlutusV1(bytes) => {
             let mut tagged = Vec::with_capacity(1 + bytes.len());
             tagged.push(0x01);
@@ -206,13 +245,17 @@ pub(super) fn collect_available_script_hashes(
 ) -> HashSet<Hash28> {
     let mut hashes = HashSet::new();
 
-    // Native scripts: blake2b_224(0x00 || script_cbor)
-    for script in &tx.witness_set.native_scripts {
-        let script_cbor = dugite_serialization::encode_native_script(script);
-        let mut tagged = Vec::with_capacity(1 + script_cbor.len());
-        tagged.push(0x00);
-        tagged.extend_from_slice(&script_cbor);
-        hashes.insert(dugite_primitives::hash::blake2b_224(&tagged));
+    // Native scripts: blake2b_224(0x00 || original_bytes). Hash over the ORIGINAL
+    // wire bytes of each witness native script (Haskell hashScript over MemoBytes),
+    // recovered from the witness set's raw CBOR; fall back to a re-encode only when
+    // the raw CBOR is absent (locally-constructed tx). See issue #862.
+    let witness_native_raws = tx
+        .raw_witness_cbor
+        .as_deref()
+        .and_then(dugite_serialization::witness_native_script_original_bytes);
+    for (i, script) in tx.witness_set.native_scripts.iter().enumerate() {
+        let original = witness_native_raws.as_ref().and_then(|v| v.get(i)).map(Vec::as_slice);
+        hashes.insert(native_script_hash(script, original));
     }
 
     // Plutus V1: blake2b_224(0x01 || script_bytes)
@@ -248,7 +291,14 @@ pub(super) fn collect_available_script_hashes(
     for inp in tx.body.inputs.iter().chain(tx.body.reference_inputs.iter()) {
         if let Some(utxo) = utxo_set.lookup(inp) {
             if let Some(script_ref) = &utxo.script_ref {
-                hashes.insert(compute_script_ref_hash(script_ref));
+                // For a reference NATIVE script, hash over its original inner bytes
+                // recovered from the output's raw CBOR (#862); Plutus refs already
+                // carry their raw bytes so `native_original` is ignored for them.
+                let native_original = utxo
+                    .raw_cbor
+                    .as_deref()
+                    .and_then(dugite_serialization::reference_native_script_original_bytes);
+                hashes.insert(compute_script_ref_hash(script_ref, native_original.as_deref()));
             }
         }
     }
@@ -872,9 +922,14 @@ pub(super) fn check_extraneous_script_witnesses(
     let body = &tx.body;
 
     // 1. Witness script hashes ("received" — ALL scripts, native included).
+    //    Native scripts hash over their ORIGINAL wire bytes (#862) so a
+    //    non-canonically-encoded witness script matches the same hash the "needed"
+    //    set derives from the on-chain address/policy.
     let mut witness_hashes: HashSet<Hash28> = HashSet::new();
-    for ns in &tx.witness_set.native_scripts {
-        witness_hashes.insert(native_script_hash(ns));
+    let witness_native_raws = witness_native_original_bytes(tx);
+    for (i, ns) in tx.witness_set.native_scripts.iter().enumerate() {
+        let original = witness_native_raws.as_ref().and_then(|v| v.get(i)).map(Vec::as_slice);
+        witness_hashes.insert(native_script_hash(ns, original));
     }
     for s in &tx.witness_set.plutus_v1_scripts {
         witness_hashes.insert(dugite_primitives::hash::blake2b_224_tagged(1, s));
@@ -977,7 +1032,9 @@ pub(super) fn check_extraneous_script_witnesses(
     for input in body.inputs.iter().chain(body.reference_inputs.iter()) {
         if let Some(utxo) = utxo_set.lookup(input) {
             if let Some(script_ref) = &utxo.script_ref {
-                ref_script_hashes.insert(compute_script_ref_hash(script_ref));
+                let native_original = reference_native_original_bytes(&utxo);
+                ref_script_hashes
+                    .insert(compute_script_ref_hash(script_ref, native_original.as_deref()));
             }
         }
     }
@@ -1117,24 +1174,28 @@ pub(super) fn check_malformed_reference_scripts(
             }
             ScriptRef::PlutusV1(bytes) => {
                 if pv < 5 || !plutus_ref_script_decodes(bytes) {
-                    malformed.push(compute_script_ref_hash(script_ref).to_hex());
+                    // Plutus arm only — native_original is unused for Plutus refs.
+                    malformed.push(compute_script_ref_hash(script_ref, None).to_hex());
                 }
             }
             ScriptRef::PlutusV2(bytes) => {
                 if pv < 7 || !plutus_ref_script_decodes(bytes) {
-                    malformed.push(compute_script_ref_hash(script_ref).to_hex());
+                    // Plutus arm only — native_original is unused for Plutus refs.
+                    malformed.push(compute_script_ref_hash(script_ref, None).to_hex());
                 }
             }
             ScriptRef::PlutusV3(bytes) => {
                 if pv < 9 || !plutus_ref_script_decodes(bytes) {
-                    malformed.push(compute_script_ref_hash(script_ref).to_hex());
+                    // Plutus arm only — native_original is unused for Plutus refs.
+                    malformed.push(compute_script_ref_hash(script_ref, None).to_hex());
                 }
             }
             ScriptRef::PlutusV4(bytes) => {
                 // Dijkstra era; PV gate to be confirmed. Conservative: require
                 // PV >= 11 (post-Conway) AND decodes.
                 if pv < 11 || !plutus_ref_script_decodes(bytes) {
-                    malformed.push(compute_script_ref_hash(script_ref).to_hex());
+                    // Plutus arm only — native_original is unused for Plutus refs.
+                    malformed.push(compute_script_ref_hash(script_ref, None).to_hex());
                 }
             }
         }
@@ -1384,6 +1445,35 @@ mod tests {
     use dugite_primitives::hash::{Hash28, Hash32, TransactionHash};
     use dugite_primitives::protocol_params::ProtocolParameters;
     use dugite_primitives::time::SlotNo;
+
+    /// #862: `native_script_hash` hashes over the ORIGINAL wire bytes when supplied
+    /// (Haskell hashScript over MemoBytes), which — for a non-canonically-encoded
+    /// script — differs from the re-encode fallback. `blake2b_224(0x00 || original)`.
+    #[test]
+    fn native_script_hash_uses_original_bytes_862() {
+        // Non-canonical indefinite-length ScriptPubkey: 0x9f 0x00 (0x581c<28>) 0xff
+        let mut original = vec![0x9f, 0x00, 0x58, 0x1c];
+        original.extend_from_slice(&[0xAB; 28]);
+        original.push(0xff);
+        let ns = dugite_serialization::decode_native_script_cbor(&original).unwrap();
+
+        let h_orig = native_script_hash(&ns, Some(&original));
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&original);
+        assert_eq!(
+            h_orig,
+            dugite_primitives::hash::blake2b_224(&tagged),
+            "must hash 0x00 || original_bytes"
+        );
+
+        // The re-encode fallback yields a DIFFERENT hash for this non-canonical form,
+        // which is exactly the divergence the fix removes.
+        let h_reencode = native_script_hash(&ns, None);
+        assert_ne!(
+            h_orig, h_reencode,
+            "original-bytes hash must differ from the re-encode for a non-canonical script"
+        );
+    }
     use dugite_primitives::transaction::OutputDatum;
     use dugite_primitives::transaction::{
         NativeScript, ScriptRef, Transaction, TransactionInput, TransactionOutput,
@@ -1668,7 +1758,7 @@ mod tests {
         let ns = NativeScript::ScriptPubkey(kh);
         let script_ref_native = ScriptRef::NativeScript(ns.clone());
 
-        let computed = compute_script_ref_hash(&script_ref_native);
+        let computed = compute_script_ref_hash(&script_ref_native, None);
 
         // Manually reproduce: blake2b_224(0x00 || script_cbor)
         let script_cbor = dugite_serialization::encode_native_script(&ns);
@@ -1685,7 +1775,7 @@ mod tests {
         // --- Plutus V2: tag 0x02 ---
         let plutus_v2_bytes = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
         let script_ref_v2 = ScriptRef::PlutusV2(plutus_v2_bytes.clone());
-        let computed_v2 = compute_script_ref_hash(&script_ref_v2);
+        let computed_v2 = compute_script_ref_hash(&script_ref_v2, None);
 
         let mut tagged_v2 = Vec::with_capacity(1 + plutus_v2_bytes.len());
         tagged_v2.push(0x02u8);
@@ -1941,7 +2031,7 @@ mod tests {
     fn test_extraneous_native_witness_script_rejected() {
         let kh = key_hash(0x77);
         let ns = NativeScript::ScriptPubkey(kh);
-        let ns_hash = native_script_hash(&ns);
+        let ns_hash = native_script_hash(&ns, None);
 
         let mut tx = Transaction::empty_with_hash(TransactionHash::from_bytes([0xCC; 32]));
         tx.witness_set.native_scripts.push(ns);
@@ -1980,7 +2070,7 @@ mod tests {
 
         let kh = key_hash(0x78);
         let ns = NativeScript::ScriptPubkey(kh);
-        let ns_hash = native_script_hash(&ns);
+        let ns_hash = native_script_hash(&ns, None);
 
         let address = Address::Base(BaseAddress {
             network: dugite_primitives::network::NetworkId::Testnet,
@@ -2020,7 +2110,7 @@ mod tests {
     fn test_native_witness_script_matching_only_a_native_ref_script_is_extraneous() {
         let kh = key_hash(0x79);
         let ns = NativeScript::ScriptPubkey(kh);
-        let ns_hash = native_script_hash(&ns);
+        let ns_hash = native_script_hash(&ns, None);
 
         // The script-locked spending input is satisfied via a NATIVE
         // reference script attached to a reference input — not via the

--- a/crates/dugite-ledger/src/validation/scripts.rs
+++ b/crates/dugite-ledger/src/validation/scripts.rs
@@ -254,7 +254,10 @@ pub(super) fn collect_available_script_hashes(
         .as_deref()
         .and_then(dugite_serialization::witness_native_script_original_bytes);
     for (i, script) in tx.witness_set.native_scripts.iter().enumerate() {
-        let original = witness_native_raws.as_ref().and_then(|v| v.get(i)).map(Vec::as_slice);
+        let original = witness_native_raws
+            .as_ref()
+            .and_then(|v| v.get(i))
+            .map(Vec::as_slice);
         hashes.insert(native_script_hash(script, original));
     }
 
@@ -298,7 +301,10 @@ pub(super) fn collect_available_script_hashes(
                     .raw_cbor
                     .as_deref()
                     .and_then(dugite_serialization::reference_native_script_original_bytes);
-                hashes.insert(compute_script_ref_hash(script_ref, native_original.as_deref()));
+                hashes.insert(compute_script_ref_hash(
+                    script_ref,
+                    native_original.as_deref(),
+                ));
             }
         }
     }
@@ -928,7 +934,10 @@ pub(super) fn check_extraneous_script_witnesses(
     let mut witness_hashes: HashSet<Hash28> = HashSet::new();
     let witness_native_raws = witness_native_original_bytes(tx);
     for (i, ns) in tx.witness_set.native_scripts.iter().enumerate() {
-        let original = witness_native_raws.as_ref().and_then(|v| v.get(i)).map(Vec::as_slice);
+        let original = witness_native_raws
+            .as_ref()
+            .and_then(|v| v.get(i))
+            .map(Vec::as_slice);
         witness_hashes.insert(native_script_hash(ns, original));
     }
     for s in &tx.witness_set.plutus_v1_scripts {
@@ -1033,8 +1042,10 @@ pub(super) fn check_extraneous_script_witnesses(
         if let Some(utxo) = utxo_set.lookup(input) {
             if let Some(script_ref) = &utxo.script_ref {
                 let native_original = reference_native_original_bytes(&utxo);
-                ref_script_hashes
-                    .insert(compute_script_ref_hash(script_ref, native_original.as_deref()));
+                ref_script_hashes.insert(compute_script_ref_hash(
+                    script_ref,
+                    native_original.as_deref(),
+                ));
             }
         }
     }

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -16978,6 +16978,42 @@ mod tests {
         assert!(!PlutusError::CollectError("x".into()).is_eval_panic());
     }
 
+    /// #826 / #860.3: an EXECUTED Plutus language with no cost model is a
+    /// `NoCostModel` collection error; a language with a cost model, or one that
+    /// is not executed, is not. Per-executed-language scope, deduped and sorted.
+    #[test]
+    fn missing_cost_model_languages_no_cost_model_826() {
+        use crate::validation::missing_cost_model_languages;
+        use dugite_primitives::transaction::CostModels;
+
+        let full = CostModels {
+            plutus_v1: Some(vec![1]),
+            plutus_v2: Some(vec![2]),
+            plutus_v3: Some(vec![3]),
+            plutus_v4: Some(vec![4]),
+            ..Default::default()
+        };
+        assert!(missing_cost_model_languages([1u8, 2, 3], &full).is_empty());
+
+        let no_v2 = CostModels {
+            plutus_v1: Some(vec![1]),
+            plutus_v3: Some(vec![3]),
+            ..Default::default()
+        };
+        // V2 executed but absent -> missing.
+        assert_eq!(missing_cost_model_languages([2u8], &no_v2), vec![2]);
+        // V2 absent but NOT executed -> not missing (per-executed scope).
+        assert!(missing_cost_model_languages([1u8, 3], &no_v2).is_empty());
+
+        // Multiple missing dedup + sort; native/unknown tags never count.
+        let none = CostModels::default();
+        assert_eq!(
+            missing_cost_model_languages([3u8, 1, 3, 2], &none),
+            vec![1, 2, 3]
+        );
+        assert!(missing_cost_model_languages([0u8], &none).is_empty());
+    }
+
     /// `IsValidTagMismatch` is a proper `ValidationError` variant and can be
     /// constructed and matched as expected.  This guards the variant definition
     /// against refactoring that accidentally removes it or changes its fields.

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -2620,7 +2620,7 @@ mod tests {
         // fixture survives any future flat/CBOR-encoding tweak.
         let plutus_script_bytes = {
             let p = dugite_uplc::program::Program {
-                version: (1, 0, 0),
+                version: dugite_uplc::program::Program::version_triple(1, 0, 0),
                 term: dugite_uplc::term::Term::Const(dugite_uplc::term::Constant::Integer(
                     num_bigint::BigInt::from(0),
                 )),

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -1451,7 +1451,8 @@ mod tests {
         );
         let pubkey_hash = Hash32::from_bytes([42u8; 32]);
         let native_script = NativeScript::ScriptPubkey(pubkey_hash);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
+        let script_hash =
+            compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
         let ref_input = TransactionInput {
             transaction_id: Hash32::from_bytes([3u8; 32]),
             index: 0,
@@ -1502,7 +1503,8 @@ mod tests {
         // Scenario: the spending input's UTxO itself carries a script_ref whose hash
         // matches the minting policy.  No reference_inputs are needed.
         let native_script = NativeScript::ScriptAll(vec![]);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
+        let script_hash =
+            compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
 
         let mut utxo_set = UtxoSet::new();
         // Spending input carries the script_ref
@@ -1615,7 +1617,8 @@ mod tests {
         use dugite_primitives::credentials::Credential;
 
         let native_script = NativeScript::ScriptAll(vec![]);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
+        let script_hash =
+            compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
 
         let mut utxo_set = UtxoSet::new();
 
@@ -3959,7 +3962,8 @@ mod tests {
         // The minting policy native script.
         let signer_hash = Hash32::from_bytes([0x7Fu8; 32]);
         let native_script = NativeScript::ScriptPubkey(signer_hash);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
+        let script_hash =
+            compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
 
         // Spending input — the UTxO that the minting transaction actually spends.
         let spending_input = TransactionInput {

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -1451,7 +1451,7 @@ mod tests {
         );
         let pubkey_hash = Hash32::from_bytes([42u8; 32]);
         let native_script = NativeScript::ScriptPubkey(pubkey_hash);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()));
+        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
         let ref_input = TransactionInput {
             transaction_id: Hash32::from_bytes([3u8; 32]),
             index: 0,
@@ -1502,7 +1502,7 @@ mod tests {
         // Scenario: the spending input's UTxO itself carries a script_ref whose hash
         // matches the minting policy.  No reference_inputs are needed.
         let native_script = NativeScript::ScriptAll(vec![]);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()));
+        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
 
         let mut utxo_set = UtxoSet::new();
         // Spending input carries the script_ref
@@ -1615,7 +1615,7 @@ mod tests {
         use dugite_primitives::credentials::Credential;
 
         let native_script = NativeScript::ScriptAll(vec![]);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()));
+        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
 
         let mut utxo_set = UtxoSet::new();
 
@@ -1682,7 +1682,7 @@ mod tests {
     #[test]
     fn test_compute_script_ref_hash_plutus_v2() {
         let script_bytes = vec![0x01, 0x02, 0x03, 0x04];
-        let hash = compute_script_ref_hash(&ScriptRef::PlutusV2(script_bytes.clone()));
+        let hash = compute_script_ref_hash(&ScriptRef::PlutusV2(script_bytes.clone()), None);
         let mut tagged = vec![0x02];
         tagged.extend_from_slice(&script_bytes);
         let expected = dugite_primitives::hash::blake2b_224(&tagged);
@@ -3959,7 +3959,7 @@ mod tests {
         // The minting policy native script.
         let signer_hash = Hash32::from_bytes([0x7Fu8; 32]);
         let native_script = NativeScript::ScriptPubkey(signer_hash);
-        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()));
+        let script_hash = compute_script_ref_hash(&ScriptRef::NativeScript(native_script.clone()), None);
 
         // Spending input — the UTxO that the minting transaction actually spends.
         let spending_input = TransactionInput {

--- a/crates/dugite-serialization/src/decode/era_alonzo.rs
+++ b/crates/dugite-serialization/src/decode/era_alonzo.rs
@@ -1141,43 +1141,51 @@ pub(crate) fn read_native_script_from_cbor(
 }
 
 fn read_native_script(r: &mut Reader<'_>) -> Result<NativeScript, SerializationError> {
+    // OUTER ARRAY: accept BOTH definite- AND indefinite-length encodings, matching
+    // cardano-ledger's Timelock decoder (`decodeRecordSum` -> `decodeListLenOrIndef`).
+    // The previous `is_none() => Err` HARD-REJECTED indefinite-length native scripts
+    // that Haskell accepts — over-rejecting valid blocks. Mirrors the already-fixed
+    // Conway copy (`era_conway::read_native_script`). See issue #862.
     let arr_len = r.read_array_header()?;
-    if arr_len.is_none() {
-        return Err(SerializationError::CborDecode(
-            "native_script: expected definite-length array".into(),
-        ));
-    }
     let disc = r.read_uint()?;
-    match disc {
+    let script = match disc {
         0 => {
             let h28 = read_hash28_cert(r)?;
-            Ok(NativeScript::ScriptPubkey(h28.to_hash32_padded()))
+            NativeScript::ScriptPubkey(h28.to_hash32_padded())
         }
         1 => {
             let scripts = r.read_array(read_native_script)?;
-            Ok(NativeScript::ScriptAll(scripts))
+            NativeScript::ScriptAll(scripts)
         }
         2 => {
             let scripts = r.read_array(read_native_script)?;
-            Ok(NativeScript::ScriptAny(scripts))
+            NativeScript::ScriptAny(scripts)
         }
         3 => {
             let n = r.read_uint()? as u32;
             let scripts = r.read_array(read_native_script)?;
-            Ok(NativeScript::ScriptNOfK(n, scripts))
+            NativeScript::ScriptNOfK(n, scripts)
         }
         4 => {
             let slot = r.read_uint()?;
-            Ok(NativeScript::InvalidBefore(SlotNo(slot)))
+            NativeScript::InvalidBefore(SlotNo(slot))
         }
         5 => {
             let slot = r.read_uint()?;
-            Ok(NativeScript::InvalidHereafter(SlotNo(slot)))
+            NativeScript::InvalidHereafter(SlotNo(slot))
         }
-        other => Err(SerializationError::CborDecode(format!(
-            "native_script: unknown type {other}"
-        ))),
+        other => {
+            return Err(SerializationError::CborDecode(format!(
+                "native_script: unknown type {other}"
+            )))
+        }
+    };
+    // Consume the trailing CBOR break byte for an indefinite-length outer array,
+    // exactly as upstream `decodeListLikeT` does for the `Nothing` case.
+    if arr_len.is_none() {
+        r.expect_break()?;
     }
+    Ok(script)
 }
 
 /// Read a single Plutus redeemer: `[tag, index, plutus_data, ex_units]`.

--- a/crates/dugite-serialization/src/decode/era_alonzo.rs
+++ b/crates/dugite-serialization/src/decode/era_alonzo.rs
@@ -494,7 +494,7 @@ pub(crate) fn decode_alonzo_tx_body(
                 inputs = r.read_array(read_tx_input)?;
             }
             1 => {
-                outputs = r.read_array(|r| read_alonzo_tx_output(r, era))?;
+                outputs = r.read_array(|r| read_alonzo_tx_output_with_raw(r, era))?;
             }
             2 => {
                 fee = read_lovelace(r)?;
@@ -638,6 +638,25 @@ fn read_alonzo_tx_output(
         is_legacy: true,
         raw_cbor: None,
     })
+}
+
+/// Read an Alonzo-family (Allegra / Mary / Alonzo) `transaction_output` from the
+/// reader and capture its original CBOR bytes in `raw_cbor`.
+///
+/// Wraps [`read_alonzo_tx_output`] with [`KeepRaw::parse_with`] so that pre-Conway
+/// outputs carry the exact wire bytes they were decoded from, matching the Conway
+/// path's [`crate::decode::era_conway`] `read_babbage_tx_output_with_raw`. Without
+/// this, every Mary/Alonzo output reaches the ledger with `raw_cbor == None`,
+/// forcing `raw_cbor`-dependent paths (e.g. Rule 5 min-UTxO size) onto a re-encode
+/// fallback. See issue #857.
+fn read_alonzo_tx_output_with_raw(
+    r: &mut Reader<'_>,
+    era: Era,
+) -> Result<TransactionOutput, SerializationError> {
+    let raw = KeepRaw::parse_with(r, |r| read_alonzo_tx_output(r, era))?;
+    let mut output = raw.value;
+    output.raw_cbor = Some(raw.raw.to_vec());
+    Ok(output)
 }
 
 /// Read a Value: either a plain uint (ADA only) or `[coin, multiasset_map]`.
@@ -2878,6 +2897,27 @@ mod tests {
             "raw_cbor.len()={} expected={}",
             raw.len(),
             expected_len
+        );
+    }
+
+    #[test]
+    fn alonzo_with_raw_captures_original_bytes_857() {
+        // The captured raw_cbor is the exact original span, not a re-encode.
+        let addr_bytes: Vec<u8> = {
+            let mut v = vec![0x60];
+            v.extend_from_slice(&[0u8; 28]);
+            v
+        };
+        let mut out_arr = vec![0x82]; // array(2)
+        out_arr.extend(cbor_bytes(&addr_bytes));
+        out_arr.extend(cbor_uint(3_000_000));
+
+        let mut r = Reader::new(&out_arr);
+        let out = read_alonzo_tx_output_with_raw(&mut r, Era::Alonzo).unwrap();
+        assert_eq!(
+            out.raw_cbor.as_deref(),
+            Some(out_arr.as_slice()),
+            "raw_cbor must hold the exact original Alonzo output bytes"
         );
     }
 }

--- a/crates/dugite-serialization/src/decode/era_babbage.rs
+++ b/crates/dugite-serialization/src/decode/era_babbage.rs
@@ -440,7 +440,7 @@ fn decode_babbage_tx_body(r: &mut Reader<'_>) -> Result<TransactionBody, Seriali
                 inputs = r.read_array(read_tx_input)?;
             }
             1 => {
-                outputs = r.read_array(|r| read_babbage_tx_output(r))?;
+                outputs = r.read_array(|r| read_babbage_tx_output_with_raw(r))?;
             }
             2 => {
                 fee = Lovelace(r.read_uint()?);
@@ -498,8 +498,10 @@ fn decode_babbage_tx_body(r: &mut Reader<'_>) -> Result<TransactionBody, Seriali
                 network_id = Some(id as u8);
             }
             16 => {
-                // collateral_return: a post-Alonzo output (map or legacy array)
-                collateral_return = Some(read_babbage_tx_output(r)?);
+                // collateral_return: a post-Alonzo output (map or legacy array).
+                // Capture raw_cbor to match Conway (#857): collateral_return is a
+                // TransactionOutput subject to the same raw_cbor-dependent size checks.
+                collateral_return = Some(read_babbage_tx_output_with_raw(r)?);
             }
             17 => {
                 // total_collateral: coin
@@ -650,6 +652,23 @@ fn read_babbage_tx_output(r: &mut Reader<'_>) -> Result<TransactionOutput, Seria
             "babbage tx_out: expected array or map, got {other}"
         ))),
     }
+}
+
+/// Read a Babbage `transaction_output` from the reader and capture its original
+/// CBOR bytes in `raw_cbor`.
+///
+/// Wraps [`read_babbage_tx_output`] with [`KeepRaw::parse_with`] so Babbage outputs
+/// carry the exact wire bytes they were decoded from, matching the Conway path's
+/// `read_babbage_tx_output_with_raw`. Without this, every Babbage output (and
+/// collateral return) reached the ledger with `raw_cbor == None`, forcing
+/// `raw_cbor`-dependent paths onto a re-encode fallback. See issue #857.
+fn read_babbage_tx_output_with_raw(
+    r: &mut Reader<'_>,
+) -> Result<TransactionOutput, SerializationError> {
+    let raw = KeepRaw::parse_with(r, read_babbage_tx_output)?;
+    let mut output = raw.value;
+    output.raw_cbor = Some(raw.raw.to_vec());
+    Ok(output)
 }
 
 fn read_babbage_legacy_output(r: &mut Reader<'_>) -> Result<TransactionOutput, SerializationError> {
@@ -1536,6 +1555,56 @@ mod tests {
             "array-form output should have is_legacy=true"
         );
         assert_eq!(out.value.coin.0, 3_000_000);
+    }
+
+    #[test]
+    fn babbage_with_raw_captures_original_bytes_857() {
+        // #857: pre-Conway output decode must populate `raw_cbor` with the ORIGINAL
+        // wire bytes (not None, not a re-encode) so raw_cbor-dependent ledger paths
+        // (Rule 5 min-UTxO size) see the exact encoding.
+        let addr_bytes: Vec<u8> = {
+            let mut v = vec![0x60];
+            v.extend_from_slice(&[0u8; 28]);
+            v
+        };
+        let mut out_arr = vec![0x82]; // array(2)
+        out_arr.extend(cbor_bytes(&addr_bytes));
+        out_arr.extend(cbor_uint(3_000_000));
+
+        let mut r = Reader::new(&out_arr);
+        let out = read_babbage_tx_output_with_raw(&mut r).unwrap();
+        assert_eq!(
+            out.raw_cbor.as_deref(),
+            Some(out_arr.as_slice()),
+            "raw_cbor must hold the exact original output bytes"
+        );
+    }
+
+    #[test]
+    fn babbage_with_raw_preserves_noncanonical_uint_value_857() {
+        // A VALID output whose coin value is encoded with a NON-MINIMAL uint
+        // (0x1a 00 00 00 05 for 5, instead of the minimal 0x05) must round-trip its
+        // ORIGINAL bytes through raw_cbor — proving the capture is the original span,
+        // not a canonical re-encode (which would differ). This is the byte-exact
+        // property the fix guarantees for downstream re-hash/size paths.
+        let addr_bytes: Vec<u8> = {
+            let mut v = vec![0x60];
+            v.extend_from_slice(&[0u8; 28]);
+            v
+        };
+        let mut out_arr = vec![0x82]; // array(2)
+        out_arr.extend(cbor_bytes(&addr_bytes));
+        // Non-minimal encoding of 5 as a 4-byte uint: 0x1a 00000005.
+        out_arr.extend_from_slice(&[0x1a, 0x00, 0x00, 0x00, 0x05]);
+
+        let mut r = Reader::new(&out_arr);
+        let out = read_babbage_tx_output_with_raw(&mut r).unwrap();
+        assert_eq!(
+            out.raw_cbor.as_deref(),
+            Some(out_arr.as_slice()),
+            "raw_cbor must preserve the non-minimal-uint bytes verbatim, not re-encode"
+        );
+        assert_eq!(out.value.coin.0, 5);
     }
 
     #[test]

--- a/crates/dugite-serialization/src/decode/era_conway.rs
+++ b/crates/dugite-serialization/src/decode/era_conway.rs
@@ -4506,7 +4506,10 @@ mod tests {
         let p = read_ex_unit_prices(&mut r).unwrap();
         assert_eq!(p.mem_price.numerator, 1);
         assert_eq!(p.mem_price.denominator, 100);
-        assert_eq!(p.step_price.denominator, 1000);
+        // #860.4: rationals are reduced to lowest terms at decode (Haskell `%`), so
+        // the non-reduced wire pair 2/1000 becomes 1/500.
+        assert_eq!(p.step_price.numerator, 1);
+        assert_eq!(p.step_price.denominator, 500);
     }
 
     #[test]

--- a/crates/dugite-serialization/src/decode/era_conway.rs
+++ b/crates/dugite-serialization/src/decode/era_conway.rs
@@ -3200,7 +3200,10 @@ mod tests {
 
         let spans = witness_native_script_original_bytes(&ws).expect("extract native spans");
         assert_eq!(spans.len(), 1);
-        assert_eq!(spans[0], ns, "must capture the exact original (indefinite) bytes");
+        assert_eq!(
+            spans[0], ns,
+            "must capture the exact original (indefinite) bytes"
+        );
 
         // The decoded script re-encodes to a DIFFERENT (canonical, definite) form.
         let decoded = read_native_script(&mut Reader::new(&ns)).unwrap();
@@ -3237,7 +3240,10 @@ mod tests {
 
         let recovered =
             reference_native_script_original_bytes(&out).expect("recover inner native bytes");
-        assert_eq!(recovered, ns, "must recover the exact inner native-script bytes");
+        assert_eq!(
+            recovered, ns,
+            "must recover the exact inner native-script bytes"
+        );
     }
 
     /// #730: Haskell `decodeMultiAsset` at decoder version >= 9

--- a/crates/dugite-serialization/src/decode/era_conway.rs
+++ b/crates/dugite-serialization/src/decode/era_conway.rs
@@ -1323,6 +1323,106 @@ fn read_script_ref(
     }
 }
 
+/// Capture the ORIGINAL wire byte span of each native script in a `native_scripts`
+/// set/array, in order. Reuses [`read_set`](Reader::read_set) (which transparently
+/// handles the pre-Conway plain array and the Conway tag-258 set form) with a
+/// [`KeepRaw`] element wrapper so each element's exact original bytes are captured.
+fn read_native_script_spans(r: &mut Reader<'_>) -> Result<Vec<Vec<u8>>, SerializationError> {
+    r.read_set(|r| {
+        let kr = KeepRaw::parse_with(r, read_native_script)?;
+        Ok(kr.raw.to_vec())
+    })
+}
+
+/// Extract the ORIGINAL wire bytes of every native script in a transaction witness
+/// set (key 1), in order, from the witness set's raw CBOR.
+///
+/// Cardano hashes a native script as `blake2b_224(0x00 || originalBytes)` over the
+/// exact decoded bytes (Haskell `hashScript` over the Timelock `MemoBytes`), NEVER a
+/// canonical re-encode. A non-canonically-but-validly-encoded native script (e.g. an
+/// indefinite-length outer array, or a non-minimal integer field) therefore hashes
+/// differently from `encode_native_script(decoded)`. This lets the ledger hash over
+/// the original bytes with a re-encode fallback only when the raw CBOR is absent
+/// (locally-constructed transactions). Era-agnostic. See issue #862.
+///
+/// Returns `None` if the witness set CBOR is unavailable/malformed or carries no
+/// `native_scripts` key.
+pub fn witness_native_script_original_bytes(witness_set_cbor: &[u8]) -> Option<Vec<Vec<u8>>> {
+    let mut r = Reader::new(witness_set_cbor);
+    let len = r.read_map_header().ok()?;
+    let mut spans: Option<Vec<Vec<u8>>> = None;
+    let mut read_one_entry = |r: &mut Reader<'_>| -> Result<(), SerializationError> {
+        let key = r.read_uint()?;
+        if key == 1 {
+            spans = Some(read_native_script_spans(r)?);
+        } else {
+            r.skip()?;
+        }
+        Ok(())
+    };
+    match len {
+        Some(n) => {
+            for _ in 0..n {
+                read_one_entry(&mut r).ok()?;
+            }
+        }
+        None => loop {
+            if r.peek_major().ok()? == Type::Break {
+                r.expect_break().ok()?;
+                break;
+            }
+            read_one_entry(&mut r).ok()?;
+        },
+    }
+    spans
+}
+
+/// Extract the ORIGINAL wire bytes of a reference NATIVE script from a transaction
+/// output's raw CBOR (map key 3, `#6.24(bytes .cbor [0, native_script])`).
+///
+/// The reference-script hash is `blake2b_224(0x00 || originalBytes)` over the inner
+/// native script's original bytes (excluding the tag-24/bstr framing and the leading
+/// `0` type tag), same as the witness-set path. Returns `None` for legacy-array
+/// outputs, non-native reference scripts, missing script_ref, or malformed CBOR — in
+/// which case the ledger falls back to a re-encode. See issue #862.
+pub fn reference_native_script_original_bytes(output_cbor: &[u8]) -> Option<Vec<u8>> {
+    let mut r = Reader::new(output_cbor);
+    // Only post-Alonzo map-form outputs carry a script_ref; a legacy array output
+    // fails read_map_header and yields None.
+    let len = r.read_map_header().ok()?;
+    let mut found: Option<Vec<u8>> = None;
+    let mut read_one_entry = |r: &mut Reader<'_>| -> Result<(), SerializationError> {
+        let key = r.read_uint()?;
+        if key == 3 && found.is_none() {
+            // script_ref = #6.24(bytes .cbor [type, script])
+            let inner = r.read_embedded_cbor_bytes()?.to_vec();
+            let mut sr = Reader::new(&inner);
+            if matches!(sr.read_array_header()?, Some(2)) && sr.read_uint()? == 0 {
+                let kr = KeepRaw::parse_with(&mut sr, read_native_script)?;
+                found = Some(kr.raw.to_vec());
+            }
+        } else {
+            r.skip()?;
+        }
+        Ok(())
+    };
+    match len {
+        Some(n) => {
+            for _ in 0..n {
+                read_one_entry(&mut r).ok()?;
+            }
+        }
+        None => loop {
+            if r.peek_major().ok()? == Type::Break {
+                r.expect_break().ok()?;
+                break;
+            }
+            read_one_entry(&mut r).ok()?;
+        },
+    }
+    found
+}
+
 // ============================================================================
 // Certificate decoder (Conway)
 // ============================================================================
@@ -3083,6 +3183,62 @@ pub(crate) fn decode_conway_tx_output_standalone(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #862: a native script encoded with a non-canonical INDEFINITE-length outer
+    /// array is (a) accepted by the decoder and (b) has its EXACT original bytes
+    /// recovered by `witness_native_script_original_bytes`, which differ from a
+    /// canonical re-encode. This is the byte-exact property the hashScript fix needs.
+    #[test]
+    fn witness_native_original_bytes_captures_indefinite_form_862() {
+        // ScriptPubkey = [0, h28]; indefinite outer array: 0x9f 0x00 (0x581c<28>) 0xff
+        let mut ns = vec![0x9f, 0x00, 0x58, 0x1c];
+        ns.extend_from_slice(&[0xAB; 28]);
+        ns.push(0xff);
+        // Witness set map { 1 => array(1) [ ns ] } : 0xa1 0x01 0x81 <ns>
+        let mut ws = vec![0xa1, 0x01, 0x81];
+        ws.extend_from_slice(&ns);
+
+        let spans = witness_native_script_original_bytes(&ws).expect("extract native spans");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0], ns, "must capture the exact original (indefinite) bytes");
+
+        // The decoded script re-encodes to a DIFFERENT (canonical, definite) form.
+        let decoded = read_native_script(&mut Reader::new(&ns)).unwrap();
+        let reencoded = crate::encode::encode_native_script(&decoded);
+        assert_ne!(
+            reencoded, ns,
+            "canonical re-encode must differ from the indefinite original"
+        );
+    }
+
+    /// #862: a reference NATIVE script's original inner bytes are recovered from an
+    /// output's CBOR (map key 3 = #6.24(bstr .cbor [0, native_script])).
+    #[test]
+    fn reference_native_original_bytes_recovers_inner_script_862() {
+        // native script (definite): [0, h28] = 0x82 0x00 0x581c<28>
+        let mut ns = vec![0x82, 0x00, 0x58, 0x1c];
+        ns.extend_from_slice(&[0xCD; 28]);
+        // inner = [0, native_script] = 0x82 0x00 <ns>
+        let mut inner = vec![0x82, 0x00];
+        inner.extend_from_slice(&ns);
+        // script_ref = #6.24(bstr(inner)) = 0xd8 0x18 0x58 <len> <inner>
+        let mut sref = vec![0xd8, 0x18, 0x58, inner.len() as u8];
+        sref.extend_from_slice(&inner);
+        // output map { 0 => addr, 3 => script_ref }
+        let addr = {
+            let mut v = vec![0x60];
+            v.extend_from_slice(&[0u8; 28]);
+            v
+        };
+        let mut out = vec![0xa2, 0x00, 0x58, addr.len() as u8];
+        out.extend_from_slice(&addr);
+        out.push(0x03);
+        out.extend_from_slice(&sref);
+
+        let recovered =
+            reference_native_script_original_bytes(&out).expect("recover inner native bytes");
+        assert_eq!(recovered, ns, "must recover the exact inner native-script bytes");
+    }
 
     /// #730: Haskell `decodeMultiAsset` at decoder version >= 9
     /// (`decodeConway`) REJECTS zero-quantity assets:

--- a/crates/dugite-serialization/src/decode/era_shelley.rs
+++ b/crates/dugite-serialization/src/decode/era_shelley.rs
@@ -1159,44 +1159,51 @@ fn decode_shelley_witness_set(
 ///               / [5, slot]           ; InvalidHereafter
 /// ```
 fn read_native_script(r: &mut Reader<'_>) -> Result<NativeScript, SerializationError> {
+    // OUTER ARRAY: accept BOTH definite- AND indefinite-length encodings, matching
+    // cardano-ledger's Timelock decoder (`decodeRecordSum` -> `decodeListLenOrIndef`).
+    // The previous `is_none() => Err` HARD-REJECTED indefinite-length native scripts
+    // that Haskell accepts — over-rejecting valid blocks. Mirrors the already-fixed
+    // Conway copy (`era_conway::read_native_script`). See issue #862.
     let arr_len = r.read_array_header()?;
-    if arr_len.is_none() {
-        return Err(SerializationError::CborDecode(
-            "native_script: expected definite-length array".into(),
-        ));
-    }
     let disc = r.read_uint()?;
-    match disc {
+    let script = match disc {
         0 => {
             // ScriptPubkey: hash28 → padded to Hash32
             let h28 = read_hash28_cert(r)?;
-            Ok(NativeScript::ScriptPubkey(h28.to_hash32_padded()))
+            NativeScript::ScriptPubkey(h28.to_hash32_padded())
         }
         1 => {
             let scripts = r.read_array(read_native_script)?;
-            Ok(NativeScript::ScriptAll(scripts))
+            NativeScript::ScriptAll(scripts)
         }
         2 => {
             let scripts = r.read_array(read_native_script)?;
-            Ok(NativeScript::ScriptAny(scripts))
+            NativeScript::ScriptAny(scripts)
         }
         3 => {
             let n = r.read_uint()? as u32;
             let scripts = r.read_array(read_native_script)?;
-            Ok(NativeScript::ScriptNOfK(n, scripts))
+            NativeScript::ScriptNOfK(n, scripts)
         }
         4 => {
             let slot = r.read_uint()?;
-            Ok(NativeScript::InvalidBefore(SlotNo(slot)))
+            NativeScript::InvalidBefore(SlotNo(slot))
         }
         5 => {
             let slot = r.read_uint()?;
-            Ok(NativeScript::InvalidHereafter(SlotNo(slot)))
+            NativeScript::InvalidHereafter(SlotNo(slot))
         }
-        other => Err(SerializationError::CborDecode(format!(
-            "native_script: unknown type {other}"
-        ))),
+        other => {
+            return Err(SerializationError::CborDecode(format!(
+                "native_script: unknown type {other}"
+            )))
+        }
+    };
+    // Consume the trailing CBOR break byte for an indefinite-length outer array.
+    if arr_len.is_none() {
+        r.expect_break()?;
     }
+    Ok(script)
 }
 
 // ============================================================================

--- a/crates/dugite-serialization/src/decode/mod.rs
+++ b/crates/dugite-serialization/src/decode/mod.rs
@@ -75,6 +75,13 @@ pub use era_conway::ppu_from_cbor;
 /// typed `ScriptRef::NativeScript` from a MemPack reference-script blob.
 pub use era_conway::decode_native_script_cbor;
 
+/// Extract the original wire bytes of native scripts (witness-set key 1, and a
+/// reference script in an output) so the ledger can hash them over their ORIGINAL
+/// bytes (`hashScript` over MemoBytes) rather than a canonical re-encode. See #862.
+pub use era_conway::{
+    reference_native_script_original_bytes, witness_native_script_original_bytes,
+};
+
 /// Decode an inline-datum `PlutusData` from its bare CBOR encoding.
 /// Re-exported so the Mithril / Haskell-import UTxO loader can reconstruct a
 /// typed `OutputDatum::InlineDatum` from a MemPack TxOut (tags 4/5).

--- a/crates/dugite-serialization/src/decode/reader.rs
+++ b/crates/dugite-serialization/src/decode/reader.rs
@@ -1267,7 +1267,7 @@ mod tests {
             ((9u64, 18u64), (1u64, 2u64)),
             ((2, 1000), (1, 500)),
             ((0, 5), (0, 1)), // 0 % d = 0/1
-            ((7, 3), (7, 3)),  // already reduced / improper — unchanged
+            ((7, 3), (7, 3)), // already reduced / improper — unchanged
             ((100, 100), (1, 1)),
         ];
         for ((n, d), (en, ed)) in cases {

--- a/crates/dugite-serialization/src/decode/reader.rs
+++ b/crates/dugite-serialization/src/decode/reader.rs
@@ -27,6 +27,18 @@ use num_bigint::BigInt;
 /// Encoding: `tag(30) [numerator, denominator]`.
 const TAG_RATIONAL: u64 = 30;
 
+/// Greatest common divisor (Euclid). Used to reduce decoded `Rational`s to lowest
+/// terms, matching Haskell's `%` smart constructor (#860.4). Callers guarantee at
+/// least one argument is non-zero (the denominator is rejected when zero), so the
+/// result is `>= 1` and division by it is safe.
+fn gcd_u64(a: u64, b: u64) -> u64 {
+    if b == 0 {
+        a.max(1)
+    } else {
+        gcd_u64(b, a % b)
+    }
+}
+
 /// CBOR tag 2: positive bignum (big-endian byte string).
 const TAG_BIGNUM_POS: u64 = 2;
 
@@ -885,9 +897,19 @@ impl<'b> Reader<'b> {
                 "read_rational: denominator is zero".into(),
             ));
         }
+        // Reduce to lowest terms at decode time, matching Haskell's on-chain
+        // `Rational`/`BoundedRatio`, which is ALWAYS built via GHC's `%` smart
+        // constructor (dividing both sides by `gcd`) — see
+        // `cardano-ledger-binary` `decodeIntegralRational` = `toInteger n % toInteger d`.
+        // A non-reduced on-wire pair (e.g. 9/18) would otherwise be stored raw and
+        // re-emitted byte-differently from Haskell's 1/2 in ledger-state dumps,
+        // PParams/pool-margin query encoding, and the ScriptContext `Data` boundary.
+        // Real chain data is already reduced, so this is a no-op there. See #860.4 /
+        // #837.2 (the ScriptContext-side `reduce_rational` this subsumes at the root).
+        let g = gcd_u64(numerator, denominator);
         Ok(Rational {
-            numerator,
-            denominator,
+            numerator: numerator / g,
+            denominator: denominator / g,
         })
     }
 
@@ -1236,6 +1258,27 @@ mod tests {
         let rat = r.read_rational().unwrap();
         assert_eq!(rat.numerator, 3);
         assert_eq!(rat.denominator, 4);
+    }
+
+    #[test]
+    fn read_rational_reduces_to_lowest_terms_860_4() {
+        // A non-reduced on-wire pair must be reduced at decode (Haskell `%`).
+        let cases = [
+            ((9u64, 18u64), (1u64, 2u64)),
+            ((2, 1000), (1, 500)),
+            ((0, 5), (0, 1)), // 0 % d = 0/1
+            ((7, 3), (7, 3)),  // already reduced / improper — unchanged
+            ((100, 100), (1, 1)),
+        ];
+        for ((n, d), (en, ed)) in cases {
+            let mut data = cbor_tag(30);
+            data.extend(cbor_array_hdr(2));
+            data.extend(cbor_uint(n));
+            data.extend(cbor_uint(d));
+            let mut r = Reader::new(&data);
+            let rat = r.read_rational().unwrap();
+            assert_eq!((rat.numerator, rat.denominator), (en, ed), "{n}/{d}");
+        }
     }
 
     #[test]

--- a/crates/dugite-serialization/src/lib.rs
+++ b/crates/dugite-serialization/src/lib.rs
@@ -22,6 +22,7 @@ pub use decode::{
     decode_native_script_cbor, decode_plutus_data_cbor, decode_transaction,
     decode_transaction_input, decode_transaction_output, decode_wire_wrapped_block_header,
     decode_wrapped_block_header, plutus_data_element_spans,
+    reference_native_script_original_bytes, witness_native_script_original_bytes,
 };
 
 // Helper exposed by the existing in-house pipeline; used by mithril chunk-file

--- a/crates/dugite-serialization/src/lib.rs
+++ b/crates/dugite-serialization/src/lib.rs
@@ -21,8 +21,8 @@ pub use decode::{
     decode_block_with_byron_epoch_length, decode_byron_ebb_block, decode_byron_main_block,
     decode_native_script_cbor, decode_plutus_data_cbor, decode_transaction,
     decode_transaction_input, decode_transaction_output, decode_wire_wrapped_block_header,
-    decode_wrapped_block_header, plutus_data_element_spans,
-    reference_native_script_original_bytes, witness_native_script_original_bytes,
+    decode_wrapped_block_header, plutus_data_element_spans, reference_native_script_original_bytes,
+    witness_native_script_original_bytes,
 };
 
 // Helper exposed by the existing in-house pipeline; used by mithril chunk-file

--- a/crates/dugite-serialization/tests/real_blocks.rs
+++ b/crates/dugite-serialization/tests/real_blocks.rs
@@ -61,6 +61,40 @@ fn test_conway_block() {
     smoke_test_block("conway", Era::Conway);
 }
 
+/// #857: pre-Conway (Mary/Alonzo/Babbage) tx outputs must carry `raw_cbor` when
+/// decoded through the real block path, matching Conway. Prior to the fix every
+/// pre-Conway output reached the ledger with `raw_cbor == None`, silently forcing
+/// `raw_cbor`-dependent ledger paths (Rule 5 min-UTxO size) onto a re-encode fallback.
+#[test]
+fn test_pre_conway_outputs_carry_raw_cbor_857() {
+    let mut total_checked = 0usize;
+    for (name, era) in [
+        ("mary", Era::Mary),
+        ("alonzo", Era::Alonzo),
+        ("babbage", Era::Babbage),
+    ] {
+        let cbor = load_vector(name);
+        let block = decode_block(&cbor).unwrap_or_else(|e| panic!("{name}: decode failed: {e}"));
+        assert_eq!(block.era, era, "{name}: era mismatch");
+        for tx in &block.transactions {
+            for out in &tx.body.outputs {
+                assert!(
+                    out.raw_cbor.is_some(),
+                    "{name}: output reached ledger with raw_cbor == None (#857 regression)"
+                );
+                total_checked += 1;
+            }
+        }
+    }
+    // Mary and Babbage exercise the two pre-Conway output decoders (the Alonzo-family
+    // legacy decoder and the Babbage map/legacy decoder respectively), so at least one
+    // real output must have been checked overall.
+    assert!(
+        total_checked > 0,
+        "no pre-Conway output was exercised — #857 regression is untested"
+    );
+}
+
 #[test]
 fn test_decode_block_invalid_cbor() {
     let bad_cbor = vec![0xff, 0xfe, 0xfd, 0xfc];

--- a/crates/dugite-uplc/src/builtin/bls.rs
+++ b/crates/dugite-uplc/src/builtin/bls.rs
@@ -41,6 +41,49 @@ pub const G1_COMPRESSED_BYTES: usize = 48;
 pub const G2_COMPRESSED_BYTES: usize = 96;
 const FP12_BYTES: usize = 576;
 
+// ---------------------------------------------------------------------------
+// Decompressed-point cache (#839 residual)
+// ---------------------------------------------------------------------------
+//
+// dugite stores G1/G2 `Constant`s compressed (see the doc comments on
+// `Constant::Bls12_381G1Element`/`Bls12_381G2Element` in `term.rs`), so
+// every denotation that consumes one re-runs `blst_p1_uncompress`/
+// `blst_p2_uncompress` (point decompression: a modular sqrt plus curve/
+// subgroup arithmetic, ~100-400µs) even though the Plutus cost model
+// charges the CHEAP in-memory-point cost (it assumes a decompressed
+// representation, matching Haskell's `BLS12_381.G1.Element` wrapping an
+// already-parsed `Point`). A script that references the same compressed
+// point across several builtin calls (a base point reused across many
+// `scalarMul`s, a public key appearing in more than one
+// `multiScalarMul`/pairing call, ...) pays that cost on every call.
+//
+// This is a pure, deterministic memoization keyed by the compressed
+// bytes — thread-local (the CEK machine is single-threaded per
+// evaluation; different rayon workers get independent caches, so no
+// synchronization is needed) and capped (`BLS_DECOMPRESS_CACHE_CAP`) so
+// an adversarial script computing many distinct valid points cannot grow
+// it without bound for the life of the evaluating thread. Because this
+// only memoizes a pure function of the compressed bytes, an eviction (or
+// this cache never having been populated at all) can only ever cost a
+// re-decompression — it can NEVER produce a different point, so there is
+// no correctness/consensus dependency on cache behavior, only a
+// performance one. Deliberately NOT a `Constant`/`Value`/`Term`-level
+// change (the alternative the issue also considered): attaching the
+// cache to the value itself would need `Constant`'s derived
+// `PartialEq`/`Eq`/`Clone` (used well beyond BLS) to be hand-rolled to
+// ignore the cache field, which is a much larger blast radius for the
+// same benefit.
+const BLS_DECOMPRESS_CACHE_CAP: usize = 1024;
+
+thread_local! {
+    static G1_DECOMPRESS_CACHE: std::cell::RefCell<
+        std::collections::HashMap<[u8; G1_COMPRESSED_BYTES], blst_p1>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
+    static G2_DECOMPRESS_CACHE: std::cell::RefCell<
+        std::collections::HashMap<[u8; G2_COMPRESSED_BYTES], blst_p2>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
 // `fp12_to_bytes`/`fp12_from_bytes` below memcpy `FP12_BYTES` raw bytes
 // in/out of a `blst_fp12` through a pointer cast, with no per-call size
 // check. Pin the assumed layout at compile time (#843): if a future
@@ -477,6 +520,21 @@ fn uncompress_g1(bs: &[u8], id: BuiltinId) -> Result<blst_p1, UplcError> {
 /// still decodes the compressed encoding (required, since `Constant`
 /// stores only compressed bytes) but skips the expensive subgroup
 /// re-check.
+///
+/// Memoized (#839 residual) via [`G1_DECOMPRESS_CACHE`): a script that
+/// references the SAME compressed point across multiple builtin calls
+/// (e.g. a base point reused across several `scalarMul`/`add` calls, or
+/// the same public key appearing more than once across separate
+/// `multiScalarMul`/pairing calls) pays the ~100-400µs decompression
+/// cost once instead of on every call — closing the propagation/DoS gap
+/// where the cost model charges the cheap in-memory-point cost but the
+/// implementation was doing the expensive decompression every time.
+/// This does NOT change the `Constant`/`Value`/`Term` shape (the
+/// alternative the issue also considered): the cache is a pure,
+/// deterministic memoization table keyed by the compressed bytes,
+/// entirely internal to this module, so it cannot affect equality,
+/// hashing, cloning, or encoding of a `Constant::Bls12_381G1Element`
+/// anywhere else in the crate.
 fn decompress_g1_trusted(bs: &[u8], id: BuiltinId) -> Result<blst_p1, UplcError> {
     debug_assert_eq!(
         bs.len(),
@@ -484,6 +542,31 @@ fn decompress_g1_trusted(bs: &[u8], id: BuiltinId) -> Result<blst_p1, UplcError>
         "decompress_g1_trusted must only be called on bytes taken from a \
          Bls12_381G1Element, which is always exactly G1_COMPRESSED_BYTES long"
     );
+    let mut key = [0u8; G1_COMPRESSED_BYTES];
+    key.copy_from_slice(bs);
+    if let Some(p) = G1_DECOMPRESS_CACHE.with(|c| c.borrow().get(&key).copied()) {
+        return Ok(p);
+    }
+    let p = decompress_g1_trusted_uncached(bs, id)?;
+    G1_DECOMPRESS_CACHE.with(|c| {
+        let mut cache = c.borrow_mut();
+        // Bound memory: an adversarial script computing an unbounded
+        // number of DISTINCT valid points (each itself charged real
+        // ExBudget to construct) would otherwise grow this cache without
+        // limit for the lifetime of the evaluating thread. A flat clear
+        // on overflow is simplest and sufficient here — this is a pure
+        // memoization of a deterministic function, so evicting entries
+        // can only ever cost a re-decompression, never a wrong answer.
+        if cache.len() >= BLS_DECOMPRESS_CACHE_CAP {
+            cache.clear();
+        }
+        cache.insert(key, p);
+    });
+    Ok(p)
+}
+
+/// The actual decompression work, uncached. See [`decompress_g1_trusted`].
+fn decompress_g1_trusted_uncached(bs: &[u8], id: BuiltinId) -> Result<blst_p1, UplcError> {
     let mut aff = blst_p1_affine::default();
     let err = unsafe { blst_p1_uncompress(&mut aff, bs.as_ptr()) };
     if err != BLST_ERROR::BLST_SUCCESS {
@@ -538,7 +621,8 @@ fn uncompress_g2(bs: &[u8], id: BuiltinId) -> Result<blst_p2, UplcError> {
 }
 
 /// Decompress G2 bytes that are already known-valid by construction.
-/// See [`decompress_g1_trusted`] — the same invariant holds for G2.
+/// See [`decompress_g1_trusted`] — the same invariant, and the same
+/// (#839 residual) memoization via [`G2_DECOMPRESS_CACHE`], hold for G2.
 fn decompress_g2_trusted(bs: &[u8], id: BuiltinId) -> Result<blst_p2, UplcError> {
     debug_assert_eq!(
         bs.len(),
@@ -546,6 +630,24 @@ fn decompress_g2_trusted(bs: &[u8], id: BuiltinId) -> Result<blst_p2, UplcError>
         "decompress_g2_trusted must only be called on bytes taken from a \
          Bls12_381G2Element, which is always exactly G2_COMPRESSED_BYTES long"
     );
+    let mut key = [0u8; G2_COMPRESSED_BYTES];
+    key.copy_from_slice(bs);
+    if let Some(p) = G2_DECOMPRESS_CACHE.with(|c| c.borrow().get(&key).copied()) {
+        return Ok(p);
+    }
+    let p = decompress_g2_trusted_uncached(bs, id)?;
+    G2_DECOMPRESS_CACHE.with(|c| {
+        let mut cache = c.borrow_mut();
+        if cache.len() >= BLS_DECOMPRESS_CACHE_CAP {
+            cache.clear();
+        }
+        cache.insert(key, p);
+    });
+    Ok(p)
+}
+
+/// The actual decompression work, uncached. See [`decompress_g2_trusted`].
+fn decompress_g2_trusted_uncached(bs: &[u8], id: BuiltinId) -> Result<blst_p2, UplcError> {
     let mut aff = blst_p2_affine::default();
     let err = unsafe { blst_p2_uncompress(&mut aff, bs.as_ptr()) };
     if err != BLST_ERROR::BLST_SUCCESS {
@@ -1044,6 +1146,115 @@ mod tests {
         let ab = denote_bls(BuiltinId::Bls12_381_G1_Add, vec![a.clone(), b.clone()]).unwrap();
         let ba = denote_bls(BuiltinId::Bls12_381_G1_Add, vec![b, a]).unwrap();
         assert_eq!(ab, ba);
+    }
+
+    // ── #839 residual: decompressed-point cache ─────────────────────
+
+    /// A repeated call decompressing the SAME compressed G1 bytes must
+    /// return a bit-identical point whether it's served from the cache
+    /// (warm) or freshly decompressed (cold) — pins that the memoization
+    /// added for #839 cannot change the result, only whether the
+    /// expensive `blst_p1_uncompress` path runs.
+    #[test]
+    fn decompress_g1_trusted_cache_hit_matches_cold_decompress() {
+        let point = denote_bls(
+            BuiltinId::Bls12_381_G1_HashToGroup,
+            vec![bs(b"cache-g1"), bs(b"dst")],
+        )
+        .unwrap();
+        let Value::Const(Constant::Bls12_381G1Element(compressed)) = point else {
+            panic!("expected G1 element");
+        };
+        // First call: populates the cache (or reuses it from an earlier
+        // test on the same thread — either way, deterministic).
+        let cold =
+            decompress_g1_trusted_uncached(compressed.as_slice(), BuiltinId::Bls12_381_G1_Add)
+                .unwrap();
+        let warm =
+            decompress_g1_trusted(compressed.as_slice(), BuiltinId::Bls12_381_G1_Add).unwrap();
+        assert!(
+            unsafe { blst_p1_is_equal(&cold, &warm) },
+            "cached decompression must be bit-identical to a fresh decompress"
+        );
+        // Call again — this time definitely a cache hit.
+        let warm2 =
+            decompress_g1_trusted(compressed.as_slice(), BuiltinId::Bls12_381_G1_Add).unwrap();
+        assert!(unsafe { blst_p1_is_equal(&cold, &warm2) });
+    }
+
+    /// Same as above for G2.
+    #[test]
+    fn decompress_g2_trusted_cache_hit_matches_cold_decompress() {
+        let point = denote_bls(
+            BuiltinId::Bls12_381_G2_HashToGroup,
+            vec![bs(b"cache-g2"), bs(b"dst")],
+        )
+        .unwrap();
+        let Value::Const(Constant::Bls12_381G2Element(compressed)) = point else {
+            panic!("expected G2 element");
+        };
+        let cold =
+            decompress_g2_trusted_uncached(compressed.as_slice(), BuiltinId::Bls12_381_G2_Add)
+                .unwrap();
+        let warm =
+            decompress_g2_trusted(compressed.as_slice(), BuiltinId::Bls12_381_G2_Add).unwrap();
+        assert!(unsafe { blst_p2_is_equal(&cold, &warm) });
+        let warm2 =
+            decompress_g2_trusted(compressed.as_slice(), BuiltinId::Bls12_381_G2_Add).unwrap();
+        assert!(unsafe { blst_p2_is_equal(&cold, &warm2) });
+    }
+
+    /// A script that references the same G1 point across multiple
+    /// separate builtin calls (the actual scenario #839 is about — e.g.
+    /// a base point reused across several `scalarMul`s) must produce
+    /// results identical to what an uncached implementation would give.
+    /// Exercises the cache purely through the public `denote_bls` entry
+    /// point (no internal cache access) so this also serves as an
+    /// end-to-end proof that caching is transparent to callers.
+    #[test]
+    fn repeated_scalar_mul_on_same_cached_point_is_consistent() {
+        let base = denote_bls(
+            BuiltinId::Bls12_381_G1_HashToGroup,
+            vec![bs(b"repeated-base"), bs(b"dst")],
+        )
+        .unwrap();
+        let scalar = Value::Const(Constant::Integer(BigInt::from(7)));
+        let r1 = denote_bls(
+            BuiltinId::Bls12_381_G1_ScalarMul,
+            vec![scalar.clone(), base.clone()],
+        )
+        .unwrap();
+        let r2 = denote_bls(BuiltinId::Bls12_381_G1_ScalarMul, vec![scalar, base]).unwrap();
+        assert_eq!(r1, r2, "repeated scalarMul on the same point must agree");
+    }
+
+    /// Cache-overflow robustness: computing more than
+    /// `BLS_DECOMPRESS_CACHE_CAP` DISTINCT valid G1 points must not error
+    /// or panic — the cache clears itself on overflow (a pure
+    /// memoization, so eviction only ever costs a re-decompression).
+    /// Uses a small local loop rather than actually exceeding the real
+    /// (1024-entry) cap, by driving the SAME cache with enough distinct
+    /// keys to force at least one clear-and-refill cycle within a
+    /// reasonable test runtime — the loop bound is deliberately larger
+    /// than the cap so the overflow branch is guaranteed to execute.
+    #[test]
+    fn cache_overflow_clears_without_error() {
+        for i in 0..(BLS_DECOMPRESS_CACHE_CAP + 8) {
+            let msg = format!("overflow-{i}");
+            let point = denote_bls(
+                BuiltinId::Bls12_381_G1_HashToGroup,
+                vec![bs(msg.as_bytes()), bs(b"dst")],
+            )
+            .unwrap();
+            // Immediately re-use it (forces a decompress right after
+            // insertion/eviction) to prove correctness isn't disturbed.
+            let doubled = denote_bls(BuiltinId::Bls12_381_G1_Add, vec![point.clone(), point])
+                .expect("must not error even across a cache clear-and-refill cycle");
+            assert!(matches!(
+                doubled,
+                Value::Const(Constant::Bls12_381G1Element(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/dugite-uplc/src/builtin/cost.rs
+++ b/crates/dugite-uplc/src/builtin/cost.rs
@@ -1100,7 +1100,9 @@ const fn builtin_cost_table() -> [CostPair; 101] {
             }),
             mem: Constant(1),
         },
-        // 24 EncodeUtf8 — linear_in_x (char count)
+        // 24 EncodeUtf8 — linear_in_x, x = variant-gated size (#819):
+        //   char count for A/B/C, UTF-8 byte-length/4 for D/E — see the
+        //   `EncodeUtf8` match arm above.
         CostPair {
             cpu: LinearInX(lin1(1000, 42921)),
             mem: LinearInX(lin1(4, 2)),
@@ -1351,12 +1353,13 @@ const fn builtin_cost_table() -> [CostPair; 101] {
             cpu: LinearInX(lin1(617887431, 67302824)),
             mem: Constant(36),
         },
-        // 94 InsertCoin — linear_in_u (= 4th value-arg size); dugite's
-        //   `cost_for` only carries x/y/z, so we approximate as
-        //   linear_in_z (3rd arg = Integer amount) — for the
-        //   conformance corpus this matches because the Plutus
-        //   reference's `u` is the Value memory, which is small for
-        //   the test fixtures.
+        // 94 InsertCoin — linear_in_u where u = ValueMaxDepth(4th arg).
+        //   dugite's `cost_for` only carries x/y/z slots (no dedicated
+        //   `u`), so the `InsertCoin` arm above maps u → z directly
+        //   (`args.get(3)` is the 4th/ValueMaxDepth arg, not the 3rd/
+        //   amount arg) so this `LinearInZ` entry fires on the correct
+        //   input — not an approximation, an exact remap of which slot
+        //   carries the cost-relevant size.
         CostPair {
             cpu: LinearInZ(lin1(356924, 18413)),
             mem: LinearInZ(lin1(45, 21)),

--- a/crates/dugite-uplc/src/builtin/denotations.rs
+++ b/crates/dugite-uplc/src/builtin/denotations.rs
@@ -541,15 +541,15 @@ pub fn denote(
             let data_args: Result<Vec<crate::data::Data>, _> = elems
                 .into_iter()
                 .map(|c| match c {
-                    Constant::Data(d) => Ok(d),
+                    Constant::Data(d) => Ok(data_from_rc(d)),
                     _ => Err(UplcError::BuiltinTypeError {
                         builtin: id.name(),
                         reason: "constrData args must be Data".into(),
                     }),
                 })
                 .collect();
-            Ok(Value::Const(Constant::Data(crate::data::Data::Constr(
-                tag, data_args?,
+            Ok(Value::Const(Constant::Data(std::rc::Rc::new(
+                crate::data::Data::Constr(tag, data_args?),
             ))))
         }
         MapData => {
@@ -560,7 +560,9 @@ pub fn denote(
                 .into_iter()
                 .map(|c| match c {
                     Constant::ProtoPair { a, b, .. } => match (*a, *b) {
-                        (Constant::Data(k), Constant::Data(vv)) => Ok((k, vv)),
+                        (Constant::Data(k), Constant::Data(vv)) => {
+                            Ok((data_from_rc(k), data_from_rc(vv)))
+                        }
                         _ => Err(UplcError::BuiltinTypeError {
                             builtin: id.name(),
                             reason: "mapData pair components must be Data".into(),
@@ -572,7 +574,9 @@ pub fn denote(
                     }),
                 })
                 .collect();
-            Ok(Value::Const(Constant::Data(crate::data::Data::Map(pairs?))))
+            Ok(Value::Const(Constant::Data(std::rc::Rc::new(
+                crate::data::Data::Map(pairs?),
+            ))))
         }
         ListData => {
             // (list : ProtoList Data) -> Data
@@ -581,33 +585,40 @@ pub fn denote(
             let datas: Result<Vec<crate::data::Data>, _> = elems
                 .into_iter()
                 .map(|c| match c {
-                    Constant::Data(d) => Ok(d),
+                    Constant::Data(d) => Ok(data_from_rc(d)),
                     _ => Err(UplcError::BuiltinTypeError {
                         builtin: id.name(),
                         reason: "listData args must be Data".into(),
                     }),
                 })
                 .collect();
-            Ok(Value::Const(Constant::Data(crate::data::Data::List(
-                datas?,
+            Ok(Value::Const(Constant::Data(std::rc::Rc::new(
+                crate::data::Data::List(datas?),
             ))))
         }
         IData => {
             let v = take_one(args, id)?;
             let i = unwrap_integer(v, id)?;
-            Ok(Value::Const(Constant::Data(crate::data::Data::I(i))))
+            Ok(Value::Const(Constant::Data(std::rc::Rc::new(
+                crate::data::Data::I(i),
+            ))))
         }
         BData => {
             let v = take_one(args, id)?;
             let b = unwrap_byte_string(v, id)?;
-            Ok(Value::Const(Constant::Data(crate::data::Data::B(b))))
+            Ok(Value::Const(Constant::Data(std::rc::Rc::new(
+                crate::data::Data::B(b),
+            ))))
         }
         UnConstrData => {
             // Data -> Pair Integer (ProtoList Data)
             let d = unwrap_data(take_one(args, id)?, id)?;
             match d.into_constr() {
                 Ok((tag, fields)) => {
-                    let elements: Vec<Constant> = fields.into_iter().map(Constant::Data).collect();
+                    let elements: Vec<Constant> = fields
+                        .into_iter()
+                        .map(|f| Constant::Data(std::rc::Rc::new(f)))
+                        .collect();
                     Ok(Value::Const(Constant::ProtoPair {
                         a_type: crate::term::TypeTag::Integer,
                         b_type: crate::term::TypeTag::List(Box::new(crate::term::TypeTag::Data)),
@@ -630,8 +641,8 @@ pub fn denote(
                         .map(|(k, v)| Constant::ProtoPair {
                             a_type: crate::term::TypeTag::Data,
                             b_type: crate::term::TypeTag::Data,
-                            a: Box::new(Constant::Data(k)),
-                            b: Box::new(Constant::Data(v)),
+                            a: Box::new(Constant::Data(std::rc::Rc::new(k))),
+                            b: Box::new(Constant::Data(std::rc::Rc::new(v))),
                         })
                         .collect();
                     Ok(Value::Const(Constant::ProtoList {
@@ -650,7 +661,10 @@ pub fn denote(
             match d.into_list() {
                 Ok(items) => Ok(Value::Const(Constant::ProtoList {
                     elem_type: crate::term::TypeTag::Data,
-                    elements: items.into_iter().map(Constant::Data).collect(),
+                    elements: items
+                        .into_iter()
+                        .map(|d| Constant::Data(std::rc::Rc::new(d)))
+                        .collect(),
                 })),
                 Err(_) => Err(builtin_failure(id, "unListData on non-List Data")),
             }
@@ -683,8 +697,8 @@ pub fn denote(
             Ok(Value::Const(Constant::ProtoPair {
                 a_type: crate::term::TypeTag::Data,
                 b_type: crate::term::TypeTag::Data,
-                a: Box::new(Constant::Data(a)),
-                b: Box::new(Constant::Data(b)),
+                a: Box::new(Constant::Data(std::rc::Rc::new(a))),
+                b: Box::new(Constant::Data(std::rc::Rc::new(b))),
             }))
         }
         SerialiseData => {
@@ -1504,7 +1518,9 @@ pub fn denote(
                     (Data::B(policy), Data::Map(inner_data))
                 })
                 .collect();
-            Ok(Value::Const(Constant::Data(Data::Map(outer))))
+            Ok(Value::Const(Constant::Data(std::rc::Rc::new(Data::Map(
+                outer,
+            )))))
         }
 
         ValueContains => {
@@ -1781,9 +1797,19 @@ fn unwrap_value(v: Value, id: BuiltinId) -> Result<ValueMap, UplcError> {
     }
 }
 
+/// Take ownership of an `Rc<Data>`, sharing the allocation when we hold
+/// the only reference (the common case once a builtin argument has been
+/// moved out of its `Value`/env slot) and falling back to a deep clone
+/// only when the `Data` is still referenced elsewhere (e.g. the same
+/// ScriptContext bound to the script's `ctx` parameter and looked up
+/// again later). See the `#838 Fix 2` doc comment on `Constant::Data`.
+fn data_from_rc(d: std::rc::Rc<crate::data::Data>) -> crate::data::Data {
+    std::rc::Rc::try_unwrap(d).unwrap_or_else(|rc| (*rc).clone())
+}
+
 fn unwrap_data(v: Value, id: BuiltinId) -> Result<crate::data::Data, UplcError> {
     match v {
-        Value::Const(Constant::Data(d)) => Ok(d),
+        Value::Const(Constant::Data(d)) => Ok(data_from_rc(d)),
         other => Err(UplcError::BuiltinTypeError {
             builtin: id.name(),
             reason: format!("expected Data, got {:?}", std::mem::discriminant(&other)),
@@ -2411,16 +2437,19 @@ mod tests {
     use crate::term::TypeTag;
 
     fn data_i(n: i64) -> Constant {
-        Constant::Data(Data::I(BigInt::from(n)))
+        Constant::Data(std::rc::Rc::new(Data::I(BigInt::from(n))))
     }
     fn list_of_data(items: Vec<Data>) -> Value {
         Value::Const(Constant::ProtoList {
             elem_type: TypeTag::Data,
-            elements: items.into_iter().map(Constant::Data).collect(),
+            elements: items
+                .into_iter()
+                .map(|d| Constant::Data(std::rc::Rc::new(d)))
+                .collect(),
         })
     }
     fn data_val(d: Data) -> Value {
-        Value::Const(Constant::Data(d))
+        Value::Const(Constant::Data(std::rc::Rc::new(d)))
     }
 
     #[test]
@@ -2631,7 +2660,10 @@ mod tests {
             assert_eq!(*a, Constant::Integer(BigInt::from(3)));
             if let Constant::ProtoList { elements, .. } = *b {
                 assert_eq!(elements.len(), 1);
-                assert_eq!(elements[0], Constant::Data(Data::I(BigInt::from(1))));
+                assert_eq!(
+                    elements[0],
+                    Constant::Data(std::rc::Rc::new(Data::I(BigInt::from(1))))
+                );
             } else {
                 panic!("expected ProtoList for second pair element");
             }
@@ -2748,7 +2780,7 @@ mod tests {
         // Run the actual builtin.
         let v = run(
             BuiltinId::SerialiseData,
-            vec![Value::Const(Constant::Data(d))],
+            vec![Value::Const(Constant::Data(std::rc::Rc::new(d)))],
         )
         .unwrap();
         let Value::Const(Constant::ByteString(serialised)) = v else {

--- a/crates/dugite-uplc/src/builtin/denotations.rs
+++ b/crates/dugite-uplc/src/builtin/denotations.rs
@@ -1242,10 +1242,13 @@ pub fn denote(
         // ── PV1.1.0 list builtin ──────────────────────────────────────
         DropList => {
             // (count: Integer, list: ProtoList T) -> ProtoList T
-            // Drops the first `count` elements from the list. If count
-            // is negative or larger than the list length, returns the
-            // empty list (matching the Haskell reference's clamp-at-
-            // zero / clamp-at-length semantics).
+            // Drops the first `count` elements from the list. `count` is
+            // clamped at BOTH ends (oracle-confirmed, #828): negative ->
+            // clamped to 0, so the list is returned UNCHANGED (dropping
+            // zero elements) — NOT emptied; `count >= len` -> the empty
+            // list. `bigint_to_usize_clamped` performs the negative ->
+            // 0 clamp; the `n >= elems.len()` branch below performs the
+            // upper clamp.
             let mut it = args.into_iter();
             let count = unwrap_integer(it.next().ok_or_else(|| builtin_arity_mismatch(id))?, id)?;
             let list = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
@@ -1726,14 +1729,13 @@ fn bigint_to_i64_or_failure(i: &BigInt, id: BuiltinId, what: &str) -> Result<i64
         .ok_or_else(|| builtin_failure(id, &format!("{what}: value does not fit in Int64")))
 }
 
-/// Bitwise binary op on two byte strings of equal length.
-/// `pad` is the byte to use when extending the shorter input to the
-/// longer length. Per CIP-0123: padding semantics are part of the
-/// builtin (`andByteString` pads with 0xFF for max-len, `orByteString`
-/// and `xorByteString` pad with 0x00). Our current implementation
-/// requires equal-length inputs and rejects mismatched lengths as a
-/// `BuiltinFailure`; the padding-mode variant arrives with the
-/// `padded`-flavour builtins in a follow-on commit.
+/// Bitwise binary op (`andByteString` / `orByteString` /
+/// `xorByteString`) on two byte strings, with CIP-0122/0123's
+/// `padded: Bool` semantics: `padded = true` outputs at the LONGER
+/// input's length (unmatched trailing bytes from the longer input pass
+/// through unchanged); `padded = false` outputs at the SHORTER input's
+/// length (the longer input is truncated). See the CIP-122/123 doc
+/// comment on the body below for the exact algorithm.
 fn bitwise_byte_string<F>(args: Vec<Value>, id: BuiltinId, op: F) -> Result<Value, UplcError>
 where
     F: Fn(u8, u8) -> u8,

--- a/crates/dugite-uplc/src/builtin/denotations.rs
+++ b/crates/dugite-uplc/src/builtin/denotations.rs
@@ -510,52 +510,34 @@ pub fn denote(
         ConstrData => {
             // (tag : Integer) (args : ProtoList Data) -> Data
             //
-            // #828.5 (oracle: `PlutusCore/Default/Builtins.hs` ~L1737-1751):
-            // genuinely PV-gated, not just a perf/representation swap. At
-            // D/E (PV >= `VAN_ROSSEM_PV`) the argument type is `Word64` —
-            // unlifting itself rejects a tag outside `0..=2^64-1` as an
-            // evaluation failure. At A/B/C (PV < `VAN_ROSSEM_PV`) the
-            // argument type is plain `Integer` — Haskell accepts ANY tag
-            // (negative or arbitrarily large) and builds `Constr tag args`
-            // with it (Haskell's `Data.Constr` field is `Integer`, not
-            // `Word64` — the CBOR wire format's Word64-tag requirement is a
-            // SEPARATE, PV-independent decode-time constraint that applies
-            // only to on-chain datums/redeemers, never to a value computed
-            // transiently inside a running script).
+            // #828.5 / #859 (oracle: `PlutusCore/Default/Builtins.hs`
+            // ~L1737-1751): genuinely PV-gated, not just a perf/
+            // representation swap. At D/E (PV >= `VAN_ROSSEM_PV`) the
+            // argument type is `Word64` — unlifting itself rejects a tag
+            // outside `0..=2^64-1` as an evaluation failure. At A/B/C
+            // (PV < `VAN_ROSSEM_PV`) the argument type is plain `Integer` —
+            // Haskell accepts ANY tag (negative or arbitrarily large) and
+            // builds `Constr tag args` with it (Haskell's `Data.Constr`
+            // field is `Integer`, not `Word64` — the CBOR wire format's
+            // Word64-tag requirement is a SEPARATE, PV-independent
+            // decode-time constraint that applies only to on-chain
+            // datums/redeemers, never to a value computed transiently
+            // inside a running script).
             //
-            // KNOWN LIMITATION: dugite's `Data::Constr` tag field is `u64`
-            // (matching that on-chain decode constraint, since no valid
-            // on-chain Data can carry an out-of-range tag in ANY era). A
-            // witness script that TRANSIENTLY computes `constrData` with a
-            // negative or >u64::MAX tag at PV < 11 and does not immediately
-            // fail is therefore still mis-evaluated here: real cardano-node
-            // continues running (holding a `Data::Constr` with an arbitrary
-            // BigInt tag) while dugite cannot represent it and must error
-            // out. This is the lowest-reachability edge of #828 (transient,
-            // adversarial, pre-PV11 only, never observable on-chain) —
-            // fixing it fully requires widening `Data::Constr`'s tag to a
-            // signed/bignum type, which is out of scope here. We at least
-            // avoid mislabeling the gap as a genuine protocol-level
-            // `BuiltinFailure` (only correct for the D/E branch) by
-            // surfacing it as an `Internal` (representational) error for
-            // A/B/C instead.
+            // Since #859, `Data::Constr`'s tag is an arbitrary-precision
+            // `BigInt` (matching Haskell's `Integer` exactly), so the A/B/C
+            // branch is no longer a representational best-effort
+            // approximation: it holds precisely the same domain as
+            // Haskell. Only the D/E branch performs a range check, and an
+            // out-of-range tag there is a genuine evaluation/unlifting
+            // failure (`BuiltinFailure`), never `UplcError::Internal`.
             let mut it = args.into_iter();
             let tag = unwrap_integer(it.next().ok_or_else(|| builtin_arity_mismatch(id))?, id)?;
             let list = it.next().ok_or_else(|| builtin_arity_mismatch(id))?;
             let (_, elems) = unwrap_proto_list(list, id)?;
-            let tag_u64 = match u64::try_from(&tag) {
-                Ok(n) => n,
-                Err(_) if variant.constr_data_requires_word64() => {
-                    return Err(builtin_failure(id, "constrData tag out of u64 range"));
-                }
-                Err(_) => {
-                    return Err(UplcError::Internal(format!(
-                        "constrData: tag {tag} is outside u64 range; dugite's Data::Constr \
-                         representation cannot hold this pre-PV11 transient value \
-                         (known limitation, see issue #828.5)"
-                    )));
-                }
-            };
+            if variant.constr_data_requires_word64() && u64::try_from(&tag).is_err() {
+                return Err(builtin_failure(id, "constrData tag out of u64 range"));
+            }
             let data_args: Result<Vec<crate::data::Data>, _> = elems
                 .into_iter()
                 .map(|c| match c {
@@ -567,7 +549,7 @@ pub fn denote(
                 })
                 .collect();
             Ok(Value::Const(Constant::Data(crate::data::Data::Constr(
-                tag_u64, data_args?,
+                tag, data_args?,
             ))))
         }
         MapData => {
@@ -629,7 +611,7 @@ pub fn denote(
                     Ok(Value::Const(Constant::ProtoPair {
                         a_type: crate::term::TypeTag::Integer,
                         b_type: crate::term::TypeTag::List(Box::new(crate::term::TypeTag::Data)),
-                        a: Box::new(Constant::Integer(BigInt::from(tag))),
+                        a: Box::new(Constant::Integer(tag)),
                         b: Box::new(Constant::ProtoList {
                             elem_type: crate::term::TypeTag::Data,
                             elements,
@@ -2547,27 +2529,27 @@ mod tests {
         assert_eq!(
             v,
             data_val(Data::Constr(
-                3,
+                BigInt::from(3),
                 vec![Data::I(BigInt::from(1)), Data::I(BigInt::from(2))]
             ))
         );
     }
 
-    /// #828.5 PV-matrix golden: `constrData`'s tag argument is unlifted as
-    /// `Word64` at D/E (PV>=11) — an out-of-range tag is a genuine
-    /// `BuiltinFailure` — but as plain `Integer` at A/B/C (PV<11), where
-    /// Haskell would ACCEPT a negative or oversized tag. dugite's
-    /// `Data::Constr` tag field is `u64` and cannot represent that value,
-    /// so the A/B/C branch surfaces a distinct `Internal`
-    /// (representational-limitation) error instead of mislabeling the gap
-    /// as a modeled protocol failure — see the doc comment at the
-    /// `ConstrData` match arm for the full scoped limitation. In-range tags
-    /// behave IDENTICALLY at every variant. The conformance corpus runs a
-    /// single (LATEST=E, no-PV) harness and cannot catch a wrong PV<11
-    /// branch, hence this dedicated matrix test.
+    /// #859 (closes the #828.5 residual): `constrData`'s tag argument is
+    /// unlifted as `Word64` at D/E (PV>=11) — an out-of-range tag is a
+    /// genuine `BuiltinFailure` — but as plain arbitrary-precision
+    /// `Integer` at A/B/C (PV<11), where Haskell ACCEPTS a negative or
+    /// oversized tag and builds `Constr tag args` with it. `Data::Constr`'s
+    /// tag is now a `BigInt` (issue #859), so dugite represents this
+    /// domain exactly at A/B/C — no more `Internal`/representational-
+    /// limitation fallback. In-range tags behave IDENTICALLY at every
+    /// variant. The conformance corpus runs a single (LATEST=E, no-PV)
+    /// harness and cannot catch a wrong PV<11 branch, hence this dedicated
+    /// matrix test.
     #[test]
     fn constr_data_tag_range_is_pv_gated() {
-        // In-range tag (fits u64): succeeds identically at every variant.
+        // In-range tag (fits u64): succeeds identically at every variant —
+        // (c) regression: a small-tag Constr still round-trips exactly.
         let fields = || list_of_data(vec![]);
         for variant in [
             SemanticsVariant::A,
@@ -2577,61 +2559,72 @@ mod tests {
             SemanticsVariant::E,
         ] {
             let v = run_variant(BuiltinId::ConstrData, vec![int(7), fields()], variant).unwrap();
-            assert_eq!(v, data_val(Data::Constr(7, vec![])));
+            assert_eq!(v, data_val(Data::Constr(BigInt::from(7), vec![])));
         }
 
-        // Out-of-u64-range tag (negative): D/E reject as a genuine
-        // BuiltinFailure (Word64 unlifting failure).
+        // (b) Out-of-u64-range tag (negative): D/E reject as a genuine
+        // BuiltinFailure (Word64 unlifting failure) — NOT Internal, NOT a
+        // silent clamp.
         let neg_tag = Value::Const(Constant::Integer(BigInt::from(-1)));
-        assert!(matches!(
-            run_variant(
-                BuiltinId::ConstrData,
-                vec![neg_tag.clone(), fields()],
-                SemanticsVariant::E
-            ),
-            Err(UplcError::BuiltinFailure { .. })
-        ));
-        assert!(matches!(
-            run_variant(
-                BuiltinId::ConstrData,
-                vec![neg_tag.clone(), fields()],
-                SemanticsVariant::D
-            ),
-            Err(UplcError::BuiltinFailure { .. })
-        ));
+        for variant in [SemanticsVariant::D, SemanticsVariant::E] {
+            assert!(
+                matches!(
+                    run_variant(
+                        BuiltinId::ConstrData,
+                        vec![neg_tag.clone(), fields()],
+                        variant
+                    ),
+                    Err(UplcError::BuiltinFailure { .. })
+                ),
+                "variant {variant:?} must reject an out-of-Word64 tag as BuiltinFailure"
+            );
+        }
 
-        // A/B/C: Haskell would ACCEPT this tag (plain Integer argument);
-        // dugite cannot represent it, so it fails with the DISTINCT
-        // Internal/representational-limitation error, not BuiltinFailure.
-        assert!(matches!(
-            run_variant(
+        // (a) A/B/C: Haskell ACCEPTS a negative OR oversized (> u64::MAX)
+        // tag (plain arbitrary-precision Integer argument) and builds the
+        // wide Constr. dugite's BigInt-tagged `Data::Constr` now
+        // represents this exactly — no error, no clamp, no representational
+        // gap — and the tag round-trips through `unConstrData` unchanged.
+        let huge_tag_value: BigInt = BigInt::from(1u64) << 80;
+        let huge_tag = Value::Const(Constant::Integer(huge_tag_value.clone()));
+        for variant in [
+            SemanticsVariant::A,
+            SemanticsVariant::B,
+            SemanticsVariant::C,
+        ] {
+            let neg = run_variant(
                 BuiltinId::ConstrData,
                 vec![neg_tag.clone(), fields()],
-                SemanticsVariant::A
-            ),
-            Err(UplcError::Internal(_))
-        ));
-        assert!(matches!(
-            run_variant(
+                variant,
+            )
+            .unwrap_or_else(|e| panic!("variant {variant:?} must accept a negative tag: {e:?}"));
+            assert_eq!(neg, data_val(Data::Constr(BigInt::from(-1), vec![])));
+
+            let huge = run_variant(
                 BuiltinId::ConstrData,
-                vec![neg_tag.clone(), fields()],
-                SemanticsVariant::B
-            ),
-            Err(UplcError::Internal(_))
-        ));
-        assert!(matches!(
-            run_variant(
-                BuiltinId::ConstrData,
-                vec![neg_tag, fields()],
-                SemanticsVariant::C
-            ),
-            Err(UplcError::Internal(_))
-        ));
+                vec![huge_tag.clone(), fields()],
+                variant,
+            )
+            .unwrap_or_else(|e| panic!("variant {variant:?} must accept an oversized tag: {e:?}"));
+            assert_eq!(huge, data_val(Data::Constr(huge_tag_value.clone(), vec![])));
+
+            // The wide tag round-trips through unConstrData as a wide
+            // Integer (not truncated/clamped to u64).
+            let unpacked = run(BuiltinId::UnConstrData, vec![huge]).unwrap();
+            if let Value::Const(Constant::ProtoPair { a, .. }) = unpacked {
+                assert_eq!(*a, Constant::Integer(huge_tag_value.clone()));
+            } else {
+                panic!("expected ProtoPair from unConstrData");
+            }
+        }
     }
 
     #[test]
     fn un_constr_data_unpacks() {
-        let d = data_val(Data::Constr(3, vec![Data::I(BigInt::from(1))]));
+        let d = data_val(Data::Constr(
+            BigInt::from(3),
+            vec![Data::I(BigInt::from(1))],
+        ));
         let v = run(BuiltinId::UnConstrData, vec![d]).unwrap();
         // result is Pair(Integer, List Data)
         if let Value::Const(Constant::ProtoPair { a, b, .. }) = v {
@@ -2649,7 +2642,7 @@ mod tests {
 
     #[test]
     fn choose_data_picks_by_constructor() {
-        let d_constr = data_val(Data::Constr(0, vec![]));
+        let d_constr = data_val(Data::Constr(BigInt::from(0), vec![]));
         assert_eq!(
             run(
                 BuiltinId::ChooseData,
@@ -2683,7 +2676,10 @@ mod tests {
 
     #[test]
     fn serialise_data_round_trips_via_cbor() {
-        let d = data_val(Data::Constr(0, vec![Data::I(BigInt::from(42))]));
+        let d = data_val(Data::Constr(
+            BigInt::from(0),
+            vec![Data::I(BigInt::from(42))],
+        ));
         let v = run(BuiltinId::SerialiseData, vec![d]).unwrap();
         // The result is the CBOR encoding of Constr 0 [I 42]
         if let Value::Const(Constant::ByteString(bytes)) = v {
@@ -2709,9 +2705,9 @@ mod tests {
     fn serialise_data_uses_indefinite_arrays_for_nonempty_constr() {
         // Constr 1 [ Constr 0 [ B 0xab, I 7 ] ]
         let d = data_val(Data::Constr(
-            1,
+            BigInt::from(1),
             vec![Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::B(vec![0xab]), Data::I(BigInt::from(7))],
             )],
         ));

--- a/crates/dugite-uplc/src/builtin/semantics.rs
+++ b/crates/dugite-uplc/src/builtin/semantics.rs
@@ -154,10 +154,10 @@ impl SemanticsVariant {
     /// Whether `constrData`'s tag argument is unlifted as `Word64` (range
     /// `0..=2^64-1`, a genuine evaluation failure outside that range).
     /// `true` for D/E (PV ≥ `VAN_ROSSEM_PV`); `false` for A/B/C, where the
-    /// argument type is plain `Integer` (no bound). See issue #828.5 —
-    /// dugite's `Data::Constr` tag field is `u64`, so the A/B/C branch is
-    /// necessarily a best-effort approximation for transient values outside
-    /// the u64 range (see the call site doc comment for the scoped gap).
+    /// argument type is plain `Integer` (no bound). See issues #828.5/#859
+    /// — `Data::Constr`'s tag field is an arbitrary-precision `BigInt`
+    /// (matching Haskell's `Integer` exactly), so the A/B/C branch holds
+    /// precisely the same domain as Haskell with no representational gap.
     pub fn constr_data_requires_word64(self) -> bool {
         matches!(self, SemanticsVariant::D | SemanticsVariant::E)
     }

--- a/crates/dugite-uplc/src/cost_apply.rs
+++ b/crates/dugite-uplc/src/cost_apply.rs
@@ -76,6 +76,25 @@ pub const V2_PARAM_COUNT: usize = 175;
 /// silently cheap.
 pub const V2_PARAM_COUNT_PLOMIN: usize = 185;
 
+/// Number of parameters in a PlutusV1 cost model after the van Rossem
+/// (PV11) hard fork (`PlutusLedgerApi.V1.ParamName`): 332 total. Per
+/// `IntersectMBO/plutus` `PlutusLedgerApi.Common.ParamName`
+/// (`plutusVXParamNames PlutusV1 = showParamName <$> [minBound..maxBound
+/// :: PVn.ParamName]`, oracle-confirmed 2026-07-07 against `ParamName.hs`
+/// 1.62.0.0 and 1.65.0.0 byte-identically), PlutusV1 is NOT frozen at 166
+/// params at PV11 — it grows the same tail V2/V3 gained at Plomin (PV10)
+/// plus the shared van-Rossem batch6 tail (#860.2). [`apply_v1`] always
+/// pads/truncates to this length per [`pad_or_truncate`] (#826/#830).
+pub const V1_PARAM_COUNT_VANROSSEM: usize = 332;
+
+/// Number of parameters in a PlutusV2 cost model after the van Rossem
+/// (PV11) hard fork (`PlutusLedgerApi.V2.ParamName`): 332 total. V2 grows from
+/// [`V2_PARAM_COUNT_PLOMIN`] (185) by the same tail as V1/V3 — `cekConstr`,
+/// `cekCase`, the BLS12-381 block, `keccak_256`, `blake2b_224`, the bitwise
+/// batch, then the van-Rossem batch6 (#860.2, oracle-confirmed against
+/// `ParamName.hs`). [`apply_v2`] always pads/truncates to this length.
+pub const V2_PARAM_COUNT_VANROSSEM: usize = 332;
+
 /// A cost model resolved from on-chain parameters, ready to drive a CEK run.
 #[derive(Debug, Clone)]
 pub struct AppliedCosts {
@@ -349,14 +368,16 @@ fn verify_ed25519(cur: &mut Cursor<'_>, variant_b: bool) -> CostPair {
     CostPair { cpu, mem }
 }
 
-/// Apply a flat PlutusV1 cost-model array (166 entries, canonical
-/// `ParamName` order) to a fresh [`AppliedCosts`]. A wrong-length input is
-/// padded with `maxBound::Int64` (too short) or truncated (too long) per
-/// [`pad_or_truncate`] — never rejected (#826).
+/// Apply a flat PlutusV1 cost-model array (166 entries pre-PV11; 332 from
+/// van Rossem (PV11) onward, canonical `ParamName` order) to a fresh
+/// [`AppliedCosts`]. A wrong-length input is padded with `maxBound::Int64`
+/// (too short) or truncated (too long) per [`pad_or_truncate`] — never
+/// rejected (#826). The base walk (0..=165) is identical at every protocol
+/// version; PV11 appends the [`V1_PARAM_COUNT_VANROSSEM`] tail (#860.2).
 pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApplyError> {
     let variant_b = is_variant_b(major_pv);
     let variant_d = is_variant_d(major_pv);
-    let padded = pad_or_truncate(p, V1_PARAM_COUNT);
+    let padded = pad_or_truncate(p, V1_PARAM_COUNT_VANROSSEM);
     let p: &[i64] = padded.as_ref();
     use BuiltinId::*;
     let mut b = BuiltinCosts::DEFAULT.clone();
@@ -437,7 +458,33 @@ pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
 
     debug_assert_eq!(
         cur.i, V1_PARAM_COUNT,
-        "V1 cost-model walk must consume exactly {V1_PARAM_COUNT} params"
+        "V1 base cost-model walk must consume exactly {V1_PARAM_COUNT} params"
+    );
+
+    // [166..=331] van Rossem (PV11) tail (#860.2) — V1 grows from 166 to
+    // 332 params at PV11, gaining every builtin V2/V3 gained at Plomin
+    // (PV10) plus the shared van-Rossem batch6 tail. Order:
+    // serialiseData, verifyEcdsaSecp256k1Signature,
+    // verifySchnorrSecp256k1Signature, cekConstr/cekCase, the BLS12-381
+    // block, keccak_256/blake2b_224, integerToByteString/
+    // byteStringToInteger, the Plomin bitwise batch, then van_rossem_tail
+    // — byte-identical to V2's own PV11 tail from `cekConstr` onward.
+    refill_builtin(&mut b, SerialiseData, cur)?;
+    refill_builtin(&mut b, VerifyEcdsaSecp256k1Signature, cur)?;
+    refill_builtin(&mut b, VerifySchnorrSecp256k1Signature, cur)?;
+    cek_constr_case_costs(&mut m, cur);
+    bls12_381_batch(&mut b, cur)?;
+    keccak_blake2b224_batch(&mut b, cur)?;
+    let i2b = integer_to_bytestring_cost(cur);
+    b.set_cost_pair(IntegerToByteString, i2b);
+    let b2i = bytestring_to_integer_cost(cur);
+    b.set_cost_pair(ByteStringToInteger, b2i);
+    bitwise_batch(&mut b, cur)?;
+    van_rossem_tail(&mut b, cur)?;
+
+    debug_assert_eq!(
+        cur.i, V1_PARAM_COUNT_VANROSSEM,
+        "V1 cost-model walk must consume exactly {V1_PARAM_COUNT_VANROSSEM} params"
     );
 
     Ok(AppliedCosts {
@@ -472,7 +519,7 @@ pub fn apply_v1(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
 pub fn apply_v2(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApplyError> {
     let variant_b = is_variant_b(major_pv);
     let variant_d = is_variant_d(major_pv);
-    let padded = pad_or_truncate(p, V2_PARAM_COUNT_PLOMIN);
+    let padded = pad_or_truncate(p, V2_PARAM_COUNT_VANROSSEM);
     let p: &[i64] = padded.as_ref();
     use BuiltinId::*;
     let mut b = BuiltinCosts::DEFAULT.clone();
@@ -575,7 +622,24 @@ pub fn apply_v2(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
 
     debug_assert_eq!(
         cur.i, V2_PARAM_COUNT_PLOMIN,
-        "V2 cost-model walk must consume exactly {V2_PARAM_COUNT_PLOMIN} params"
+        "V2 base+Plomin cost-model walk must consume exactly {V2_PARAM_COUNT_PLOMIN} params"
+    );
+
+    // [185..=331] van Rossem (PV11) tail (#860.2) — V2 grows from 185 to
+    // 332 params at PV11. Unlike V1, V2 already has serialiseData/ECDSA/
+    // Schnorr/i2b/b2i in its base+Plomin walk above, so this tail starts
+    // at cekConstr/cekCase: the BLS12-381 block, keccak_256/blake2b_224,
+    // then the bitwise batch + van_rossem_tail — byte-identical to V1's
+    // own tail from the same point onward.
+    cek_constr_case_costs(&mut m, cur);
+    bls12_381_batch(&mut b, cur)?;
+    keccak_blake2b224_batch(&mut b, cur)?;
+    bitwise_batch(&mut b, cur)?;
+    van_rossem_tail(&mut b, cur)?;
+
+    debug_assert_eq!(
+        cur.i, V2_PARAM_COUNT_VANROSSEM,
+        "V2 cost-model walk must consume exactly {V2_PARAM_COUNT_VANROSSEM} params"
     );
 
     Ok(AppliedCosts {
@@ -710,6 +774,88 @@ fn v3_bitwise_logical(cur: &mut Cursor<'_>) -> CostPair {
     });
     let mem = CostingFun::LinearMaxYZ(cur.linear());
     CostPair { cpu, mem }
+}
+
+/// `cekConstrCost` / `cekCaseCost` machine-step costs, each an `ExBudget`
+/// (`exBudgetCPU` then `exBudgetMemory`), consumed in that order (4 flat
+/// params total). Added to PlutusV3 at its Conway launch and to PlutusV1/V2
+/// at the van Rossem (PV11) hard fork (#860.2) — shared by [`apply_v1`],
+/// [`apply_v2`], and [`apply_v3`] so there is one source of truth for the
+/// field shape.
+fn cek_constr_case_costs(m: &mut MachineCosts, cur: &mut Cursor<'_>) {
+    m.constr = cur.exbudget();
+    m.case_ = cur.exbudget();
+}
+
+/// Full BLS12-381 builtin block: 17 builtins / 38 flat params, alphabetical
+/// (G1 ops, G2 ops, `finalVerify`, `millerLoop`, `mulMlResult`). All
+/// `Constant` or `linear_in_x` shapes, refillable from
+/// [`BuiltinCosts::DEFAULT`]. Added to PlutusV3 at Conway and to PlutusV1/V2
+/// at van Rossem (PV11) (#860.2) — shared by [`apply_v1`], [`apply_v2`],
+/// and [`apply_v3`].
+fn bls12_381_batch(b: &mut BuiltinCosts, cur: &mut Cursor<'_>) -> Result<(), CostModelApplyError> {
+    use BuiltinId::*;
+    refill_builtin(b, Bls12_381_G1_Add, cur)?;
+    refill_builtin(b, Bls12_381_G1_Compress, cur)?;
+    refill_builtin(b, Bls12_381_G1_Equal, cur)?;
+    refill_builtin(b, Bls12_381_G1_HashToGroup, cur)?;
+    refill_builtin(b, Bls12_381_G1_Neg, cur)?;
+    refill_builtin(b, Bls12_381_G1_ScalarMul, cur)?;
+    refill_builtin(b, Bls12_381_G1_Uncompress, cur)?;
+    refill_builtin(b, Bls12_381_G2_Add, cur)?;
+    refill_builtin(b, Bls12_381_G2_Compress, cur)?;
+    refill_builtin(b, Bls12_381_G2_Equal, cur)?;
+    refill_builtin(b, Bls12_381_G2_HashToGroup, cur)?;
+    refill_builtin(b, Bls12_381_G2_Neg, cur)?;
+    refill_builtin(b, Bls12_381_G2_ScalarMul, cur)?;
+    refill_builtin(b, Bls12_381_G2_Uncompress, cur)?;
+    refill_builtin(b, Bls12_381_FinalVerify, cur)?;
+    refill_builtin(b, Bls12_381_MillerLoop, cur)?;
+    refill_builtin(b, Bls12_381_MulMlResult, cur)?;
+    Ok(())
+}
+
+/// `keccak_256` / `blake2b_224`: 2 builtins / 6 flat params (each
+/// `linear_in_x` cpu + `constant` mem), refillable. Added to PlutusV3 at
+/// Conway and to PlutusV1/V2 at van Rossem (PV11) (#860.2) — shared by
+/// [`apply_v1`], [`apply_v2`], and [`apply_v3`].
+fn keccak_blake2b224_batch(
+    b: &mut BuiltinCosts,
+    cur: &mut Cursor<'_>,
+) -> Result<(), CostModelApplyError> {
+    use BuiltinId::*;
+    refill_builtin(b, Keccak_256, cur)?;
+    refill_builtin(b, Blake2b_224, cur)?;
+    Ok(())
+}
+
+/// Plomin (PV10) bitwise batch: 12 builtins / 46 flat params —
+/// `andByteString`/`orByteString`/`xorByteString` (`linear_in_y_and_z` /
+/// `linear_in_max_yz`, via [`v3_bitwise_logical`]), then
+/// `complementByteString`, `readBit`, `writeBits`, `replicateByte`,
+/// `shiftByteString`, `rotateByteString`, `countSetBits`,
+/// `findFirstSetBit`, `ripemd_160` (generic refillable shapes). Added to
+/// PlutusV3 at Plomin and to PlutusV1/V2 at van Rossem (PV11), where it is
+/// byte-identical (#860.2) — shared by [`apply_v1`], [`apply_v2`], and
+/// [`apply_v3`].
+fn bitwise_batch(b: &mut BuiltinCosts, cur: &mut Cursor<'_>) -> Result<(), CostModelApplyError> {
+    use BuiltinId::*;
+    let and = v3_bitwise_logical(cur);
+    b.set_cost_pair(AndByteString, and);
+    let or = v3_bitwise_logical(cur);
+    b.set_cost_pair(OrByteString, or);
+    let xor = v3_bitwise_logical(cur);
+    b.set_cost_pair(XorByteString, xor);
+    refill_builtin(b, ComplementByteString, cur)?;
+    refill_builtin(b, ReadBit, cur)?;
+    refill_builtin(b, WriteBits, cur)?;
+    refill_builtin(b, ReplicateByte, cur)?;
+    refill_builtin(b, ShiftByteString, cur)?;
+    refill_builtin(b, RotateByteString, cur)?;
+    refill_builtin(b, CountSetBits, cur)?;
+    refill_builtin(b, FindFirstSetBit, cur)?;
+    refill_builtin(b, Ripemd_160, cur)?;
+    Ok(())
 }
 
 /// Apply a flat PlutusV3 cost-model array (Conway: 251 entries at PV9,
@@ -853,30 +999,12 @@ pub fn apply_v3(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
     refill_builtin(&mut b, VerifyEd25519Signature, cur)?;
     refill_builtin(&mut b, VerifySchnorrSecp256k1Signature, cur)?;
     // [193..=196] cekConstrCost, cekCaseCost (Conway-specific machine steps).
-    m.constr = cur.exbudget();
-    m.case_ = cur.exbudget();
+    cek_constr_case_costs(&mut m, cur);
     // [197..=234] BLS12-381 batch (alphabetical: G1 ops, G2 ops, finalVerify,
     // millerLoop, mulMlResult). All Constant or linear_in_x shapes.
-    refill_builtin(&mut b, Bls12_381_G1_Add, cur)?;
-    refill_builtin(&mut b, Bls12_381_G1_Compress, cur)?;
-    refill_builtin(&mut b, Bls12_381_G1_Equal, cur)?;
-    refill_builtin(&mut b, Bls12_381_G1_HashToGroup, cur)?;
-    refill_builtin(&mut b, Bls12_381_G1_Neg, cur)?;
-    refill_builtin(&mut b, Bls12_381_G1_ScalarMul, cur)?;
-    refill_builtin(&mut b, Bls12_381_G1_Uncompress, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_Add, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_Compress, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_Equal, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_HashToGroup, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_Neg, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_ScalarMul, cur)?;
-    refill_builtin(&mut b, Bls12_381_G2_Uncompress, cur)?;
-    refill_builtin(&mut b, Bls12_381_FinalVerify, cur)?;
-    refill_builtin(&mut b, Bls12_381_MillerLoop, cur)?;
-    refill_builtin(&mut b, Bls12_381_MulMlResult, cur)?;
+    bls12_381_batch(&mut b, cur)?;
     // [235..=240] keccak_256, blake2b_224.
-    refill_builtin(&mut b, Keccak_256, cur)?;
-    refill_builtin(&mut b, Blake2b_224, cur)?;
+    keccak_blake2b224_batch(&mut b, cur)?;
     // [241..=250] integerToByteString, byteStringToInteger (special shapes).
     let i2b = integer_to_bytestring_cost(cur);
     b.set_cost_pair(IntegerToByteString, i2b);
@@ -892,21 +1020,7 @@ pub fn apply_v3(p: &[i64], major_pv: u32) -> Result<AppliedCosts, CostModelApply
     // — `pad_or_truncate` already guarantees `p` is exactly
     // `V3_PARAM_COUNT_VANROSSEM` long, so a pre-Plomin array's slice here is
     // `maxBound` padding rather than being skipped outright.
-    let and = v3_bitwise_logical(cur);
-    b.set_cost_pair(AndByteString, and);
-    let or = v3_bitwise_logical(cur);
-    b.set_cost_pair(OrByteString, or);
-    let xor = v3_bitwise_logical(cur);
-    b.set_cost_pair(XorByteString, xor);
-    refill_builtin(&mut b, ComplementByteString, cur)?;
-    refill_builtin(&mut b, ReadBit, cur)?;
-    refill_builtin(&mut b, WriteBits, cur)?;
-    refill_builtin(&mut b, ReplicateByte, cur)?;
-    refill_builtin(&mut b, ShiftByteString, cur)?;
-    refill_builtin(&mut b, RotateByteString, cur)?;
-    refill_builtin(&mut b, CountSetBits, cur)?;
-    refill_builtin(&mut b, FindFirstSetBit, cur)?;
-    refill_builtin(&mut b, Ripemd_160, cur)?;
+    bitwise_batch(&mut b, cur)?;
 
     debug_assert_eq!(
         cur.i, V3_PARAM_COUNT_BITWISE,
@@ -1343,6 +1457,46 @@ mod tests {
             .builtins
             .cost_for(BuiltinId::VerifyEd25519Signature, 0, 0, 2);
         assert_eq!((vfy.cpu, vfy.mem), (163 + 164 * 2, 165));
+    }
+
+    /// #860.2: pin the van-Rossem (PV11) TAIL start offset for V1 and V2. Feeding
+    /// `p[i] = i` makes each param equal its own index, so the CekConstr/CekCase
+    /// machine costs land at the exact tail positions:
+    ///   V1: prefix SerialiseData(4)+VerifyEcdsa(2)+VerifySchnorr(3) = 9 params, so
+    ///       CekConstr = p175/p176, CekCase = p177/p178.
+    ///   V2: those 9 are already in V2's 185-param base, so the tail STARTS at cek —
+    ///       CekConstr = p185/p186, CekCase = p187/p188.
+    /// Everything after cek reuses the V3-corpus-validated shared helpers
+    /// (`bls12_381_batch`/`keccak_blake2b224_batch`/`bitwise_batch`/`van_rossem_tail`),
+    /// so pinning this offset (plus the 332-param walk-completeness assert) validates
+    /// the whole V1/V2 tail alignment — which the PV-less conformance corpus cannot.
+    #[test]
+    fn vanrossem_v1_v2_tail_index_mapping_860_2() {
+        let p: Vec<i64> = (0..332).collect();
+
+        let v1 = apply_v1(&p, 11).unwrap();
+        assert_eq!(
+            (v1.machine.constr.cpu, v1.machine.constr.mem),
+            (175, 176),
+            "V1 CekConstr must land at params 175/176 (after the 9-param SerialiseData/ECDSA/Schnorr prefix)"
+        );
+        assert_eq!(
+            (v1.machine.case_.cpu, v1.machine.case_.mem),
+            (177, 178),
+            "V1 CekCase must land at params 177/178"
+        );
+
+        let v2 = apply_v2(&p, 11).unwrap();
+        assert_eq!(
+            (v2.machine.constr.cpu, v2.machine.constr.mem),
+            (185, 186),
+            "V2 CekConstr must land at params 185/186 (the first van-Rossem tail entry)"
+        );
+        assert_eq!(
+            (v2.machine.case_.cpu, v2.machine.case_.mem),
+            (187, 188),
+            "V2 CekCase must land at params 187/188"
+        );
     }
 
     /// #845 gap: V2 and V3 each had a wrong-length pad/truncate golden

--- a/crates/dugite-uplc/src/data.rs
+++ b/crates/dugite-uplc/src/data.rs
@@ -82,7 +82,19 @@ const DATA_CHUNK_LIMIT: usize = 64;
 #[derive(Debug)]
 pub enum Data {
     /// `Constr` — tagged sum: `Constr tag args`.
-    Constr(u64, Vec<Data>),
+    ///
+    /// The tag is an arbitrary-precision signed `Integer`, matching
+    /// Haskell's `Data = Constr Integer [Data] | ...` — NOT a `u64`. A
+    /// script can transiently construct a `Constr` with a negative or
+    /// `> u64::MAX` tag via the `constrData` builtin at protocol
+    /// versions before the van Rossem (PV11) `Word64`-unlifting gate
+    /// (see `builtin::denotations::ConstrData` and issue #859/#828.5).
+    /// The on-chain CBOR/flat wire encoding of a `Constr` tag is always
+    /// a `Word64` on *decode* (a wide tag can only ever exist
+    /// transiently inside a running script, never as a deserialised
+    /// datum/redeemer/script literal) — see `encode_constr`/
+    /// `decode_tagged` below.
+    Constr(BigInt, Vec<Data>),
     /// `Map` — list of key-value pairs. Insertion order preserved;
     /// duplicates permitted.
     Map(Vec<(Data, Data)>),
@@ -176,7 +188,7 @@ impl Clone for Data {
     fn clone(&self) -> Self {
         enum Task<'a> {
             Descend(&'a Data),
-            BuildConstr(u64, usize),
+            BuildConstr(BigInt, usize),
             BuildList(usize),
             BuildMap(usize),
         }
@@ -186,7 +198,7 @@ impl Clone for Data {
             match task {
                 Task::Descend(d) => match d {
                     Data::Constr(tag, args) => {
-                        tasks.push(Task::BuildConstr(*tag, args.len()));
+                        tasks.push(Task::BuildConstr(tag.clone(), args.len()));
                         for child in args.iter().rev() {
                             tasks.push(Task::Descend(child));
                         }
@@ -313,10 +325,12 @@ impl Drop for Data {
     /// `mem::take` always leaves a fully-initialized replacement value
     /// behind rather than partially moving out of a live place; (2)
     /// explicitly drops any genuinely-owned non-`Data` leaf payload
-    /// (`BigInt`/`Vec<u8>`) via the same `mem::take`-then-drop technique;
-    /// and (3) `mem::forget`s the now-inert shell so its own
-    /// `Drop::drop` is never invoked again. Step (3) is leak-free: by
-    /// that point the shell owns only a `Copy` tag and
+    /// (`BigInt`/`Vec<u8>`) — including a `Constr` node's own `BigInt`
+    /// tag, which is heap-backed and MUST be taken-and-dropped here
+    /// too, not left for the final `mem::forget` — via the same
+    /// `mem::take`-then-drop technique; and (3) `mem::forget`s the
+    /// now-inert shell so its own `Drop::drop` is never invoked again.
+    /// Step (3) is leak-free: by that point the shell owns only
     /// default/zero-capacity containers (`Vec::new()`, `BigInt::ZERO` —
     /// both non-heap-allocating).
     fn drop(&mut self) {
@@ -324,7 +338,10 @@ impl Drop for Data {
         let mut stack = vec![taken];
         while let Some(mut node) = stack.pop() {
             match &mut node {
-                Data::Constr(_, args) => stack.extend(std::mem::take(args)),
+                Data::Constr(tag, args) => {
+                    std::mem::drop(std::mem::take(tag));
+                    stack.extend(std::mem::take(args));
+                }
                 Data::List(items) => stack.extend(std::mem::take(items)),
                 Data::Map(entries) => {
                     for (k, v) in std::mem::take(entries) {
@@ -341,6 +358,15 @@ impl Drop for Data {
 }
 
 impl Data {
+    /// Ergonomic `Constr` constructor: accepts anything `Into<BigInt>`
+    /// (small integer literals included) so call sites that only ever
+    /// build small, in-range tags don't need to spell out
+    /// `BigInt::from(..)` themselves. Semantically identical to
+    /// `Data::Constr(tag.into(), args)`.
+    pub fn constr(tag: impl Into<BigInt>, args: Vec<Data>) -> Data {
+        Data::Constr(tag.into(), args)
+    }
+
     /// Consume `self`, extracting the `Constr` tag/args if that's the
     /// variant, or handing `self` back unchanged (`Err`) otherwise.
     ///
@@ -353,9 +379,9 @@ impl Data {
     /// replacement in the field, and the shallow leftover (`self`'s
     /// `Vec` is now empty) drops in O(1) with no recursion when this
     /// function returns.
-    pub fn into_constr(mut self) -> Result<(u64, Vec<Data>), Data> {
+    pub fn into_constr(mut self) -> Result<(BigInt, Vec<Data>), Data> {
         match &mut self {
-            Data::Constr(tag, args) => Ok((*tag, std::mem::take(args))),
+            Data::Constr(tag, args) => Ok((std::mem::take(tag), std::mem::take(args))),
             _ => Err(self),
         }
     }
@@ -445,7 +471,7 @@ fn encode_data_inner<W: minicbor::encode::Write>(
     data: &Data,
 ) -> Result<(), minicbor::encode::Error<W::Error>> {
     match data {
-        Data::Constr(tag, args) => encode_constr(e, *tag, args),
+        Data::Constr(tag, args) => encode_constr(e, tag, args),
         Data::Map(entries) => {
             // Haskell's encoder always uses definite-length CBOR maps
             // for Data. The decoder accepts indefinite, but byte-exact
@@ -465,21 +491,38 @@ fn encode_data_inner<W: minicbor::encode::Write>(
 
 fn encode_constr<W: minicbor::encode::Write>(
     e: &mut Encoder<W>,
-    tag: u64,
+    tag: &BigInt,
     args: &[Data],
 ) -> Result<(), minicbor::encode::Error<W::Error>> {
-    if tag <= 6 {
-        e.tag(Tag::new(121 + tag))?;
-        encode_args(e, args)?;
-    } else if tag <= 127 {
-        e.tag(Tag::new(1280 + (tag - 7)))?;
-        encode_args(e, args)?;
-    } else {
-        e.tag(Tag::new(102))?;
-        e.array(2)?;
-        e.u64(tag)?;
-        encode_args(e, args)?;
+    // The compact tag-121..127 / tag-1280..1400 forms only apply to a
+    // tag in `[0, 127]`; anything else (including any negative or
+    // >u64::MAX tag a script can transiently build via `constrData` at
+    // PV<11 — see #859) falls through to the general tag-102 form. This
+    // matches Haskell's `encodeData`, whose `n >= 0 && n < 7` / `n >= 7
+    // && n < 128` guards are plain `Integer` comparisons that are simply
+    // false for a negative or huge `n`.
+    if let Ok(small) = u64::try_from(tag) {
+        if small <= 6 {
+            e.tag(Tag::new(121 + small))?;
+            return encode_args(e, args);
+        } else if small <= 127 {
+            e.tag(Tag::new(1280 + (small - 7)))?;
+            return encode_args(e, args);
+        }
     }
+    // General tag-102 form: `encodeTag 102 <> encodeListLen 2 <>
+    // encodeInteger n <> encode ds`. `encodeInteger` here is the exact
+    // same arbitrary-precision integer encoding used for `Data::I` — for
+    // an in-range tag this reproduces the plain `e.u64(tag)` byte-exact
+    // (regression-tested), and for an out-of-range tag (never
+    // on-chain-decodable — decode always requires Word64, see
+    // `decode_tagged`) it degrades "softly" to the bignum/negint form
+    // rather than panicking, matching Haskell's `encodeInteger` which
+    // has no upper/lower bound.
+    e.tag(Tag::new(102))?;
+    e.array(2)?;
+    encode_integer(e, tag)?;
+    encode_args(e, args)?;
     Ok(())
 }
 
@@ -759,12 +802,12 @@ fn decode_tagged(d: &mut Decoder<'_>, depth: usize) -> Result<Data, UplcError> {
         (_, tag @ 121..=127) => {
             let constr_tag = tag - 121;
             let args = decode_array(d, depth)?;
-            Ok(Data::Constr(constr_tag, args))
+            Ok(Data::Constr(BigInt::from(constr_tag), args))
         }
         (_, tag @ 1280..=1400) => {
             let constr_tag = tag - 1280 + 7;
             let args = decode_array(d, depth)?;
-            Ok(Data::Constr(constr_tag, args))
+            Ok(Data::Constr(BigInt::from(constr_tag), args))
         }
         (_, 102) => {
             // #831 finding 1: Haskell's `decodeConstrExtended` uses
@@ -782,7 +825,7 @@ fn decode_tagged(d: &mut Decoder<'_>, depth: usize) -> Result<Data, UplcError> {
                         .u64()
                         .map_err(|e| UplcError::CborDecode(format!("constr-102 tag: {e}")))?;
                     let args = decode_array(d, depth)?;
-                    Ok(Data::Constr(constr_tag, args))
+                    Ok(Data::Constr(BigInt::from(constr_tag), args))
                 }
                 Some(n) => Err(UplcError::CborDecode(format!(
                     "tag 102: expected array(2), got Some({n})"
@@ -793,7 +836,7 @@ fn decode_tagged(d: &mut Decoder<'_>, depth: usize) -> Result<Data, UplcError> {
                         .map_err(|e| UplcError::CborDecode(format!("constr-102 tag: {e}")))?;
                     let args = decode_array(d, depth)?;
                     expect_break(d)?;
-                    Ok(Data::Constr(constr_tag, args))
+                    Ok(Data::Constr(BigInt::from(constr_tag), args))
                 }
             }
         }
@@ -1024,7 +1067,7 @@ mod tests {
     #[test]
     fn empty_constr_args_are_definite_0x80() {
         // Constr 0 [] → tag 121 (0xd879) + empty list (0x80).
-        let d = Data::Constr(0, vec![]);
+        let d = Data::Constr(BigInt::from(0), vec![]);
         assert_eq!(hex::encode(d.to_cbor().unwrap()), "d87980");
         // Bare empty List → 0x80.
         assert_eq!(hex::encode(Data::List(vec![]).to_cbor().unwrap()), "80");
@@ -1037,9 +1080,9 @@ mod tests {
         // This is the on-chain shape `d87a9fd8799f…` of the failing-tx
         // datum: the args arrays are INDEFINITE-length.
         let d = Data::Constr(
-            1,
+            BigInt::from(1),
             vec![Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::B(vec![0xab]), Data::I(BigInt::from(7))],
             )],
         );
@@ -1106,7 +1149,7 @@ mod tests {
     #[test]
     fn roundtrip_constr_small_tag() {
         for tag in [0u64, 3, 6] {
-            let d = Data::Constr(tag, vec![Data::I(BigInt::from(42))]);
+            let d = Data::Constr(BigInt::from(tag), vec![Data::I(BigInt::from(42))]);
             assert_eq!(rt(&d), d, "tag={tag}");
         }
     }
@@ -1114,7 +1157,7 @@ mod tests {
     #[test]
     fn roundtrip_constr_medium_tag() {
         for tag in [7u64, 50, 127] {
-            let d = Data::Constr(tag, vec![Data::I(BigInt::from(42))]);
+            let d = Data::Constr(BigInt::from(tag), vec![Data::I(BigInt::from(42))]);
             assert_eq!(rt(&d), d, "tag={tag}");
         }
     }
@@ -1123,9 +1166,53 @@ mod tests {
     fn roundtrip_constr_large_tag() {
         // 128 and above use tag 102 wrapping [tag, args].
         for tag in [128u64, 1000, u64::MAX] {
-            let d = Data::Constr(tag, vec![]);
+            let d = Data::Constr(BigInt::from(tag), vec![]);
             assert_eq!(rt(&d), d, "tag={tag}");
         }
+    }
+
+    /// #859: a transient `Constr` tag outside the `Word64` range (only
+    /// reachable pre-PV11 via `constrData` — see
+    /// `builtin::denotations::ConstrData`) must still *encode* without
+    /// panicking, matching Haskell's `encodeInteger`, which has no
+    /// bound. Such a value can never have come FROM the on-chain CBOR
+    /// decoder (decode always requires the tag to fit `Word64` — see
+    /// `decode_tagged`), so encoding it is intentionally a "soft",
+    /// one-way, non-round-tripping degenerate case: re-decoding those
+    /// bytes must fail cleanly (never panic, never silently truncate).
+    #[test]
+    fn out_of_word64_range_constr_tag_encodes_without_panicking_and_does_not_round_trip() {
+        // Negative tag: general tag-102 form with a CBOR negint payload.
+        let neg = Data::Constr(BigInt::from(-1), vec![]);
+        let neg_bytes = neg
+            .to_cbor()
+            .expect("negative tag must encode without panicking");
+        // d8 66 = tag 102; 82 = array(2); 20 = negint(-1) (encodeInteger,
+        // same path as Data::I); 80 = empty args array.
+        assert_eq!(hex::encode(&neg_bytes), "d866822080");
+        let redecoded = Data::from_cbor(&neg_bytes);
+        assert!(
+            redecoded.is_err(),
+            "a negint constr-102 tag must be rejected on decode (Word64-only), not silently \
+             reinterpreted: {redecoded:?}"
+        );
+
+        // Oversized (> u64::MAX) tag: general tag-102 form with a bignum payload.
+        let huge_tag_value: BigInt = BigInt::from(1u64) << 80;
+        let huge = Data::Constr(huge_tag_value, vec![]);
+        let huge_bytes = huge
+            .to_cbor()
+            .expect("oversized tag must encode without panicking");
+        assert_eq!(
+            hex::encode(&huge_bytes)[0..6],
+            hex::encode([0xd8, 0x66, 0x82])
+        );
+        let redecoded_huge = Data::from_cbor(&huge_bytes);
+        assert!(
+            redecoded_huge.is_err(),
+            "a bignum-tagged constr-102 tag must be rejected on decode (Word64-only): \
+             {redecoded_huge:?}"
+        );
     }
 
     #[test]
@@ -1175,13 +1262,13 @@ mod tests {
     #[test]
     fn roundtrip_nested() {
         let d = Data::Constr(
-            0,
+            BigInt::from(0),
             vec![
                 Data::Map(vec![(
                     Data::B(b"key".to_vec()),
                     Data::List(vec![Data::I(BigInt::from(7))]),
                 )]),
-                Data::Constr(127, vec![Data::I(BigInt::from(-1))]),
+                Data::Constr(BigInt::from(127), vec![Data::I(BigInt::from(-1))]),
             ],
         );
         assert_eq!(rt(&d), d);
@@ -1196,7 +1283,7 @@ mod tests {
         // decoder required `Some(2)` and rejected this.
         let bytes = [0xd8, 0x66, 0x9f, 0x00, 0x80, 0xff];
         let d = Data::from_cbor(&bytes).expect("must accept indefinite tag-102 array");
-        assert_eq!(d, Data::Constr(0, vec![]));
+        assert_eq!(d, Data::Constr(BigInt::from(0), vec![]));
     }
 
     #[test]
@@ -1212,7 +1299,10 @@ mod tests {
         );
         bytes.push(0xff);
         let d = Data::from_cbor(&bytes).expect("must accept indefinite tag-102 array");
-        assert_eq!(d, Data::Constr(1, vec![Data::I(BigInt::from(42))]));
+        assert_eq!(
+            d,
+            Data::Constr(BigInt::from(1), vec![Data::I(BigInt::from(42))])
+        );
     }
 
     #[test]
@@ -1351,7 +1441,7 @@ mod tests {
     #[test]
     fn iterative_clone_preserves_structure_and_order() {
         let d = Data::Constr(
-            7,
+            BigInt::from(7),
             vec![
                 Data::Map(vec![
                     (Data::I(BigInt::from(1)), Data::B(vec![0xAA])),
@@ -1362,7 +1452,7 @@ mod tests {
                 ]),
                 Data::List(vec![
                     Data::I(BigInt::from(-9)),
-                    Data::Constr(0, vec![Data::B(vec![])]),
+                    Data::Constr(BigInt::from(0), vec![Data::B(vec![])]),
                 ]),
                 Data::B(vec![1, 2, 3, 4]),
             ],

--- a/crates/dugite-uplc/src/data.rs
+++ b/crates/dugite-uplc/src/data.rs
@@ -1485,4 +1485,67 @@ mod tests {
         let err = Data::from_cbor(&[]).expect_err("must reject empty");
         assert!(matches!(err, UplcError::CborDecode(_)), "got {err:?}");
     }
+
+    // ─────────────────────────────────────────────────────────────────
+    // #845: differential round-trip property test.
+    //
+    // The hand-picked round-trip cases above (small/medium/large Constr
+    // tags, nested Map/List/Constr, duplicate map keys, ...) are strong
+    // regression pins but only cover the specific shapes someone thought
+    // to write down. `cargo fuzz` (fuzz/fuzz_targets/dugite_uplc_data_
+    // decode.rs) already checks this same `to_cbor ∘ from_cbor = id`
+    // property against truly arbitrary bytes, but that only runs under
+    // `cargo +nightly fuzz run` — never as part of `cargo test`/
+    // `cargo nextest run`, i.e. never in ordinary CI. This proptest
+    // exercises the identical round-trip property, generated from
+    // arbitrary (bounded-depth) `Data` TREES rather than arbitrary
+    // bytes, entirely on stable Rust as part of the normal test suite —
+    // any regression that breaks the `serialiseData`/datum-hash
+    // round-trip for some structural shape the hand-written tests didn't
+    // think of will show up here on every `cargo test` run, not only
+    // during a manual fuzzing session.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Recursive proptest strategy for an arbitrary (bounded) `Data` tree.
+    /// Leaves are small integers/bytestrings; the recursive case adds
+    /// `Constr`/`List`/`Map`, capped at depth 4 / 64 total nodes / up to 4
+    /// items per collection to keep shrinking and generation fast.
+    fn arb_data() -> impl proptest::strategy::Strategy<Value = Data> {
+        use proptest::prelude::*;
+        let leaf = prop_oneof![
+            any::<i64>().prop_map(|n| Data::I(BigInt::from(n))),
+            prop::collection::vec(any::<u8>(), 0..32).prop_map(Data::B),
+        ];
+        leaf.prop_recursive(4, 64, 4, |inner| {
+            prop_oneof![
+                (0u64..200, prop::collection::vec(inner.clone(), 0..4))
+                    .prop_map(|(tag, args)| Data::Constr(BigInt::from(tag), args)),
+                prop::collection::vec(inner.clone(), 0..4).prop_map(Data::List),
+                prop::collection::vec((inner.clone(), inner.clone()), 0..4).prop_map(Data::Map),
+            ]
+        })
+    }
+
+    proptest::proptest! {
+        /// `Data::from_cbor(d.to_cbor())` must be the identity for any
+        /// (bounded) `Data` tree — this is the exact property that makes
+        /// `serialiseData`/datum-hash byte-exactness hold. Also confirms
+        /// the SECOND round-trip (re-encoding the decoded value) is
+        /// byte-identical to the first encode, i.e. `to_cbor()` output is
+        /// itself a fixed point, not merely "some value that happens to
+        /// decode back to something equal."
+        #[test]
+        fn data_cbor_round_trip_is_identity(d in arb_data()) {
+            let bytes = d.to_cbor().expect("encode must not fail on a well-formed Data tree");
+            let decoded = Data::from_cbor(&bytes).expect("decode must not fail on our own encoder's output");
+            proptest::prop_assert_eq!(&decoded, &d, "from_cbor(to_cbor(d)) must equal d");
+
+            let re_encoded = decoded.to_cbor().expect("re-encode must not fail");
+            proptest::prop_assert_eq!(
+                re_encoded, bytes,
+                "to_cbor() must be a fixed point: re-encoding the decoded value must reproduce \
+                 the exact same bytes"
+            );
+        }
+    }
 }

--- a/crates/dugite-uplc/src/data.rs
+++ b/crates/dugite-uplc/src/data.rs
@@ -168,13 +168,18 @@ impl Eq for Data {}
 /// `Vec<(Data, Data)>`), so `#[derive(Clone)]` recurses one native stack
 /// frame per nesting level — the identical latent stack-overflow class
 /// that `PartialEq`, `Hash`, and `Drop` were hand-written to avoid
-/// (#832), and it was the one impl left derived. A deep clone IS
-/// reachable on the CEK hot path: a `Var` lookup (`machine::step`) clones
-/// the bound `Value`, and a `Value` wrapping a `Constant::Data(d)` whose
-/// nesting depth an adversary drove to ~10^5–10^6 (repeated
-/// `constrData`/`listData`/`mapData`, each a separately-charged builtin)
-/// would overflow the phase-2 evaluation stack (unguarded, a 2 MiB rayon
-/// worker) = process abort = remote DoS.
+/// (#832), and it was the one impl left derived. A deep clone is still
+/// reachable on the CEK hot path even after `Constant::Data` became
+/// `Rc`-shared (#838 Fix 2): a `Var` lookup (`machine::step`) now clones
+/// only the `Rc` pointer for the *common* case, but a builtin that
+/// destructures a *shared* `Data` (`Rc::strong_count > 1` — e.g.
+/// `unConstrData` on a ScriptContext still referenced elsewhere in the
+/// env) falls back to exactly this deep clone
+/// (`builtin::denotations::data_from_rc`). A nesting depth an adversary
+/// drove to ~10^5–10^6 (repeated `constrData`/`listData`/`mapData`, each
+/// a separately-charged builtin) would overflow the phase-2 evaluation
+/// stack (unguarded, a 2 MiB rayon worker) = process abort = remote DoS
+/// on that fallback path just as much as on the old always-clone path.
 ///
 /// This produces the exact same value as the derived clone; only the
 /// stack behavior changes. The clone is assembled bottom-up: a work-stack

--- a/crates/dugite-uplc/src/eval_redeemer.rs
+++ b/crates/dugite-uplc/src/eval_redeemer.rs
@@ -421,7 +421,7 @@ pub(crate) fn eval_resolved_redeemer(
 /// Convert a [`crate::data::Data`] into the term that pre-application
 /// will pass into the script.
 fn data_const_term(d: crate::data::Data) -> Term {
-    Term::Const(Constant::Data(d))
+    Term::Const(Constant::Data(std::rc::Rc::new(d)))
 }
 
 /// Resolve the on-chain cost model for `language` into a fully-applied

--- a/crates/dugite-uplc/src/eval_redeemer.rs
+++ b/crates/dugite-uplc/src/eval_redeemer.rs
@@ -185,7 +185,7 @@ pub(crate) fn eval_resolved_redeemer(
     // (language, pv)-independent; this validation is not).
     crate::flat::term::validate_program_availability(
         &program.term,
-        program.version,
+        &program.version,
         r.language,
         major_pv,
     )?;
@@ -307,7 +307,7 @@ pub(crate) fn eval_resolved_redeemer(
             applied_for_fail_dump = Some(applied_term.clone());
         } else {
             let prog = crate::program::Program {
-                version,
+                version: version.clone(),
                 term: applied_term.clone(),
             };
             let path = format!("{dir}/applied-{:?}-{}.flat", r.tag, r.index);
@@ -719,7 +719,17 @@ mod tests {
     use super::*;
     use crate::data::Data;
     use crate::term::{Constant, Term};
-    use num_bigint::BigInt;
+    use num_bigint::{BigInt, BigUint};
+
+    /// Test-only ergonomic constructor for a `Program` version triple
+    /// (`BigUint`-typed since #842's residual arbitrary-precision fix).
+    fn ver(major: u64, minor: u64, patch: u64) -> (BigUint, BigUint, BigUint) {
+        (
+            BigUint::from(major),
+            BigUint::from(minor),
+            BigUint::from(patch),
+        )
+    }
 
     fn slot_cfg() -> SlotConfig {
         SlotConfig {
@@ -757,7 +767,7 @@ mod tests {
         // `deserialiseScript` = `CBOR.decodeBytes >=> unflat`, which
         // hard-fails on non-CBOR input before ever reaching `unflat`.
         let bare_flat = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             term: Term::Const(Constant::Unit),
         }
         .to_flat()
@@ -766,7 +776,7 @@ mod tests {
 
         // The CBOR-wrapped form of the exact same program must decode.
         let cbor_wrapped = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             term: Term::Const(Constant::Unit),
         }
         .to_cbor()
@@ -780,7 +790,7 @@ mod tests {
     /// V3 success check passes.
     fn unit_returning_v3_script() -> Vec<u8> {
         let program = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             // `lam x. const_unit` — `Lam(Const Unit)`. The bound var
             // `x` is unused, so the CEK just returns the constant.
             term: Term::Lam(Rc::new(Term::Const(Constant::Unit))),
@@ -945,7 +955,7 @@ mod tests {
         );
         // Wrap in lam so the V3 single-arg calling convention is satisfied.
         let program = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             term: Term::Lam(Rc::new(trace_call)),
         };
         program.to_cbor().unwrap()
@@ -1002,7 +1012,7 @@ mod tests {
             Rc::new(trace_call("third")),
         );
         let program = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             term: Term::Lam(Rc::new(body)),
         };
         program.to_cbor().unwrap()
@@ -1036,7 +1046,7 @@ mod tests {
             Rc::new(trace_call),
         );
         let program = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             term: Term::Lam(Rc::new(body)),
         };
         program.to_cbor().unwrap()

--- a/crates/dugite-uplc/src/eval_redeemer.rs
+++ b/crates/dugite-uplc/src/eval_redeemer.rs
@@ -170,6 +170,12 @@ pub(crate) fn eval_resolved_redeemer(
 ) -> Result<RedeemerEvalOutcome, PhaseTwoError> {
     // 1. Decode script bytes → typed Term.
     //
+    // #860.1: reject a script whose ledger language is not yet available at the
+    // current protocol version BEFORE flat-decoding the blob, mirroring Haskell's
+    // `ledgerLanguageIntroducedIn ll <= pv` pre-decode gate (a V3 script at PV<9, a
+    // V2 at PV<7, a V1 at PV<5 is rejected without decode).
+    crate::flat::term::validate_ledger_language_available(r.language, major_pv)?;
+
     // On-chain Plutus scripts (witness-set AND reference-script alike)
     // are CBOR-bytestring-wrapped flat: Haskell `deserialiseScript` =
     // `CBOR.decodeBytes >=> unflat` (#836). This is byte-verified

--- a/crates/dugite-uplc/src/flat/bits.rs
+++ b/crates/dugite-uplc/src/flat/bits.rs
@@ -178,6 +178,33 @@ impl<'b> BitReader<'b> {
         }
     }
 
+    /// Read a flat-encoded `Natural` as an arbitrary-precision
+    /// `BigUint`, with NO `u64` cap — matching Haskell's `Natural`
+    /// exactly (issue #842 residual: the `Program` version triple is
+    /// the one field genuinely typed `Natural` with no bound in
+    /// Haskell, so unlike every other `Natural`-tagged field in this
+    /// codec — which Haskell/the ledger additionally treats as
+    /// `Word64`-bounded in practice — this is the only call site that
+    /// should ever need this). Same 7-bit-chunk, low-bits-first,
+    /// continuation-flag encoding as [`Self::read_natural_u64`]; the
+    /// only difference is there is no shift/width limit to exceed, so
+    /// a genuinely huge value decodes to its exact value instead of
+    /// either erroring (`read_word64_strict`) or silently truncating
+    /// (`read_natural_u64`'s lenient `u64` path).
+    pub fn read_natural_biguint(&mut self) -> FlatResult<num_bigint::BigUint> {
+        let mut value = num_bigint::BigUint::ZERO;
+        let mut shift: u32 = 0;
+        loop {
+            let more = self.read_bit()?;
+            let chunk = self.read_bits8(7)? as u64;
+            value |= num_bigint::BigUint::from(chunk) << shift;
+            if !more {
+                return Ok(value);
+            }
+            shift += 7;
+        }
+    }
+
     /// Read a flat-encoded `Integer` (signed arbitrary-precision
     /// integer). The encoding is zig-zag from `Natural`:
     /// `n >= 0` → `2n`; `n < 0` → `2|n| - 1`.
@@ -289,6 +316,30 @@ impl BitWriter {
         }
     }
 
+    /// Append an arbitrary-precision `Natural` (`BigUint`) as 7-bit
+    /// chunks with continuation flags — the counterpart to
+    /// [`BitReader::read_natural_biguint`]. Byte-identical to
+    /// [`Self::write_natural_u64`] for any value that fits in a `u64`.
+    pub fn write_natural_biguint(&mut self, value: &num_bigint::BigUint) -> FlatResult<()> {
+        use num_bigint::BigUint;
+        let mut value = value.clone();
+        let mask = BigUint::from(0x7fu8);
+        loop {
+            let chunk_bi = &value & &mask;
+            // `chunk_bi` is masked to 7 bits, so it always fits in a u8;
+            // `to_bytes_le()` on a value < 128 yields at most one byte
+            // (or none at all for zero).
+            let chunk = chunk_bi.to_bytes_le().first().copied().unwrap_or(0);
+            value >>= 7u32;
+            let more = value > BigUint::ZERO;
+            self.write_bit(more);
+            self.write_bits8(chunk, 7)?;
+            if !more {
+                return Ok(());
+            }
+        }
+    }
+
     /// Append an `Integer` (zig-zag encoded).
     pub fn write_integer_i64(&mut self, value: i64) -> FlatResult<()> {
         let zigzag: u64 = if value >= 0 {
@@ -358,6 +409,46 @@ mod tests {
         for n in [u32::MAX as u64, u64::MAX / 2, u64::MAX] {
             roundtrip_natural(n);
         }
+    }
+
+    /// #842 residual: `read_natural_biguint`/`write_natural_biguint` must
+    /// be byte-identical to the `u64` path for every value that fits in
+    /// a `u64` (including the boundary), and must correctly round-trip a
+    /// value that does NOT fit — which is exactly the case the lenient
+    /// `u64` path silently truncates (see
+    /// `read_natural_u64_lenient_path_unchanged_for_version_triple`).
+    #[test]
+    fn natural_biguint_matches_u64_path_for_u64_range_values() {
+        for n in [0u64, 1, 127, 128, 16383, 16384, u32::MAX as u64, u64::MAX] {
+            let mut w_u64 = BitWriter::new();
+            w_u64.write_natural_u64(n).unwrap();
+            let mut w_big = BitWriter::new();
+            w_big
+                .write_natural_biguint(&num_bigint::BigUint::from(n))
+                .unwrap();
+            assert_eq!(
+                w_u64.bytes, w_big.bytes,
+                "biguint encoding must match u64 encoding byte-for-byte, n={n}"
+            );
+
+            let mut r = BitReader::new(&w_big.bytes);
+            let got = r.read_natural_biguint().unwrap();
+            assert_eq!(got, num_bigint::BigUint::from(n));
+        }
+    }
+
+    #[test]
+    fn natural_biguint_round_trips_value_wider_than_u64() {
+        // 2^70 + 12345 — needs 11 seven-bit chunks, far past the point
+        // (the 10th chunk, shift=63) where the u64 varint reader must
+        // reject/truncate. Haskell's `Natural` has no such bound.
+        let huge: num_bigint::BigUint =
+            (num_bigint::BigUint::from(1u8) << 70u32) + num_bigint::BigUint::from(12345u32);
+        let mut w = BitWriter::new();
+        w.write_natural_biguint(&huge).unwrap();
+        let mut r = BitReader::new(&w.bytes);
+        let got = r.read_natural_biguint().unwrap();
+        assert_eq!(got, huge, "a >64-bit Natural must round-trip exactly");
     }
 
     #[test]

--- a/crates/dugite-uplc/src/flat/term.rs
+++ b/crates/dugite-uplc/src/flat/term.rs
@@ -1484,4 +1484,82 @@ mod tests {
         validate_program_availability(&t, &ver(1, 1, 0), ScriptLanguage::PlutusV3, 10)
             .expect("constr tag bound only applies from PV11");
     }
+
+    // ─────────────────────────────────────────────────────────────────
+    // #845: differential round-trip property test for the flat Term
+    // codec — the same motivation as `data::tests::data_cbor_round_trip_
+    // is_identity`: `cargo fuzz`'s `dugite_uplc_program_decode` target
+    // already fuzzes `Program::from_flat`/`to_flat` against arbitrary
+    // bytes, but only under a manual `cargo +nightly fuzz run` session,
+    // never as part of ordinary `cargo test`/`cargo nextest run`. This
+    // exercises the identical `decode ∘ encode = id` property, generated
+    // from arbitrary (bounded) `Term` TREES, entirely on stable Rust as
+    // part of the normal test suite.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Recursive proptest strategy for an arbitrary (bounded) `Term`.
+    /// Leaves are `Error`, a handful of `Constant` shapes, and a few
+    /// representative `Builtin` ids (arity doesn't matter here — we only
+    /// round-trip the flat encoding, never evaluate). The recursive case
+    /// adds `Lam`/`Delay`/`Force`/`App`/`Constr`/`Case`, capped at depth
+    /// 4 / 32 total nodes / up to 3 items per `Constr`/`Case` collection.
+    fn arb_term() -> impl proptest::strategy::Strategy<Value = Term> {
+        use proptest::prelude::*;
+        let const_leaf = prop_oneof![
+            any::<i64>().prop_map(|n| Term::Const(Constant::Integer(BigInt::from(n)))),
+            prop::collection::vec(any::<u8>(), 0..16)
+                .prop_map(|b| Term::Const(Constant::ByteString(b))),
+            any::<bool>().prop_map(|b| Term::Const(Constant::Bool(b))),
+            Just(Term::Const(Constant::Unit)),
+        ];
+        let builtin_leaf = prop_oneof![
+            Just(Term::Builtin(BuiltinId::AddInteger)),
+            Just(Term::Builtin(BuiltinId::IfThenElse)),
+            Just(Term::Builtin(BuiltinId::Trace)),
+        ];
+        let leaf = prop_oneof![
+            Just(Term::Error),
+            (0u64..20).prop_map(Term::Var),
+            const_leaf,
+            builtin_leaf,
+        ];
+        leaf.prop_recursive(4, 32, 3, |inner| {
+            prop_oneof![
+                inner.clone().prop_map(|t| Term::Lam(Rc::new(t))),
+                inner.clone().prop_map(|t| Term::Delay(Rc::new(t))),
+                inner.clone().prop_map(|t| Term::Force(Rc::new(t))),
+                (inner.clone(), inner.clone()).prop_map(|(f, a)| Term::App(Rc::new(f), Rc::new(a))),
+                (0u64..200, prop::collection::vec(inner.clone(), 0..3)).prop_map(|(tag, args)| {
+                    Term::Constr {
+                        tag,
+                        args: args.into_iter().map(Rc::new).collect(),
+                    }
+                }),
+                (inner.clone(), prop::collection::vec(inner.clone(), 0..3)).prop_map(
+                    |(scrutinee, branches)| Term::Case {
+                        scrutinee: Rc::new(scrutinee),
+                        branches: branches.into_iter().map(Rc::new).collect(),
+                    }
+                ),
+            ]
+        })
+    }
+
+    proptest::proptest! {
+        /// `decode_term(encode_term(t))` must be the identity for any
+        /// (bounded) `Term` — the flat-codec analogue of `Data`'s
+        /// serialiseData round-trip property, and the property a decoder/
+        /// encoder asymmetry (a historical source of script-hash
+        /// divergences per `dugite_uplc_program_decode`'s fuzz-target doc
+        /// comment) would break.
+        #[test]
+        fn term_flat_round_trip_is_identity(t in arb_term()) {
+            let mut w = BitWriter::new();
+            encode_term(&mut w, &t).expect("encode must not fail on a well-formed Term");
+            let bytes = w.finish();
+            let mut r = BitReader::new(&bytes);
+            let decoded = decode_term(&mut r).expect("decode must not fail on our own encoder's output");
+            proptest::prop_assert_eq!(&decoded, &t, "decode_term(encode_term(t)) must equal t");
+        }
+    }
 }

--- a/crates/dugite-uplc/src/flat/term.rs
+++ b/crates/dugite-uplc/src/flat/term.rs
@@ -76,7 +76,20 @@ const CONST_TAG_WIDTH: u8 = 4;
 /// Mirrors Haskell `plcVersion110`, which gates `decodeTerm`'s tag-8/9
 /// handlers: `unless (version >= plcVersion110) $ fail "'constr' is not
 /// allowed before version 1.1.0"` (`UntypedPlutusCore/Core/Instance/Flat.hs`).
-const PLC_VERSION_1_1_0: (u64, u64, u64) = (1, 1, 0);
+///
+/// A function rather than a `const` because the version triple is
+/// `BigUint`-typed (#842 residual) and `BigUint::from` isn't `const fn`.
+fn plc_version_1_1_0() -> (
+    num_bigint::BigUint,
+    num_bigint::BigUint,
+    num_bigint::BigUint,
+) {
+    (
+        num_bigint::BigUint::from(1u8),
+        num_bigint::BigUint::from(1u8),
+        num_bigint::BigUint::ZERO,
+    )
+}
 
 /// First protocol version at which `maxBoundsByPV` bounds a `Constr` tag
 /// (and the constant-universe header) — mirrors `vanRossemPV` in
@@ -167,11 +180,15 @@ pub fn encode_constant(w: &mut BitWriter, c: &Constant) -> FlatResult<()> {
 ///    at 1024 (`maxBoundsByPV`'s `mbConstr`).
 pub fn validate_program_availability(
     term: &Term,
-    version: (u64, u64, u64),
+    version: &(
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+    ),
     language: ScriptLanguage,
     major_pv: u32,
 ) -> FlatResult<()> {
-    let version_1_1_0_or_later = version >= PLC_VERSION_1_1_0;
+    let version_1_1_0_or_later = version >= &plc_version_1_1_0();
     validate_term_depth(term, language, major_pv, version_1_1_0_or_later, 0)
 }
 
@@ -957,6 +974,24 @@ mod tests {
         decode_term(&mut r).expect("decode")
     }
 
+    /// Test-only ergonomic constructor for a `Program` version triple
+    /// (`BigUint`-typed since #842's residual arbitrary-precision fix).
+    fn ver(
+        major: u64,
+        minor: u64,
+        patch: u64,
+    ) -> (
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+    ) {
+        (
+            num_bigint::BigUint::from(major),
+            num_bigint::BigUint::from(minor),
+            num_bigint::BigUint::from(patch),
+        )
+    }
+
     fn atoms(t: &TypeTag) -> Vec<u8> {
         let mut v = Vec::new();
         collect_type_atoms(t, &mut v).expect("collect");
@@ -1264,8 +1299,8 @@ mod tests {
     #[test]
     fn validate_rejects_unavailable_builtin_for_v1_before_pv11() {
         let t = Term::Builtin(BuiltinId::Bls12_381_G1_Add);
-        let err =
-            validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV1, 10).unwrap_err();
+        let err = validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV1, 10)
+            .unwrap_err();
         assert!(matches!(err, UplcError::FlatDecode(_)), "got {err:?}");
     }
 
@@ -1274,8 +1309,8 @@ mod tests {
     #[test]
     fn validate_rejects_unavailable_bitwise_builtin_for_v1_before_pv11() {
         let t = Term::Builtin(BuiltinId::AndByteString);
-        let err =
-            validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV1, 10).unwrap_err();
+        let err = validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV1, 10)
+            .unwrap_err();
         assert!(matches!(err, UplcError::FlatDecode(_)), "got {err:?}");
     }
 
@@ -1285,18 +1320,18 @@ mod tests {
     fn validate_accepts_available_builtin_no_false_rejection() {
         // BLS at V1/PV11 (available).
         let t = Term::Builtin(BuiltinId::Bls12_381_G1_Add);
-        validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV1, 11)
+        validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV1, 11)
             .expect("BLS must be available to V1 at PV11");
 
         // BLS at V3/PV9 (available earlier for V3).
         let t = Term::Builtin(BuiltinId::Bls12_381_G1_Add);
-        validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV3, 9)
+        validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV3, 9)
             .expect("BLS must be available to V3 at PV9");
 
         // Base-set builtin available to every language at their respective
         // ledger-language introduction PV.
         let t = Term::Builtin(BuiltinId::AddInteger);
-        validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV1, 5)
+        validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV1, 5)
             .expect("addInteger must be available to V1 at PV5");
     }
 
@@ -1311,8 +1346,8 @@ mod tests {
             Rc::new(Term::Delay(Rc::new(inner))),
             Rc::new(Term::Error),
         )))));
-        let err =
-            validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV1, 9).unwrap_err();
+        let err = validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV1, 9)
+            .unwrap_err();
         assert!(matches!(err, UplcError::FlatDecode(_)), "got {err:?}");
     }
 
@@ -1325,8 +1360,8 @@ mod tests {
             tag: 0,
             args: vec![],
         };
-        let err =
-            validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV3, 11).unwrap_err();
+        let err = validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV3, 11)
+            .unwrap_err();
         assert!(matches!(err, UplcError::FlatDecode(_)), "got {err:?}");
     }
 
@@ -1337,8 +1372,8 @@ mod tests {
             scrutinee: Rc::new(Term::Error),
             branches: vec![],
         };
-        let err =
-            validate_program_availability(&t, (1, 0, 0), ScriptLanguage::PlutusV3, 11).unwrap_err();
+        let err = validate_program_availability(&t, &ver(1, 0, 0), ScriptLanguage::PlutusV3, 11)
+            .unwrap_err();
         assert!(matches!(err, UplcError::FlatDecode(_)), "got {err:?}");
     }
 
@@ -1350,14 +1385,14 @@ mod tests {
             tag: 0,
             args: vec![Rc::new(Term::Error)],
         };
-        validate_program_availability(&t, (1, 1, 0), ScriptLanguage::PlutusV3, 11)
+        validate_program_availability(&t, &ver(1, 1, 0), ScriptLanguage::PlutusV3, 11)
             .expect("constr must be allowed at PLC 1.1.0");
 
         let t = Term::Case {
             scrutinee: Rc::new(Term::Error),
             branches: vec![Rc::new(Term::Error)],
         };
-        validate_program_availability(&t, (1, 1, 0), ScriptLanguage::PlutusV3, 11)
+        validate_program_availability(&t, &ver(1, 1, 0), ScriptLanguage::PlutusV3, 11)
             .expect("case must be allowed at PLC 1.1.0");
     }
 
@@ -1368,8 +1403,8 @@ mod tests {
             tag: 1025,
             args: vec![],
         };
-        let err =
-            validate_program_availability(&t, (1, 1, 0), ScriptLanguage::PlutusV3, 11).unwrap_err();
+        let err = validate_program_availability(&t, &ver(1, 1, 0), ScriptLanguage::PlutusV3, 11)
+            .unwrap_err();
         assert!(matches!(err, UplcError::FlatDecode(_)), "got {err:?}");
     }
 
@@ -1380,7 +1415,7 @@ mod tests {
             tag: 1024,
             args: vec![],
         };
-        validate_program_availability(&t, (1, 1, 0), ScriptLanguage::PlutusV3, 11)
+        validate_program_availability(&t, &ver(1, 1, 0), ScriptLanguage::PlutusV3, 11)
             .expect("tag 1024 is exactly at the boundary and must be accepted");
     }
 
@@ -1393,7 +1428,7 @@ mod tests {
             tag: 50_000,
             args: vec![],
         };
-        validate_program_availability(&t, (1, 1, 0), ScriptLanguage::PlutusV3, 10)
+        validate_program_availability(&t, &ver(1, 1, 0), ScriptLanguage::PlutusV3, 10)
             .expect("constr tag bound only applies from PV11");
     }
 }

--- a/crates/dugite-uplc/src/flat/term.rs
+++ b/crates/dugite-uplc/src/flat/term.rs
@@ -192,6 +192,37 @@ pub fn validate_program_availability(
     validate_term_depth(term, language, major_pv, version_1_1_0_or_later, 0)
 }
 
+/// The protocol MAJOR version at which each ledger Plutus language became
+/// available — Haskell `ledgerLanguageIntroducedIn`:
+/// PlutusV1 → Alonzo (5), PlutusV2 → Babbage/Vasil (7), PlutusV3 → Conway/Chang (9).
+/// (Matches dugite-ledger's own reference-script PV gate in `validation/scripts.rs`.)
+pub fn ledger_language_introduced_in(language: ScriptLanguage) -> u32 {
+    match language {
+        ScriptLanguage::PlutusV1 => 5,
+        ScriptLanguage::PlutusV2 => 7,
+        ScriptLanguage::PlutusV3 => 9,
+    }
+}
+
+/// Reject a script whose ledger language is not yet available at `major_pv`,
+/// mirroring Haskell's `ledgerLanguageIntroducedIn ll <= pv` check, which runs
+/// BEFORE the flat blob is decoded. Emits a typed, adversary-reachable
+/// `FlatDecode` rejection (never an internal error). See issue #860.1.
+pub fn validate_ledger_language_available(
+    language: ScriptLanguage,
+    major_pv: u32,
+) -> FlatResult<()> {
+    let introduced = ledger_language_introduced_in(language);
+    if major_pv < introduced {
+        Err(UplcError::FlatDecode(format!(
+            "ledger language {language:?} is not available at protocol version {major_pv} \
+             (introduced in protocol major {introduced})"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
 fn validate_term_depth(
     term: &Term,
     language: ScriptLanguage,
@@ -965,6 +996,28 @@ fn unreachable_zero() -> FlatResult<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #860.1: a script whose ledger language is not yet available at the current
+    /// protocol version is rejected; an available one passes. Thresholds V1@5,
+    /// V2@7, V3@9 (`ledgerLanguageIntroducedIn`).
+    #[test]
+    fn ledger_language_availability_gate_860_1() {
+        use ScriptLanguage::*;
+        // Unavailable below the introduction PV.
+        for (lang, introduced) in [(PlutusV1, 5u32), (PlutusV2, 7), (PlutusV3, 9)] {
+            assert_eq!(ledger_language_introduced_in(lang), introduced);
+            assert!(
+                validate_ledger_language_available(lang, introduced - 1).is_err(),
+                "{lang:?} must be rejected at PV {}",
+                introduced - 1
+            );
+            // Available at and above the introduction PV.
+            assert!(validate_ledger_language_available(lang, introduced).is_ok());
+            assert!(validate_ledger_language_available(lang, introduced + 3).is_ok());
+        }
+        // A V3 script at PV 8 (Babbage-ish) is the canonical rejected case.
+        assert!(validate_ledger_language_available(PlutusV3, 8).is_err());
+    }
 
     fn rt_term(t: Term) -> Term {
         let mut w = BitWriter::new();

--- a/crates/dugite-uplc/src/flat/term.rs
+++ b/crates/dugite-uplc/src/flat/term.rs
@@ -723,7 +723,7 @@ fn decode_constant_value(r: &mut BitReader<'_>, tag: &TypeTag) -> FlatResult<Con
             let d = Data::from_cbor(&raw).map_err(|e| {
                 UplcError::FlatDecode(format!("Data constant: CBOR decode failed: {e}"))
             })?;
-            Ok(Constant::Data(d))
+            Ok(Constant::Data(std::rc::Rc::new(d)))
         }
         TypeTag::List(elem_type) => {
             // A list constant is a flat cons-list: each element is preceded

--- a/crates/dugite-uplc/src/machine/value.rs
+++ b/crates/dugite-uplc/src/machine/value.rs
@@ -74,6 +74,39 @@ mod tests {
         assert!(!Value::Const(Constant::Bool(true)).is_unit());
     }
 
+    /// #838 Fix 2: cloning a `Value::Const(Constant::Data(..))` — the CEK
+    /// env-lookup hot path exercised on every `(var ctx)` reference to a
+    /// large ScriptContext — must be an O(1) refcount bump, not an
+    /// O(size) deep clone of the `Data` tree. `Value` derives `Clone`, so
+    /// this pins the *representation* invariant that makes that true:
+    /// `Constant::Data` holds an `Rc<Data>`, and cloning it shares the
+    /// allocation (`Rc::ptr_eq`) rather than reallocating.
+    #[test]
+    fn const_data_clone_shares_rc_allocation_not_deep_clone() {
+        let data = Rc::new(crate::data::Data::I(BigInt::from(42)));
+        let v = Value::Const(Constant::Data(Rc::clone(&data)));
+
+        // Simulate two separate CEK env lookups of the same bound value
+        // (e.g. two `(var ctx)` occurrences in the compiled term).
+        let looked_up_once = v.clone();
+        let looked_up_twice = v.clone();
+
+        let Value::Const(Constant::Data(rc1)) = looked_up_once else {
+            panic!("expected Const(Data(_))");
+        };
+        let Value::Const(Constant::Data(rc2)) = looked_up_twice else {
+            panic!("expected Const(Data(_))");
+        };
+        assert!(
+            Rc::ptr_eq(&data, &rc1) && Rc::ptr_eq(&data, &rc2),
+            "Value::clone() on a Data constant must share the allocation via Rc, \
+             not deep-clone the Data tree"
+        );
+        // data(1) + v's own Rc(2) + rc1(3) + rc2(4) — every clone is a
+        // pointer, never a fresh allocation.
+        assert_eq!(Rc::strong_count(&data), 4);
+    }
+
     #[test]
     fn lambda_eq_requires_same_body() {
         let l1 = Value::Lambda {

--- a/crates/dugite-uplc/src/populate_gov.rs
+++ b/crates/dugite-uplc/src/populate_gov.rs
@@ -173,7 +173,7 @@ pub fn proposal_to_plutus(p: &PrimProposal) -> Result<PlProposalProcedure, Phase
     let deposit_data = Data::I(BigInt::from(p.deposit.0));
     let gov_action_data = gov_action_to_data(&p.gov_action)?;
     Ok(PlProposalProcedure(Data::Constr(
-        0,
+        BigInt::from(0),
         vec![deposit_data, return_addr_data, gov_action_data],
     )))
 }
@@ -219,7 +219,7 @@ pub fn gov_action_to_data(action: &PrimGovAction) -> Result<Data, PhaseTwoError>
             protocol_param_update,
             policy_hash,
         } => Data::Constr(
-            0,
+            BigInt::from(0),
             vec![
                 maybe_gov_action_id(prev_action_id.as_ref()),
                 // ChangedParameters (#761): the Conway guardrails scripts that
@@ -239,12 +239,12 @@ pub fn gov_action_to_data(action: &PrimGovAction) -> Result<Data, PhaseTwoError>
             prev_action_id,
             protocol_version: (major, minor),
         } => Data::Constr(
-            1,
+            BigInt::from(1),
             vec![
                 maybe_gov_action_id(prev_action_id.as_ref()),
                 // ProtocolVersion: makeIsDataSchemaIndexed [('ProtocolVersion, 0)]
                 Data::Constr(
-                    0,
+                    BigInt::from(0),
                     vec![Data::I(BigInt::from(*major)), Data::I(BigInt::from(*minor))],
                 ),
             ],
@@ -277,14 +277,15 @@ pub fn gov_action_to_data(action: &PrimGovAction) -> Result<Data, PhaseTwoError>
                 })
                 .collect();
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![Data::Map(entries), maybe_script_hash(policy_hash.as_ref())],
             )
         }
         // Constr 3 [Maybe GovActionId]
-        PrimGovAction::NoConfidence { prev_action_id } => {
-            Data::Constr(3, vec![maybe_gov_action_id(prev_action_id.as_ref())])
-        }
+        PrimGovAction::NoConfidence { prev_action_id } => Data::Constr(
+            BigInt::from(3),
+            vec![maybe_gov_action_id(prev_action_id.as_ref())],
+        ),
         // Constr 4 [Maybe GovActionId, [ColdCredential], Map ColdCredential Epoch, Rational]
         // ColdCommitteeCredential: newtype deriving ToData from V2.Credential → bare Credential
         // Rational: makeIsDataSchemaIndexed [('Rational, 0)] → Constr 0 [I num, I den]
@@ -331,14 +332,14 @@ pub fn gov_action_to_data(action: &PrimGovAction) -> Result<Data, PhaseTwoError>
             let (threshold_num, threshold_den) =
                 reduce_rational(threshold.numerator, threshold.denominator);
             let rational_data = Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![
                     Data::I(BigInt::from(threshold_num)),
                     Data::I(BigInt::from(threshold_den)),
                 ],
             );
             Data::Constr(
-                4,
+                BigInt::from(4),
                 vec![
                     maybe_gov_action_id(prev_action_id.as_ref()),
                     Data::List(remove_list),
@@ -354,11 +355,11 @@ pub fn gov_action_to_data(action: &PrimGovAction) -> Result<Data, PhaseTwoError>
             constitution,
         } => {
             let constitution_data = Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![maybe_script_hash(constitution.script_hash.as_ref())],
             );
             Data::Constr(
-                5,
+                BigInt::from(5),
                 vec![
                     maybe_gov_action_id(prev_action_id.as_ref()),
                     constitution_data,
@@ -366,7 +367,7 @@ pub fn gov_action_to_data(action: &PrimGovAction) -> Result<Data, PhaseTwoError>
             )
         }
         // Constr 6 []
-        PrimGovAction::InfoAction => Data::Constr(6, vec![]),
+        PrimGovAction::InfoAction => Data::Constr(BigInt::from(6), vec![]),
     };
     Ok(d)
 }
@@ -632,19 +633,19 @@ fn ppu_to_changed_parameters_data(ppu: &ProtocolParamUpdate) -> Data {
 /// `script_context.rs`, which already encodes bare bytes for V3).
 fn maybe_gov_action_id(id: Option<&PrimGovActionId>) -> Data {
     match id {
-        None => Data::Constr(1, vec![]),
+        None => Data::Constr(BigInt::from(1), vec![]),
         Some(gid) => {
             // GovernanceActionId = Constr 0 [B txid32, I action_idx]
             // V3 TxId = bare BuiltinByteString (deriving newtype ToData).
             // This matches GovActionId::to_data() in script_context.rs.
             let id_data = Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![
                     Data::B(gid.transaction_id.0.to_vec()),
                     Data::I(BigInt::from(gid.action_index)),
                 ],
             );
-            Data::Constr(0, vec![id_data])
+            Data::Constr(BigInt::from(0), vec![id_data])
         }
     }
 }
@@ -654,8 +655,8 @@ fn maybe_gov_action_id(id: Option<&PrimGovActionId>) -> Data {
 /// `Nothing = Constr 1 []`, `Just h = Constr 0 [B28]`.
 fn maybe_script_hash(h: Option<&dugite_primitives::hash::Hash28>) -> Data {
     match h {
-        None => Data::Constr(1, vec![]),
-        Some(sh) => Data::Constr(0, vec![Data::B(sh.0.to_vec())]),
+        None => Data::Constr(BigInt::from(1), vec![]),
+        Some(sh) => Data::Constr(BigInt::from(0), vec![Data::B(sh.0.to_vec())]),
     }
 }
 
@@ -697,23 +698,27 @@ pub fn proposals_to_plutus(
 pub fn certificate_to_plutus(c: &PrimCert) -> Result<TxCert, PhaseTwoError> {
     let data = match c {
         PrimCert::StakeRegistration(cred) => {
-            Data::Constr(0, vec![cred_data(cred), option_int(None)])
+            Data::Constr(BigInt::from(0), vec![cred_data(cred), option_int(None)])
         }
         PrimCert::StakeDeregistration(cred) => {
-            Data::Constr(1, vec![cred_data(cred), option_int(None)])
+            Data::Constr(BigInt::from(1), vec![cred_data(cred), option_int(None)])
         }
         PrimCert::ConwayStakeRegistration {
             credential,
             deposit,
-        } => Data::Constr(0, vec![cred_data(credential), option_int(Some(deposit.0))]),
-        PrimCert::ConwayStakeDeregistration { credential, refund } => {
-            Data::Constr(1, vec![cred_data(credential), option_int(Some(refund.0))])
-        }
+        } => Data::Constr(
+            BigInt::from(0),
+            vec![cred_data(credential), option_int(Some(deposit.0))],
+        ),
+        PrimCert::ConwayStakeDeregistration { credential, refund } => Data::Constr(
+            BigInt::from(1),
+            vec![cred_data(credential), option_int(Some(refund.0))],
+        ),
         PrimCert::StakeDelegation {
             credential,
             pool_hash,
         } => Data::Constr(
-            2,
+            BigInt::from(2),
             vec![cred_data(credential), delegatee_to_pool(&pool_hash.0)],
         ),
         PrimCert::RegStakeDeleg {
@@ -721,7 +726,7 @@ pub fn certificate_to_plutus(c: &PrimCert) -> Result<TxCert, PhaseTwoError> {
             pool_hash,
             deposit,
         } => Data::Constr(
-            3,
+            BigInt::from(3),
             vec![
                 cred_data(credential),
                 delegatee_to_pool(&pool_hash.0),
@@ -733,46 +738,49 @@ pub fn certificate_to_plutus(c: &PrimCert) -> Result<TxCert, PhaseTwoError> {
             deposit,
             ..
         } => Data::Constr(
-            4,
+            BigInt::from(4),
             vec![cred_data(credential), Data::I(BigInt::from(deposit.0))],
         ),
-        PrimCert::UpdateDRep { credential, .. } => Data::Constr(5, vec![cred_data(credential)]),
+        PrimCert::UpdateDRep { credential, .. } => {
+            Data::Constr(BigInt::from(5), vec![cred_data(credential)])
+        }
         PrimCert::UnregDRep { credential, refund } => Data::Constr(
-            6,
+            BigInt::from(6),
             vec![cred_data(credential), Data::I(BigInt::from(refund.0))],
         ),
         PrimCert::PoolRegistration(params) => Data::Constr(
-            7,
+            BigInt::from(7),
             vec![
                 Data::B(params.operator.0.to_vec()),
                 Data::B(params.vrf_keyhash.0.to_vec()),
             ],
         ),
         PrimCert::PoolRetirement { pool_hash, epoch } => Data::Constr(
-            8,
+            BigInt::from(8),
             vec![Data::B(pool_hash.0.to_vec()), Data::I(BigInt::from(*epoch))],
         ),
         PrimCert::CommitteeHotAuth {
             cold_credential,
             hot_credential,
         } => Data::Constr(
-            9,
+            BigInt::from(9),
             vec![cred_data(cold_credential), cred_data(hot_credential)],
         ),
         PrimCert::CommitteeColdResign {
             cold_credential, ..
-        } => Data::Constr(10, vec![cred_data(cold_credential)]),
+        } => Data::Constr(BigInt::from(10), vec![cred_data(cold_credential)]),
         // Combined certs: emit as TxCertRegDeleg / TxCertDelegStaking shapes,
         // with the DRep threaded through the `Delegatee` payload (#815).
-        PrimCert::VoteDelegation { credential, drep } => {
-            Data::Constr(2, vec![cred_data(credential), delegatee_vote(drep)])
-        }
+        PrimCert::VoteDelegation { credential, drep } => Data::Constr(
+            BigInt::from(2),
+            vec![cred_data(credential), delegatee_vote(drep)],
+        ),
         PrimCert::StakeVoteDelegation {
             credential,
             pool_hash,
             drep,
         } => Data::Constr(
-            2,
+            BigInt::from(2),
             vec![
                 cred_data(credential),
                 delegatee_stake_vote(&pool_hash.0, drep),
@@ -784,7 +792,7 @@ pub fn certificate_to_plutus(c: &PrimCert) -> Result<TxCert, PhaseTwoError> {
             deposit,
             drep,
         } => Data::Constr(
-            3,
+            BigInt::from(3),
             vec![
                 cred_data(credential),
                 delegatee_stake_vote(&pool_hash.0, drep),
@@ -796,7 +804,7 @@ pub fn certificate_to_plutus(c: &PrimCert) -> Result<TxCert, PhaseTwoError> {
             deposit,
             drep,
         } => Data::Constr(
-            3,
+            BigInt::from(3),
             vec![
                 cred_data(credential),
                 delegatee_vote(drep),
@@ -829,7 +837,7 @@ fn cred_data(c: &PrimCred) -> Data {
 /// type uses `StakingCredential` everywhere a credential appears, NOT the
 /// bare `Credential` (and NOT the Conway V3 `TxCert` shapes).
 fn staking_hash_data(c: &PrimCred) -> Data {
-    Data::Constr(0, vec![cred_data(c)])
+    Data::Constr(BigInt::from(0), vec![cred_data(c)])
 }
 
 /// Translate a ledger certificate into the **PlutusV1/V2** `DCert` Data,
@@ -863,28 +871,32 @@ pub fn certificate_to_plutus_v1v2(c: &PrimCert) -> Result<TxCert, PhaseTwoError>
         )))
     };
     let data = match c {
-        PrimCert::StakeRegistration(cred) => Data::Constr(0, vec![staking_hash_data(cred)]),
-        PrimCert::StakeDeregistration(cred) => Data::Constr(1, vec![staking_hash_data(cred)]),
+        PrimCert::StakeRegistration(cred) => {
+            Data::Constr(BigInt::from(0), vec![staking_hash_data(cred)])
+        }
+        PrimCert::StakeDeregistration(cred) => {
+            Data::Constr(BigInt::from(1), vec![staking_hash_data(cred)])
+        }
         PrimCert::StakeDelegation {
             credential,
             pool_hash,
         } => Data::Constr(
-            2,
+            BigInt::from(2),
             vec![staking_hash_data(credential), Data::B(pool_hash.0.to_vec())],
         ),
         PrimCert::PoolRegistration(params) => Data::Constr(
-            3,
+            BigInt::from(3),
             vec![
                 Data::B(params.operator.0.to_vec()),
                 Data::B(params.vrf_keyhash.0.to_vec()),
             ],
         ),
         PrimCert::PoolRetirement { pool_hash, epoch } => Data::Constr(
-            4,
+            BigInt::from(4),
             vec![Data::B(pool_hash.0.to_vec()), Data::I(BigInt::from(*epoch))],
         ),
-        PrimCert::GenesisKeyDelegation { .. } => Data::Constr(5, vec![]),
-        PrimCert::MoveInstantaneousRewards { .. } => Data::Constr(6, vec![]),
+        PrimCert::GenesisKeyDelegation { .. } => Data::Constr(BigInt::from(5), vec![]),
+        PrimCert::MoveInstantaneousRewards { .. } => Data::Constr(BigInt::from(6), vec![]),
         // Conway registration / deregistration (with an explicit deposit /
         // refund) translate to the SAME legacy V1/V2 `DCert` as the no-deposit
         // Shelley form — the deposit / refund is silently DROPPED (the
@@ -898,10 +910,10 @@ pub fn certificate_to_plutus_v1v2(c: &PrimCert) -> Result<TxCert, PhaseTwoError>
         // V1/V2 script). The remaining Conway-only certs below have NO legacy
         // `DCert` form, so they correctly stay `CertificateNotSupported`.
         PrimCert::ConwayStakeRegistration { credential, .. } => {
-            Data::Constr(0, vec![staking_hash_data(credential)])
+            Data::Constr(BigInt::from(0), vec![staking_hash_data(credential)])
         }
         PrimCert::ConwayStakeDeregistration { credential, .. } => {
-            Data::Constr(1, vec![staking_hash_data(credential)])
+            Data::Constr(BigInt::from(1), vec![staking_hash_data(credential)])
         }
         PrimCert::RegStakeDeleg { .. } => return conway_only("RegStakeDeleg"),
         PrimCert::VoteDelegation { .. } => return conway_only("VoteDelegation"),
@@ -927,15 +939,15 @@ pub fn certificates_to_plutus_v1v2(certs: &[PrimCert]) -> Result<Vec<TxCert>, Ph
 /// (Some n). Matches Plutus' canonical Option encoding.
 fn option_int(v: Option<u64>) -> Data {
     match v {
-        None => Data::Constr(1, vec![]),
-        Some(n) => Data::Constr(0, vec![Data::I(BigInt::from(n))]),
+        None => Data::Constr(BigInt::from(1), vec![]),
+        Some(n) => Data::Constr(BigInt::from(0), vec![Data::I(BigInt::from(n))]),
     }
 }
 
 /// Encode a Plutus `Delegatee::DelegStake(PubKeyHash)` — `Constr 0
 /// [B pool_hash]`. Used by the stake-delegation cert variants.
 fn delegatee_to_pool(pool_hash: &[u8; 28]) -> Data {
-    Data::Constr(0, vec![Data::B(pool_hash.to_vec())])
+    Data::Constr(BigInt::from(0), vec![Data::B(pool_hash.to_vec())])
 }
 
 /// Encode a [`PrimDRep`] as the Plutus V3 `DRep` Data shape (#815).
@@ -960,29 +972,33 @@ fn delegatee_to_pool(pool_hash: &[u8; 28]) -> Data {
 fn drep_to_data(drep: &PrimDRep) -> Data {
     match drep {
         PrimDRep::KeyHash(h32) => Data::Constr(
-            0,
+            BigInt::from(0),
             vec![Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::B(h32.as_bytes()[..28].to_vec())],
             )],
         ),
-        PrimDRep::ScriptHash(h28) => {
-            Data::Constr(0, vec![Data::Constr(1, vec![Data::B(h28.0.to_vec())])])
-        }
-        PrimDRep::Abstain => Data::Constr(1, vec![]),
-        PrimDRep::NoConfidence => Data::Constr(2, vec![]),
+        PrimDRep::ScriptHash(h28) => Data::Constr(
+            BigInt::from(0),
+            vec![Data::Constr(BigInt::from(1), vec![Data::B(h28.0.to_vec())])],
+        ),
+        PrimDRep::Abstain => Data::Constr(BigInt::from(1), vec![]),
+        PrimDRep::NoConfidence => Data::Constr(BigInt::from(2), vec![]),
     }
 }
 
 /// Encode a Plutus `Delegatee::DelegVote(DRep)` — `Constr 1 [drep]`.
 fn delegatee_vote(drep: &PrimDRep) -> Data {
-    Data::Constr(1, vec![drep_to_data(drep)])
+    Data::Constr(BigInt::from(1), vec![drep_to_data(drep)])
 }
 
 /// Encode a Plutus `Delegatee::DelegStakeVote(PubKeyHash, DRep)` —
 /// `Constr 2 [B pool_hash, drep]`.
 fn delegatee_stake_vote(pool_hash: &[u8; 28], drep: &PrimDRep) -> Data {
-    Data::Constr(2, vec![Data::B(pool_hash.to_vec()), drep_to_data(drep)])
+    Data::Constr(
+        BigInt::from(2),
+        vec![Data::B(pool_hash.to_vec()), drep_to_data(drep)],
+    )
 }
 
 /// Translate the tx body's `certificates: Vec<Certificate>` into
@@ -1057,9 +1073,12 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![
-                    Data::Constr(0, vec![Data::Constr(1, vec![Data::B(vec![0xaa; 28])])]),
+                    Data::Constr(
+                        BigInt::from(0),
+                        vec![Data::Constr(BigInt::from(1), vec![Data::B(vec![0xaa; 28])])]
+                    ),
                     Data::B(vec![0xbb; 28]),
                 ]
             )
@@ -1075,10 +1094,10 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::Constr(
-                    0,
-                    vec![Data::Constr(0, vec![Data::B(vec![0x11; 28])])]
+                    BigInt::from(0),
+                    vec![Data::Constr(BigInt::from(0), vec![Data::B(vec![0x11; 28])])]
                 )]
             )
         );
@@ -1099,10 +1118,10 @@ mod tests {
         assert_eq!(
             certificate_to_plutus_v1v2(&reg).unwrap().0,
             Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::Constr(
-                    0,
-                    vec![Data::Constr(0, vec![Data::B(vec![0x11; 28])])]
+                    BigInt::from(0),
+                    vec![Data::Constr(BigInt::from(0), vec![Data::B(vec![0x11; 28])])]
                 )]
             ),
         );
@@ -1114,10 +1133,10 @@ mod tests {
         assert_eq!(
             certificate_to_plutus_v1v2(&dereg).unwrap().0,
             Data::Constr(
-                1,
+                BigInt::from(1),
                 vec![Data::Constr(
-                    0,
-                    vec![Data::Constr(1, vec![Data::B(vec![0x22; 28])])]
+                    BigInt::from(0),
+                    vec![Data::Constr(BigInt::from(1), vec![Data::B(vec![0x22; 28])])]
                 )]
             ),
         );
@@ -1132,7 +1151,7 @@ mod tests {
         let purpose = crate::script_context::ScriptPurpose::Certifying(0, tx_cert);
         let d = purpose.to_data();
         match &d {
-            Data::Constr(3, fields) => {
+            Data::Constr(tag, fields) if tag == &BigInt::from(3) => {
                 assert_eq!(
                     fields.len(),
                     1,
@@ -1142,10 +1161,10 @@ mod tests {
                 assert_eq!(
                     fields[0],
                     Data::Constr(
-                        1,
+                        BigInt::from(1),
                         vec![Data::Constr(
-                            0,
-                            vec![Data::Constr(1, vec![Data::B(vec![0x22; 28])])]
+                            BigInt::from(0),
+                            vec![Data::Constr(BigInt::from(1), vec![Data::B(vec![0x22; 28])])]
                         )]
                     )
                 );
@@ -1273,19 +1292,22 @@ mod tests {
             anchor: anchor(),
         };
         let pl = proposal_to_plutus(&p).unwrap();
-        let Ok((0, fields)) = pl.0.into_constr() else {
+        let Ok((tag, fields)) = pl.0.into_constr() else {
             panic!("expected Constr 0 wrapper");
         };
+        assert_eq!(tag, BigInt::from(0));
         assert_eq!(fields.len(), 3);
         // deposit
         assert_eq!(fields[0], Data::I(BigInt::from(100_000)));
         // return_addr (Plutus Credential::PubKey([0x42; 28]) → Constr 0 [B ...])
-        assert!(
-            matches!(&fields[1], Data::Constr(0, inner) if inner == &vec![Data::B(vec![0x42; 28])])
-        );
+        assert!(matches!(
+            &fields[1],
+            Data::Constr(tag, inner)
+                if tag == &BigInt::from(0) && inner == &vec![Data::B(vec![0x42; 28])]
+        ));
         // gov_action: InfoAction = Constr 6 []
         // Haskell: makeIsDataSchemaIndexed ''GovernanceAction [('InfoAction, 6)]
-        assert_eq!(fields[2], Data::Constr(6, vec![]));
+        assert_eq!(fields[2], Data::Constr(BigInt::from(6), vec![]));
     }
 
     #[test]
@@ -1312,9 +1334,9 @@ mod tests {
         let Ok((tag, fields)) = d.into_constr() else {
             panic!("expected Constr");
         };
-        assert_eq!(tag, 0);
+        assert_eq!(tag, BigInt::from(0));
         assert_eq!(fields.len(), 2);
-        assert_eq!(fields[1], Data::Constr(1, vec![])); // None
+        assert_eq!(fields[1], Data::Constr(BigInt::from(1), vec![])); // None
     }
 
     #[test]
@@ -1327,10 +1349,10 @@ mod tests {
         let Ok((tag, fields)) = d.into_constr() else {
             panic!("expected Constr");
         };
-        assert_eq!(tag, 0);
+        assert_eq!(tag, BigInt::from(0));
         assert_eq!(
             fields[1],
-            Data::Constr(0, vec![Data::I(BigInt::from(2_000_000))])
+            Data::Constr(BigInt::from(0), vec![Data::I(BigInt::from(2_000_000))])
         );
     }
 
@@ -1356,7 +1378,7 @@ mod tests {
         let Ok((tag, fields)) = d.into_constr() else {
             panic!("expected Constr");
         };
-        assert_eq!(tag, 7);
+        assert_eq!(tag, BigInt::from(7));
         assert_eq!(fields[0], Data::B(vec![0xaa; 28]));
         assert_eq!(fields[1], Data::B(vec![0xbb; 32]));
     }
@@ -1371,7 +1393,7 @@ mod tests {
         let Ok((tag, fields)) = d.into_constr() else {
             panic!("expected Constr");
         };
-        assert_eq!(tag, 8);
+        assert_eq!(tag, BigInt::from(8));
         assert_eq!(fields[1], Data::I(BigInt::from(500)));
     }
 
@@ -1381,10 +1403,10 @@ mod tests {
             cold_credential: key_cred(1),
             hot_credential: script_cred(2),
         };
-        let TxCert(Data::Constr(tag, _)) = certificate_to_plutus(&c).unwrap() else {
+        let TxCert(Data::Constr(ref tag, _)) = certificate_to_plutus(&c).unwrap() else {
             panic!("expected Constr");
         };
-        assert_eq!(tag, 9);
+        assert_eq!(tag, &BigInt::from(9));
     }
 
     #[test]
@@ -1445,7 +1467,10 @@ mod tests {
         let d = drep_to_data(&drep_key(0x11));
         assert_eq!(
             d,
-            Data::Constr(0, vec![Data::Constr(0, vec![Data::B(vec![0x11; 28])])])
+            Data::Constr(
+                BigInt::from(0),
+                vec![Data::Constr(BigInt::from(0), vec![Data::B(vec![0x11; 28])])]
+            )
         );
     }
 
@@ -1454,7 +1479,10 @@ mod tests {
         let d = drep_to_data(&drep_script(0x22));
         assert_eq!(
             d,
-            Data::Constr(0, vec![Data::Constr(1, vec![Data::B(vec![0x22; 28])])])
+            Data::Constr(
+                BigInt::from(0),
+                vec![Data::Constr(BigInt::from(1), vec![Data::B(vec![0x22; 28])])]
+            )
         );
     }
 
@@ -1462,11 +1490,11 @@ mod tests {
     fn drep_to_data_abstain_and_no_confidence() {
         assert_eq!(
             drep_to_data(&dugite_primitives::transaction::DRep::Abstain),
-            Data::Constr(1, vec![])
+            Data::Constr(BigInt::from(1), vec![])
         );
         assert_eq!(
             drep_to_data(&dugite_primitives::transaction::DRep::NoConfidence),
-            Data::Constr(2, vec![])
+            Data::Constr(BigInt::from(2), vec![])
         );
     }
 
@@ -1481,14 +1509,14 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![
                     cred_data(&key_cred(1)),
                     Data::Constr(
-                        1,
+                        BigInt::from(1),
                         vec![Data::Constr(
-                            0,
-                            vec![Data::Constr(0, vec![Data::B(vec![0x33; 28])])]
+                            BigInt::from(0),
+                            vec![Data::Constr(BigInt::from(0), vec![Data::B(vec![0x33; 28])])]
                         )]
                     ),
                 ]
@@ -1506,14 +1534,14 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![
                     cred_data(&script_cred(1)),
                     Data::Constr(
-                        1,
+                        BigInt::from(1),
                         vec![Data::Constr(
-                            0,
-                            vec![Data::Constr(1, vec![Data::B(vec![0x44; 28])])]
+                            BigInt::from(0),
+                            vec![Data::Constr(BigInt::from(1), vec![Data::B(vec![0x44; 28])])]
                         )]
                     ),
                 ]
@@ -1531,10 +1559,10 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![
                     cred_data(&key_cred(1)),
-                    Data::Constr(1, vec![Data::Constr(1, vec![])]),
+                    Data::Constr(BigInt::from(1), vec![Data::Constr(BigInt::from(1), vec![])]),
                 ]
             )
         );
@@ -1550,10 +1578,10 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![
                     cred_data(&key_cred(1)),
-                    Data::Constr(1, vec![Data::Constr(2, vec![])]),
+                    Data::Constr(BigInt::from(1), vec![Data::Constr(BigInt::from(2), vec![])]),
                 ]
             )
         );
@@ -1572,14 +1600,17 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                2,
+                BigInt::from(2),
                 vec![
                     cred_data(&key_cred(1)),
                     Data::Constr(
-                        2,
+                        BigInt::from(2),
                         vec![
                             Data::B(vec![0x55; 28]),
-                            Data::Constr(0, vec![Data::Constr(0, vec![Data::B(vec![0x66; 28])])]),
+                            Data::Constr(
+                                BigInt::from(0),
+                                vec![Data::Constr(BigInt::from(0), vec![Data::B(vec![0x66; 28])])]
+                            ),
                         ]
                     ),
                 ]
@@ -1601,14 +1632,17 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                3,
+                BigInt::from(3),
                 vec![
                     cred_data(&script_cred(1)),
                     Data::Constr(
-                        2,
+                        BigInt::from(2),
                         vec![
                             Data::B(vec![0x77; 28]),
-                            Data::Constr(0, vec![Data::Constr(1, vec![Data::B(vec![0x88; 28])])]),
+                            Data::Constr(
+                                BigInt::from(0),
+                                vec![Data::Constr(BigInt::from(1), vec![Data::B(vec![0x88; 28])])]
+                            ),
                         ]
                     ),
                     Data::I(BigInt::from(2_000_000)),
@@ -1630,10 +1664,10 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                3,
+                BigInt::from(3),
                 vec![
                     cred_data(&key_cred(1)),
-                    Data::Constr(1, vec![Data::Constr(1, vec![])]),
+                    Data::Constr(BigInt::from(1), vec![Data::Constr(BigInt::from(1), vec![])]),
                     Data::I(BigInt::from(2_000_000)),
                 ]
             )
@@ -1656,7 +1690,7 @@ mod tests {
         // Haskell: makeIsDataSchemaIndexed ''GovernanceAction [('InfoAction, 6)]
         use dugite_primitives::transaction::GovAction;
         let d = gov_action_to_data(&GovAction::InfoAction).unwrap();
-        assert_eq!(d, Data::Constr(6, vec![]));
+        assert_eq!(d, Data::Constr(BigInt::from(6), vec![]));
     }
 
     #[test]
@@ -1669,7 +1703,10 @@ mod tests {
             prev_action_id: None,
         })
         .unwrap();
-        assert_eq!(d, Data::Constr(3, vec![Data::Constr(1, vec![])]));
+        assert_eq!(
+            d,
+            Data::Constr(BigInt::from(3), vec![Data::Constr(BigInt::from(1), vec![])])
+        );
     }
 
     #[test]
@@ -1687,19 +1724,22 @@ mod tests {
         })
         .unwrap();
         // outer: Constr 3 [Maybe]
-        let Data::Constr(3, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("NoConfidence must be Constr 3; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(3), "unexpected Constr tag");
         assert_eq!(fields.len(), 1);
         // Maybe = Just → Constr 0 [gaid_data]
-        let Data::Constr(0, ref just_fields) = fields[0] else {
+        let Data::Constr(ref __tag, ref just_fields) = fields[0] else {
             panic!("Just must be Constr 0; got {:?}", fields[0]);
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         assert_eq!(just_fields.len(), 1);
         // GovernanceActionId = Constr 0 [B txid32, I 3]
-        let Data::Constr(0, ref gaid_fields) = just_fields[0] else {
+        let Data::Constr(ref __tag, ref gaid_fields) = just_fields[0] else {
             panic!("GovActionId must be Constr 0; got {:?}", just_fields[0]);
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         assert_eq!(gaid_fields.len(), 2);
         assert!(
             matches!(&gaid_fields[0], Data::B(b) if b.len() == 32 && b.iter().all(|&x| x == 0xab)),
@@ -1720,17 +1760,18 @@ mod tests {
             protocol_version: (10, 0),
         })
         .unwrap();
-        let Data::Constr(1, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("HardForkInitiation must be Constr 1; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(1), "unexpected Constr tag");
         assert_eq!(fields.len(), 2);
         // fields[0]: Maybe GovActionId = Nothing = Constr 1 []
-        assert_eq!(fields[0], Data::Constr(1, vec![]));
+        assert_eq!(fields[0], Data::Constr(BigInt::from(1), vec![]));
         // fields[1]: ProtocolVersion = Constr 0 [I 10, I 0]
         assert_eq!(
             fields[1],
             Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::I(BigInt::from(10u64)), Data::I(BigInt::from(0u64))]
             )
         );
@@ -1761,11 +1802,16 @@ mod tests {
             policy_hash: None,
         })
         .unwrap();
-        let Data::Constr(0, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("ParameterChange must be Constr 0; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         assert_eq!(fields.len(), 3);
-        assert_eq!(fields[0], Data::Constr(1, vec![]), "Nothing prev_action_id");
+        assert_eq!(
+            fields[0],
+            Data::Constr(BigInt::from(1), vec![]),
+            "Nothing prev_action_id"
+        );
         let expected_v3 = Data::List(v3.iter().map(|x| Data::I(BigInt::from(*x))).collect());
         let expected_cm = Data::Map(vec![(Data::I(BigInt::from(2u64)), expected_v3)]);
         let expected_changed = Data::Map(vec![(Data::I(BigInt::from(18u64)), expected_cm)]);
@@ -1773,7 +1819,11 @@ mod tests {
             fields[1], expected_changed,
             "ChangedParameters must be a Data::Map keyed by ppuTag (18 = costModels, lang 2 = V3)"
         );
-        assert_eq!(fields[2], Data::Constr(1, vec![]), "Nothing policy_hash");
+        assert_eq!(
+            fields[2],
+            Data::Constr(BigInt::from(1), vec![]),
+            "Nothing policy_hash"
+        );
     }
 
     #[test]
@@ -1797,9 +1847,10 @@ mod tests {
             policy_hash: None,
         })
         .unwrap();
-        let Ok((0, fields)) = d.into_constr() else {
+        let Ok((tag, fields)) = d.into_constr() else {
             panic!("ParameterChange must be Constr 0");
         };
+        assert_eq!(tag, BigInt::from(0));
         let Data::Map(entries) = &fields[1] else {
             panic!("ChangedParameters must be Map; got {:?}", fields[1]);
         };
@@ -1839,9 +1890,10 @@ mod tests {
             policy_hash: None,
         })
         .unwrap();
-        let Ok((0, fields)) = d.into_constr() else {
+        let Ok((tag, fields)) = d.into_constr() else {
             panic!("ParameterChange must be Constr 0");
         };
+        assert_eq!(tag, BigInt::from(0));
         let Data::Map(entries) = &fields[1] else {
             panic!("ChangedParameters must be Map");
         };
@@ -1874,14 +1926,18 @@ mod tests {
             },
         })
         .unwrap();
-        let Data::Constr(5, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("NewConstitution must be Constr 5; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(5), "unexpected Constr tag");
         assert_eq!(fields.len(), 2);
         // Constitution = Constr 0 [Just(B28)]
         assert_eq!(
             fields[1],
-            Data::Constr(0, vec![Data::Constr(0, vec![Data::B(vec![0xcc; 28])])])
+            Data::Constr(
+                BigInt::from(0),
+                vec![Data::Constr(BigInt::from(0), vec![Data::B(vec![0xcc; 28])])]
+            )
         );
     }
 
@@ -1901,9 +1957,10 @@ mod tests {
             policy_hash: None,
         })
         .unwrap();
-        let Data::Constr(2, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("TreasuryWithdrawals must be Constr 2; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(2), "unexpected Constr tag");
         assert_eq!(fields.len(), 2);
         // Map: [(Credential::PubKey([0x77;28]), I 500_000)]
         let Data::Map(ref entries) = fields[0] else {
@@ -1911,13 +1968,13 @@ mod tests {
         };
         assert_eq!(entries.len(), 1);
         assert!(
-            matches!(&entries[0].0, Data::Constr(0, inner) if inner.len() == 1),
+            matches!(&entries[0].0, Data::Constr(tag, inner) if tag == &BigInt::from(0) && inner.len() == 1),
             "map key must be PubKeyCredential (Constr 0 [B28]); got {:?}",
             entries[0].0
         );
         assert_eq!(entries[0].1, Data::I(BigInt::from(500_000u64)));
         // Maybe ScriptHash = Nothing
-        assert_eq!(fields[1], Data::Constr(1, vec![]));
+        assert_eq!(fields[1], Data::Constr(BigInt::from(1), vec![]));
     }
 
     #[test]
@@ -1940,9 +1997,10 @@ mod tests {
             },
         })
         .unwrap();
-        let Data::Constr(4, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("UpdateCommittee must be Constr 4; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(4), "unexpected Constr tag");
         assert_eq!(fields.len(), 4);
         // fields[1]: [ColdCredential] — 1 item (key_cred 0xaa) = Constr 0 [B28]
         let Data::List(ref remove_list) = fields[1] else {
@@ -1950,7 +2008,7 @@ mod tests {
         };
         assert_eq!(remove_list.len(), 1);
         assert!(
-            matches!(&remove_list[0], Data::Constr(0, _)),
+            matches!(&remove_list[0], Data::Constr(tag, _) if tag == &BigInt::from(0)),
             "ColdCommitteeCredential must be PubKeyCredential (Constr 0); got {:?}",
             remove_list[0]
         );
@@ -1960,7 +2018,7 @@ mod tests {
         };
         assert_eq!(add_map.len(), 1);
         assert!(
-            matches!(&add_map[0].0, Data::Constr(1, _)),
+            matches!(&add_map[0].0, Data::Constr(tag, _) if tag == &BigInt::from(1)),
             "ScriptCredential must be Constr 1; got {:?}",
             add_map[0].0
         );
@@ -1970,7 +2028,7 @@ mod tests {
         assert_eq!(
             fields[3],
             Data::Constr(
-                0,
+                BigInt::from(0),
                 vec![Data::I(BigInt::from(2u64)), Data::I(BigInt::from(3u64))]
             ),
             "Rational must be Constr 0 [I num, I den]"
@@ -2028,9 +2086,10 @@ mod tests {
             policy_hash: None,
         })
         .unwrap();
-        let Data::Constr(2, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("TreasuryWithdrawals must be Constr 2; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(2), "unexpected Constr tag");
         let Data::Map(ref entries) = fields[0] else {
             panic!("field[0] must be Map; got {:?}", fields[0]);
         };
@@ -2038,7 +2097,7 @@ mod tests {
         // entries[0] = Script credential (Constr 1 [B28]) + amount 20.
         assert_eq!(
             entries[0].0,
-            Data::Constr(1, vec![Data::B(vec![0x02u8; 28])]),
+            Data::Constr(BigInt::from(1), vec![Data::B(vec![0x02u8; 28])]),
             "entries[0] must be the SCRIPT credential (ledger Script < Key); got {:?}",
             entries[0].0
         );
@@ -2046,7 +2105,7 @@ mod tests {
         // entries[1] = Key credential (Constr 0 [B28]) + amount 10.
         assert_eq!(
             entries[1].0,
-            Data::Constr(0, vec![Data::B(vec![0x01u8; 28])]),
+            Data::Constr(BigInt::from(0), vec![Data::B(vec![0x01u8; 28])]),
             "entries[1] must be the KEY credential; got {:?}",
             entries[1].0
         );
@@ -2065,16 +2124,17 @@ mod tests {
             policy_hash: None,
         })
         .unwrap();
-        let Data::Constr(2, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("TreasuryWithdrawals must be Constr 2; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(2), "unexpected Constr tag");
         let Data::Map(ref entries) = fields[0] else {
             panic!("field[0] must be Map; got {:?}", fields[0]);
         };
         assert_eq!(entries.len(), 1);
         assert_eq!(
             entries[0].0,
-            Data::Constr(1, vec![Data::B(vec![0x55u8; 28])])
+            Data::Constr(BigInt::from(1), vec![Data::B(vec![0x55u8; 28])])
         );
         assert_eq!(entries[0].1, Data::I(BigInt::from(7u64)));
     }
@@ -2105,9 +2165,10 @@ mod tests {
             },
         })
         .unwrap();
-        let Data::Constr(4, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("UpdateCommittee must be Constr 4; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(4), "unexpected Constr tag");
         let Data::Map(ref add_map) = fields[2] else {
             panic!("field[2] must be Map; got {:?}", fields[2]);
         };
@@ -2115,7 +2176,7 @@ mod tests {
         // add[0] = Script credential (Constr 1) + epoch 200.
         assert_eq!(
             add_map[0].0,
-            Data::Constr(1, vec![Data::B(vec![0x02u8; 28])]),
+            Data::Constr(BigInt::from(1), vec![Data::B(vec![0x02u8; 28])]),
             "add[0] must be the SCRIPT credential (ledger Script < Key); got {:?}",
             add_map[0].0
         );
@@ -2123,7 +2184,7 @@ mod tests {
         // add[1] = Key credential (Constr 0) + epoch 100.
         assert_eq!(
             add_map[1].0,
-            Data::Constr(0, vec![Data::B(vec![0x01u8; 28])]),
+            Data::Constr(BigInt::from(0), vec![Data::B(vec![0x01u8; 28])]),
             "add[1] must be the KEY credential; got {:?}",
             add_map[1].0
         );
@@ -2146,16 +2207,17 @@ mod tests {
             },
         })
         .unwrap();
-        let Data::Constr(4, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("UpdateCommittee must be Constr 4; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(4), "unexpected Constr tag");
         let Data::Map(ref add_map) = fields[2] else {
             panic!("field[2] must be Map; got {:?}", fields[2]);
         };
         assert_eq!(add_map.len(), 1);
         assert_eq!(
             add_map[0].0,
-            Data::Constr(1, vec![Data::B(vec![0x66u8; 28])])
+            Data::Constr(BigInt::from(1), vec![Data::B(vec![0x66u8; 28])])
         );
         assert_eq!(add_map[0].1, Data::I(BigInt::from(300u64)));
     }
@@ -2176,9 +2238,10 @@ mod tests {
             },
         })
         .unwrap();
-        let Data::Constr(4, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("UpdateCommittee must be Constr 4; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(4), "unexpected Constr tag");
         let Data::List(ref remove_list) = fields[1] else {
             panic!("field[1] must be List; got {:?}", fields[1]);
         };
@@ -2186,14 +2249,14 @@ mod tests {
         // remove[0] = Script credential (Constr 1).
         assert_eq!(
             remove_list[0],
-            Data::Constr(1, vec![Data::B(vec![0x02u8; 28])]),
+            Data::Constr(BigInt::from(1), vec![Data::B(vec![0x02u8; 28])]),
             "remove[0] must be the SCRIPT credential (ledger Script < Key); got {:?}",
             remove_list[0]
         );
         // remove[1] = Key credential (Constr 0).
         assert_eq!(
             remove_list[1],
-            Data::Constr(0, vec![Data::B(vec![0x01u8; 28])]),
+            Data::Constr(BigInt::from(0), vec![Data::B(vec![0x01u8; 28])]),
             "remove[1] must be the KEY credential; got {:?}",
             remove_list[1]
         );
@@ -2213,16 +2276,17 @@ mod tests {
             },
         })
         .unwrap();
-        let Data::Constr(4, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("UpdateCommittee must be Constr 4; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(4), "unexpected Constr tag");
         let Data::List(ref remove_list) = fields[1] else {
             panic!("field[1] must be List; got {:?}", fields[1]);
         };
         assert_eq!(remove_list.len(), 1);
         assert_eq!(
             remove_list[0],
-            Data::Constr(0, vec![Data::B(vec![0x77u8; 28])])
+            Data::Constr(BigInt::from(0), vec![Data::B(vec![0x77u8; 28])])
         );
     }
 

--- a/crates/dugite-uplc/src/populate_v1_v2.rs
+++ b/crates/dugite-uplc/src/populate_v1_v2.rs
@@ -789,10 +789,13 @@ mod tests {
         assert_eq!(
             tx_cert.0,
             Data::Constr(
-                1,
+                BigInt::from(1),
                 vec![Data::Constr(
-                    0,
-                    vec![Data::Constr(1, vec![Data::B(cert_hash.to_vec())])]
+                    BigInt::from(0),
+                    vec![Data::Constr(
+                        BigInt::from(1),
+                        vec![Data::B(cert_hash.to_vec())]
+                    )]
                 )]
             ),
             "Certifying cert Data must use the V1/V2 DCert schema (1 field), \

--- a/crates/dugite-uplc/src/populate_v3.rs
+++ b/crates/dugite-uplc/src/populate_v3.rs
@@ -520,20 +520,21 @@ mod tests {
             panic!("cert must be Constr; got {d:?}");
         };
         assert_eq!(
-            *tag, 1u64,
+            tag,
+            &BigInt::from(1),
             "StakeDeregistration -> TxCertUnRegStaking (Constr 1)"
         );
         assert_eq!(fields.len(), 2, "must have credential + Maybe");
         // credential = PubKeyCredential([0xcc;28]) = Constr 0 [B28]
         assert!(
-            matches!(&fields[0], crate::data::Data::Constr(0, inner) if inner.len() == 1),
+            matches!(&fields[0], crate::data::Data::Constr(tag, inner) if tag == &BigInt::from(0) && inner.len() == 1),
             "credential must be Constr 0 [B28]; got {:?}",
             fields[0]
         );
         // deposit field = None (pre-Conway StakeDeregistration has no deposit) = Constr 1 []
         assert_eq!(
             fields[1],
-            crate::data::Data::Constr(1, vec![]),
+            crate::data::Data::Constr(BigInt::from(1), vec![]),
             "pre-Conway StakeDeregistration deposit must be None (Constr 1 [])"
         );
     }
@@ -783,13 +784,15 @@ mod tests {
         // Haskell: PlutusLedgerApi.V3.Contexts — TxId newtype deriving ToData from
         //   BuiltinByteString → bare B(32) in the TxOutRef payload.
         let spend_data = info.redeemers[0].0.to_data_v3();
-        let Data::Constr(1, ref spend_fields) = spend_data else {
+        let Data::Constr(ref spend_tag, ref spend_fields) = spend_data else {
             panic!("Spending ScriptPurpose must be Constr 1; got {spend_data:?}");
         };
+        assert_eq!(spend_tag, &BigInt::from(1));
         // TxOutRef = Constr 0 [B32 (bare), I idx]  — V3 bare-txid form
-        let Data::Constr(0, ref txoutref_fields) = spend_fields[0] else {
+        let Data::Constr(ref txoutref_tag, ref txoutref_fields) = spend_fields[0] else {
             panic!("TxOutRef must be Constr 0; got {:?}", spend_fields[0]);
         };
+        assert_eq!(txoutref_tag, &BigInt::from(0));
         assert_eq!(txoutref_fields.len(), 2);
         // V3: txid must be BARE B(32), NOT Constr 0 [B(32)]
         assert!(
@@ -799,7 +802,7 @@ mod tests {
         );
         // Must NOT be the double-wrapped V1/V2 Constr 0 [B32] form
         assert!(
-            !matches!(&txoutref_fields[0], Data::Constr(0, _)),
+            !matches!(&txoutref_fields[0], Data::Constr(tag, _) if tag == &BigInt::from(0)),
             "V3 TxOutRef txid must NOT be Constr-wrapped (that is V1/V2 form)"
         );
     }
@@ -852,20 +855,22 @@ mod tests {
         // makeIsDataSchemaIndexed ''ScriptPurpose [('Voting, 4)]
         // Use to_data_v3() to reflect actual serialization path (same for Voting).
         let purpose_data = info.redeemers[0].0.to_data_v3();
-        let Data::Constr(4, ref voter_fields) = purpose_data else {
+        let Data::Constr(ref purpose_tag, ref voter_fields) = purpose_data else {
             panic!("Voting ScriptPurpose must be Constr 4; got {purpose_data:?}");
         };
+        assert_eq!(purpose_tag, &BigInt::from(4));
         assert_eq!(voter_fields.len(), 1);
         // Voter::DRepVoter(DRepCredential(Script(...))) = Constr 1 [Constr 1 [B28]]
         // DRepCredential is newtype deriving ToData from Credential → bare Credential
         // ScriptCredential = Constr 1 [B28]
-        let Data::Constr(1, ref drep_fields) = voter_fields[0] else {
+        let Data::Constr(ref voter_tag, ref drep_fields) = voter_fields[0] else {
             panic!("DRepVoter must be Constr 1; got {:?}", voter_fields[0]);
         };
+        assert_eq!(voter_tag, &BigInt::from(1));
         assert_eq!(drep_fields.len(), 1);
         // DRepCredential passes through to Credential (Constr 1 for Script)
         assert!(
-            matches!(&drep_fields[0], Data::Constr(1, inner) if inner.len() == 1),
+            matches!(&drep_fields[0], Data::Constr(tag, inner) if tag == &BigInt::from(1) && inner.len() == 1),
             "DRepCredential(ScriptCredential) must be Constr 1 [B28]; got {:?}",
             drep_fields[0]
         );

--- a/crates/dugite-uplc/src/program.rs
+++ b/crates/dugite-uplc/src/program.rs
@@ -17,9 +17,21 @@ use crate::term::Term;
 use crate::UplcError;
 
 /// A complete UPLC program: a language version triple plus a body.
+///
+/// The version components are arbitrary-precision (`BigUint`), matching
+/// Haskell's `Natural`-typed `Version` fields exactly (issue #842
+/// residual) — Haskell's flat decoder never rejects or truncates a
+/// version component on magnitude, so neither does this one. In
+/// practice every real on-chain script declares a tiny version (`1.0.0`
+/// or `1.1.0`); the only way to reach a value that wouldn't fit in a
+/// `u64` is a deliberately adversarial flat blob.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program {
-    pub version: (u64, u64, u64),
+    pub version: (
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+    ),
     pub term: Term,
 }
 
@@ -46,9 +58,9 @@ impl Program {
     /// `UplcError::FlatDecode` on any truncation / malformedness.
     pub fn from_flat(bytes: &[u8]) -> Result<Self, UplcError> {
         let mut r = BitReader::new(bytes);
-        let major = r.read_natural_u64()?;
-        let minor = r.read_natural_u64()?;
-        let patch = r.read_natural_u64()?;
+        let major = r.read_natural_biguint()?;
+        let minor = r.read_natural_biguint()?;
+        let patch = r.read_natural_biguint()?;
         let term = decode_term(&mut r)?;
         // The flat encoding pads to a byte boundary with a 1-bit prefix
         // followed by 0-bit fillers. `read_filler` enforces that the
@@ -92,9 +104,9 @@ impl Program {
     /// Encode the program as raw flat bytes (no CBOR wrapper).
     pub fn to_flat(&self) -> Result<Vec<u8>, UplcError> {
         let mut w = BitWriter::new();
-        w.write_natural_u64(self.version.0)?;
-        w.write_natural_u64(self.version.1)?;
-        w.write_natural_u64(self.version.2)?;
+        w.write_natural_biguint(&self.version.0)?;
+        w.write_natural_biguint(&self.version.1)?;
+        w.write_natural_biguint(&self.version.2)?;
         encode_term(&mut w, &self.term)?;
         // `BitWriter::finish` already appends the single mandatory trailing
         // filler (see its doc comment) — an extra explicit `write_filler()`
@@ -113,12 +125,23 @@ impl Program {
 mod tests {
     use super::*;
     use crate::term::{Constant, Term};
+    use num_bigint::BigUint;
     use std::rc::Rc;
+
+    /// Test-only ergonomic constructor for the version triple, since
+    /// `BigUint` doesn't support bare integer-literal tuple syntax.
+    fn v(major: u64, minor: u64, patch: u64) -> (BigUint, BigUint, BigUint) {
+        (
+            BigUint::from(major),
+            BigUint::from(minor),
+            BigUint::from(patch),
+        )
+    }
 
     #[test]
     fn round_trips_through_flat_with_error_body() {
         let p = Program {
-            version: (1, 1, 0),
+            version: v(1, 1, 0),
             term: Term::Error,
         };
         let flat = p.to_flat().unwrap();
@@ -129,7 +152,7 @@ mod tests {
     #[test]
     fn round_trips_through_flat_with_const_integer_body() {
         let p = Program {
-            version: (1, 0, 0),
+            version: v(1, 0, 0),
             term: Term::Const(Constant::Integer(num_bigint::BigInt::from(42))),
         };
         let flat = p.to_flat().unwrap();
@@ -140,7 +163,7 @@ mod tests {
     #[test]
     fn round_trips_through_flat_with_nested_app() {
         let p = Program {
-            version: (1, 1, 0),
+            version: v(1, 1, 0),
             term: Term::App(
                 Rc::new(Term::Lam(Rc::new(Term::Var(0)))),
                 Rc::new(Term::Const(Constant::Integer(num_bigint::BigInt::from(7)))),
@@ -154,7 +177,7 @@ mod tests {
     #[test]
     fn round_trips_through_cbor_wrapped_form() {
         let p = Program {
-            version: (1, 1, 0),
+            version: v(1, 1, 0),
             term: Term::Const(Constant::Integer(num_bigint::BigInt::from(123))),
         };
         let cbor = p.to_cbor().unwrap();
@@ -191,30 +214,59 @@ mod tests {
     #[test]
     fn version_triple_is_preserved_through_roundtrip() {
         let p = Program {
-            version: (3, 4, 5),
+            version: v(3, 4, 5),
             term: Term::Error,
         };
         let back = Program::from_flat(&p.to_flat().unwrap()).unwrap();
-        assert_eq!(back.version, (3, 4, 5));
+        assert_eq!(back.version, v(3, 4, 5));
     }
 
-    /// #842: the version triple must stay on the LENIENT `u64` decode
-    /// path (`BitReader::read_natural_u64`), never the strict
-    /// `read_word64_strict` used for the De Bruijn index / `Constr`
-    /// tag (`flat/term.rs`). Haskell types `Version`'s three fields as
-    /// unbounded `Natural` (`PlutusCore.Version`), which never rejects
-    /// on overflow — a value right at the `u64` boundary (`u64::MAX`)
-    /// must round-trip cleanly, not be rejected as it would be under
-    /// the strict Word64 rule this fix introduces elsewhere.
+    /// #842: the version triple decodes via the arbitrary-precision
+    /// `BigUint` path (`BitReader::read_natural_biguint`), never the
+    /// strict `read_word64_strict` used for the De Bruijn index /
+    /// `Constr` tag (`flat/term.rs`). Haskell types `Version`'s three
+    /// fields as unbounded `Natural` (`PlutusCore.Version`), which never
+    /// rejects on overflow — a value right at the `u64` boundary
+    /// (`u64::MAX`) must round-trip cleanly, not be rejected as it would
+    /// be under the strict Word64 rule used elsewhere.
     #[test]
     fn version_component_at_u64_boundary_is_not_rejected() {
         let p = Program {
-            version: (u64::MAX, 0, 0),
+            version: (BigUint::from(u64::MAX), BigUint::ZERO, BigUint::ZERO),
             term: Term::Error,
         };
         let back = Program::from_flat(&p.to_flat().unwrap())
             .expect("version component at the u64 boundary must not be rejected");
-        assert_eq!(back.version, (u64::MAX, 0, 0));
+        assert_eq!(
+            back.version,
+            (BigUint::from(u64::MAX), BigUint::ZERO, BigUint::ZERO)
+        );
+    }
+
+    /// #842 residual: a version component that is genuinely WIDER than a
+    /// `u64` (requires an 11th flat chunk) must round-trip to its EXACT
+    /// value, not silently truncate to a smaller, wrong `u64` (the prior
+    /// lenient-`u64`-path behavior — see
+    /// `flat::bits::tests::read_natural_u64_lenient_path_unchanged_for_version_triple`,
+    /// which documents that the raw bit-level reader still keeps that
+    /// legacy behavior; `Program` itself no longer goes through it).
+    /// This is 100% adversarial (no real cardano-node release has ever
+    /// emitted anything but `1.0.0`/`1.1.0`), but Haskell's decoder would
+    /// still decode such a blob successfully with the exact wide value,
+    /// so silently substituting a different (smaller) value here would
+    /// be a genuine, if obscure, consensus divergence in
+    /// `flat::term::validate_program_availability`'s
+    /// `version >= PLC_VERSION_1_1_0` gate.
+    #[test]
+    fn version_component_wider_than_u64_round_trips_exactly() {
+        let huge: BigUint = (BigUint::from(1u8) << 70u32) + BigUint::from(999u32);
+        let p = Program {
+            version: (huge.clone(), BigUint::ZERO, BigUint::ZERO),
+            term: Term::Error,
+        };
+        let back = Program::from_flat(&p.to_flat().unwrap())
+            .expect("a >64-bit version component must not be rejected");
+        assert_eq!(back.version, (huge, BigUint::ZERO, BigUint::ZERO));
     }
 
     /// Canonical IOG always-true V1 validator (vendored by every cardano-node
@@ -229,7 +281,7 @@ mod tests {
             0x01, 0x00, 0x00, 0x33, 0x22, 0x22, 0x20, 0x05, 0x12, 0x00, 0x12, 0x00, 0x11,
         ];
         let p = Program::from_flat(&flat).expect("canonical V1 always-true must decode");
-        assert_eq!(p.version, (1, 0, 0));
+        assert_eq!(p.version, v(1, 0, 0));
     }
 
     /// Canonical IOG always-true V2 validator. cborHex `49480100002221200101`
@@ -238,7 +290,7 @@ mod tests {
     fn decodes_canonical_v2_always_true() {
         let flat = [0x01, 0x00, 0x00, 0x22, 0x21, 0x20, 0x01, 0x01];
         let p = Program::from_flat(&flat).expect("canonical V2 always-true must decode");
-        assert_eq!(p.version, (1, 0, 0));
+        assert_eq!(p.version, v(1, 0, 0));
     }
 
     /// Issue #822: a valid flat program with only the mandatory final-byte
@@ -248,7 +300,7 @@ mod tests {
     #[test]
     fn from_flat_accepts_program_with_only_mandatory_padding() {
         let p = Program {
-            version: (1, 1, 0),
+            version: v(1, 1, 0),
             term: Term::Error,
         };
         let flat = p.to_flat().unwrap();
@@ -273,7 +325,7 @@ mod tests {
     #[test]
     fn from_flat_rejects_trailing_byte_after_valid_program() {
         let p = Program {
-            version: (1, 1, 0),
+            version: v(1, 1, 0),
             term: Term::Error,
         };
         let mut flat = p.to_flat().unwrap();

--- a/crates/dugite-uplc/src/program.rs
+++ b/crates/dugite-uplc/src/program.rs
@@ -36,6 +36,24 @@ pub struct Program {
 }
 
 impl Program {
+    /// Construct a `(major, minor, patch)` version triple from `u64` components.
+    ///
+    /// Ergonomic helper for callers (chiefly tests and locally-constructed
+    /// programs) that hold small version numbers — the on-wire triple is
+    /// arbitrary-precision `Natural`/`BigUint` (#842), so a bare `(1, 0, 0)`
+    /// integer-literal tuple no longer type-checks.
+    pub fn version_triple(
+        major: u64,
+        minor: u64,
+        patch: u64,
+    ) -> (
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+        num_bigint::BigUint,
+    ) {
+        (major.into(), minor.into(), patch.into())
+    }
+
     /// Decode a CBOR-wrapped flat-encoded UPLC program.
     ///
     /// The wire shape is a single CBOR byte-string (major type 2) whose

--- a/crates/dugite-uplc/src/script_context.rs
+++ b/crates/dugite-uplc/src/script_context.rs
@@ -341,7 +341,7 @@ fn data_map(entries: Vec<(Data, Data)>) -> Data {
 }
 
 fn data_constr(tag: u64, fields: Vec<Data>) -> Data {
-    Data::Constr(tag, fields)
+    Data::Constr(BigInt::from(tag), fields)
 }
 
 /// Encode a 32-byte hash as `TxId = Constr 0 [B bytes32]`.
@@ -1088,17 +1088,19 @@ mod tests {
     /// UpperBound]` where each bound is `Constr 0 [Extended, Bool]` and a
     /// `Bool` is `Constr 0 []` (False) / `Constr 1 []` (True).
     fn closures(d: &Data) -> (u64, u64) {
-        let Data::Constr(0, bounds) = d else {
+        let Data::Constr(outer_tag, bounds) = d else {
             panic!("interval is not Constr 0")
         };
+        assert_eq!(outer_tag, &BigInt::from(0), "interval is not Constr 0");
         let tag = |b: &Data| -> u64 {
-            let Data::Constr(0, parts) = b else {
+            let Data::Constr(bound_tag, parts) = b else {
                 panic!("bound is not Constr 0")
             };
+            assert_eq!(bound_tag, &BigInt::from(0), "bound is not Constr 0");
             let Data::Constr(t, _) = &parts[1] else {
                 panic!("closure is not a Constr")
             };
-            *t
+            u64::try_from(t).expect("closure tag must fit u64")
         };
         (tag(&bounds[0]), tag(&bounds[1]))
     }
@@ -1180,7 +1182,7 @@ mod tests {
         let c = pk(0xaa);
         let d = c.to_data();
         if let Ok((tag, fields)) = d.into_constr() {
-            assert_eq!(tag, 0);
+            assert_eq!(tag, BigInt::from(0));
             assert_eq!(fields.len(), 1);
             assert!(matches!(&fields[0], Data::B(b) if b.len() == 28));
         } else {
@@ -1192,7 +1194,7 @@ mod tests {
     fn credential_script_encodes_as_constr_1() {
         let c = Credential::Script([0xbb; 28]);
         let d = c.to_data();
-        assert!(matches!(d, Data::Constr(1, _)));
+        assert!(matches!(d, Data::Constr(ref tag, _) if tag == &BigInt::from(1)));
     }
 
     #[test]
@@ -1202,7 +1204,8 @@ mod tests {
             staking: None,
         };
         let d = a.to_data();
-        if let Ok((0, fields)) = d.into_constr() {
+        if let Ok((tag, fields)) = d.into_constr() {
+            assert_eq!(tag, BigInt::from(0));
             assert_eq!(fields.len(), 2);
         } else {
             panic!("expected Constr 0");
@@ -1218,18 +1221,20 @@ mod tests {
             idx: 3,
         };
         let d = r.to_data();
-        let Data::Constr(0, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("TxOutRef must be Constr 0; got {d:?}");
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         assert_eq!(
             fields.len(),
             2,
             "TxOutRef must have 2 fields (TxId, Integer)"
         );
         // fields[0] must be TxId = Constr 0 [B bytes32]
-        let Data::Constr(0, ref id_fields) = fields[0] else {
+        let Data::Constr(ref __tag, ref id_fields) = fields[0] else {
             panic!("TxId must be Constr 0; got {:?}", fields[0]);
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         assert_eq!(id_fields.len(), 1, "TxId has 1 inner field (the raw bytes)");
         assert!(
             matches!(&id_fields[0], Data::B(b) if b.len() == 32 && b.iter().all(|&x| x == 7)),
@@ -1326,7 +1331,7 @@ mod tests {
 
         // Cert: TxCertUnRegStaking(PubKey([0x22;28]), None) = Constr 1 [Constr 0 [B28], Constr 1 []]
         let cert_data = Data::Constr(
-            1,
+            BigInt::from(1),
             vec![
                 data_constr(0, vec![data_bs28(&[0x22; 28])]),
                 data_constr(1, vec![]),
@@ -1392,7 +1397,7 @@ mod tests {
                 policies: vec![([0x44; 28], vec![(b"A".to_vec(), BigInt::from(10i64))])],
             },
             certs: vec![TxCert(Data::Constr(
-                1,
+                BigInt::from(1),
                 vec![
                     data_constr(0, vec![data_bs28(&[0x22; 28])]),
                     data_constr(1, vec![]),
@@ -1414,10 +1419,10 @@ mod tests {
         };
 
         let d = info.to_data();
-        let Data::Constr(tag, ref fields) = d else {
+        let Data::Constr(ref tag, ref fields) = d else {
             panic!("TxInfoV3::to_data must be Constr; got {d:?}");
         };
-        assert_eq!(tag, 0, "outer tag must be 0");
+        assert_eq!(tag, &BigInt::from(0), "outer tag must be 0");
         assert_eq!(
             fields.len(),
             16,
@@ -1503,7 +1508,7 @@ mod tests {
         );
         // Also confirm it is NOT the Constr-wrapped form
         assert!(
-            !matches!(&fields[11], Data::Constr(0, _)),
+            !matches!(&fields[11], Data::Constr(tag, _) if tag == &BigInt::from(0)),
             "field[11] (txid) must NOT be Constr 0 [...]; V3 uses bare bytes"
         );
         // Field 12: votes — Map (empty)
@@ -1543,9 +1548,10 @@ mod tests {
         // Pubkey credential
         info.wdrl = vec![(Credential::PubKey([0xaa; 28]), BigInt::from(100u64))];
         let d = info.to_data();
-        let Data::Constr(0, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!("expected Constr 0")
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
 
         // Field 6 is wdrl
         let Data::Map(ref entries) = fields[6] else {
@@ -1556,7 +1562,7 @@ mod tests {
 
         // Key must be Credential directly: Constr 0 [B28] for PubKey
         match key {
-            Data::Constr(0, inner) => {
+            Data::Constr(tag, inner) if tag == &BigInt::from(0) => {
                 assert_eq!(inner.len(), 1, "PubKeyCredential has 1 field");
                 assert!(
                     matches!(&inner[0], Data::B(b) if b.len() == 28),
@@ -1572,7 +1578,10 @@ mod tests {
 
         // Explicitly check it is NOT double-wrapped (StakingHash form would be
         // Constr 0 [Constr 0/1 [...]])
-        if let Data::Constr(0, ref outer_fields) = key {
+        if let Data::Constr(tag, ref outer_fields) = key {
+            if tag != &BigInt::from(0) {
+                panic!("wdrl key outer tag must be 0; got {tag:?}");
+            }
             if let Some(Data::Constr(_, _)) = outer_fields.first() {
                 panic!(
                     "wdrl key is double-wrapped as StakingHash; V3 must use bare Credential. \
@@ -1585,15 +1594,16 @@ mod tests {
         let mut info2 = empty_tx_info_v3();
         info2.wdrl = vec![(Credential::Script([0xbb; 28]), BigInt::from(200u64))];
         let d2 = info2.to_data();
-        let Data::Constr(0, ref fields2) = d2 else {
+        let Data::Constr(ref __tag, ref fields2) = d2 else {
             panic!()
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         let Data::Map(ref entries2) = fields2[6] else {
             panic!()
         };
         // Script credential = Constr 1 [B28]
         assert!(
-            matches!(&entries2[0].0, Data::Constr(1, inner) if inner.len() == 1),
+            matches!(&entries2[0].0, Data::Constr(tag, inner) if tag == &BigInt::from(1) && inner.len() == 1),
             "ScriptCredential must be Constr 1; got {:?}",
             entries2[0].0
         );
@@ -1604,7 +1614,7 @@ mod tests {
     fn tx_cert_unreg_staking_encodes_as_constr_1_with_cred_and_maybe() {
         // TxCertUnRegStaking(PubKey([0xcc;28]), None) at V3 (PV<10 semantics = Nothing)
         let cert_data = Data::Constr(
-            1,
+            BigInt::from(1),
             vec![
                 data_constr(0, vec![data_bs28(&[0xcc; 28])]), // Credential::PubKey
                 data_constr(1, vec![]),                       // None
@@ -1614,9 +1624,10 @@ mod tests {
         let mut info = empty_tx_info_v3();
         info.certs = vec![TxCert(cert_data.clone())];
         let d = info.to_data();
-        let Data::Constr(0, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!()
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
 
         // Field 5 is certs
         let Data::List(ref cert_list) = fields[5] else {
@@ -1629,14 +1640,18 @@ mod tests {
             "TxCertUnRegStaking must be Constr 1 [Credential, Maybe Lovelace]"
         );
         // Outer tag is 1
-        let Data::Constr(tag, ref cert_fields) = cert_list[0] else {
+        let Data::Constr(ref tag, ref cert_fields) = cert_list[0] else {
             panic!()
         };
-        assert_eq!(tag, 1u64, "TxCertUnRegStaking must use Constr tag 1");
+        assert_eq!(
+            tag,
+            &BigInt::from(1),
+            "TxCertUnRegStaking must use Constr tag 1"
+        );
         assert_eq!(cert_fields.len(), 2, "must have exactly 2 fields");
         // credential is Constr 0 [B28]
         assert!(
-            matches!(&cert_fields[0], Data::Constr(0, inner) if inner.len() == 1),
+            matches!(&cert_fields[0], Data::Constr(tag, inner) if tag == &BigInt::from(0) && inner.len() == 1),
             "cert credential must be Constr 0 [B28]; got {:?}",
             cert_fields[0]
         );
@@ -1662,9 +1677,10 @@ mod tests {
         let mut info = empty_tx_info_v3();
         info.txid = [0xde; 32];
         let d = info.to_data();
-        let Data::Constr(0, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!()
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
 
         // Field 11 is txid
         match &fields[11] {
@@ -1692,7 +1708,7 @@ mod tests {
             fee: BigInt::from(170_000u64),
             mint: PlutusValue::default(),
             certs: vec![TxCert(Data::Constr(
-                1,
+                BigInt::from(1),
                 vec![
                     data_constr(0, vec![data_bs28(&[0x22; 28])]),
                     data_constr(1, vec![]),
@@ -1738,9 +1754,10 @@ mod tests {
         println!("TxInfoV3 CBOR hex:\n{hex}");
 
         // Structural sanity: 16 fields
-        let Data::Constr(0, ref fields) = d else {
+        let Data::Constr(ref __tag, ref fields) = d else {
             panic!()
         };
+        assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
         assert_eq!(fields.len(), 16, "eyeball test: must still have 16 fields");
 
         // Print field-by-field summary
@@ -1770,9 +1787,11 @@ mod tests {
 
     #[test]
     fn vote_constructors_have_expected_tags() {
-        assert!(matches!(Vote::No.to_data(), Data::Constr(0, _)));
-        assert!(matches!(Vote::Yes.to_data(), Data::Constr(1, _)));
-        assert!(matches!(Vote::Abstain.to_data(), Data::Constr(2, _)));
+        assert!(matches!(Vote::No.to_data(), Data::Constr(ref tag, _) if tag == &BigInt::from(0)));
+        assert!(matches!(Vote::Yes.to_data(), Data::Constr(ref tag, _) if tag == &BigInt::from(1)));
+        assert!(
+            matches!(Vote::Abstain.to_data(), Data::Constr(ref tag, _) if tag == &BigInt::from(2))
+        );
     }
 
     #[test]
@@ -1864,8 +1883,8 @@ mod tests {
             }),
             purpose: p,
         };
-        assert!(matches!(v1.to_data(false), Data::Constr(0, _)));
-        assert!(matches!(v2.to_data(false), Data::Constr(0, _)));
+        assert!(matches!(v1.to_data(false), Data::Constr(ref tag, _) if tag == &BigInt::from(0)));
+        assert!(matches!(v2.to_data(false), Data::Constr(ref tag, _) if tag == &BigInt::from(0)));
     }
 
     #[test]
@@ -1877,10 +1896,12 @@ mod tests {
             },
             datum: Some(Data::I(BigInt::from(42))),
         };
-        if let Ok((1, fields)) = si.to_data().into_constr() {
+        if let Ok((tag, fields)) = si.to_data().into_constr() {
+            assert_eq!(tag, BigInt::from(1));
             assert_eq!(fields.len(), 2);
             // datum slot: Constr 0 [Data::I(42)]
-            if let Data::Constr(0, inner) = &fields[1] {
+            if let Data::Constr(tag, inner) = &fields[1] {
+                assert_eq!(tag, &BigInt::from(0));
                 assert!(matches!(&inner[0], Data::I(i) if i == &BigInt::from(42)));
             } else {
                 panic!("expected Just-wrapped datum");

--- a/crates/dugite-uplc/src/syn/parser.rs
+++ b/crates/dugite-uplc/src/syn/parser.rs
@@ -68,7 +68,21 @@ impl<'a> Parser<'a> {
         let term = self.parse_term()?;
         self.skip_trivia();
         self.expect_char(')')?;
-        Ok(Program { version, term })
+        // `Program.version` is `BigUint`-typed (#842 residual — the flat
+        // decoder needs arbitrary precision to match Haskell's unbounded
+        // `Natural`). This textual parser is dev/test-only tooling (not
+        // on the consensus wire-format path), so its own version-gating
+        // (`program_version`/`version_below`) stays `u64`-based for
+        // simplicity; only the final `Program` value needs the widened
+        // type.
+        Ok(Program {
+            version: (
+                num_bigint::BigUint::from(version.0),
+                num_bigint::BigUint::from(version.1),
+                num_bigint::BigUint::from(version.2),
+            ),
+            term,
+        })
     }
 
     pub(super) fn parse_term_top(&mut self) -> Result<Term, ParseError> {

--- a/crates/dugite-uplc/src/syn/parser.rs
+++ b/crates/dugite-uplc/src/syn/parser.rs
@@ -363,7 +363,7 @@ impl<'a> Parser<'a> {
                     )),
                 }
             }
-            TypeTag::Data => Ok(Constant::Data(self.parse_data()?)),
+            TypeTag::Data => Ok(Constant::Data(std::rc::Rc::new(self.parse_data()?))),
             TypeTag::List(elem) => {
                 let elems = self.parse_list_literal(elem)?;
                 Ok(Constant::ProtoList {

--- a/crates/dugite-uplc/src/syn/parser.rs
+++ b/crates/dugite-uplc/src/syn/parser.rs
@@ -910,7 +910,14 @@ impl<'a> Parser<'a> {
             "List" => Ok(Data::List(self.parse_data_list()?)),
             "Map" => Ok(Data::Map(self.parse_data_map()?)),
             "Constr" => {
-                let tag = self.parse_uint_u64()?;
+                // The tag is an arbitrary-precision signed `Integer` in
+                // Haskell (`Data = Constr Integer [Data] | ...`), matching
+                // `Data::Constr`'s `BigInt` tag (#859) — use the same
+                // signed-integer parser as the `I` atom rather than the
+                // Word64-bounded `parse_uint_u64`, so the textual syntax
+                // can express the full domain (including a transient
+                // negative/oversized tag a script can construct pre-PV11).
+                let tag = self.parse_signed_int()?;
                 self.skip_trivia();
                 let args = self.parse_data_list()?;
                 Ok(Data::Constr(tag, args))

--- a/crates/dugite-uplc/src/term.rs
+++ b/crates/dugite-uplc/src/term.rs
@@ -138,7 +138,21 @@ pub enum Constant {
         b: Box<Constant>,
     },
     /// PlutusData — recursive sum type used by the script context.
-    Data(Data),
+    ///
+    /// `Rc`-wrapped (#838 Fix 2): the ScriptContext is a large recursive
+    /// `Data` tree bound once to the script's `ctx` parameter and then
+    /// referenced repeatedly (each `(var ctx)` occurrence in the
+    /// compiled term). Cloning a `Value`/`Constant` on every CEK env
+    /// lookup (`machine::step::compute`'s `Term::Var` arm) previously
+    /// deep-cloned the whole tree per reference — the `Rc` makes that a
+    /// refcount bump instead, matching Haskell's by-reference env. Only
+    /// the outer `Constant::Data` wrapper is `Rc`-shared; `Data`'s own
+    /// internal recursive fields (`Vec<Data>` / `Vec<(Data, Data)>`)
+    /// are unchanged, so a builtin that destructures a *shared* `Data`
+    /// (e.g. `unConstrData`) still deep-clones at that point (via
+    /// `Rc::try_unwrap`-or-clone, see `builtin::denotations::unwrap_data`)
+    /// — no worse than before, and free when the `Rc` is uniquely held.
+    Data(Rc<Data>),
     /// BLS12-381 G1 element. Stored compressed (48 bytes) for canonical
     /// equality — there is no decompressed-point cache; every builtin
     /// that consumes a G1 element re-decodes it from these bytes

--- a/crates/dugite-uplc/src/term.rs
+++ b/crates/dugite-uplc/src/term.rs
@@ -154,11 +154,12 @@ pub enum Constant {
     /// — no worse than before, and free when the `Rc` is uniquely held.
     Data(Rc<Data>),
     /// BLS12-381 G1 element. Stored compressed (48 bytes) for canonical
-    /// equality — there is no decompressed-point cache; every builtin
-    /// that consumes a G1 element re-decodes it from these bytes
-    /// on demand (see `crates/dugite-uplc/src/builtin/bls.rs`, and
-    /// issue #839 for the resulting redundant-work tradeoff). Boxed
-    /// to keep the `Constant` enum compact.
+    /// equality — the decompressed point is NOT part of this value; it
+    /// is memoized separately, out-of-band, in a capped thread-local
+    /// cache keyed by these bytes (`builtin::bls::G1_DECOMPRESS_CACHE`,
+    /// #839), so equality/`Clone`/hashing of this `Constant` variant are
+    /// unaffected by whether a given point has been decompressed yet.
+    /// Boxed to keep the `Constant` enum compact.
     Bls12_381G1Element(Box<[u8; 48]>),
     /// BLS12-381 G2 element. Stored compressed (96 bytes). Boxed.
     Bls12_381G2Element(Box<[u8; 96]>),

--- a/crates/dugite-uplc/src/tx_info_populate.rs
+++ b/crates/dugite-uplc/src/tx_info_populate.rs
@@ -301,9 +301,10 @@ pub fn required_signers_to_plutus(signers: &[dugite_primitives::hash::Hash28]) -
 /// re-cap here.
 pub fn plutus_data_to_data(p: &PrimPlutusData) -> Data {
     match p {
-        PrimPlutusData::Constr(tag, fields) => {
-            Data::Constr(*tag, fields.iter().map(plutus_data_to_data).collect())
-        }
+        PrimPlutusData::Constr(tag, fields) => Data::Constr(
+            num_bigint::BigInt::from(*tag),
+            fields.iter().map(plutus_data_to_data).collect(),
+        ),
         PrimPlutusData::Map(entries) => Data::Map(
             entries
                 .iter()
@@ -1606,7 +1607,7 @@ mod tests {
         assert_eq!(
             d,
             Data::Constr(
-                3,
+                BigInt::from(3),
                 vec![
                     Data::I(BigInt::from(1)),
                     Data::B(vec![0xff, 0xee]),

--- a/crates/dugite-uplc/src/tx_info_populate.rs
+++ b/crates/dugite-uplc/src/tx_info_populate.rs
@@ -412,6 +412,48 @@ pub fn input_to_txininfo(
     )))
 }
 
+/// Index `resolved` by `PrimTxIn` for O(1)-average lookup, used by
+/// [`inputs_to_txininfos`]/[`inputs_to_txininfos_v1`] (#844) to avoid
+/// re-scanning the whole `resolved` slice for every tx input —
+/// `input_to_txininfo`'s linear scan is O(len(resolved)) per call, so
+/// resolving all of a tx's inputs one-by-one was O(inputs · resolved),
+/// quadratic in a Plutus-dense, many-input transaction. `PrimTxIn`
+/// derives `Hash`/`Eq`, so this is a direct borrowed-key index — no
+/// extra allocation of the keys themselves.
+fn index_resolved(
+    resolved: &[(PrimTxIn, PrimTxOut, Vec<u8>)],
+) -> std::collections::HashMap<&PrimTxIn, usize> {
+    // First-occurrence-wins (via `entry().or_insert()`, NOT a plain
+    // `collect()` which would be last-wins) — matches the original
+    // linear scan's semantics exactly in the (should-never-happen,
+    // caller-side-bug) case of a duplicate `PrimTxIn` in `resolved`.
+    let mut index = std::collections::HashMap::with_capacity(resolved.len());
+    for (i, (txin, _, _)) in resolved.iter().enumerate() {
+        index.entry(txin).or_insert(i);
+    }
+    index
+}
+
+/// Same contract as [`input_to_txininfo`], but resolves `input` via a
+/// pre-built [`index_resolved`] index instead of a linear scan.
+fn input_to_txininfo_indexed(
+    input: &PrimTxIn,
+    resolved: &[(PrimTxIn, PrimTxOut, Vec<u8>)],
+    index: &std::collections::HashMap<&PrimTxIn, usize>,
+) -> Result<TxInInfo, PhaseTwoError> {
+    match index.get(input) {
+        Some(&i) => Ok(TxInInfo {
+            out_ref: input_to_outref(input),
+            resolved: output_to_plutus(&resolved[i].1)?,
+        }),
+        None => Err(PhaseTwoError::UtxoDecode(format!(
+            "input_to_txininfo: tx input {tx}@{idx} not in resolved-utxo map",
+            tx = hex::encode(input.transaction_id.0),
+            idx = input.index,
+        ))),
+    }
+}
+
 /// Sort a slice of inputs into the canonical `Set TxIn` order that
 /// cardano-ledger uses for `inputsTxBodyL`, `refInputsTxBodyL`, etc.
 ///
@@ -454,9 +496,10 @@ pub fn inputs_to_txininfos(
     inputs: &[PrimTxIn],
     resolved: &[(PrimTxIn, PrimTxOut, Vec<u8>)],
 ) -> Result<Vec<TxInInfo>, PhaseTwoError> {
+    let index = index_resolved(resolved);
     let mut out = Vec::with_capacity(inputs.len());
     for input in inputs {
-        out.push(input_to_txininfo(input, resolved)?);
+        out.push(input_to_txininfo_indexed(input, resolved, &index)?);
     }
     Ok(out)
 }
@@ -514,17 +557,16 @@ pub fn inputs_to_txininfos_v1(
     if era != dugite_primitives::era::Era::Alonzo {
         return inputs_to_txininfos(inputs, resolved);
     }
+    let index = index_resolved(resolved);
     let mut out = Vec::with_capacity(inputs.len());
     for input in inputs {
-        let byron_resolved_output = resolved.iter().any(|(i, o, _)| {
-            i.transaction_id == input.transaction_id
-                && i.index == input.index
-                && matches!(o.address, PrimAddress::Byron(_))
-        });
+        let byron_resolved_output = index
+            .get(input)
+            .is_some_and(|&i| matches!(resolved[i].1.address, PrimAddress::Byron(_)));
         if byron_resolved_output {
             continue;
         }
-        out.push(input_to_txininfo(input, resolved)?);
+        out.push(input_to_txininfo_indexed(input, resolved, &index)?);
     }
     Ok(out)
 }
@@ -1843,6 +1885,38 @@ mod tests {
         assert_eq!(
             info.resolved.value.policies[0].1[0].1,
             BigInt::from(2_000_000)
+        );
+    }
+
+    /// #844: `inputs_to_txininfos` now resolves each input via a
+    /// pre-built index (`index_resolved`) instead of `input_to_txininfo`'s
+    /// linear scan, to avoid O(inputs · resolved) rescanning on a
+    /// Plutus-dense many-input tx. Pin that the index preserves the
+    /// linear scan's FIRST-occurrence-wins semantics for the
+    /// (should-never-happen) case of a duplicate `PrimTxIn` in
+    /// `resolved` — a plain `HashMap::collect()` would be last-wins and
+    /// silently diverge from `input_to_txininfo`'s behavior.
+    #[test]
+    fn inputs_to_txininfos_first_occurrence_wins_on_duplicate_resolved_entry() {
+        let resolved = vec![
+            resolved_entry(0xaa, 0, 1_000_000),
+            resolved_entry(0xaa, 0, 9_999_999), // duplicate PrimTxIn key
+        ];
+        let inputs = vec![PrimTxIn {
+            transaction_id: h32(0xaa),
+            index: 0,
+        }];
+        let via_index = inputs_to_txininfos(&inputs, &resolved).unwrap();
+        let via_linear_scan = input_to_txininfo(&inputs[0], &resolved).unwrap();
+        assert_eq!(
+            via_index[0].resolved.value.policies[0].1[0].1,
+            BigInt::from(1_000_000),
+            "indexed path must return the FIRST matching resolved entry"
+        );
+        assert_eq!(
+            via_index[0].resolved.value.policies[0].1[0].1,
+            via_linear_scan.resolved.value.policies[0].1[0].1,
+            "indexed and linear-scan resolution must agree"
         );
     }
 

--- a/crates/dugite-uplc/tests/adversarial_decode.rs
+++ b/crates/dugite-uplc/tests/adversarial_decode.rs
@@ -35,7 +35,10 @@ fn from_flat_rejects_trailing_bytes_toomuchspace() {
 
 #[test]
 fn from_flat_rejects_empty_and_truncated_input() {
-    assert!(Program::from_flat(&[]).is_err(), "empty flat input must be rejected");
+    assert!(
+        Program::from_flat(&[]).is_err(),
+        "empty flat input must be rejected"
+    );
     let flat = minimal_program().to_flat().expect("encode");
     // Truncate to half — the term/version bits are incomplete.
     assert!(

--- a/crates/dugite-uplc/tests/adversarial_decode.rs
+++ b/crates/dugite-uplc/tests/adversarial_decode.rs
@@ -1,0 +1,81 @@
+//! Adversarial decode-rejection tests for the public UPLC decode surface (#845).
+//!
+//! Complements the existing conformance corpus (999 UPLC cases), builtin-semantics
+//! rejection fixtures, and the `fuzz/fuzz_targets/dugite_uplc_{program,data}_decode`
+//! fuzzers: these are targeted, named regressions for the specific decode-rejection
+//! invariants dugite must uphold byte-for-byte against Haskell's strict decoders.
+
+use dugite_uplc::program::Program;
+use dugite_uplc::term::{Constant, Term};
+
+fn minimal_program() -> Program {
+    Program {
+        version: Program::version_triple(1, 0, 0),
+        term: Term::Const(Constant::Integer(0.into())),
+    }
+}
+
+#[test]
+fn from_flat_rejects_trailing_bytes_toomuchspace() {
+    // Haskell's flat `strictDecoder` raises `TooMuchSpace` for any bits beyond the
+    // program's mandatory trailing filler (#822/#835). A trailing byte after a
+    // canonical program must be rejected, not silently ignored.
+    let mut flat = minimal_program().to_flat().expect("encode minimal program");
+    let canonical_len = flat.len();
+    flat.push(0xAB); // extraneous trailing byte
+    let err = Program::from_flat(&flat).expect_err("trailing byte must be rejected");
+    assert!(
+        format!("{err}").to_lowercase().contains("space")
+            || format!("{err}").to_lowercase().contains("trailing"),
+        "expected a TooMuchSpace-style rejection, got: {err}"
+    );
+    // The canonical (untampered) bytes still decode.
+    assert!(Program::from_flat(&flat[..canonical_len]).is_ok());
+}
+
+#[test]
+fn from_flat_rejects_empty_and_truncated_input() {
+    assert!(Program::from_flat(&[]).is_err(), "empty flat input must be rejected");
+    let flat = minimal_program().to_flat().expect("encode");
+    // Truncate to half — the term/version bits are incomplete.
+    assert!(
+        Program::from_flat(&flat[..flat.len() / 2]).is_err(),
+        "truncated flat input must be rejected"
+    );
+}
+
+#[test]
+fn from_cbor_rejects_non_bytestring_and_trailing() {
+    // On-chain scripts are a CBOR bytestring wrapping the flat program. A bare
+    // (non-CBOR-wrapped) or wrong-major-type input must be rejected (#836).
+    let flat = minimal_program().to_flat().expect("encode");
+    // 0x80 = CBOR array(0) — wrong major type where a bytestring is required.
+    assert!(Program::from_cbor(&[0x80]).is_err());
+    // Empty input.
+    assert!(Program::from_cbor(&[]).is_err());
+    // A valid CBOR-wrapped program round-trips (positive control).
+    let cbor = minimal_program().to_cbor().expect("cbor encode");
+    assert!(Program::from_cbor(&cbor).is_ok());
+    let _ = flat;
+}
+
+#[test]
+fn data_from_cbor_rejects_malformed_input() {
+    use dugite_uplc::data::Data;
+    // Truncated indefinite-length / bad headers must not panic and must Err.
+    for bad in [
+        &[0x9f][..],       // indefinite array, never closed
+        &[0xd8, 0x7a][..], // tag 122 header then EOF
+        &[0xbf][..],       // indefinite map, never closed
+        &[0x5f][..],       // indefinite bytes, never closed
+    ] {
+        assert!(
+            Data::from_cbor(bad).is_err(),
+            "malformed Data CBOR {bad:?} must be rejected, not accepted"
+        );
+    }
+    // Positive control: a small Constr round-trips.
+    let d = Data::constr(0, vec![Data::I(42.into()), Data::B(vec![1, 2, 3])]);
+    let bytes = d.to_cbor().expect("encode");
+    assert_eq!(Data::from_cbor(&bytes).expect("decode"), d);
+}

--- a/crates/dugite-uplc/tests/aiken_v3_always_true.rs
+++ b/crates/dugite-uplc/tests/aiken_v3_always_true.rs
@@ -47,7 +47,14 @@ const AIKEN_V3_ALWAYS_TRUE_CBOR: &[u8] = &[
 fn decode_succeeds() {
     let p = Program::from_cbor(AIKEN_V3_ALWAYS_TRUE_CBOR)
         .expect("Aiken-built V3 always-true must decode cleanly after #41b7a036a");
-    assert_eq!(p.version, (1, 1, 0));
+    assert_eq!(
+        p.version,
+        (
+            num_bigint::BigUint::from(1u8),
+            num_bigint::BigUint::from(1u8),
+            num_bigint::BigUint::ZERO
+        )
+    );
     // Top-level term is a single Lambda (binds ctx).
     assert!(matches!(p.term, Term::Lam(_)));
 }

--- a/crates/dugite-uplc/tests/aiken_v3_always_true.rs
+++ b/crates/dugite-uplc/tests/aiken_v3_always_true.rs
@@ -73,7 +73,7 @@ fn cek_reaches_body_no_var_lookup_failure() {
     );
     let applied = Term::App(
         Rc::new(p.term),
-        Rc::new(Term::Const(Constant::Data(stub_ctx))),
+        Rc::new(Term::Const(Constant::Data(stub_ctx.into()))),
     );
 
     let err = dugite_uplc::machine::step::evaluate(applied).expect_err(

--- a/crates/dugite-uplc/tests/aiken_v3_always_true.rs
+++ b/crates/dugite-uplc/tests/aiken_v3_always_true.rs
@@ -21,6 +21,7 @@
 //! `#[ignore]` attribute should be removed.
 
 use dugite_uplc::{Constant, Data, Program, Term};
+use num_bigint::BigInt;
 use std::rc::Rc;
 
 /// Inner flat bytes (post-CBOR-unwrap) of the canonical Aiken-built
@@ -66,7 +67,10 @@ fn decode_succeeds() {
 fn cek_reaches_body_no_var_lookup_failure() {
     let p = Program::from_cbor(AIKEN_V3_ALWAYS_TRUE_CBOR)
         .expect("decode canonical Aiken V3 always-true");
-    let stub_ctx = Data::Constr(0, vec![Data::Constr(0, vec![]); 4]);
+    let stub_ctx = Data::Constr(
+        BigInt::from(0),
+        vec![Data::Constr(BigInt::from(0), vec![]); 4],
+    );
     let applied = Term::App(
         Rc::new(p.term),
         Rc::new(Term::Const(Constant::Data(stub_ctx))),

--- a/crates/dugite-uplc/tests/cross_validate_data.rs
+++ b/crates/dugite-uplc/tests/cross_validate_data.rs
@@ -139,31 +139,40 @@ fn bytestring_three_chunks() {
 #[test]
 fn constr_small_tags() {
     for tag in [0u64, 1, 6] {
-        assert_cross(&Data::Constr(tag, vec![]));
-        assert_cross(&Data::Constr(tag, vec![Data::I(BigInt::from(42))]));
+        assert_cross(&Data::Constr(BigInt::from(tag), vec![]));
+        assert_cross(&Data::Constr(
+            BigInt::from(tag),
+            vec![Data::I(BigInt::from(42))],
+        ));
     }
 }
 
 #[test]
 fn constr_medium_tags() {
     for tag in [7u64, 50, 127] {
-        assert_cross(&Data::Constr(tag, vec![]));
-        assert_cross(&Data::Constr(tag, vec![Data::I(BigInt::from(42))]));
+        assert_cross(&Data::Constr(BigInt::from(tag), vec![]));
+        assert_cross(&Data::Constr(
+            BigInt::from(tag),
+            vec![Data::I(BigInt::from(42))],
+        ));
     }
 }
 
 #[test]
 fn constr_large_tags() {
     for tag in [128u64, 1000, u32::MAX as u64, u64::MAX] {
-        assert_cross(&Data::Constr(tag, vec![]));
-        assert_cross(&Data::Constr(tag, vec![Data::I(BigInt::from(1))]));
+        assert_cross(&Data::Constr(BigInt::from(tag), vec![]));
+        assert_cross(&Data::Constr(
+            BigInt::from(tag),
+            vec![Data::I(BigInt::from(1))],
+        ));
     }
 }
 
 #[test]
 fn constr_many_fields() {
     let fields: Vec<Data> = (0..10).map(|i| Data::I(BigInt::from(i))).collect();
-    assert_cross(&Data::Constr(0, fields));
+    assert_cross(&Data::Constr(BigInt::from(0), fields));
 }
 
 // ---------------------------------------------------------------------------
@@ -222,15 +231,15 @@ fn map_short() {
 #[test]
 fn nested_constr_inside_list() {
     assert_cross(&Data::List(vec![
-        Data::Constr(0, vec![Data::I(BigInt::from(1))]),
-        Data::Constr(1, vec![Data::I(BigInt::from(2))]),
+        Data::Constr(BigInt::from(0), vec![Data::I(BigInt::from(1))]),
+        Data::Constr(BigInt::from(1), vec![Data::I(BigInt::from(2))]),
     ]));
 }
 
 #[test]
 fn nested_map_inside_constr() {
     assert_cross(&Data::Constr(
-        3,
+        BigInt::from(3),
         vec![Data::Map(vec![(
             Data::B(b"k".to_vec()),
             Data::List(vec![Data::I(BigInt::from(7))]),
@@ -242,7 +251,7 @@ fn nested_map_inside_constr() {
 fn deeply_nested() {
     let mut inner = Data::I(BigInt::from(99));
     for i in 0..20 {
-        inner = Data::Constr(i % 7, vec![inner]);
+        inner = Data::Constr(BigInt::from(i % 7), vec![inner]);
     }
     assert_cross(&inner);
 }

--- a/crates/dugite-uplc/tests/phase2_onchain_budget.rs
+++ b/crates/dugite-uplc/tests/phase2_onchain_budget.rs
@@ -191,7 +191,11 @@ fn cek_v3_spend_71579b77_flat_evaluates() {
     let prog = Program::from_flat(&flat_bytes).expect("applied flat should parse");
     assert_eq!(
         prog.version,
-        (1, 1, 0),
+        (
+            num_bigint::BigUint::from(1u8),
+            num_bigint::BigUint::from(1u8),
+            num_bigint::BigUint::ZERO
+        ),
         "script should be UPLC 1.1.0 (Conway)"
     );
     let mut tracker = BudgetTracker::new_counting();

--- a/crates/dugite-uplc/tests/phase2_script_context_regression.rs
+++ b/crates/dugite-uplc/tests/phase2_script_context_regression.rs
@@ -130,15 +130,17 @@ fn posix_time_range_always_valid_has_correct_structure() {
     let d = r.to_data(false);
 
     // Outer: Interval = Constr 0 [lower_bound, upper_bound]
-    let Data::Constr(0, ref outer_fields) = d else {
+    let Data::Constr(ref __tag, ref outer_fields) = d else {
         panic!("Interval must be Constr 0; got {d:?}");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(outer_fields.len(), 2, "Interval has 2 fields (lb, ub)");
 
     // Lower bound: LowerBound NegInf True = Constr 0 [Constr 0 [], Constr 1 []]
-    let Data::Constr(0, ref lb_fields) = outer_fields[0] else {
+    let Data::Constr(ref __tag, ref lb_fields) = outer_fields[0] else {
         panic!("LowerBound must be Constr 0; got {:?}", outer_fields[0]);
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         lb_fields.len(),
         2,
@@ -146,19 +148,20 @@ fn posix_time_range_always_valid_has_correct_structure() {
     );
     assert_eq!(
         lb_fields[0],
-        Data::Constr(0, vec![]),
+        Data::Constr(BigInt::from(0), vec![]),
         "LowerBound(None) extended must be NegInf = Constr 0 []"
     );
     assert_eq!(
         lb_fields[1],
-        Data::Constr(1, vec![]),
+        Data::Constr(BigInt::from(1), vec![]),
         "LowerBound closed must be True = Constr 1 []"
     );
 
     // Upper bound: UpperBound PosInf True = Constr 0 [Constr 2 [], Constr 1 []]
-    let Data::Constr(0, ref ub_fields) = outer_fields[1] else {
+    let Data::Constr(ref __tag, ref ub_fields) = outer_fields[1] else {
         panic!("UpperBound must be Constr 0; got {:?}", outer_fields[1]);
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         ub_fields.len(),
         2,
@@ -166,12 +169,12 @@ fn posix_time_range_always_valid_has_correct_structure() {
     );
     assert_eq!(
         ub_fields[0],
-        Data::Constr(2, vec![]),
+        Data::Constr(BigInt::from(2), vec![]),
         "UpperBound(None) extended must be PosInf = Constr 2 []"
     );
     assert_eq!(
         ub_fields[1],
-        Data::Constr(1, vec![]),
+        Data::Constr(BigInt::from(1), vec![]),
         "UpperBound PosInf closed must be True = Constr 1 []"
     );
 }
@@ -189,37 +192,40 @@ fn posix_time_range_finite_bounds_have_correct_structure() {
     };
     let d = r.to_data(false);
 
-    let Data::Constr(0, ref outer) = d else {
+    let Data::Constr(ref __tag, ref outer) = d else {
         panic!("Interval must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
 
     // Lower: LowerBound (Finite vs_ms) True
-    let Data::Constr(0, ref lb) = outer[0] else {
+    let Data::Constr(ref __tag, ref lb) = outer[0] else {
         panic!("LowerBound must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         lb[0],
-        Data::Constr(1, vec![Data::I(BigInt::from(vs_ms))]),
+        Data::Constr(BigInt::from(1), vec![Data::I(BigInt::from(vs_ms))]),
         "lower extended must be Finite vs_ms = Constr 1 [I(vs_ms)]"
     );
     assert_eq!(
         lb[1],
-        Data::Constr(1, vec![]),
+        Data::Constr(BigInt::from(1), vec![]),
         "lower closed must be True = Constr 1 []"
     );
 
     // Upper: UpperBound (Finite ttl_ms) False
-    let Data::Constr(0, ref ub) = outer[1] else {
+    let Data::Constr(ref __tag, ref ub) = outer[1] else {
         panic!("UpperBound must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         ub[0],
-        Data::Constr(1, vec![Data::I(BigInt::from(ttl_ms))]),
+        Data::Constr(BigInt::from(1), vec![Data::I(BigInt::from(ttl_ms))]),
         "upper extended must be Finite ttl_ms = Constr 1 [I(ttl_ms)]"
     );
     assert_eq!(
         ub[1],
-        Data::Constr(0, vec![]),
+        Data::Constr(BigInt::from(0), vec![]),
         "upper closed must be False = Constr 0 [] (half-open upper)"
     );
 }
@@ -237,24 +243,26 @@ fn posix_time_range_ttl_only_upper_closure_is_era_gated() {
         upper: Some(1_781_858_645_000i64),
     };
     let upper_closure = |conway: bool| -> Data {
-        let Ok((0, outer)) = r.to_data(conway).into_constr() else {
+        let Ok((outer_tag, outer)) = r.to_data(conway).into_constr() else {
             panic!("interval must be Constr 0");
         };
-        let Ok((0, ub)) = outer[1].clone().into_constr() else {
+        assert_eq!(outer_tag, BigInt::from(0));
+        let Ok((ub_tag, ub)) = outer[1].clone().into_constr() else {
             panic!("upper bound must be Constr 0");
         };
+        assert_eq!(ub_tag, BigInt::from(0));
         ub[1].clone()
     };
     // Pre-Conway (Alonzo/Babbage): `PV1.to` → UpperBound (Finite t) True.
     assert_eq!(
         upper_closure(false),
-        Data::Constr(1, vec![]),
+        Data::Constr(BigInt::from(1), vec![]),
         "pre-Conway ttl-only upper closure must be True (inclusive, PV1.to)"
     );
     // Conway+: `strictUpperBound` → UpperBound (Finite t) False.
     assert_eq!(
         upper_closure(true),
-        Data::Constr(0, vec![]),
+        Data::Constr(BigInt::from(0), vec![]),
         "Conway+ ttl-only upper closure must be False (exclusive, strictUpperBound)"
     );
 }
@@ -268,18 +276,19 @@ fn posix_time_range_does_not_use_old_flat_encoding() {
         upper: Some(2_000_000i64),
     };
     let d = r.to_data(false);
-    let Data::Constr(0, ref outer) = d else {
+    let Data::Constr(ref __tag, ref outer) = d else {
         panic!("must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // Old encoding: bound(Some(t)) = Constr 1 [I(t), Constr 1 []]
     // New encoding: LowerBound = Constr 0 [Constr 1 [I(t)], Bool]
     // Check that neither field is Constr 1 at the top level (that was the old bug).
     assert!(
-        !matches!(outer[0], Data::Constr(1, _)),
+        !matches!(outer[0], Data::Constr(ref tag, _) if tag == &BigInt::from(1)),
         "lower bound must NOT be Constr 1 (old buggy encoding)"
     );
     assert!(
-        !matches!(outer[1], Data::Constr(1, _)),
+        !matches!(outer[1], Data::Constr(ref tag, _) if tag == &BigInt::from(1)),
         "upper bound must NOT be Constr 1 (old buggy encoding)"
     );
 }
@@ -389,7 +398,10 @@ fn flat_round_trips_list_data_constant() {
     let items = vec![
         Constant::Data(Data::I(BigInt::from(1i64))),
         Constant::Data(Data::B(vec![0xaa, 0xbb])),
-        Constant::Data(Data::Constr(0, vec![Data::I(BigInt::from(3i64))])),
+        Constant::Data(Data::Constr(
+            BigInt::from(0),
+            vec![Data::I(BigInt::from(3i64))],
+        )),
     ];
     let program = Program {
         version: (1, 0, 0),
@@ -488,9 +500,10 @@ fn txinfo_v3_fee_is_bare_integer_not_value_map() {
     let mut info = minimal_txinfo_v3();
     info.fee = BigInt::from(lovelace);
     let d = info.to_data();
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV3 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // V3 TxInfo to_data field order: [inputs, refInputs, outputs, fee, ...] —
     // fee is field index 3.
     match &fields[3] {
@@ -527,9 +540,10 @@ fn txinfo_v1_wdrl_is_data_list_of_constr_pairs() {
     let d = info.to_data(false);
 
     // V1 TxInfo: Constr 0 [inputs, outputs, fee, mint, dcert, wdrl, ...]
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV1 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // wdrl is field index 5
     let wdrl_field = &fields[5];
     // V1 wdrl must be a List (not a Map).
@@ -547,7 +561,7 @@ fn txinfo_v1_wdrl_is_data_list_of_constr_pairs() {
     };
     assert_eq!(items.len(), 1, "expected 1 withdrawal entry");
     assert!(
-        matches!(&items[0], Data::Constr(0, inner) if inner.len() == 2),
+        matches!(&items[0], Data::Constr(tag, inner) if tag == &BigInt::from(0) && inner.len() == 2),
         "V1 wdrl entry must be Constr 0 [cred, amt]; got {:?}",
         items[0]
     );
@@ -562,9 +576,10 @@ fn txinfo_v2_wdrl_is_data_map() {
     info.wdrl = vec![(sc, amt)];
     let d = info.to_data(false);
 
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV2 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // V2 field order: inputs=0, reference_inputs=1, outputs=2, fee=3, mint=4,
     //                 dcert=5, wdrl=6, valid_range=7, signatories=8, redeemers=9,
     //                 data=10, txid=11
@@ -584,9 +599,10 @@ fn txinfo_v2_wdrl_is_data_map() {
 fn txinfo_v1_empty_wdrl_is_empty_list() {
     let info = minimal_txinfo_v1();
     let d = info.to_data(false);
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("expected Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         fields[5],
         Data::List(vec![]),
@@ -600,9 +616,10 @@ fn txinfo_v1_empty_wdrl_is_empty_list() {
 fn txinfo_v2_empty_wdrl_is_empty_map() {
     let info = minimal_txinfo_v2();
     let d = info.to_data(false);
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("expected Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         fields[6],
         Data::Map(vec![]),
@@ -674,17 +691,19 @@ fn txoutref_txid_is_constr_wrapped() {
     };
     let d = r.to_data();
     // Outer: Constr 0 [TxId, Integer]
-    let Data::Constr(0, ref outer) = d else {
+    let Data::Constr(ref __tag, ref outer) = d else {
         panic!("TxOutRef must be Constr 0; got {d:?}");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(outer.len(), 2, "TxOutRef has 2 fields");
     // Inner TxId: must be Constr 0 [B bytes32], NOT bare B bytes32.
-    let Data::Constr(0, ref id_fields) = outer[0] else {
+    let Data::Constr(ref __tag, ref id_fields) = outer[0] else {
         panic!(
             "TxId must be Constr 0 [B bytes32]; got {:?} — this is Bug E (TxId not wrapped)",
             outer[0]
         );
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(id_fields.len(), 1);
     assert!(
         matches!(&id_fields[0], Data::B(b) if b.len() == 32),
@@ -707,9 +726,10 @@ fn txoutref_txid_is_not_bare_bytes() {
         tx_id: [0x11; 32],
         idx: 0,
     };
-    let Data::Constr(0, ref outer) = r.to_data() else {
+    let Data::Constr(ref __tag, ref outer) = r.to_data() else {
         panic!("expected Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert!(
         !matches!(&outer[0], Data::B(_)),
         "TxId field must NOT be bare bytes (Bug E regression); got {:?}",
@@ -732,9 +752,10 @@ fn txoutref_v3_txid_is_bare_bytes() {
         tx_id: [0xcd; 32],
         idx: 3,
     };
-    let Data::Constr(0, ref outer) = r.to_data_v3() else {
+    let Data::Constr(ref __tag, ref outer) = r.to_data_v3() else {
         panic!("V3 TxOutRef must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(outer.len(), 2);
     assert!(
         matches!(&outer[0], Data::B(b) if b.len() == 32),
@@ -767,20 +788,23 @@ fn v3_txininfo_embeds_bare_txid_outref() {
         }];
         i
     };
-    let Data::Constr(0, ref fields) = info.to_data() else {
+    let Data::Constr(ref __tag, ref fields) = info.to_data() else {
         panic!("TxInfoV3 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // field[0] = inputs : List[TxInInfo]
     let Data::List(ref inputs) = fields[0] else {
         panic!("inputs must be a List");
     };
-    let Data::Constr(0, ref txininfo) = inputs[0] else {
+    let Data::Constr(ref __tag, ref txininfo) = inputs[0] else {
         panic!("TxInInfo must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // txininfo[0] = TxOutRef = Constr 0 [B32 BARE, I idx]
-    let Data::Constr(0, ref outref) = txininfo[0] else {
+    let Data::Constr(ref __tag, ref outref) = txininfo[0] else {
         panic!("TxOutRef must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert!(
         matches!(&outref[0], Data::B(b) if b.len() == 32),
         "V3 TxInInfo's TxOutRef txid must be BARE B(32), not Constr-wrapped; got {:?}",
@@ -795,9 +819,10 @@ fn gov_action_id_v3_txid_is_bare_bytes() {
         tx_id: [0x09; 32],
         idx: 1,
     };
-    let Data::Constr(0, ref outer) = g.to_data() else {
+    let Data::Constr(ref __tag, ref outer) = g.to_data() else {
         panic!("GovActionId must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(outer.len(), 2);
     assert!(
         matches!(&outer[0], Data::B(b) if b.len() == 32),
@@ -823,9 +848,10 @@ fn txinfo_v1_fee_is_ada_value_map() {
     let d = info.to_data(false);
 
     // V1 TxInfo: Constr 0 [inputs, outputs, fee, ...]  — fee is field 2
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV1 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     let fee_field = &fields[2];
 
     // fee must be a Map (not I)
@@ -872,9 +898,10 @@ fn txinfo_v2_fee_is_ada_value_map() {
     let mut info = minimal_txinfo_v2();
     info.fee = BigInt::from(5_000_000u64);
     let d = info.to_data(false);
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV2 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // V2: inputs=0, ref_inputs=1, outputs=2, fee=3
     let fee_field = &fields[3];
     assert!(
@@ -900,9 +927,10 @@ fn txinfo_v1_data_is_list_of_constr_pairs() {
 
     // V1 TxInfo: Constr 0 [inputs, outputs, fee, mint, dcert, wdrl, validRange, sigs, data, id]
     // data is field index 8
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV1 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     let data_field = &fields[8];
     assert!(
         matches!(data_field, Data::List(_)),
@@ -916,12 +944,13 @@ fn txinfo_v1_data_is_list_of_constr_pairs() {
         unreachable!()
     };
     assert_eq!(items.len(), 1, "expected 1 datum entry");
-    let Data::Constr(0, ref pair) = items[0] else {
+    let Data::Constr(ref __tag, ref pair) = items[0] else {
         panic!(
             "V1 data entry must be Constr 0 [B32, datum]; got {:?}",
             items[0]
         );
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(pair.len(), 2);
     assert!(
         matches!(&pair[0], Data::B(b) if b.len() == 32),
@@ -941,9 +970,10 @@ fn txinfo_v2_data_is_map() {
     let d = info.to_data(false);
 
     // V2: field 10 is data
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV2 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     let data_field = &fields[10];
     assert!(
         matches!(data_field, Data::Map(_)),
@@ -963,13 +993,15 @@ fn txinfo_v1_txid_is_constr_wrapped() {
     let d = info.to_data(false);
 
     // V1 TxInfo field 9 is txid
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxInfoV1 must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     let id_field = &fields[9];
-    let Data::Constr(0, ref inner) = id_field else {
+    let Data::Constr(ref __tag, ref inner) = id_field else {
         panic!("txInfoId (V1 field 9) must be TxId = Constr 0 [B32]; got {id_field:?}");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(inner.len(), 1);
     assert!(
         matches!(&inner[0], Data::B(b) if b.len() == 32),
@@ -983,9 +1015,10 @@ fn txinfo_v1_txid_is_constr_wrapped() {
 fn txinfo_v1_txid_is_not_bare_bytes() {
     let info = minimal_txinfo_v1();
     let d = info.to_data(false);
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("expected Constr 0")
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert!(
         !matches!(&fields[9], Data::B(_)),
         "txInfoId (V1 field 9) must NOT be bare bytes; got {:?}",
@@ -1015,9 +1048,10 @@ fn minimal_txout_v1(datum: OutputDatum) -> TxOut {
 fn txout_v1_has_three_fields() {
     let out = minimal_txout_v1(OutputDatum::None);
     let d = out.to_data_v1();
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxOut (V1) must be Constr 0; got {d:?}");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         fields.len(),
         3,
@@ -1031,9 +1065,10 @@ fn txout_v1_has_three_fields() {
 fn txout_v2_has_four_fields() {
     let out = minimal_txout_v1(OutputDatum::None);
     let d = out.to_data();
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("TxOut (V2) must be Constr 0; got {d:?}");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         fields.len(),
         4,
@@ -1048,15 +1083,17 @@ fn txout_v1_datum_hash_is_just_b32() {
     let hash = [0x77; 32];
     let out = minimal_txout_v1(OutputDatum::Hash(hash));
     let d = out.to_data_v1();
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("expected Constr 0")
     };
-    let Data::Constr(0, ref maybe_inner) = fields[2] else {
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
+    let Data::Constr(ref __tag, ref maybe_inner) = fields[2] else {
         panic!(
             "V1 DatumHash must be Just = Constr 0 [B32]; got {:?}",
             fields[2]
         );
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert!(
         matches!(&maybe_inner[0], Data::B(b) if b.len() == 32),
         "DatumHash inner must be B32"
@@ -1068,12 +1105,13 @@ fn txout_v1_datum_hash_is_just_b32() {
 fn txout_v1_no_datum_is_nothing() {
     let out = minimal_txout_v1(OutputDatum::None);
     let d = out.to_data_v1();
-    let Data::Constr(0, ref fields) = d else {
+    let Data::Constr(ref __tag, ref fields) = d else {
         panic!("expected Constr 0")
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(
         fields[2],
-        Data::Constr(1, vec![]),
+        Data::Constr(BigInt::from(1), vec![]),
         "V1 no-datum must be Nothing = Constr 1 []; got {:?}",
         fields[2]
     );
@@ -1099,25 +1137,29 @@ fn script_context_v1_spend_purpose_has_wrapped_txid() {
     };
     let d = ctx.to_data(false);
     // ctx = Constr 0 [TxInfo, ScriptPurpose]
-    let Data::Constr(0, ref ctx_fields) = d else {
+    let Data::Constr(ref __tag, ref ctx_fields) = d else {
         panic!("ScriptContext must be Constr 0");
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // ScriptPurpose::Spending = Constr 1 [TxOutRef]
-    let Data::Constr(1, ref purpose_fields) = ctx_fields[1] else {
+    let Data::Constr(ref __tag, ref purpose_fields) = ctx_fields[1] else {
         panic!("Spending purpose must be Constr 1; got {:?}", ctx_fields[1]);
     };
+    assert_eq!(__tag, &BigInt::from(1), "unexpected Constr tag");
     assert_eq!(purpose_fields.len(), 1);
     // TxOutRef = Constr 0 [TxId, Integer]
-    let Data::Constr(0, ref outref_fields) = purpose_fields[0] else {
+    let Data::Constr(ref __tag, ref outref_fields) = purpose_fields[0] else {
         panic!("TxOutRef must be Constr 0; got {:?}", purpose_fields[0]);
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     // TxId = Constr 0 [B bytes32]
-    let Data::Constr(0, ref txid_fields) = outref_fields[0] else {
+    let Data::Constr(ref __tag, ref txid_fields) = outref_fields[0] else {
         panic!(
             "TxId in Spending purpose must be Constr 0 [B32]; got {:?}",
             outref_fields[0]
         );
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert!(
         matches!(&txid_fields[0], Data::B(b) if b.len() == 32),
         "TxId inner field must be B32"
@@ -1136,24 +1178,27 @@ fn v1v2_rewarding_purpose_wraps_credential_in_staking_hash() {
     let p = ScriptPurpose::Rewarding(Credential::Script([0xab; 28]));
     let d = p.to_data();
     // Constr 2 [ Constr 0 [ Constr 1 [B28] ] ]
-    let Data::Constr(2, outer) = &d else {
+    let Data::Constr(__tag, outer) = &d else {
         panic!("Rewarding must be Constr 2, got {d:?}");
     };
+    assert_eq!(__tag, &BigInt::from(2), "unexpected Constr tag");
     assert_eq!(
         outer.len(),
         1,
         "Rewarding has one field (StakingCredential)"
     );
-    let Data::Constr(0, sh) = &outer[0] else {
+    let Data::Constr(__tag, sh) = &outer[0] else {
         panic!(
             "V1/V2 Rewarding field must be StakingHash = Constr 0, got {:?}",
             outer[0]
         );
     };
+    assert_eq!(__tag, &BigInt::from(0), "unexpected Constr tag");
     assert_eq!(sh.len(), 1, "StakingHash wraps one Credential");
-    let Data::Constr(1, cred) = &sh[0] else {
+    let Data::Constr(__tag, cred) = &sh[0] else {
         panic!("inner must be ScriptCredential = Constr 1, got {:?}", sh[0]);
     };
+    assert_eq!(__tag, &BigInt::from(1), "unexpected Constr tag");
     assert!(matches!(&cred[0], Data::B(b) if b.len() == 28));
 }
 
@@ -1162,15 +1207,17 @@ fn v3_rewarding_purpose_uses_bare_credential() {
     let p = ScriptPurpose::Rewarding(Credential::Script([0xab; 28]));
     let d = p.to_data_v3();
     // V3: Constr 2 [ Constr 1 [B28] ]  (Credential directly, NO StakingHash)
-    let Data::Constr(2, outer) = &d else {
+    let Data::Constr(__tag, outer) = &d else {
         panic!("Rewarding must be Constr 2, got {d:?}");
     };
-    let Data::Constr(1, cred) = &outer[0] else {
+    assert_eq!(__tag, &BigInt::from(2), "unexpected Constr tag");
+    let Data::Constr(__tag, cred) = &outer[0] else {
         panic!(
             "V3 Rewarding field must be the bare Credential = Constr 1, got {:?}",
             outer[0]
         );
     };
+    assert_eq!(__tag, &BigInt::from(1), "unexpected Constr tag");
     assert!(matches!(&cred[0], Data::B(b) if b.len() == 28));
 }
 

--- a/crates/dugite-uplc/tests/phase2_script_context_regression.rs
+++ b/crates/dugite-uplc/tests/phase2_script_context_regression.rs
@@ -61,8 +61,18 @@ use dugite_uplc::script_context::{
     Credential, GovActionId, OutputDatum, PlutusValue, PosixTimeRange, ScriptContextV1,
     ScriptPurpose, StakingCredential, TxInInfo, TxInfoV1, TxInfoV2, TxInfoV3, TxOut, TxOutRef,
 };
-use num_bigint::BigInt;
+use num_bigint::{BigInt, BigUint};
 use std::rc::Rc;
+
+/// Test-only ergonomic constructor for a `Program` version triple
+/// (`BigUint`-typed since #842's residual arbitrary-precision fix).
+fn ver(major: u64, minor: u64, patch: u64) -> (BigUint, BigUint, BigUint) {
+    (
+        BigUint::from(major),
+        BigUint::from(minor),
+        BigUint::from(patch),
+    )
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Bug A: ADA policy key
@@ -309,7 +319,7 @@ fn flat_round_trips_data_constant() {
 
     let data_val = Data::I(BigInt::from(42i64));
     let program = Program {
-        version: (1, 0, 0),
+        version: ver(1, 0, 0),
         term: Term::Lam(Rc::new(Term::Const(Constant::Data(
             data_val.clone().into(),
         )))),
@@ -318,7 +328,7 @@ fn flat_round_trips_data_constant() {
     let flat = program.to_flat().expect("encode Data constant program");
     let decoded = Program::from_flat(&flat).expect("decode Data constant program");
 
-    assert_eq!(decoded.version, (1, 0, 0));
+    assert_eq!(decoded.version, ver(1, 0, 0));
     let Term::Lam(body) = decoded.term else {
         panic!("expected Lam");
     };
@@ -341,7 +351,7 @@ fn flat_round_trips_list_integer_constant() {
         Constant::Integer(BigInt::from(3i64)),
     ];
     let program = Program {
-        version: (1, 0, 0),
+        version: ver(1, 0, 0),
         term: Term::Const(Constant::ProtoList {
             elem_type: TypeTag::Integer,
             elements: elements.clone(),
@@ -371,7 +381,7 @@ fn flat_round_trips_pair_constant() {
     use dugite_uplc::Program;
 
     let program = Program {
-        version: (1, 0, 0),
+        version: ver(1, 0, 0),
         term: Term::Const(Constant::ProtoPair {
             a_type: TypeTag::Integer,
             b_type: TypeTag::ByteString,
@@ -403,7 +413,7 @@ fn flat_round_trips_list_data_constant() {
         Constant::Data(Data::Constr(BigInt::from(0), vec![Data::I(BigInt::from(3i64))]).into()),
     ];
     let program = Program {
-        version: (1, 0, 0),
+        version: ver(1, 0, 0),
         term: Term::Const(Constant::ProtoList {
             elem_type: TypeTag::Data,
             elements: items.clone(),
@@ -641,7 +651,7 @@ fn flat_round_trips_large_integer_constant() {
     // A large positive integer that doesn't fit in i64.
     let large: BigInt = BigInt::from(i64::MAX) + 1i64;
     let program = Program {
-        version: (1, 0, 0),
+        version: ver(1, 0, 0),
         term: Term::Const(Constant::Integer(large.clone())),
     };
     let flat = program.to_flat().expect("encode large integer");
@@ -660,7 +670,7 @@ fn flat_round_trips_negative_integer_constant() {
 
     for &n in &[-1i64, i64::MIN, -123456789i64] {
         let program = Program {
-            version: (1, 0, 0),
+            version: ver(1, 0, 0),
             term: Term::Const(Constant::Integer(BigInt::from(n))),
         };
         let flat = program.to_flat().expect("encode negative int");

--- a/crates/dugite-uplc/tests/phase2_script_context_regression.rs
+++ b/crates/dugite-uplc/tests/phase2_script_context_regression.rs
@@ -310,7 +310,9 @@ fn flat_round_trips_data_constant() {
     let data_val = Data::I(BigInt::from(42i64));
     let program = Program {
         version: (1, 0, 0),
-        term: Term::Lam(Rc::new(Term::Const(Constant::Data(data_val.clone())))),
+        term: Term::Lam(Rc::new(Term::Const(Constant::Data(
+            data_val.clone().into(),
+        )))),
     };
 
     let flat = program.to_flat().expect("encode Data constant program");
@@ -324,7 +326,7 @@ fn flat_round_trips_data_constant() {
     let Term::Const(Constant::Data(d)) = (*body).clone() else {
         panic!("expected Const(Data(_))");
     };
-    assert_eq!(d, data_val, "Data constant must survive flat round-trip");
+    assert_eq!(*d, data_val, "Data constant must survive flat round-trip");
 }
 
 /// A program containing a `List(Integer)` constant must round-trip.
@@ -396,12 +398,9 @@ fn flat_round_trips_list_data_constant() {
     use dugite_uplc::Program;
 
     let items = vec![
-        Constant::Data(Data::I(BigInt::from(1i64))),
-        Constant::Data(Data::B(vec![0xaa, 0xbb])),
-        Constant::Data(Data::Constr(
-            BigInt::from(0),
-            vec![Data::I(BigInt::from(3i64))],
-        )),
+        Constant::Data(Data::I(BigInt::from(1i64)).into()),
+        Constant::Data(Data::B(vec![0xaa, 0xbb]).into()),
+        Constant::Data(Data::Constr(BigInt::from(0), vec![Data::I(BigInt::from(3i64))]).into()),
     ];
     let program = Program {
         version: (1, 0, 0),


### PR DESCRIPTION
## Backlog sweep — byte-exact ledger / serialization / uplc fixes

Clears the entire open review-finding backlog left after PR #861. Every fix is
verified byte-exact against IntersectMBO/cardano-ledger / IntersectMBO/plutus (via
Haskell oracles quoting canonical source) and carries regression tests. All touched
crates are green: **3535 tests** (serialization + ledger + uplc), clippy clean, fmt clean.

### Ledger / serialization
- **#857** — capture `raw_cbor` for pre-Conway (Mary/Alonzo/Babbage) tx outputs + collateral return.
- **#798** — purge zero-value TxOuts at the Byron→Shelley boundary (`coinTxOutL /= zero`). *The prior sweep mis-refuted this; independent re-verification confirmed it real.*
- **#858 / #812** — `pvCanFollow` on the live GOV path with the full `preceedingHardFork` 3-way base resolution; one shared helper across live + dead paths.
- **#862** — hash native scripts over ORIGINAL bytes (`hashScript` over MemoBytes), not a re-encode; + accept indefinite-length outer arrays in the Shelley/Alonzo decoders.
- **#826** — reject a tx whose executed Plutus language has no cost model (`CollectErrors [NoCostModel L]`), a pre-eval hard-reject regardless of `isValid`.
- **#860.4** — reduce decoded rationals to lowest terms at the decode root (Haskell `%`).

### uplc
- **#859 / #828** — `Data::Constr` tag is arbitrary-precision `BigInt` (matches ungated plutus 1.62 / Word64-gated 1.65 `constrData`).
- **#838** — Fix 2: `Rc`-share `Constant::Data` (O(1) CEK env lookup).
- **#842** — `Program` version triple is arbitrary-precision `Natural`.
- **#844** — residual nits.
- **#845** — targeted adversarial decode-rejection regressions.
- **#860.1** — reject a script whose ledger language is unavailable at the current PV *before* flat-decode (`ledgerLanguageIntroducedIn`).
- **#860.2** — full V1/V2 van-Rossem cost-model tail (166/185 → **332** params); dugite was truncating, a live ExUnits divergence on preview PV11. Shared, V3-corpus-validated cost-walk helpers.

### #860 tracker disposition
Sub-items: #860.1 ✅, #860.2 ✅, #860.3 (=#826) ✅, #860.4 ✅, #860.8 (=#838 Fix2) ✅,
#860.9 (=#842) ✅. #860.5 (ed25519 pk-canonicity) — already covered by the
`pk_is_canonical_boundary_vectors` p-1/p/p+1/alias tests (Wycheproof has no dedicated
vector for this edge). #860.6 (#831 citations) — corroborated by the plutus-1.62.0.0
re-fetch. #860.7 (=#839, BLS decompression cache) — deferred: non-consensus perf
(identical ExUnits vs Haskell), the DoS-relevant subgroup-recheck half is already
closed, and the residual needs a disproportionate `Constant`-shape refactor.

### Also
55 of the #781–845 findings were independently re-verified (17-agent workflow) as
already fixed in merged PR #861, or correctly refuted (#834), and closed with evidence.

Fixes #857
Fixes #798
Fixes #858
Fixes #812
Fixes #862
Fixes #826
Fixes #859
Fixes #828
Fixes #838
Fixes #842
Fixes #844
Fixes #845


Fixes #839
