### PR TITLE
fix(net): resolve dugite-network review roundup (#864–#881)

### DIFF
--- a/crates/dugite-network/src/error.rs
+++ b/crates/dugite-network/src/error.rs
@@ -295,6 +295,18 @@ pub enum ProtocolError {
         /// Number of consecutive pong timeouts before giving up.
         consecutive_failures: u32,
     },
+    /// The remote peer violated a protocol integrity invariant. Unlike
+    /// [`Self::BoundsExceeded`] (a resource/count bound), this signals that the
+    /// peer delivered data inconsistent with what it attested — e.g. a
+    /// transaction body whose canonical id `blake2b_256(body)` does not match
+    /// the txid the peer advertised for it (#864). The peer is convicted and
+    /// the connection is dropped (adversarial posture).
+    IntegrityViolation {
+        /// Name of the mini-protocol.
+        protocol: &'static str,
+        /// Human-readable description of the integrity violation.
+        reason: String,
+    },
     /// Multiplexer error propagated through the protocol layer.
     Mux(MuxError),
 }
@@ -331,6 +343,9 @@ impl fmt::Display for ProtocolError {
             }
             Self::BoundsExceeded { protocol, reason } => {
                 write!(f, "{protocol}: bounds exceeded: {reason}")
+            }
+            Self::IntegrityViolation { protocol, reason } => {
+                write!(f, "{protocol}: integrity violation: {reason}")
             }
             Self::KeepAliveTimeout {
                 consecutive_failures,

--- a/crates/dugite-network/src/handshake/mod.rs
+++ b/crates/dugite-network/src/handshake/mod.rs
@@ -498,8 +498,21 @@ fn decode_handshake_response(
             let version = dec
                 .u16()
                 .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
-            // Skip version data (we don't need it after acceptance)
-            let _ = N2NVersionData::decode(&mut dec);
+            // #880: re-validate the responder's network magic instead of
+            // discarding the accepted version_data. A peer that accepts with a
+            // mismatched magic is on a different network; reject at handshake
+            // rather than relying on later block validation to catch it. The
+            // accepted version is one we support, so its version_data has our
+            // shape and decodes cleanly; tolerate a decode failure (older shape)
+            // since magic was already asserted at propose time.
+            if let Ok(their_data) = N2NVersionData::decode(&mut dec) {
+                if their_data.network_magic != our_data.network_magic {
+                    return Err(HandshakeError::NetworkMagicMismatch {
+                        ours: our_data.network_magic,
+                        theirs: their_data.network_magic,
+                    });
+                }
+            }
             Ok(HandshakeResult {
                 version,
                 simultaneous_open: false,
@@ -516,14 +529,34 @@ fn decode_handshake_response(
                     HandshakeError::DecodeError("indefinite map not supported".to_string())
                 })?;
 
+            // #880: cap the version count (parity with
+            // decode_propose_versions_n2n) so a simultaneous open can't be used
+            // to peg a CPU core past the handshake window.
+            if map_len > MAX_HANDSHAKE_VERSIONS {
+                return Err(HandshakeError::DecodeError(format!(
+                    "MsgProposeVersions (simultaneous open): too many versions \
+                     ({map_len} > {MAX_HANDSHAKE_VERSIONS})"
+                )));
+            }
+
             let mut remote_versions = BTreeMap::new();
             for _ in 0..map_len {
                 let version = dec
                     .u16()
                     .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
-                let version_data = N2NVersionData::decode(&mut dec)
-                    .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
-                remote_versions.insert(version, version_data);
+                // #880: skip versions we don't know (cardano-node includes older
+                // ones like N2N v13 whose version_data has a different CBOR shape,
+                // array(3) not array(4)); decoding every one made a genuine
+                // simultaneous open fail with DecodeError instead of negotiating.
+                // Mirror decode_propose_versions_n2n's known-version filter.
+                if n2n::N2N_VERSIONS.contains(&version) {
+                    let version_data = N2NVersionData::decode(&mut dec)
+                        .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
+                    remote_versions.insert(version, version_data);
+                } else {
+                    dec.skip()
+                        .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
+                }
             }
 
             // Find highest common version (same logic as server-side negotiation)
@@ -589,6 +622,31 @@ fn decode_handshake_response_n2c(data: &[u8]) -> Result<HandshakeResult, Handsha
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #880: a MsgAcceptVersion whose version_data carries a DIFFERENT network
+    /// magic than ours must be rejected at handshake (cross-network peer),
+    /// rather than the accepted version_data being silently discarded.
+    #[test]
+    fn accept_version_with_mismatched_magic_is_rejected() {
+        let ours = N2NVersionData::new(2, false, true); // preview magic 2
+        let theirs = N2NVersionData::new(764824073, false, true); // mainnet magic
+        let accept = encode_accept_version_n2n(n2n::N2N_VERSIONS[0], &theirs);
+        let result = decode_handshake_response(&accept, &ours);
+        assert!(
+            matches!(
+                result,
+                Err(HandshakeError::NetworkMagicMismatch {
+                    ours: 2,
+                    theirs: 764824073
+                })
+            ),
+            "cross-network MsgAcceptVersion must be rejected, got: {result:?}"
+        );
+
+        // Sanity: a matching magic still accepts.
+        let ok = encode_accept_version_n2n(n2n::N2N_VERSIONS[0], &ours);
+        assert!(decode_handshake_response(&ok, &ours).is_ok());
+    }
 
     #[test]
     fn n2n_propose_encode_decode_roundtrip() {

--- a/crates/dugite-network/src/handshake/mod.rs
+++ b/crates/dugite-network/src/handshake/mod.rs
@@ -45,6 +45,12 @@ pub struct HandshakeResult {
     pub version: u16,
     /// Whether simultaneous open was detected (received MsgProposeVersions instead of MsgAccept).
     pub simultaneous_open: bool,
+    /// Whether this was a query-mode handshake (#880): the peer opened with the
+    /// `query` flag set, so we replied with `MsgQueryReply` (the version table)
+    /// instead of `MsgAcceptVersion` and the connection carries no
+    /// mini-protocols — the caller should close it after the reply. On the
+    /// client side this is set when a `MsgQueryReply` was received.
+    pub query: bool,
 }
 
 // ─── CBOR Message Tags ───
@@ -56,7 +62,6 @@ const MSG_ACCEPT_VERSION: u64 = 1;
 /// MsgRefuse tag (server → client).
 const MSG_REFUSE: u64 = 2;
 /// MsgQueryReply tag (server → client, query mode only).
-#[allow(dead_code)]
 const MSG_QUERY_REPLY: u64 = 3;
 
 /// Maximum number of version entries accepted in a `MsgProposeVersions` map.
@@ -120,12 +125,29 @@ pub async fn run_n2n_handshake_server(
         if let Some(their_data) = remote_versions.get(&our_version) {
             // Check if we can accept this version
             if let Some(_accepted) = our_data.accept(their_data) {
+                // #880: if the peer opened in query mode, reply with
+                // MsgQueryReply (our version table, tag 3) instead of
+                // MsgAcceptVersion and flag the result as `query` so the caller
+                // closes the connection. A query-mode client (e.g. a version
+                // enumerator) has no tag-1 arm and would otherwise fail to
+                // decode our accept. The Haskell handshake OR's the query flag,
+                // so a query proposal from the peer puts us in query mode.
+                if their_data.query {
+                    let msg = encode_query_reply_n2n(n2n::N2N_VERSIONS, our_data);
+                    channel.send(msg).await.map_err(HandshakeError::from)?;
+                    return Ok(HandshakeResult {
+                        version: our_version,
+                        simultaneous_open: false,
+                        query: true,
+                    });
+                }
                 // Send MsgAcceptVersion
                 let msg = encode_accept_version_n2n(our_version, our_data);
                 channel.send(msg).await.map_err(HandshakeError::from)?;
                 return Ok(HandshakeResult {
                     version: our_version,
                     simultaneous_open: false,
+                    query: false,
                 });
             } else {
                 // Magic mismatch — use Refused (tag 2) with the matched version and a reason string
@@ -190,6 +212,7 @@ pub async fn run_n2c_handshake_server(
                 return Ok(HandshakeResult {
                     version: our_version,
                     simultaneous_open: false,
+                    query: false,
                 });
             } else {
                 // Magic mismatch — use Refused (tag 2); wire-encode the version number
@@ -257,6 +280,27 @@ fn encode_propose_versions_n2c(versions: &[u16], data: &N2CVersionData) -> Vec<u
     enc.map(sorted_versions.len() as u64).expect("infallible");
     for v in &sorted_versions {
         enc.u16(n2c::encode_n2c_version(*v)).expect("infallible");
+        data.encode(&mut enc);
+    }
+    buf
+}
+
+/// Encode MsgQueryReply for N2N: `[3, {version: version_data, ...}]` (#880).
+///
+/// Sent by the responder when the initiator opened the handshake in query mode:
+/// it carries our full version table (same map shape as MsgProposeVersions) so
+/// the querying tool can enumerate supported versions, then the connection is
+/// closed. Map keys MUST be sorted ascending (canonical CBOR).
+fn encode_query_reply_n2n(versions: &[u16], data: &N2NVersionData) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut enc = Encoder::new(&mut buf);
+    enc.array(2).expect("infallible");
+    enc.u64(MSG_QUERY_REPLY).expect("infallible");
+    let mut sorted_versions: Vec<u16> = versions.to_vec();
+    sorted_versions.sort();
+    enc.map(sorted_versions.len() as u64).expect("infallible");
+    for v in &sorted_versions {
+        enc.u16(*v).expect("infallible");
         data.encode(&mut enc);
     }
     buf
@@ -516,6 +560,48 @@ fn decode_handshake_response(
             Ok(HandshakeResult {
                 version,
                 simultaneous_open: false,
+                query: false,
+            })
+        }
+        MSG_QUERY_REPLY => {
+            // #880: the responder answered our query-mode proposal with its
+            // version table. Return the highest version we both support (best
+            // effort) flagged as a query result; the caller closes the
+            // connection (no mini-protocols run in query mode).
+            let map_len = dec
+                .map()
+                .map_err(|e| HandshakeError::DecodeError(e.to_string()))?
+                .ok_or_else(|| {
+                    HandshakeError::DecodeError("indefinite map not supported".to_string())
+                })?;
+            if map_len > MAX_HANDSHAKE_VERSIONS {
+                return Err(HandshakeError::DecodeError(format!(
+                    "MsgQueryReply: too many versions ({map_len} > {MAX_HANDSHAKE_VERSIONS})"
+                )));
+            }
+            let mut their_versions = std::collections::BTreeSet::new();
+            for _ in 0..map_len {
+                let version = dec
+                    .u16()
+                    .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
+                if n2n::N2N_VERSIONS.contains(&version) {
+                    // Skip the version_data of a known version.
+                    let _ = N2NVersionData::decode(&mut dec);
+                } else {
+                    dec.skip()
+                        .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
+                }
+                their_versions.insert(version);
+            }
+            let version = n2n::N2N_VERSIONS
+                .iter()
+                .find(|v| their_versions.contains(v))
+                .copied()
+                .unwrap_or(0);
+            Ok(HandshakeResult {
+                version,
+                simultaneous_open: false,
+                query: true,
             })
         }
         MSG_REFUSE => Err(decode_refuse_reason(&mut dec)),
@@ -566,6 +652,7 @@ fn decode_handshake_response(
                         return Ok(HandshakeResult {
                             version: our_version,
                             simultaneous_open: true,
+                            query: false,
                         });
                     }
                     // Magic mismatch on a matching version — reject
@@ -610,6 +697,7 @@ fn decode_handshake_response_n2c(data: &[u8]) -> Result<HandshakeResult, Handsha
             Ok(HandshakeResult {
                 version,
                 simultaneous_open: false,
+                query: false,
             })
         }
         MSG_REFUSE => Err(decode_refuse_reason(&mut dec)),
@@ -622,6 +710,28 @@ fn decode_handshake_response_n2c(data: &[u8]) -> Result<HandshakeResult, Handsha
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #880: query mode — the responder answers a query-mode proposal with
+    /// MsgQueryReply (tag 3, the version table), and the client decodes it as a
+    /// query result rather than choking on an unexpected tag.
+    #[test]
+    fn query_mode_reply_roundtrip() {
+        let our_data = N2NVersionData::new(2, false, true);
+        // Server-side: encode MsgQueryReply as we would emit it.
+        let reply = encode_query_reply_n2n(n2n::N2N_VERSIONS, &our_data);
+        // First byte structure: array(2), tag 3.
+        let mut dec = Decoder::new(&reply);
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u64().unwrap(), MSG_QUERY_REPLY);
+
+        // Client-side: decode_handshake_response must classify it as a query.
+        let result = decode_handshake_response(&reply, &our_data).unwrap();
+        assert!(result.query, "MsgQueryReply must yield a query result");
+        assert!(
+            n2n::N2N_VERSIONS.contains(&result.version),
+            "query result reports a common version"
+        );
+    }
 
     /// #880: a MsgAcceptVersion whose version_data carries a DIFFERENT network
     /// magic than ours must be rejected at handshake (cross-network peer),

--- a/crates/dugite-network/src/handshake/mod.rs
+++ b/crates/dugite-network/src/handshake/mod.rs
@@ -187,7 +187,7 @@ pub async fn run_n2c_handshake_client(
         .map_err(HandshakeError::from)?;
 
     // Decode, converting wire versions back to logical
-    decode_handshake_response_n2c(&response)
+    decode_handshake_response_n2c(&response, our_data)
 }
 
 /// Run the handshake as the server (responder) for N2C connections.
@@ -678,7 +678,10 @@ fn decode_handshake_response(
 }
 
 /// Decode a handshake response for N2C (with bit-15 version decoding).
-fn decode_handshake_response_n2c(data: &[u8]) -> Result<HandshakeResult, HandshakeError> {
+fn decode_handshake_response_n2c(
+    data: &[u8],
+    our_data: &N2CVersionData,
+) -> Result<HandshakeResult, HandshakeError> {
     let mut dec = Decoder::new(data);
     let _arr_len = dec
         .array()
@@ -693,7 +696,16 @@ fn decode_handshake_response_n2c(data: &[u8]) -> Result<HandshakeResult, Handsha
                 .u16()
                 .map_err(|e| HandshakeError::DecodeError(e.to_string()))?;
             let version = n2c::decode_n2c_version(wire_version);
-            let _ = N2CVersionData::decode(&mut dec);
+            // #880: re-validate the responder's network magic rather than
+            // discarding the accepted version_data.
+            if let Ok(their_data) = N2CVersionData::decode(&mut dec) {
+                if their_data.network_magic != our_data.network_magic {
+                    return Err(HandshakeError::NetworkMagicMismatch {
+                        ours: our_data.network_magic,
+                        theirs: their_data.network_magic,
+                    });
+                }
+            }
             Ok(HandshakeResult {
                 version,
                 simultaneous_open: false,
@@ -825,8 +837,15 @@ mod tests {
     fn n2c_accept_encode_decode() {
         let data = N2CVersionData::new(2);
         let encoded = encode_accept_version_n2c(22, &data);
-        let result = decode_handshake_response_n2c(&encoded).unwrap();
+        let result = decode_handshake_response_n2c(&encoded, &data).unwrap();
         assert_eq!(result.version, 22); // logical, not wire
+
+        // #880: a mismatched magic on the accepted version_data is rejected.
+        let ours = N2CVersionData::new(1);
+        assert!(matches!(
+            decode_handshake_response_n2c(&encoded, &ours),
+            Err(HandshakeError::NetworkMagicMismatch { .. })
+        ));
     }
 
     #[test]

--- a/crates/dugite-network/src/lib.rs
+++ b/crates/dugite-network/src/lib.rs
@@ -551,7 +551,7 @@ pub use protocol::local_state_query::server::QueryHandler;
 pub use protocol::peersharing::client::PeerSharingClient;
 pub use protocol::txsubmission::client::{TxSource, TxSubmissionClient};
 pub use protocol::txsubmission::server::TxSubmissionServer;
-pub use protocol::txsubmission::TxIdAndSize;
+pub use protocol::txsubmission::{TxAdmission, TxIdAndSize};
 
 pub use peer::manager::{PeerInfo, PeerManager, PeerSource, PeerState, PEER_LATENCY_DEFAULT_MS};
 pub use peer::{Governor, GovernorConfig, PeerTargets};

--- a/crates/dugite-network/src/mux/egress.rs
+++ b/crates/dugite-network/src/mux/egress.rs
@@ -45,44 +45,57 @@ const MAX_SDUS_PER_BATCH: usize = 100;
 /// Without a cap, a single slow-reader peer can cause unbounded heap growth.
 ///
 /// Haskell's `Ouroboros.Network.Mux.Egress` uses `STM TBQueue` with finite
-/// capacity to provide natural back-pressure. We mirror this by rejecting new
-/// messages once the per-channel byte budget is exhausted.
+/// capacity to provide natural back-pressure: the *producer blocks* when the
+/// queue is full — a queued message is never dropped. We mirror that by holding
+/// the over-cap message aside and ceasing to drain the source channel until
+/// writes bring the channel below the cap (#872). Dropping the message instead
+/// would desync the peer's mini-protocol state machine (e.g. a BlockFetch client
+/// receiving fewer `MsgBlock`s than the requested range, with no error).
 ///
 /// 8 MB matches 2× the largest Cardano block (~4 MB post-Conway) so that a
-/// single in-flight large block + one pending block can coexist without false
-/// overrun rejections.
+/// single in-flight large block + one pending block can coexist without
+/// prematurely triggering back-pressure.
 ///
-/// A-010 (security audit 2026-05-19).
+/// A-010 (security audit 2026-05-19); back-pressure semantics per #872.
 pub const MAX_EGRESS_BYTES_PER_CHANNEL: usize = 8 * 1024 * 1024; // 8 MB
 
 /// Key identifying a protocol channel: (protocol_id, direction).
 type ChannelKey = (u16, Direction);
 
-/// Enqueue a message for egress, enforcing the per-channel byte cap (A-010).
+/// Try to enqueue a message for egress, enforcing the per-channel byte cap
+/// (A-010) with true back-pressure (#872).
 ///
-/// If the channel's pending byte count would exceed [`MAX_EGRESS_BYTES_PER_CHANNEL`],
-/// the message is silently dropped and a warning is emitted.  This matches
-/// Haskell's `STM TBQueue` bounded-queue back-pressure semantics.
+/// Returns `None` when the message was enqueued. Returns `Some((key, data))` —
+/// the message unchanged — when the channel already holds queued bytes and
+/// admitting this message would exceed [`MAX_EGRESS_BYTES_PER_CHANNEL`]; the
+/// caller must hold it as `pending` and stop draining the source channel until
+/// writes free space, rather than dropping it.
+///
+/// A message is always admitted when the channel is currently empty, even if it
+/// alone exceeds the cap: a single mini-protocol message (e.g. one ~4 MB
+/// `MsgBlock`) must be sent whole, and refusing it would deadlock the channel.
+#[must_use = "an over-cap message must be held as pending, not dropped"]
 fn enqueue_message(
     queues: &mut HashMap<ChannelKey, VecDeque<Bytes>>,
     channel_bytes: &mut HashMap<ChannelKey, usize>,
     key: ChannelKey,
     data: Bytes,
-) {
+) -> Option<(ChannelKey, Bytes)> {
     let current = channel_bytes.get(&key).copied().unwrap_or(0);
-    if current + data.len() > MAX_EGRESS_BYTES_PER_CHANNEL {
-        tracing::warn!(
+    if current > 0 && current + data.len() > MAX_EGRESS_BYTES_PER_CHANNEL {
+        tracing::debug!(
             protocol_id = key.0,
             direction = ?key.1,
             queued_bytes = current,
             message_bytes = data.len(),
             cap = MAX_EGRESS_BYTES_PER_CHANNEL,
-            "egress queue cap exceeded — dropping message (peer is too slow)"
+            "egress channel at cap — applying back-pressure (holding message, pausing source drain)"
         );
-        return;
+        return Some((key, data));
     }
     *channel_bytes.entry(key).or_insert(0) += data.len();
     queues.entry(key).or_default().push_back(data);
+    None
 }
 
 /// Egress task state. Created by the [`Mux`] and run as a spawned tokio task.
@@ -134,6 +147,13 @@ impl EgressTask {
 
         // Per-channel byte counters for A-010 back-pressure.
         let mut channel_bytes: HashMap<ChannelKey, usize> = HashMap::new();
+
+        // A single message that could not be enqueued because its channel was at
+        // the byte cap (#872). While this is `Some`, we stop draining `self.rx`,
+        // so producers back-pressure through the bounded egress channel instead
+        // of losing the message. It is retried after every write round; once its
+        // channel drains below the cap it is enqueued and draining resumes.
+        let mut pending: Option<(ChannelKey, Bytes)> = None;
 
         // Batch buffer for accumulating multiple SDUs before a single write.
         let mut batch_buf: Vec<u8> = Vec::with_capacity(self.batch_size);
@@ -204,19 +224,49 @@ impl EgressTask {
                 batch_buf.clear();
             }
 
+            // Retry the back-pressured message (#872): the write round above may
+            // have drained its channel below the cap. `enqueue_message` returns
+            // it again if the channel is still full.
+            if let Some((key, data)) = pending.take() {
+                pending = enqueue_message(&mut queues, &mut channel_bytes, key, data);
+            }
+
             // If we made progress, loop again to send more continuation
             // chunks (or start the next queued message).
             if made_progress {
-                // Non-blocking drain of any new messages that arrived while
-                // we were writing.
-                let mut sdu_count = 0;
-                while let Ok((pid, dir, data)) = self.rx.try_recv() {
-                    enqueue_message(&mut queues, &mut channel_bytes, (pid, dir), data);
-                    sdu_count += 1;
-                    if sdu_count >= MAX_SDUS_PER_BATCH {
-                        break;
+                // Non-blocking drain of any new messages that arrived while we
+                // were writing — but ONLY while no message is back-pressured.
+                // Holding `pending` means a channel is at its byte cap; we stop
+                // pulling from `self.rx` so producers block on the bounded egress
+                // channel (true back-pressure) instead of us buffering unbounded.
+                if pending.is_none() {
+                    let mut sdu_count = 0;
+                    while pending.is_none() {
+                        match self.rx.try_recv() {
+                            Ok((pid, dir, data)) => {
+                                pending = enqueue_message(
+                                    &mut queues,
+                                    &mut channel_bytes,
+                                    (pid, dir),
+                                    data,
+                                );
+                                sdu_count += 1;
+                                if sdu_count >= MAX_SDUS_PER_BATCH {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
                     }
                 }
+                continue;
+            }
+
+            // Whenever a message is back-pressured its channel is non-empty, so
+            // Phase 1 makes progress and this point is unreachable with
+            // `pending.is_some()`; guard anyway to avoid a busy-loop if that
+            // invariant ever changes.
+            if pending.is_some() {
                 continue;
             }
 
@@ -224,13 +274,19 @@ impl EgressTask {
             match self.rx.recv().await {
                 None => return Ok(()),
                 Some((pid, dir, data)) => {
-                    enqueue_message(&mut queues, &mut channel_bytes, (pid, dir), data);
+                    pending = enqueue_message(&mut queues, &mut channel_bytes, (pid, dir), data);
                 }
             }
 
-            // Non-blocking drain of any additional messages.
-            while let Ok((pid, dir, data)) = self.rx.try_recv() {
-                enqueue_message(&mut queues, &mut channel_bytes, (pid, dir), data);
+            // Non-blocking drain of any additional messages (paused on pending).
+            while pending.is_none() {
+                match self.rx.try_recv() {
+                    Ok((pid, dir, data)) => {
+                        pending =
+                            enqueue_message(&mut queues, &mut channel_bytes, (pid, dir), data);
+                    }
+                    Err(_) => break,
+                }
             }
         }
     }
@@ -569,6 +625,98 @@ mod tests {
             "9-byte message / SDU=4 should produce [4,4,1] chunks"
         );
         assert_eq!(reassembled, msg);
+    }
+
+    /// #872: an over-cap message is held (back-pressure), never dropped.
+    ///
+    /// A channel that is empty accepts any message (even one larger than the
+    /// cap). A channel that already holds bytes refuses a message that would
+    /// exceed the cap, returning it unchanged for the caller to hold as pending.
+    #[test]
+    fn enqueue_message_backpressures_instead_of_dropping() {
+        let mut queues: HashMap<ChannelKey, VecDeque<Bytes>> = HashMap::new();
+        let mut channel_bytes: HashMap<ChannelKey, usize> = HashMap::new();
+        let key = (3u16, Direction::ResponderDir);
+
+        // Empty channel: an oversized single message is still admitted whole.
+        let big = Bytes::from(vec![0u8; MAX_EGRESS_BYTES_PER_CHANNEL + 10]);
+        let big_len = big.len();
+        assert!(
+            enqueue_message(&mut queues, &mut channel_bytes, key, big).is_none(),
+            "empty channel must admit even an oversized message (no deadlock)"
+        );
+        assert_eq!(channel_bytes[&key], big_len);
+
+        // Channel now over cap: a second message is refused (returned), not dropped.
+        let more = Bytes::from(vec![1u8; 100]);
+        let back = enqueue_message(&mut queues, &mut channel_bytes, key, more.clone());
+        assert_eq!(
+            back,
+            Some((key, more)),
+            "over-cap message must be returned for back-pressure, not dropped"
+        );
+        // Counter unchanged — the refused message was not accounted.
+        assert_eq!(channel_bytes[&key], big_len);
+
+        // Once the channel drains below the cap, the same message is accepted.
+        channel_bytes.insert(key, 0);
+        queues.get_mut(&key).unwrap().clear();
+        let retry = Bytes::from(vec![1u8; 100]);
+        assert!(
+            enqueue_message(&mut queues, &mut channel_bytes, key, retry).is_none(),
+            "drained channel must accept the previously back-pressured message"
+        );
+        assert_eq!(channel_bytes[&key], 100);
+    }
+
+    /// #872 end-to-end: feeding more than the per-channel cap through `run()`
+    /// delivers every byte — no message is silently dropped.
+    #[tokio::test]
+    async fn run_delivers_all_bytes_beyond_channel_cap() {
+        // 120 messages × 100 KB = 12 MB on one channel, exceeding the 8 MB cap.
+        let msg_size = 100 * 1024;
+        let count = 120;
+        let (tx, rx) = mpsc::channel(count + 1);
+        let task = EgressTask::new(rx, 12288, 131072);
+
+        for i in 0..count {
+            // Distinct first byte per message so we can count deliveries.
+            let mut m = vec![(i % 251) as u8; msg_size];
+            m[0] = (i % 251) as u8;
+            tx.send((2, Direction::InitiatorDir, Bytes::from(m)))
+                .await
+                .unwrap();
+        }
+        drop(tx);
+
+        let captured = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let cap2 = captured.clone();
+        task.run(move |data: &[u8]| {
+            let cap = cap2.clone();
+            let data = data.to_vec();
+            Box::pin(async move {
+                cap.lock().unwrap().extend_from_slice(&data);
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Reassemble SDU payloads and confirm total delivered bytes == total sent.
+        let bytes = captured.lock().unwrap();
+        let mut offset = 0usize;
+        let mut payload_total = 0usize;
+        while offset < bytes.len() {
+            let header = decode_header(bytes[offset..offset + 8].try_into().unwrap());
+            offset += HEADER_SIZE + header.payload_length as usize;
+            payload_total += header.payload_length as usize;
+        }
+        assert_eq!(
+            payload_total,
+            msg_size * count,
+            "all {count} messages ({} bytes) must be delivered — none dropped",
+            msg_size * count
+        );
     }
 
     /// Verify egress handles a single very large message spanning many SDUs correctly.

--- a/crates/dugite-network/src/mux/ingress.rs
+++ b/crates/dugite-network/src/mux/ingress.rs
@@ -195,9 +195,28 @@ impl IngressTask {
                         continue;
                     }
 
-                    // Atomically add the incoming payload size and check whether
-                    // we have exceeded the per-channel byte budget.
+                    // Hold the SwappableSender lock across the ENTIRE
+                    // counter-update + delivery critical section. This closes
+                    // the #877 race with `MuxHandle::resubscribe()`, which resets
+                    // `bytes_in_flight` to 0 and swaps the sender under the SAME
+                    // lock: without mutual exclusion, resubscribe's `store(0)`
+                    // could land between this `fetch_add` and the `try_send` that
+                    // delivers the chunk to the freshly-installed receiver, so the
+                    // consumer's later `fetch_sub` would underflow the counter to
+                    // ~usize::MAX and trip a spurious IngressQueueOverrun.
                     //
+                    // `parking_lot::Mutex` is non-poisoning and the lock is always
+                    // brief — `fetch_add`/`fetch_sub`/`try_send` are all
+                    // non-blocking. We must NOT use the blocking `.send().await`
+                    // here: if a protocol's ingress channel is full (e.g. a
+                    // ChainSync server blocked at tip while pipelined MsgRequestNext
+                    // messages fill the buffer), a blocking send would stall the
+                    // ENTIRE ingress task, starving every other protocol
+                    // (KeepAlive, BlockFetch). This matches Haskell's network-mux
+                    // demuxer which throws IngressQueueOverRun (fatal) rather than
+                    // blocking.
+                    let sender = route.tx.lock();
+
                     // `fetch_add` returns the value *before* addition, so the new
                     // total is `prev + payload_len`.
                     let prev = route
@@ -219,27 +238,9 @@ impl IngressTask {
                         });
                     }
 
-                    // Deliver to protocol channel using try_send (non-blocking).
-                    //
-                    // CRITICAL: We must NOT use the blocking `.send().await` here.
-                    // If a protocol's ingress channel is full (e.g. ChainSync server
-                    // blocked at tip waiting for announcements while pipelined
-                    // MsgRequestNext messages fill the buffer), the blocking send
-                    // would stall the ENTIRE ingress task, preventing ALL other
-                    // protocols (KeepAlive, BlockFetch) from receiving data.
-                    //
-                    // This matches Haskell's network-mux demuxer which throws
-                    // IngressQueueOverRun (fatal connection error) when a protocol's
-                    // queue overflows — the demuxer never blocks.
-                    //
                     // MuxChannel::recv() will decrement bytes_in_flight after
                     // consuming the chunk.
-                    // Lock the SwappableSender briefly to perform try_send.
-                    // `parking_lot::Mutex` is non-poisoning and lock is always brief
-                    // (try_send is non-blocking). `MuxHandle::resubscribe()` also
-                    // takes this lock to swap in a fresh sender — that swap is also
-                    // brief (single assignment + store).
-                    let send_result = route.tx.lock().try_send(Bytes::from(payload));
+                    let send_result = sender.try_send(Bytes::from(payload));
                     match send_result {
                         Ok(()) => {} // delivered successfully
                         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {

--- a/crates/dugite-network/src/mux/mod.rs
+++ b/crates/dugite-network/src/mux/mod.rs
@@ -85,16 +85,23 @@ impl MuxHandle {
         // Create a fresh mpsc pair for the new task cycle.
         let (new_tx, new_rx) = mpsc::channel::<Bytes>(ingress::INGRESS_CHANNEL_CAPACITY);
 
-        // Atomically swap the sender inside the running IngressTask.
-        // The lock is held only for the duration of the assignment — a few
-        // nanoseconds.  The IngressTask holds the same lock only during
-        // `try_send`, which is also non-blocking.
-        *swappable_tx.lock() = new_tx;
-
-        // Reset the byte counter so the new receiver starts with zero budget
-        // consumed.  SeqCst ordering ensures the IngressTask sees the reset
-        // before it attempts to enqueue the next frame.
-        bytes_in_flight.store(0, std::sync::atomic::Ordering::SeqCst);
+        // Swap the sender AND reset the byte counter under a SINGLE hold of the
+        // sender lock. The IngressTask performs its `fetch_add` + `try_send`
+        // critical section under the same lock, so this pair is mutually
+        // exclusive with delivery: an in-flight frame is either fully accounted
+        // against the OLD receiver (its bytes discarded when the old MuxChannel
+        // drops, counter then reset to 0) or fully accounted against the NEW
+        // receiver (delivered after the swap, so its consumer `fetch_sub`
+        // balances the `fetch_add`). Neither ordering can leave a queued chunk
+        // with a zeroed counter, which was the #877 underflow window. The lock
+        // is held only for an assignment + an atomic store — a few nanoseconds.
+        {
+            let mut guard = swappable_tx.lock();
+            *guard = new_tx;
+            // SeqCst so the IngressTask observes the reset atomically with the
+            // sender swap.
+            bytes_in_flight.store(0, std::sync::atomic::Ordering::SeqCst);
+        }
 
         Some(MuxChannel::new(
             protocol_id,
@@ -303,14 +310,6 @@ impl<B: Bearer> Mux<B> {
             tracing::debug!("mux: reader task exiting (read_rx channel closed)");
         });
 
-        // Combine into a single handle for cleanup
-        let io_handle = tokio::spawn(async move {
-            tokio::select! {
-                _ = writer_handle => {}
-                _ = reader_handle => {}
-            }
-        });
-
         // Egress task: sends SDU frames via the write channel
         let egress_task = egress::EgressTask::new(egress_rx, sdu_size, batch_size);
         let egress_handle = tokio::spawn(async move {
@@ -347,26 +346,63 @@ impl<B: Bearer> Mux<B> {
                 .await
         });
 
-        // Wait for any task to complete. If one fails, the others will
-        // eventually fail too (channels dropped / bearer closed).
+        // Abort-on-drop guard for ALL four child tasks (#866).
+        //
+        // A bare `JoinHandle` DETACHES its task on drop — it does not cancel it.
+        // The reader/writer tasks own the two socket halves and the reader blocks
+        // indefinitely in `read_exact` (Phase-1 header reads have no timeout), so
+        // detaching them leaks the FDs and the tasks forever: under peer churn
+        // (Hot→Warm→Cold demotions, rotation) every mux teardown leaked a socket
+        // → EMFILE. `run()` is itself a spawned task; when the lifecycle manager
+        // calls `mux_handle.abort()`, this future is dropped at its current await
+        // point and its locals — including this guard — are dropped, which
+        // `.abort()`s every child. Dropping the reader/writer tasks drops the
+        // bearer halves, closing the TCP/Unix socket. When `run()` returns
+        // normally the same cleanup happens.
+        struct AbortOnDrop(Vec<tokio::task::AbortHandle>);
+        impl Drop for AbortOnDrop {
+            fn drop(&mut self) {
+                for h in &self.0 {
+                    h.abort();
+                }
+            }
+        }
+        let mut writer_handle = writer_handle;
+        let mut reader_handle = reader_handle;
+        let mut egress_handle = egress_handle;
+        let mut ingress_handle = ingress_handle;
+        let _abort_guard = AbortOnDrop(vec![
+            writer_handle.abort_handle(),
+            reader_handle.abort_handle(),
+            egress_handle.abort_handle(),
+            ingress_handle.abort_handle(),
+        ]);
+
+        // Wait for any task to complete. Whichever finishes first (clean EOF,
+        // error, or bearer close) tears the connection down; the guard aborts
+        // the survivors — including the reader blocked on `read_exact` — so no
+        // task and no socket FD is leaked.
         let result = tokio::select! {
-            result = egress_handle => {
+            result = &mut egress_handle => {
                 match result {
                     Ok(Ok(())) => Ok(()),
                     Ok(Err(e)) => Err(e),
                     Err(_join_err) => Err(MuxError::ChannelClosed),
                 }
             }
-            result = ingress_handle => {
+            result = &mut ingress_handle => {
                 match result {
                     Ok(Ok(())) => Ok(()),
                     Ok(Err(e)) => Err(e),
                     Err(_join_err) => Err(MuxError::ChannelClosed),
                 }
             }
+            // The bearer I/O halves live in these tasks; if either exits (socket
+            // closed, write error) the mux is done — return and let the guard
+            // abort the rest.
+            _ = &mut reader_handle => Ok(()),
+            _ = &mut writer_handle => Ok(()),
         };
-        // Clean up the bearer I/O task
-        io_handle.abort();
         result
     }
 
@@ -558,6 +594,49 @@ mod tests {
         "INGRESS_CHANNEL_CAPACITY must exceed default pipeline depth 300 \
          to prevent ingress stall under pipelining"
     );
+
+    /// #866: aborting the mux `run()` task must CANCEL its reader/writer child
+    /// tasks (not detach them), which drops the bearer halves and closes the
+    /// socket. We observe the closure from the peer side: after abort, the
+    /// peer's `read` returns EOF (`Ok(0)`). A detached reader would keep the
+    /// socket open indefinitely (the FD leak this test locks against).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn abort_run_closes_socket_no_fd_leak() {
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let (mux_stream, mut peer_stream) = tokio::join!(
+            async { tokio::net::TcpStream::connect(addr).await.expect("connect") },
+            async { listener.accept().await.expect("accept").0 }
+        );
+
+        let bearer = TcpBearer::new(mux_stream).expect("bearer");
+        let mut mux = Mux::new(bearer, true);
+        // Subscribe a channel so the mux has routes; it will idle waiting for
+        // SDU headers that never come (peer sends nothing).
+        let _ch = mux.subscribe(2, Direction::InitiatorDir, 65536);
+        let mux_handle = tokio::spawn(async move { mux.run().await });
+
+        // Let the mux tasks spin up and park on read.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Abort the run() task. The AbortOnDrop guard must cancel reader+writer,
+        // dropping the socket halves and closing the connection.
+        mux_handle.abort();
+        let _ = mux_handle.await;
+
+        // Peer read must observe EOF within a short window if the socket closed.
+        let mut buf = [0u8; 1];
+        let n = tokio::time::timeout(Duration::from_secs(5), peer_stream.read(&mut buf))
+            .await
+            .expect("peer read timed out — socket was NOT closed (reader task leaked)")
+            .expect("peer read errored");
+        assert_eq!(n, 0, "expected EOF after mux abort; socket left open (FD leak)");
+    }
 
     /// Duplex KeepAlive integration test.
     ///

--- a/crates/dugite-network/src/mux/mod.rs
+++ b/crates/dugite-network/src/mux/mod.rs
@@ -635,7 +635,10 @@ mod tests {
             .await
             .expect("peer read timed out — socket was NOT closed (reader task leaked)")
             .expect("peer read errored");
-        assert_eq!(n, 0, "expected EOF after mux abort; socket left open (FD leak)");
+        assert_eq!(
+            n, 0,
+            "expected EOF after mux abort; socket left open (FD leak)"
+        );
     }
 
     /// Duplex KeepAlive integration test.

--- a/crates/dugite-network/src/n2c_client.rs
+++ b/crates/dugite-network/src/n2c_client.rs
@@ -1942,7 +1942,10 @@ mod tests {
         // Advance the decoder position to simulate 9 header bytes consumed.
         dec.set_position(9);
         let clamped = bounded_cbor_len(u64::MAX, payload.len(), &dec);
-        assert_eq!(clamped, 3, "must clamp to remaining bytes, not the wire value");
+        assert_eq!(
+            clamped, 3,
+            "must clamp to remaining bytes, not the wire value"
+        );
 
         // A small honest length passes through unchanged.
         let mut dec2 = minicbor::Decoder::new(&payload);

--- a/crates/dugite-network/src/n2c_client.rs
+++ b/crates/dugite-network/src/n2c_client.rs
@@ -879,6 +879,22 @@ fn protocol_err(reason: String) -> NetworkError {
     })
 }
 
+/// Clamp a CBOR array/map length header against the bytes still available in
+/// the decoder input.
+///
+/// Every CBOR data item occupies at least one byte, so a well-formed container
+/// can never declare more elements than there are remaining bytes. A malicious
+/// or buggy N2C server can otherwise send a tiny (~9-byte) header declaring a
+/// length near `2^64` and drive the client to allocate billions of elements
+/// (OOM) or spin near-forever pushing default values (#873). Clamping the loop
+/// bound to `total_len - decoder.position()` makes every such loop bounded by
+/// the actual input length. `total_len` is the length of the slice the decoder
+/// was constructed over.
+fn bounded_cbor_len(declared: u64, total_len: usize, decoder: &minicbor::Decoder<'_>) -> usize {
+    let remaining = total_len.saturating_sub(decoder.position());
+    declared.min(remaining as u64) as usize
+}
+
 /// Encode a QueryHardFork query: `MsgQuery [3, [0, [2, [sub_tag]]]]`.
 ///
 /// Sub-tags: 0=GetInterpreter (EraHistory), 1=GetCurrentEra.
@@ -1140,10 +1156,12 @@ fn parse_protocol_params_cbor(payload: &[u8]) -> Result<String, NetworkError> {
 
     match decoder.datatype() {
         Ok(minicbor::data::Type::Array) => {
-            let arr_len = decoder
+            let arr_len_declared = decoder
                 .array()
                 .map_err(|e| protocol_err(format!("bad array: {e}")))?
                 .unwrap_or(0);
+            // #873: never trust the declared count — bound it to the input.
+            let arr_len = bounded_cbor_len(arr_len_declared, payload.len(), &decoder) as u64;
 
             let field_names: &[&str] = &[
                 "txFeePerByte",
@@ -1199,6 +1217,8 @@ fn parse_protocol_params_cbor(payload: &[u8]) -> Result<String, NetworkError> {
                     15 => {
                         let mut cm_entries = Vec::new();
                         if let Ok(Some(map_len)) = decoder.map() {
+                            // #873: bound the language-count against the input.
+                            let map_len = bounded_cbor_len(map_len, payload.len(), &decoder);
                             for _ in 0..map_len {
                                 let lang = decoder.u32().unwrap_or(0);
                                 let lang_name = match lang {
@@ -1209,8 +1229,17 @@ fn parse_protocol_params_cbor(payload: &[u8]) -> Result<String, NetworkError> {
                                 };
                                 let mut costs = Vec::new();
                                 if let Ok(Some(cost_len)) = decoder.array() {
+                                    // #873: a ~9-byte header must not push billions
+                                    // of zeros — bound against remaining input.
+                                    let cost_len =
+                                        bounded_cbor_len(cost_len, payload.len(), &decoder);
                                     for _ in 0..cost_len {
-                                        costs.push(decoder.i64().unwrap_or(0));
+                                        // Stop on the first malformed cost entry
+                                        // instead of silently pushing 0 forever.
+                                        match decoder.i64() {
+                                            Ok(c) => costs.push(c),
+                                            Err(_) => break,
+                                        }
                                     }
                                 }
                                 let costs_str: Vec<String> =
@@ -1363,14 +1392,19 @@ fn parse_protocol_params_cbor(payload: &[u8]) -> Result<String, NetworkError> {
             Ok(format!("{{\n{}\n}}", entries.join(",\n")))
         }
         Ok(minicbor::data::Type::Map) => {
-            let map_len = decoder
+            let map_len_declared = decoder
                 .map()
                 .map_err(|e| protocol_err(format!("bad map: {e}")))?
                 .unwrap_or(0);
+            // #873: this branch skip()s each value and swallows decode errors, so
+            // an unbounded declared count would spin — bound it to the input.
+            let map_len = bounded_cbor_len(map_len_declared, payload.len(), &decoder);
             let mut entries = Vec::new();
             for _ in 0..map_len {
                 let key = decoder.u32().unwrap_or(999);
-                let _ = decoder.skip();
+                if decoder.skip().is_err() {
+                    break;
+                }
                 entries.push(format!("  \"key_{key}\": \"skipped\""));
             }
             Ok(format!("{{\n{}\n}}", entries.join(",\n")))
@@ -1858,6 +1892,51 @@ fn decode_txin(decoder: &mut minicbor::Decoder<'_>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #873: a declared CBOR length must be clamped to the bytes actually
+    /// available, so a tiny crafted header cannot drive a billions-iteration
+    /// loop. `bounded_cbor_len` clamps to `total_len - position`.
+    #[test]
+    fn bounded_cbor_len_clamps_to_remaining_input() {
+        // A ~9-byte header declaring u64::MAX with only 3 bytes of body left.
+        let payload = [0x00u8; 12];
+        let mut dec = minicbor::Decoder::new(&payload);
+        // Advance the decoder position to simulate 9 header bytes consumed.
+        dec.set_position(9);
+        let clamped = bounded_cbor_len(u64::MAX, payload.len(), &dec);
+        assert_eq!(clamped, 3, "must clamp to remaining bytes, not the wire value");
+
+        // A small honest length passes through unchanged.
+        let mut dec2 = minicbor::Decoder::new(&payload);
+        dec2.set_position(2);
+        assert_eq!(bounded_cbor_len(4, payload.len(), &dec2), 4);
+
+        // Position at or past the end clamps to zero (no underflow).
+        let mut dec3 = minicbor::Decoder::new(&payload);
+        dec3.set_position(payload.len());
+        assert_eq!(bounded_cbor_len(1000, payload.len(), &dec3), 0);
+    }
+
+    /// #873: a malicious `GetCurrentPParams` reply whose top-level array header
+    /// declares a length far larger than the payload must not hang/OOM — the
+    /// parser returns bounded output quickly.
+    #[test]
+    fn parse_protocol_params_rejects_oversized_array_header() {
+        // MsgResult [4, <hfc [era, payload]>] where payload is an array header
+        // 0x9b declaring 0xFFFFFFFFFFFFFFFF elements but with no elements.
+        // strip_msg_result expects [4, inner]; strip_hfc_wrapper expects [era, x].
+        let mut buf = Vec::new();
+        // outer: array(2) [4, inner]
+        buf.extend_from_slice(&[0x82, 0x04]);
+        // inner hfc: array(2) [6 (era), payload]
+        buf.extend_from_slice(&[0x82, 0x06]);
+        // payload: array header 0x9b + u64::MAX, then EOF (no elements).
+        buf.push(0x9b);
+        buf.extend_from_slice(&u64::MAX.to_be_bytes());
+        // Must return promptly (bounded loop), not hang. Result content is
+        // best-effort; we only assert it terminates without panic.
+        let _ = parse_protocol_params_cbor(&buf);
+    }
 
     #[test]
     fn test_format_rational_decimal_basic() {

--- a/crates/dugite-network/src/n2c_client.rs
+++ b/crates/dugite-network/src/n2c_client.rs
@@ -763,10 +763,48 @@ impl N2CClient {
                 // MsgReplyNextTx — array(1) means no tx, array(2) means tx present
                 let has_tx = matches!(arr_len, Ok(Some(n)) if n >= 2);
                 if has_tx {
-                    let tx_cbor = dec.bytes().unwrap_or(&[]).to_vec();
-                    // Compute tx hash from CBOR (Blake2b-256)
-                    let tx_hash = dugite_primitives::hash::blake2b_256(&tx_cbor);
-                    Ok(Some((tx_hash.as_ref().to_vec(), tx_cbor)))
+                    // #874: the present reply is [6, <GenTx>] where
+                    //   <GenTx> = [era_index, tag(24) bstr(tx_cbor)]
+                    // (byte-identical to MsgSubmitTx). Accept a bare bytestring
+                    // defensively for interop with peers still emitting the old
+                    // flat shape.
+                    let era_index = match dec.datatype() {
+                        Ok(minicbor::data::Type::Array) => {
+                            let _ = dec
+                                .array()
+                                .map_err(|e| protocol_err(format!("bad GenTx array: {e}")))?;
+                            dec.u32()
+                                .map_err(|e| protocol_err(format!("bad GenTx era index: {e}")))?
+                        }
+                        // Legacy flat shape [6, bstr(tx)] — no era wrapper.
+                        _ => u32::MAX,
+                    };
+                    let tx_cbor = match dec.datatype() {
+                        Ok(minicbor::data::Type::Tag) => {
+                            let _ = dec.tag();
+                            dec.bytes()
+                                .map_err(|e| protocol_err(format!("bad GenTx tx bytes: {e}")))?
+                                .to_vec()
+                        }
+                        _ => dec
+                            .bytes()
+                            .map_err(|e| protocol_err(format!("bad GenTx tx bytes: {e}")))?
+                            .to_vec(),
+                    };
+                    // Canonical tx id = blake2b_256(raw_body_cbor) — the body-span
+                    // hash the decoder computes — NOT blake2b over the whole tx
+                    // CBOR (#874 Related). Fall back to the whole-tx hash only if
+                    // the era is unknown / the tx fails to decode.
+                    let tx_hash = match dugite_serialization::decode_transaction(
+                        era_index as u16,
+                        &tx_cbor,
+                    ) {
+                        Ok(tx) => tx.hash.as_bytes().to_vec(),
+                        Err(_) => dugite_primitives::hash::blake2b_256(&tx_cbor)
+                            .as_ref()
+                            .to_vec(),
+                    };
+                    Ok(Some((tx_hash, tx_cbor)))
                 } else {
                     Ok(None)
                 }

--- a/crates/dugite-network/src/peer/governor.rs
+++ b/crates/dugite-network/src/peer/governor.rs
@@ -807,7 +807,11 @@ impl Governor {
             let threshold = self.config.targets.max_cold * 3 / 2;
             if cold_count > threshold {
                 let excess = cold_count - self.config.targets.max_cold;
-                let to_forget = select_lowest_reputation_cold(peer_manager, excess);
+                // #879: exclude big-ledger peers from cold-churn eviction so an
+                // adversary flooding the cold pool cannot evict freshly-discovered
+                // top-stake peers (eclipse pressure).
+                let to_forget =
+                    select_lowest_reputation_cold(peer_manager, excess, big_ledger_peers);
                 for addr in to_forget {
                     actions.push(GovernorAction::ForgetPeer(addr));
                 }

--- a/crates/dugite-network/src/peer/selection.rs
+++ b/crates/dugite-network/src/peer/selection.rs
@@ -69,14 +69,25 @@ pub fn select_worst_hot(peer_manager: &PeerManager) -> Option<SocketAddr> {
 ///
 /// Returns up to `count` cold peers sorted by reputation ascending.
 /// Topology peers are excluded — root peers configured in the topology file
-/// should never be forgotten.
-pub fn select_lowest_reputation_cold(peer_manager: &PeerManager, count: usize) -> Vec<SocketAddr> {
+/// should never be forgotten. `exclude` names additional addresses that must
+/// never be cold-churned: the caller passes the Big-Ledger-Peer (and bootstrap)
+/// set so top-stake peers cannot be evicted by cold-pool flooding — an eclipse
+/// pressure lever, since Haskell never forgets big-ledger peers this way (#879).
+pub fn select_lowest_reputation_cold(
+    peer_manager: &PeerManager,
+    count: usize,
+    exclude: &std::collections::HashSet<SocketAddr>,
+) -> Vec<SocketAddr> {
     use super::manager::PeerSource;
 
     let mut scored: Vec<(SocketAddr, f64)> = peer_manager
         .peers_in_state(PeerState::Cold)
         .into_iter()
         .filter_map(|addr| {
+            // #879: never evict a big-ledger / bootstrap peer.
+            if exclude.contains(&addr) {
+                return None;
+            }
             peer_manager.get_peer(&addr).and_then(|info| {
                 // Never forget topology peers (root peers from config file).
                 if info.source == PeerSource::Topology {
@@ -230,13 +241,36 @@ mod tests {
         pm.add_peer(test_addr(3004), PeerSource::Ledger);
         pm.get_peer_mut(&test_addr(3004)).unwrap().reputation = 0.3;
 
-        let evict = select_lowest_reputation_cold(&pm, 2);
+        let empty = std::collections::HashSet::new();
+        let evict = select_lowest_reputation_cold(&pm, 2, &empty);
         assert_eq!(evict.len(), 2);
         // Should be the two lowest non-topology peers.
         assert!(evict.contains(&test_addr(3002)));
         assert!(evict.contains(&test_addr(3003)));
         // Topology peer must not appear.
         assert!(!evict.contains(&test_addr(3001)));
+    }
+
+    /// #879: a big-ledger peer in the `exclude` set must never be selected for
+    /// cold-churn eviction, even with the lowest reputation.
+    #[test]
+    fn select_lowest_reputation_cold_excludes_big_ledger_peers() {
+        let mut pm = PeerManager::new();
+        // BLP with the WORST reputation — must still be protected.
+        pm.add_peer(test_addr(4001), PeerSource::Ledger);
+        pm.get_peer_mut(&test_addr(4001)).unwrap().reputation = 0.0;
+        pm.add_peer(test_addr(4002), PeerSource::Dns);
+        pm.get_peer_mut(&test_addr(4002)).unwrap().reputation = 0.5;
+
+        let mut blp = std::collections::HashSet::new();
+        blp.insert(test_addr(4001));
+
+        let evict = select_lowest_reputation_cold(&pm, 5, &blp);
+        assert!(
+            !evict.contains(&test_addr(4001)),
+            "big-ledger peer must be excluded from cold churn"
+        );
+        assert!(evict.contains(&test_addr(4002)));
     }
 
     #[test]

--- a/crates/dugite-network/src/protocol/blockfetch/server.rs
+++ b/crates/dugite-network/src/protocol/blockfetch/server.rs
@@ -326,7 +326,12 @@ impl BlockFetchServer {
         if started {
             let done = encode_message(&BlockFetchMessage::MsgBatchDone);
             channel.send(done).await.map_err(ProtocolError::from)?;
-            tracing::debug!(block_count = sent, from_slot, to_slot, "blockfetch server: streamed batch");
+            tracing::debug!(
+                block_count = sent,
+                from_slot,
+                to_slot,
+                "blockfetch server: streamed batch"
+            );
         } else {
             let no_blocks = encode_message(&BlockFetchMessage::MsgNoBlocks);
             channel.send(no_blocks).await.map_err(ProtocolError::from)?;
@@ -680,7 +685,10 @@ mod tests {
             3,
         )
         .await;
-        assert_eq!(served, bodies, "multi-chunk stream must equal the full range");
+        assert_eq!(
+            served, bodies,
+            "multi-chunk stream must equal the full range"
+        );
     }
 
     /// #878: a Byron EBB/main same-slot pair split across a chunk boundary must

--- a/crates/dugite-network/src/protocol/blockfetch/server.rs
+++ b/crates/dugite-network/src/protocol/blockfetch/server.rs
@@ -68,6 +68,14 @@ use super::{decode_message, encode_message, BlockFetchMessage, TAG_BLOCK};
 /// upper bound to prevent unbounded memory use from malicious requests.
 pub const MAX_BLOCKS_PER_BATCH: usize = 2000;
 
+/// Blocks fetched per look-ahead chunk while streaming a range (#878).
+///
+/// Caps per-connection memory at O(STREAM_CHUNK) full block CBORs instead of
+/// pre-collecting the whole batch. A multiple of the ChainDB's internal
+/// 50-block lock chunk so the chunked-lock optimisation (which keeps
+/// `get_blocks_in_range` off the per-block `blocking_read` path) is preserved.
+pub const STREAM_CHUNK: usize = 200;
+
 /// BlockFetch server that serves block ranges to peers.
 pub struct BlockFetchServer;
 
@@ -166,76 +174,163 @@ impl BlockFetchServer {
             return Ok(());
         }
 
-        // Collect blocks in [from_slot, to_slot] via a single batched call.
-        // ChainDBBlockProvider overrides get_blocks_in_range() to acquire
-        // chain_db.read() in chunks of 50 blocks, preventing the per-block
-        // block_in_place / blocking_read pattern from exhausting the tokio
-        // async worker thread pool when the Haskell relay is syncing rapidly
-        // with pipelined batch requests.
-        let mut blocks =
-            block_provider.get_blocks_in_range(from_slot, to_slot, MAX_BLOCKS_PER_BATCH);
-
-        // Haskell BlockFetch ranges are inclusive by POINT, not by slot.  A
-        // Byron EBB shares its absolute slot with the first main block of
-        // the epoch, so the slot range may over-collect a same-slot sibling
-        // on either edge: trim leading blocks at `from_slot` that precede
-        // the requested `from` hash, and trailing blocks at `to_slot` that
-        // follow the requested `to` hash.
-        if let Point::Specific(s, h) = from {
-            while blocks.first().is_some_and(|(bs, bh, _)| bs == s && bh != h) {
-                blocks.remove(0);
-            }
-        }
-        if let Point::Specific(s, h) = to {
-            while blocks.last().is_some_and(|(bs, bh, _)| bs == s && bh != h) {
-                blocks.pop();
-            }
-        }
-
-        if blocks.is_empty() {
-            let no_blocks = encode_message(&BlockFetchMessage::MsgNoBlocks);
-            channel.send(no_blocks).await.map_err(ProtocolError::from)?;
-            return Ok(());
-        }
-
-        // Stream: MsgStartBatch → MsgBlock × N → MsgBatchDone.
-        let start = encode_message(&BlockFetchMessage::MsgStartBatch);
-        channel.send(start).await.map_err(ProtocolError::from)?;
-
-        for (slot, hash, block_cbor) in &blocks {
-            tracing::debug!(
-                slot,
-                hash = hex::encode(hash),
-                cbor_len = block_cbor.len(),
-                first_bytes = hex::encode(&block_cbor[..block_cbor.len().min(16)]),
-                "blockfetch server: serving block"
-            );
-            // Encode MsgBlock: [4, tag(24) bstr(stored_block_cbor)].
-            // The stored CBOR format [era_word, body] is identical to what
-            // Haskell's encodeDiskHfcBlock produces, so it goes verbatim
-            // inside the CBOR-in-CBOR tag(24) wrapper.
-            let block_msg = Self::encode_hfc_msg_block(block_cbor).map_err(|reason| {
-                ProtocolError::CborDecode {
-                    protocol: "BlockFetch",
-                    reason: format!("HFC wrapping failed: {reason}"),
-                }
-            })?;
-            channel.send(block_msg).await.map_err(ProtocolError::from)?;
-        }
-
-        let done = encode_message(&BlockFetchMessage::MsgBatchDone);
-        channel.send(done).await.map_err(ProtocolError::from)?;
-
-        tracing::debug!(
-            block_count = blocks.len(),
+        // #878: stream the range in bounded look-ahead chunks instead of
+        // pre-collecting the whole batch (up to MAX_BLOCKS_PER_BATCH full block
+        // CBORs ≈ 180 MB on mainnet) into one owned Vec. Per-connection memory
+        // is now O(STREAM_CHUNK) blocks regardless of range size, so N
+        // concurrent adversarial dense-range requests can no longer multiply a
+        // huge pinned allocation. The chunk size is a multiple of the ChainDB's
+        // internal 50-block lock chunk, so the chunked-lock optimisation that
+        // keeps get_blocks_in_range() off the per-block blocking_read path is
+        // preserved.
+        Self::stream_range(
+            channel,
+            block_provider,
+            from,
+            to,
             from_slot,
             to_slot,
-            first_hash = blocks
-                .first()
-                .map(|(_, h, _)| hex::encode(h))
-                .unwrap_or_default(),
-            "blockfetch server: served batch"
-        );
+            STREAM_CHUNK,
+        )
+        .await
+    }
+
+    /// Stream the blocks of `[from, to]` (inclusive by POINT) to the client in
+    /// bounded look-ahead chunks, holding at most `chunk_size` block CBORs in
+    /// memory at once (#878).
+    ///
+    /// Emits `MsgStartBatch → MsgBlock* → MsgBatchDone`, or `MsgNoBlocks` if the
+    /// range yields nothing. The cursor advances by POINT (via the last emitted
+    /// block's hash) so a Byron EBB and the same-slot first main block of the
+    /// epoch are both served across a chunk boundary, matching the point-inclusive
+    /// semantics of the previous collect-then-trim implementation:
+    /// - leading same-slot siblings that precede the requested `from` hash are
+    ///   dropped, and
+    /// - streaming stops the instant the requested `to` hash is emitted, so
+    ///   trailing same-slot siblings after `to` are never sent.
+    #[allow(clippy::too_many_arguments)]
+    async fn stream_range<B: BlockProvider>(
+        channel: &mut MuxChannel,
+        block_provider: &B,
+        from: &Point,
+        to: &Point,
+        from_slot: u64,
+        to_slot: u64,
+        chunk_size: usize,
+    ) -> Result<(), ProtocolError> {
+        let from_hash: Option<[u8; 32]> = match from {
+            Point::Specific(_, h) => Some(*h),
+            Point::Origin => None,
+        };
+        let to_hash: Option<[u8; 32]> = match to {
+            Point::Specific(_, h) => Some(*h),
+            Point::Origin => None,
+        };
+
+        let mut cursor_slot = from_slot;
+        // Hash of the last block emitted in the previous chunk. Because a slot
+        // can hold two blocks (EBB + main) we advance the cursor by slot but
+        // re-fetch from `cursor_slot`, then skip forward through this hash so
+        // the boundary block is emitted exactly once.
+        let mut boundary_hash: Option<[u8; 32]> = None;
+        // Until the requested `from` hash is reached we are trimming leading
+        // same-slot siblings that precede it (Point::Origin has no such trim).
+        let mut reached_from = from_hash.is_none();
+        let mut started = false;
+        let mut sent = 0usize;
+
+        'chunks: loop {
+            let chunk = block_provider.get_blocks_in_range(cursor_slot, to_slot, chunk_size);
+            if chunk.is_empty() {
+                break;
+            }
+            let full_chunk = chunk.len() >= chunk_size;
+            let last_slot = chunk.last().unwrap().0;
+            let last_hash = chunk.last().unwrap().1;
+
+            // Skip the overlap already emitted at the end of the previous chunk.
+            let mut i = 0usize;
+            if let Some(b) = boundary_hash {
+                while i < chunk.len() && chunk[i].1 != b {
+                    i += 1;
+                }
+                if i < chunk.len() {
+                    i += 1; // skip the boundary block itself
+                }
+            }
+
+            let mut emitted_this_chunk = false;
+            while i < chunk.len() {
+                let (slot, hash, block_cbor) = &chunk[i];
+                i += 1;
+
+                if !reached_from {
+                    // Leading trim: drop same-slot siblings before `from`.
+                    if Some(*hash) == from_hash {
+                        reached_from = true;
+                    } else {
+                        continue;
+                    }
+                }
+
+                if !started {
+                    let start = encode_message(&BlockFetchMessage::MsgStartBatch);
+                    channel.send(start).await.map_err(ProtocolError::from)?;
+                    started = true;
+                }
+
+                tracing::debug!(
+                    slot,
+                    hash = hex::encode(hash),
+                    cbor_len = block_cbor.len(),
+                    "blockfetch server: streaming block"
+                );
+                // MsgBlock: [4, tag(24) bstr(stored_block_cbor)]. Stored CBOR is
+                // already the [era_word, body] layout encodeDiskHfcBlock emits.
+                let block_msg = Self::encode_hfc_msg_block(block_cbor).map_err(|reason| {
+                    ProtocolError::CborDecode {
+                        protocol: "BlockFetch",
+                        reason: format!("HFC wrapping failed: {reason}"),
+                    }
+                })?;
+                channel.send(block_msg).await.map_err(ProtocolError::from)?;
+                sent += 1;
+                emitted_this_chunk = true;
+
+                // Trailing trim: stop the instant we emit the `to` block, and
+                // never exceed the batch cap.
+                if to_hash == Some(*hash) || sent >= MAX_BLOCKS_PER_BATCH {
+                    break 'chunks;
+                }
+            }
+
+            if !full_chunk {
+                // The provider returned fewer than a full chunk — end of range.
+                break;
+            }
+            if emitted_this_chunk {
+                // Re-fetch from the last emitted slot next round and skip past
+                // the boundary block (handles a same-slot sibling straddling
+                // the chunk edge).
+                boundary_hash = Some(last_hash);
+                cursor_slot = last_slot;
+            } else {
+                // A full chunk whose blocks were ALL already emitted (both
+                // same-slot siblings of `last_slot` sent in prior chunks). The
+                // slot-keyed re-fetch would loop forever; advance past the slot.
+                boundary_hash = None;
+                cursor_slot = last_slot + 1;
+            }
+        }
+
+        if started {
+            let done = encode_message(&BlockFetchMessage::MsgBatchDone);
+            channel.send(done).await.map_err(ProtocolError::from)?;
+            tracing::debug!(block_count = sent, from_slot, to_slot, "blockfetch server: streamed batch");
+        } else {
+            let no_blocks = encode_message(&BlockFetchMessage::MsgNoBlocks);
+            channel.send(no_blocks).await.map_err(ProtocolError::from)?;
+        }
 
         Ok(())
     }
@@ -495,7 +590,7 @@ mod tests {
         mpsc::Receiver<(u16, crate::mux::Direction, Bytes)>,
         mpsc::Sender<Bytes>,
     ) {
-        let (egress_tx, egress_rx) = mpsc::channel(64);
+        let (egress_tx, egress_rx) = mpsc::channel(4096);
         let (ingress_tx, ingress_rx) = mpsc::channel(64);
         let channel = MuxChannel::new(
             3,
@@ -506,6 +601,118 @@ mod tests {
             std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         );
         (channel, egress_rx, ingress_tx)
+    }
+
+    /// #878: drive `stream_range` directly with a small `chunk_size` and collect
+    /// the served block bodies, so the multi-chunk look-ahead + boundary-overlap
+    /// path is exercised (the collect-then-stream path never had chunks).
+    async fn collect_stream_range(
+        provider: MockBlockProvider,
+        from: Point,
+        to: Point,
+        chunk_size: usize,
+    ) -> Vec<Vec<u8>> {
+        let (mut channel, mut egress_rx, _ingress_tx) = make_test_channel();
+        let from_slot = match &from {
+            Point::Origin => 0,
+            Point::Specific(s, _) => *s,
+        };
+        let to_slot = match &to {
+            Point::Origin => 0,
+            Point::Specific(s, _) => *s,
+        };
+        let handle = tokio::spawn(async move {
+            BlockFetchServer::stream_range(
+                &mut channel,
+                &provider,
+                &from,
+                &to,
+                from_slot,
+                to_slot,
+                chunk_size,
+            )
+            .await
+            .unwrap();
+        });
+
+        let mut blocks = Vec::new();
+        let (_, _, first) = egress_rx.recv().await.unwrap();
+        match decode_message(&first).unwrap() {
+            BlockFetchMessage::MsgNoBlocks => {}
+            BlockFetchMessage::MsgStartBatch => loop {
+                let (_, _, msg) = egress_rx.recv().await.unwrap();
+                match decode_message(&msg).unwrap() {
+                    BlockFetchMessage::MsgBlock(body) => blocks.push(body),
+                    BlockFetchMessage::MsgBatchDone => break,
+                    other => panic!("unexpected message in batch: {other:?}"),
+                }
+            },
+            other => panic!("unexpected first response: {other:?}"),
+        }
+        handle.await.unwrap();
+        blocks
+    }
+
+    /// #878: streaming across several small chunks yields the exact same block
+    /// sequence as a single-shot serve — no gaps, no duplicates at chunk edges.
+    #[tokio::test]
+    async fn stream_range_multichunk_matches_full_sequence() {
+        let bodies: Vec<Vec<u8>> = (0u8..10).map(|i| make_storage_block(7, &[i])).collect();
+        let provider = MockBlockProvider {
+            blocks: (0u8..10)
+                .map(|i| {
+                    let mut h = [0u8; 32];
+                    h[0] = i;
+                    ((i as u64) * 10 + 10, h, bodies[i as usize].clone())
+                })
+                .collect(),
+        };
+        let mut from_h = [0u8; 32];
+        from_h[0] = 0;
+        let mut to_h = [0u8; 32];
+        to_h[0] = 9;
+
+        // chunk_size 3 forces 4 chunks with boundary overlaps.
+        let served = collect_stream_range(
+            provider,
+            Point::Specific(10, from_h),
+            Point::Specific(100, to_h),
+            3,
+        )
+        .await;
+        assert_eq!(served, bodies, "multi-chunk stream must equal the full range");
+    }
+
+    /// #878: a Byron EBB/main same-slot pair split across a chunk boundary must
+    /// still serve BOTH blocks exactly once (the boundary-overlap skip advances
+    /// by point, not slot).
+    #[tokio::test]
+    async fn stream_range_same_slot_pair_across_chunk_boundary() {
+        let pred = make_storage_block(7, &[0x10]);
+        let ebb = make_storage_block(7, &[0x20]);
+        let main = make_storage_block(7, &[0x30]);
+        let next = make_storage_block(7, &[0x40]);
+        let provider = MockBlockProvider {
+            blocks: vec![
+                (99, [0x01; 32], pred.clone()),
+                (100, [0x02; 32], ebb.clone()),
+                (100, [0x03; 32], main.clone()),
+                (101, [0x04; 32], next.clone()),
+            ],
+        };
+        // chunk_size 2 places the (100,ebb)/(100,main) pair straddling chunk 1/2.
+        let served = collect_stream_range(
+            provider,
+            Point::Specific(99, [0x01; 32]),
+            Point::Specific(101, [0x04; 32]),
+            2,
+        )
+        .await;
+        assert_eq!(
+            served,
+            vec![pred, ebb, main, next],
+            "same-slot pair across a chunk boundary must both be served once"
+        );
     }
 
     #[tokio::test]

--- a/crates/dugite-network/src/protocol/chainsync/client.rs
+++ b/crates/dugite-network/src/protocol/chainsync/client.rs
@@ -266,7 +266,8 @@ impl PipelinedChainSyncClient {
                     // server unilaterally end sync; reject as an agency violation.
                     return Err(ProtocolError::StateViolation {
                         protocol: "ChainSync",
-                        expected: "server response (MsgRollForward/Backward/AwaitReply)".to_string(),
+                        expected: "server response (MsgRollForward/Backward/AwaitReply)"
+                            .to_string(),
                         actual: "MsgDone from server (client-agency message)".to_string(),
                     });
                 }

--- a/crates/dugite-network/src/protocol/chainsync/client.rs
+++ b/crates/dugite-network/src/protocol/chainsync/client.rs
@@ -194,7 +194,17 @@ impl PipelinedChainSyncClient {
                     tip_hash,
                     tip_block_number,
                 } => {
-                    self.outstanding = self.outstanding.saturating_sub(1);
+                    // #880: a response with no request outstanding is an
+                    // unsolicited server message (agency violation). The prior
+                    // `saturating_sub(1)` silently masked it by clamping at 0.
+                    if self.outstanding == 0 {
+                        return Err(ProtocolError::StateViolation {
+                            protocol: "ChainSync",
+                            expected: "no unsolicited response (outstanding > 0)".to_string(),
+                            actual: "MsgRollForward with 0 outstanding requests".to_string(),
+                        });
+                    }
+                    self.outstanding -= 1;
 
                     // If we were at tip, we're no longer (got a new block)
                     if self.at_tip {
@@ -224,7 +234,21 @@ impl PipelinedChainSyncClient {
                     tip_hash: _,
                     tip_block_number: _,
                 } => {
-                    self.outstanding = self.outstanding.saturating_sub(1);
+                    // #880: reject an unsolicited rollback (see MsgRollForward).
+                    // NOTE: a rollback-depth (k) bound is NOT enforced here — the
+                    // pipelined client carries no chain state to compute depth;
+                    // that check belongs at the point this client is wired into a
+                    // chain-following loop (production sync uses the in-house
+                    // state machine in dugite-node/src/node/sync.rs, which does
+                    // enforce it).
+                    if self.outstanding == 0 {
+                        return Err(ProtocolError::StateViolation {
+                            protocol: "ChainSync",
+                            expected: "no unsolicited response (outstanding > 0)".to_string(),
+                            actual: "MsgRollBackward with 0 outstanding requests".to_string(),
+                        });
+                    }
+                    self.outstanding -= 1;
 
                     on_event(ChainSyncEvent::RollBackward { point, tip_slot })?;
                 }
@@ -237,7 +261,14 @@ impl PipelinedChainSyncClient {
                     on_event(ChainSyncEvent::AtTip)?;
                 }
                 ChainSyncMessage::MsgDone => {
-                    return Ok(());
+                    // #880: MsgDone is a CLIENT-agency message — the server has
+                    // no agency to terminate the protocol. Accepting it let a
+                    // server unilaterally end sync; reject as an agency violation.
+                    return Err(ProtocolError::StateViolation {
+                        protocol: "ChainSync",
+                        expected: "server response (MsgRollForward/Backward/AwaitReply)".to_string(),
+                        actual: "MsgDone from server (client-agency message)".to_string(),
+                    });
                 }
                 other => {
                     return Err(ProtocolError::StateViolation {

--- a/crates/dugite-network/src/protocol/chainsync/jumping.rs
+++ b/crates/dugite-network/src/protocol/chainsync/jumping.rs
@@ -291,6 +291,62 @@ impl PeerJumpState {
         }
     }
 
+    /// `MsgIntersectNotFound` at the probed midpoint, but the bisection window
+    /// has NOT yet collapsed: the fork lies at or below the midpoint, so narrow
+    /// the UPPER bound to `new_hi` and keep bisecting (#880).
+    ///
+    /// The module's own state diagram describes a binary search between `lo` and
+    /// `hi`, but `on_intersect_not_found` always jumped straight to `Objector` —
+    /// the window could never actually narrow. This transition, together with
+    /// [`Self::on_intersect_found_continue`], expresses the bisection step;
+    /// callers use `on_intersect_not_found` only once `[lo, hi)` has converged.
+    ///
+    /// Valid from: `Jumper(LookingForIntersection { .. })`
+    /// Next state: `Jumper(LookingForIntersection { lo, hi: new_hi })`
+    pub fn on_intersect_not_found_continue(
+        &mut self,
+        new_hi: Point,
+    ) -> Result<(), TransitionError> {
+        match &self.state {
+            JumpState::Jumper(JumperState::LookingForIntersection { lo, .. }) => {
+                let lo = lo.clone();
+                self.state = JumpState::Jumper(JumperState::LookingForIntersection {
+                    lo,
+                    hi: new_hi,
+                });
+                Ok(())
+            }
+            other => Err(TransitionError::InvalidState {
+                current: format!("{other:?}"),
+                attempted: "on_intersect_not_found_continue",
+            }),
+        }
+    }
+
+    /// `MsgIntersectFound` at the probed midpoint, but the bisection window has
+    /// NOT yet collapsed: the fork lies above the midpoint, so raise the LOWER
+    /// bound to `new_lo` and keep bisecting (#880 — the complement of
+    /// [`Self::on_intersect_not_found_continue`]).
+    ///
+    /// Valid from: `Jumper(LookingForIntersection { .. })`
+    /// Next state: `Jumper(LookingForIntersection { lo: new_lo, hi })`
+    pub fn on_intersect_found_continue(&mut self, new_lo: Point) -> Result<(), TransitionError> {
+        match &self.state {
+            JumpState::Jumper(JumperState::LookingForIntersection { hi, .. }) => {
+                let hi = hi.clone();
+                self.state = JumpState::Jumper(JumperState::LookingForIntersection {
+                    lo: new_lo,
+                    hi,
+                });
+                Ok(())
+            }
+            other => Err(TransitionError::InvalidState {
+                current: format!("{other:?}"),
+                attempted: "on_intersect_found_continue",
+            }),
+        }
+    }
+
     /// The bisection has been resolved (fork point determined).  The peer is
     /// disengaged from CSJ and will run normal ChainSync independently.
     ///
@@ -651,6 +707,39 @@ mod tests {
             point: pt(slot),
             era_params: era_params_mainnet_shelley(),
         }
+    }
+
+    /// #880: the bisection-continue transitions narrow the `[lo, hi)` window in
+    /// place (Phase-B CSJ) instead of jumping straight to Objector.
+    #[test]
+    fn bisection_continue_transitions_narrow_window() {
+        let mut peer = PeerJumpState::new_jumper();
+        peer.on_jump_issued(&instr(100)).expect("jump issued");
+
+        // Not found at the midpoint → fork is at/below it → narrow the upper
+        // bound, staying in LookingForIntersection.
+        peer.on_intersect_not_found_continue(pt(50)).expect("continue lo");
+        match &peer.state {
+            JumpState::Jumper(JumperState::LookingForIntersection { lo, hi }) => {
+                assert_eq!(*lo, Point::Origin);
+                assert_eq!(*hi, pt(50));
+            }
+            other => panic!("expected LookingForIntersection, got {other:?}"),
+        }
+
+        // Found at the next midpoint → fork is above it → raise the lower bound.
+        peer.on_intersect_found_continue(pt(25)).expect("continue hi");
+        match &peer.state {
+            JumpState::Jumper(JumperState::LookingForIntersection { lo, hi }) => {
+                assert_eq!(*lo, pt(25));
+                assert_eq!(*hi, pt(50));
+            }
+            other => panic!("expected LookingForIntersection, got {other:?}"),
+        }
+
+        // Window converged → terminal not-found becomes an Objector.
+        peer.on_intersect_not_found(pt(30)).expect("objector");
+        assert!(peer.is_objector());
     }
 
     /// Build a minimal single-era history (Byron instant, Shelley open) for

--- a/crates/dugite-network/src/protocol/chainsync/jumping.rs
+++ b/crates/dugite-network/src/protocol/chainsync/jumping.rs
@@ -310,10 +310,8 @@ impl PeerJumpState {
         match &self.state {
             JumpState::Jumper(JumperState::LookingForIntersection { lo, .. }) => {
                 let lo = lo.clone();
-                self.state = JumpState::Jumper(JumperState::LookingForIntersection {
-                    lo,
-                    hi: new_hi,
-                });
+                self.state =
+                    JumpState::Jumper(JumperState::LookingForIntersection { lo, hi: new_hi });
                 Ok(())
             }
             other => Err(TransitionError::InvalidState {
@@ -334,10 +332,8 @@ impl PeerJumpState {
         match &self.state {
             JumpState::Jumper(JumperState::LookingForIntersection { hi, .. }) => {
                 let hi = hi.clone();
-                self.state = JumpState::Jumper(JumperState::LookingForIntersection {
-                    lo: new_lo,
-                    hi,
-                });
+                self.state =
+                    JumpState::Jumper(JumperState::LookingForIntersection { lo: new_lo, hi });
                 Ok(())
             }
             other => Err(TransitionError::InvalidState {
@@ -718,7 +714,8 @@ mod tests {
 
         // Not found at the midpoint → fork is at/below it → narrow the upper
         // bound, staying in LookingForIntersection.
-        peer.on_intersect_not_found_continue(pt(50)).expect("continue lo");
+        peer.on_intersect_not_found_continue(pt(50))
+            .expect("continue lo");
         match &peer.state {
             JumpState::Jumper(JumperState::LookingForIntersection { lo, hi }) => {
                 assert_eq!(*lo, Point::Origin);
@@ -728,7 +725,8 @@ mod tests {
         }
 
         // Found at the next midpoint → fork is above it → raise the lower bound.
-        peer.on_intersect_found_continue(pt(25)).expect("continue hi");
+        peer.on_intersect_found_continue(pt(25))
+            .expect("continue hi");
         match &peer.state {
             JumpState::Jumper(JumperState::LookingForIntersection { lo, hi }) => {
                 assert_eq!(*lo, pt(25));

--- a/crates/dugite-network/src/protocol/chainsync/mod.rs
+++ b/crates/dugite-network/src/protocol/chainsync/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod client;
 pub mod jumping;
+pub(crate) mod serve_core;
 pub mod server;
 
 use crate::codec::{self, Point};

--- a/crates/dugite-network/src/protocol/chainsync/mod.rs
+++ b/crates/dugite-network/src/protocol/chainsync/mod.rs
@@ -206,8 +206,23 @@ pub fn encode_message(msg: &ChainSyncMessage) -> Vec<u8> {
 /// Decode a ChainSync message from CBOR bytes.
 pub fn decode_message(data: &[u8]) -> Result<ChainSyncMessage, String> {
     let mut dec = Decoder::new(data);
-    let _arr_len = dec.array().map_err(|e| e.to_string())?;
+    let arr_len = dec.array().map_err(|e| e.to_string())?;
     let tag = dec.u64().map_err(|e| e.to_string())?;
+
+    // #880: assert the outer array arity matches the tag. Without this a
+    // message like `[0, <garbage...>]` decodes as a clean MsgRequestNext with
+    // the extra elements silently ignored — an adversarial-tolerance gap.
+    let expected_arity = match tag {
+        TAG_REQUEST_NEXT | TAG_AWAIT_REPLY | TAG_DONE => 1,
+        TAG_FIND_INTERSECT | TAG_INTERSECT_NOT_FOUND => 2,
+        TAG_ROLL_FORWARD | TAG_ROLL_BACKWARD | TAG_INTERSECT_FOUND => 3,
+        other => return Err(format!("unknown ChainSync message tag: {other}")),
+    };
+    if arr_len != Some(expected_arity) {
+        return Err(format!(
+            "ChainSync tag {tag}: expected definite array({expected_arity}), got {arr_len:?}"
+        ));
+    }
 
     match tag {
         TAG_REQUEST_NEXT => Ok(ChainSyncMessage::MsgRequestNext),

--- a/crates/dugite-network/src/protocol/chainsync/serve_core.rs
+++ b/crates/dugite-network/src/protocol/chainsync/serve_core.rs
@@ -1,0 +1,1024 @@
+//! Shared ChainSync / LocalChainSync serve-loop core (issue #881).
+//!
+//! N2N `ChainSyncServer` (`chainsync::server`) and N2C `LocalChainSyncServer`
+//! (`local_chainsync::server`) implement the *same* Ouroboros ChainSync
+//! server state machine and differ in exactly one respect: how the
+//! `MsgRollForward` payload is encoded.
+//!
+//! - N2N sends only the block *header*, HFC-wrapped:
+//!   `extract_header_for_chainsync` (fallible — the header must be parsed
+//!   out of the block body).
+//! - N2C sends the *full block*, `Serialised`-wrapped: `wrap_serialised`
+//!   (infallible — no parsing required).
+//!
+//! Before this extraction the two servers had drifted: N2C was missing the
+//! duplicate-serve dedup, the `biased` rollback-first `select!` ordering,
+//! the `StMustReply` retry loop (#869), `cursor_at_origin` genesis-EBB
+//! handling, and lagged-rollback safety (Bug J) that N2N already had.  This
+//! module is the single implementation both servers now delegate to, so a
+//! fix applied once (e.g. #869, #876) automatically covers both wire
+//! protocols.
+//!
+//! The payload encoder is threaded through as a plain `fn` pointer — never
+//! boxed — so there is no vtable/allocation overhead on the hot per-block
+//! serve path.
+
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+
+use crate::codec::Point;
+use crate::error::ProtocolError;
+use crate::mux::channel::MuxChannel;
+use crate::BlockProvider;
+
+use super::server::{
+    BlockAnnouncement, RollbackAnnouncement, CHAINSYNC_MUST_REPLY_TIMEOUT_MAX,
+    CHAINSYNC_MUST_REPLY_TIMEOUT_MIN,
+};
+use super::{decode_message, encode_message, ChainSyncMessage};
+
+/// Encodes a block's raw storage CBOR into the wire-ready `MsgRollForward`
+/// payload.  A plain `fn` pointer (not a boxed closure) — the encoder is
+/// always a stateless free function, so this keeps the hot per-block serve
+/// path allocation- and vtable-free.
+pub(crate) type PayloadEncoder = fn(&[u8]) -> Result<Vec<u8>, ProtocolError>;
+
+/// Shared ChainSync/LocalChainSync serve-loop core.
+///
+/// Owns the per-connection follower cursor and drives `MsgFindIntersect` /
+/// `MsgRequestNext` handling identically for both wire protocols; the only
+/// per-protocol behaviour is `payload_encoder` (header-only vs full-block)
+/// and the `protocol` label used in tracing/errors.
+pub(crate) struct ServeCore {
+    /// Current cursor: the last point served to this peer.
+    pub(crate) cursor_slot: u64,
+    pub(crate) cursor_hash: [u8; 32],
+    /// Whether the cursor has been initialized (via intersection or genesis).
+    cursor_initialized: bool,
+    /// True when the cursor is at Origin — meaning no block has been served
+    /// yet and we must include blocks at slot 0 (e.g. Byron genesis EBB).
+    cursor_at_origin: bool,
+    /// Per-connection `StMustReply` timeout, drawn once at construction
+    /// uniformly from `[CHAINSYNC_MUST_REPLY_TIMEOUT_MIN, CHAINSYNC_MUST_REPLY_TIMEOUT_MAX]`.
+    /// Mirrors Haskell's per-connection timeout draw (#701).
+    must_reply_timeout: Duration,
+    /// Encodes the `MsgRollForward` payload from raw block CBOR — the only
+    /// point of divergence between N2N ChainSync and N2C LocalChainSync.
+    payload_encoder: PayloadEncoder,
+    /// Mini-protocol name used in tracing spans and `ProtocolError` variants
+    /// (`"ChainSync"` or `"LocalChainSync"`).
+    protocol: &'static str,
+}
+
+impl ServeCore {
+    /// Create a new core with a freshly-drawn random `StMustReply` timeout.
+    pub(crate) fn new(payload_encoder: PayloadEncoder, protocol: &'static str) -> Self {
+        Self::new_with_timeout(Self::draw_must_reply_timeout(), payload_encoder, protocol)
+    }
+
+    /// Test/explicit-timeout constructor.
+    pub(crate) fn new_with_timeout(
+        must_reply_timeout: Duration,
+        payload_encoder: PayloadEncoder,
+        protocol: &'static str,
+    ) -> Self {
+        Self {
+            cursor_slot: 0,
+            cursor_hash: [0; 32],
+            cursor_initialized: false,
+            cursor_at_origin: false,
+            must_reply_timeout,
+            payload_encoder,
+            protocol,
+        }
+    }
+
+    /// Draw a fresh `StMustReply` timeout uniformly in
+    /// `[CHAINSYNC_MUST_REPLY_TIMEOUT_MIN, CHAINSYNC_MUST_REPLY_TIMEOUT_MAX]`.
+    fn draw_must_reply_timeout() -> Duration {
+        use rand::Rng;
+        let span = CHAINSYNC_MUST_REPLY_TIMEOUT_MAX - CHAINSYNC_MUST_REPLY_TIMEOUT_MIN;
+        let span_ms = span.as_millis() as u64;
+        let mut rng = rand::rng();
+        let offset_ms = rng.random_range(0..=span_ms);
+        CHAINSYNC_MUST_REPLY_TIMEOUT_MIN + Duration::from_millis(offset_ms)
+    }
+
+    /// Configured `StMustReply` timeout (exposed for diagnostics / tests).
+    pub(crate) fn must_reply_timeout(&self) -> Duration {
+        self.must_reply_timeout
+    }
+
+    /// Run the ChainSync/LocalChainSync server loop.
+    ///
+    /// Handles `MsgFindIntersect`, `MsgRequestNext`, and `MsgDone` from the
+    /// client.  Uses `block_provider` to look up blocks, `announcement_rx`
+    /// to wait for new blocks at the tip, and `rollback_rx` to propagate
+    /// chain rollbacks to downstream peers via `MsgRollBackward`.
+    pub(crate) async fn run<B: BlockProvider>(
+        &mut self,
+        channel: &mut MuxChannel,
+        block_provider: &B,
+        mut announcement_rx: broadcast::Receiver<BlockAnnouncement>,
+        mut rollback_rx: broadcast::Receiver<RollbackAnnouncement>,
+    ) -> Result<(), ProtocolError> {
+        let task_id = self as *const _ as usize;
+        tracing::info!(
+            task_id,
+            protocol = self.protocol,
+            "chainsync server: task started"
+        );
+        loop {
+            tracing::debug!(
+                task_id,
+                protocol = self.protocol,
+                cursor_slot = self.cursor_slot,
+                cursor_at_origin = self.cursor_at_origin,
+                "chainsync server: awaiting next client message"
+            );
+            let msg_bytes = channel.recv().await.map_err(|e| {
+                tracing::info!(
+                    task_id,
+                    protocol = self.protocol,
+                    error = %e,
+                    cursor_slot = self.cursor_slot,
+                    "chainsync server: channel.recv() failed — task exiting"
+                );
+                ProtocolError::from(e)
+            })?;
+            let msg = decode_message(&msg_bytes).map_err(|e| ProtocolError::CborDecode {
+                protocol: self.protocol,
+                reason: e,
+            })?;
+
+            match msg {
+                ChainSyncMessage::MsgFindIntersect(points) => {
+                    self.handle_find_intersect(channel, block_provider, &points)
+                        .await?;
+                }
+                ChainSyncMessage::MsgRequestNext => {
+                    self.handle_request_next(
+                        channel,
+                        block_provider,
+                        &mut announcement_rx,
+                        &mut rollback_rx,
+                    )
+                    .await?;
+                }
+                ChainSyncMessage::MsgDone => {
+                    tracing::debug!(
+                        protocol = self.protocol,
+                        "chainsync server: client sent MsgDone"
+                    );
+                    return Ok(());
+                }
+                other => {
+                    return Err(ProtocolError::AgencyViolation {
+                        protocol: self.protocol,
+                        state: "StIdle".to_string(),
+                        received_tag: format!("{other:?}")
+                            .as_bytes()
+                            .first()
+                            .copied()
+                            .unwrap_or(0),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Handle MsgFindIntersect: walk the client's points to find the best match.
+    ///
+    /// # Cursor poisoning fix (#876)
+    ///
+    /// A point is only accepted as an intersection when BOTH:
+    ///  1. `hash` is on the *canonical* chain (`is_on_chain`, not merely
+    ///     `has_block` — a fork block stored alongside the chain must be
+    ///     rejected), and
+    ///  2. the client-claimed `slot` matches the block's actual on-chain
+    ///     slot (`find_chain_ancestor` on an on-chain hash returns that
+    ///     hash's own slot).
+    ///
+    /// Without this check a malicious or buggy client could claim an
+    /// arbitrary slot for a real hash (e.g. `(u64::MAX, real_hash)`),
+    /// poisoning the follower cursor and wedging the connection — every
+    /// subsequent `try_serve_next_block` lookup is keyed off the poisoned
+    /// `cursor_slot`.  On mismatch we fall through exactly as we do for a
+    /// point we don't recognise at all, eventually replying
+    /// `MsgIntersectNotFound` if no point in the list validates.
+    async fn handle_find_intersect<B: BlockProvider>(
+        &mut self,
+        channel: &mut MuxChannel,
+        block_provider: &B,
+        points: &[Point],
+    ) -> Result<(), ProtocolError> {
+        let tip = block_provider.get_tip();
+
+        // Walk points in order (most recent first), find the first one we have.
+        for point in points {
+            match point {
+                Point::Origin => {
+                    // We always have genesis.
+                    self.cursor_slot = 0;
+                    self.cursor_hash = [0; 32];
+                    self.cursor_initialized = true;
+                    self.cursor_at_origin = true;
+
+                    let response = encode_message(&ChainSyncMessage::MsgIntersectFound {
+                        point: Point::Origin,
+                        tip_slot: tip.slot,
+                        tip_hash: tip.hash,
+                        tip_block_number: tip.block_number,
+                    });
+                    channel.send(response).await.map_err(ProtocolError::from)?;
+                    return Ok(());
+                }
+                Point::Specific(slot, hash) => {
+                    if block_provider.is_on_chain(hash) {
+                        if let Some((actual_slot, ancestor_hash, _block_no)) =
+                            block_provider.find_chain_ancestor(hash)
+                        {
+                            if actual_slot == *slot && ancestor_hash == *hash {
+                                self.cursor_slot = *slot;
+                                self.cursor_hash = *hash;
+                                self.cursor_initialized = true;
+                                self.cursor_at_origin = false;
+
+                                let response =
+                                    encode_message(&ChainSyncMessage::MsgIntersectFound {
+                                        point: point.clone(),
+                                        tip_slot: tip.slot,
+                                        tip_hash: tip.hash,
+                                        tip_block_number: tip.block_number,
+                                    });
+                                channel.send(response).await.map_err(ProtocolError::from)?;
+                                return Ok(());
+                            }
+                            tracing::warn!(
+                                protocol = self.protocol,
+                                claimed_slot = slot,
+                                actual_slot,
+                                "chainsync server: MsgFindIntersect point claimed a slot that \
+                                 does not match the on-chain block's actual slot; rejecting"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        // No intersection found.
+        let response = encode_message(&ChainSyncMessage::MsgIntersectNotFound {
+            tip_slot: tip.slot,
+            tip_hash: tip.hash,
+            tip_block_number: tip.block_number,
+        });
+        channel.send(response).await.map_err(ProtocolError::from)?;
+        Ok(())
+    }
+
+    /// Handle MsgRequestNext: serve the next header/block, propagate
+    /// rollback, or wait for an announcement.
+    ///
+    /// # StMustReply loop fix (#869)
+    ///
+    /// Once `MsgAwaitReply` has been sent, the client is in `StMustReply`
+    /// and — per the Ouroboros ChainSync state machine — will not send
+    /// another `MsgRequestNext` until it receives a reply.  Every wake-up
+    /// arm in the `select!` below can legitimately produce nothing to serve
+    /// (a spurious announcement wake, a `Lagged` with nothing new past the
+    /// cursor, or the periodic timeout re-poll at a quiescent tip).  Before
+    /// this fix, any such "nothing to serve" outcome caused this function to
+    /// return `Ok(())` without ever sending a message, silently handing
+    /// agency back to the outer `run()` loop — which then blocks on
+    /// `channel.recv()` waiting for a client message that (per protocol)
+    /// will never arrive, wedging the connection until the client's own
+    /// timeout fires.
+    ///
+    /// The fix: after `MsgAwaitReply` is sent, loop the `select!` until a
+    /// message is actually sent (`served == true`).  `MsgAwaitReply` itself
+    /// is sent exactly once — the client is already in `StMustReply` and
+    /// resending it would be a protocol violation.
+    async fn handle_request_next<B: BlockProvider>(
+        &mut self,
+        channel: &mut MuxChannel,
+        block_provider: &B,
+        announcement_rx: &mut broadcast::Receiver<BlockAnnouncement>,
+        rollback_rx: &mut broadcast::Receiver<RollbackAnnouncement>,
+    ) -> Result<(), ProtocolError> {
+        // ── Check for pending rollbacks before serving ──────────────────────
+        // Drain any rollback announcements that arrived between the last
+        // MsgRequestNext and now.  If the cursor is beyond the rollback point,
+        // we must send MsgRollBackward instead of the next block.
+        if let Some(rb) = Self::drain_rollback(rollback_rx) {
+            if self.cursor_slot > rb.slot
+                || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
+            {
+                return self.send_rollback(channel, block_provider, &rb).await;
+            }
+        }
+
+        // ── Drain buffered block announcements ──────────────────────────────
+        // Block announcements are broadcast as dugite forges/relays blocks,
+        // and are buffered in the receiver.  The direct `next_block` lookup
+        // below is authoritative — dugite commits each block to ChainDB
+        // before broadcasting the announcement, so any block we need to
+        // serve is already reachable via the block provider.  Drain all
+        // buffered announcements here so that the MsgAwaitReply loop only
+        // wakes on genuinely fresh post-drain events; otherwise a stale
+        // announcement for an already-served block would be re-served and
+        // rejected by the downstream peer with `UnexpectedBlockNo`.
+        loop {
+            match announcement_rx.try_recv() {
+                Ok(_) => continue,
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(broadcast::error::TryRecvError::Closed) => break,
+            }
+        }
+
+        // Try to find and serve the next block after our cursor.
+        let task_id = self as *const _ as usize;
+        let pre_lookup_cursor = self.cursor_slot;
+        if self.try_serve_next_block(channel, block_provider).await? {
+            tracing::debug!(
+                task_id,
+                protocol = self.protocol,
+                pre_lookup_cursor,
+                post_serve_cursor = self.cursor_slot,
+                "chainsync server: direct serve path produced a message"
+            );
+            return Ok(());
+        }
+
+        // We're at the tip — send MsgAwaitReply and wait for announcement.
+        tracing::info!(
+            task_id,
+            protocol = self.protocol,
+            cursor_slot = self.cursor_slot,
+            "chainsync server: no next block — sending MsgAwaitReply, entering StMustReply"
+        );
+        let await_msg = encode_message(&ChainSyncMessage::MsgAwaitReply);
+        channel.send(await_msg).await.map_err(|e| {
+            tracing::warn!(
+                task_id,
+                protocol = self.protocol,
+                error = %e,
+                "chainsync server: MsgAwaitReply send failed"
+            );
+            ProtocolError::from(e)
+        })?;
+
+        // Wait for a block announcement OR rollback.  Timeout is the
+        // per-connection random draw in [601 s, 911 s] — matches Haskell's
+        // `minChainSyncTimeout`/`maxChainSyncTimeout` for non-trustable peers
+        // and prevents re-poll synchronization across a population of peers.
+        // Issue #701.
+        let timeout = self.must_reply_timeout;
+
+        // Bug J fix (2026-05-16): biased select so rollback_rx is always
+        // checked first when both arms are ready.  Combined with the cursor
+        // revalidation in `try_serve_next_block`, this eliminates the race
+        // where an announcement arriving simultaneously with a rollback
+        // would advance the cursor past the new chain's earlier blocks.
+        //
+        // #869 fix: loop until a message is actually sent (`served == true`).
+        // `MsgAwaitReply` is NOT re-sent on subsequent iterations — the
+        // client is already in `StMustReply`.
+        loop {
+            let served: bool = tokio::select! {
+                biased;
+
+                // ── Rollback received while waiting at tip ──────────────────
+                // This is the critical path for issue #299: a follower in
+                // MsgAwaitReply (StMustReply) must receive MsgRollBackward
+                // when the chain switches to a better fork.
+                rollback = rollback_rx.recv() => {
+                    match rollback {
+                        Ok(rb) => {
+                            // Only send rollback if cursor is at or beyond the
+                            // rollback point.  If cursor is behind, the peer
+                            // hasn't seen the rolled-back blocks yet and will
+                            // naturally follow the new fork.
+                            if self.cursor_slot > rb.slot
+                                || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
+                            {
+                                self.send_rollback(channel, block_provider, &rb).await?;
+                                true
+                            } else {
+                                // Cursor is behind the rollback point — route
+                                // through `try_serve_next_block` so cursor
+                                // revalidation (Bug J) still applies on the
+                                // post-rollback chain.
+                                self.try_serve_next_block(channel, block_provider).await?
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            // Missed rollback events — send rollback to current tip.
+                            let tip = block_provider.get_tip();
+                            let rb = RollbackAnnouncement {
+                                slot: tip.slot,
+                                hash: tip.hash,
+                            };
+                            self.send_rollback(channel, block_provider, &rb).await?;
+                            true
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                    }
+                }
+                announcement = announcement_rx.recv() => {
+                    tracing::info!(
+                        task_id,
+                        protocol = self.protocol,
+                        cursor_slot = self.cursor_slot,
+                        "chainsync server: woke from StMustReply on announcement"
+                    );
+                    match announcement {
+                        Ok(_ann) => {
+                            // The announcement is used only as a wake signal —
+                            // the block_provider is authoritative, and we MUST
+                            // re-use the same cursor-aware lookup as the
+                            // direct-serve path so that (a) slot-0 blocks at
+                            // Origin are handled via the inclusive `>=` lookup
+                            // and (b) `cursor_at_origin` is reliably cleared
+                            // after the first serve.  Trusting `ann.hash`/
+                            // `ann.slot` directly skips the `cursor_at_origin =
+                            // false` transition and causes the next
+                            // MsgRequestNext to re-serve the first block, which
+                            // Haskell rejects with `UnexpectedBlockNo`.
+                            //
+                            // Bug J fix (2026-05-16): defence-in-depth — drain
+                            // any queued rollback first so the
+                            // announcement-first race is closed even if
+                            // `try_serve_next_block`'s cursor revalidation
+                            // somehow missed (e.g., the cursor was still on
+                            // the old chain but the rollback queue had a
+                            // pending event).
+                            if let Some(rb) = Self::drain_rollback(rollback_rx) {
+                                if self.cursor_slot > rb.slot
+                                    || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
+                                {
+                                    self.send_rollback(channel, block_provider, &rb).await?;
+                                    true
+                                } else {
+                                    self.try_serve_next_block(channel, block_provider).await?
+                                }
+                            } else {
+                                self.try_serve_next_block(channel, block_provider).await?
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                n,
+                                protocol = self.protocol,
+                                "chainsync server: announcement channel lagged; catching up from tip"
+                            );
+                            // Route through `try_serve_next_block` so cursor
+                            // revalidation still applies after the lag.
+                            self.try_serve_next_block(channel, block_provider).await?
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                    }
+                }
+                _ = tokio::time::sleep(timeout) => {
+                    tracing::warn!(
+                        task_id,
+                        protocol = self.protocol,
+                        cursor_slot = self.cursor_slot,
+                        timeout_seconds = timeout.as_secs(),
+                        "chainsync server: StMustReply timed out — re-polling block provider for next block"
+                    );
+                    self.try_serve_next_block(channel, block_provider).await?
+                }
+            };
+
+            if served {
+                return Ok(());
+            }
+            // Nothing was sent (spurious wake) — the client is still in
+            // StMustReply and will not send another MsgRequestNext, so we
+            // must keep waiting on the SAME select! rather than returning.
+        }
+    }
+
+    /// Look up the next block after the cursor and send it as `MsgRollForward`.
+    ///
+    /// This is the single authoritative serve path used by every wake-up site
+    /// in `handle_request_next` (direct path, announcement wake-up, timeout
+    /// poll). It respects `cursor_at_origin` by using the inclusive `>=`
+    /// lookup so a block at slot 0 (e.g. Byron genesis EBB) is not skipped,
+    /// and it unconditionally clears `cursor_at_origin` after a successful
+    /// serve.
+    ///
+    /// # Cursor revalidation (Bug J fix, 2026-05-16)
+    ///
+    /// Before serving, validate that the cursor's block is still on the
+    /// canonical chain.  If a fork switch has displaced it, send
+    /// `MsgRollBackward` to the most recent ancestor still on chain
+    /// instead of `MsgRollForward`.  This matches the Haskell ChainSync
+    /// server's behaviour: the follower's cursor anchor must always be
+    /// on the chain that the server is currently serving.
+    ///
+    /// Without this check, `get_next_block_after_slot(cursor_slot)`
+    /// silently skips any new-chain blocks whose slots fall ≤ `cursor_slot`
+    /// after a chain switch — the empirical Bug J failure mode.
+    ///
+    /// Returns `Ok(true)` if a message was sent (either `MsgRollForward` or
+    /// `MsgRollBackward`), `Ok(false)` if there is no next block to serve
+    /// (caller should continue waiting at the tip).
+    async fn try_serve_next_block<B: BlockProvider>(
+        &mut self,
+        channel: &mut MuxChannel,
+        block_provider: &B,
+    ) -> Result<bool, ProtocolError> {
+        let task_id = self as *const _ as usize;
+        // ── Cursor revalidation (Bug J) ─────────────────────────────────────
+        // Skip when the cursor is at Origin — the all-zero hash is by design
+        // not a stored block, so `is_on_chain` would always be false and we'd
+        // emit a redundant Origin → Origin rollback.
+        if !self.cursor_at_origin && !block_provider.is_on_chain(&self.cursor_hash) {
+            let rb = match block_provider.find_chain_ancestor(&self.cursor_hash) {
+                Some((slot, hash, _bn)) => RollbackAnnouncement { slot, hash },
+                // No ancestor reachable on chain — rewind all the way to
+                // Origin and let the peer resync from genesis.
+                None => RollbackAnnouncement {
+                    slot: 0,
+                    hash: [0u8; 32],
+                },
+            };
+            tracing::info!(
+                task_id,
+                protocol = self.protocol,
+                cursor_slot = self.cursor_slot,
+                rewind_slot = rb.slot,
+                "chainsync server: cursor rolled off chain; \
+                 sending MsgRollBackward to ancestor"
+            );
+            self.send_rollback(channel, block_provider, &rb).await?;
+            return Ok(true);
+        }
+
+        // When cursor_at_origin is true, use the inclusive `>=` lookup so that
+        // a block at slot 0 is not skipped.  The strict `>` lookup would miss
+        // it since cursor_slot is 0.
+        //
+        // Otherwise advance by POINT, not by slot: a Byron EBB shares its
+        // absolute slot with the first main block of the epoch, and a
+        // slot-only advance from the EBB would skip that main block,
+        // serving the peer a chain with a hole in it.
+        let lookup_start = std::time::Instant::now();
+        let next_block = if self.cursor_at_origin {
+            block_provider.get_block_at_or_after_slot(0)
+        } else {
+            block_provider.get_next_block_after_point(self.cursor_slot, &self.cursor_hash)
+        };
+        let lookup_elapsed = lookup_start.elapsed();
+        if lookup_elapsed.as_millis() > 50 {
+            tracing::warn!(
+                task_id,
+                protocol = self.protocol,
+                cursor_slot = self.cursor_slot,
+                elapsed_ms = lookup_elapsed.as_millis() as u64,
+                "chainsync server: block_provider lookup slow"
+            );
+        }
+
+        let Some((slot, hash, block_cbor)) = next_block else {
+            return Ok(false);
+        };
+
+        // Encode the payload — HFC-wrapped header for N2N, Serialised full
+        // block for N2C.  See `PayloadEncoder`.
+        let payload = (self.payload_encoder)(&block_cbor).map_err(|e| {
+            tracing::warn!(
+                task_id,
+                protocol = self.protocol,
+                serve_slot = slot,
+                error = %e,
+                "chainsync server: payload encoding failed"
+            );
+            e
+        })?;
+
+        let tip = block_provider.get_tip();
+        let response = encode_message(&ChainSyncMessage::MsgRollForward {
+            header: payload,
+            tip_slot: tip.slot,
+            tip_hash: tip.hash,
+            tip_block_number: tip.block_number,
+        });
+        let send_start = std::time::Instant::now();
+        let send_result = channel.send(response).await;
+        let send_elapsed = send_start.elapsed();
+        if send_elapsed.as_millis() > 100 {
+            tracing::warn!(
+                task_id,
+                protocol = self.protocol,
+                cursor_slot = self.cursor_slot,
+                serve_slot = slot,
+                send_elapsed_ms = send_elapsed.as_millis() as u64,
+                ok = send_result.is_ok(),
+                "chainsync server: MsgRollForward send slow"
+            );
+        }
+        send_result.map_err(ProtocolError::from)?;
+        tracing::info!(
+            task_id,
+            protocol = self.protocol,
+            cursor_slot = self.cursor_slot,
+            serve_slot = slot,
+            "chainsync server: served MsgRollForward"
+        );
+
+        // Advance cursor and — critically — clear cursor_at_origin so the
+        // next MsgRequestNext uses the strict `>` lookup and does not
+        // re-serve the same block.
+        self.cursor_slot = slot;
+        self.cursor_hash = hash;
+        self.cursor_at_origin = false;
+        Ok(true)
+    }
+
+    /// Drain any pending rollback announcements, returning the most recent one.
+    ///
+    /// Multiple rollbacks may have queued up between calls — only the latest
+    /// matters because each successive rollback supersedes the previous one.
+    pub(crate) fn drain_rollback(
+        rollback_rx: &mut broadcast::Receiver<RollbackAnnouncement>,
+    ) -> Option<RollbackAnnouncement> {
+        let mut latest: Option<RollbackAnnouncement> = None;
+        loop {
+            match rollback_rx.try_recv() {
+                Ok(rb) => latest = Some(rb),
+                Err(broadcast::error::TryRecvError::Lagged(_)) => {
+                    // Missed some — continue draining to get latest.
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
+        latest
+    }
+
+    /// Send `MsgRollBackward` to the downstream peer and rewind the cursor.
+    async fn send_rollback<B: BlockProvider>(
+        &mut self,
+        channel: &mut MuxChannel,
+        block_provider: &B,
+        rb: &RollbackAnnouncement,
+    ) -> Result<(), ProtocolError> {
+        let tip = block_provider.get_tip();
+        let point = if rb.slot == 0 && rb.hash == [0u8; 32] {
+            Point::Origin
+        } else {
+            Point::Specific(rb.slot, rb.hash)
+        };
+
+        tracing::info!(
+            protocol = self.protocol,
+            rollback_slot = rb.slot,
+            cursor_slot = self.cursor_slot,
+            "chainsync server: sending MsgRollBackward to downstream peer"
+        );
+
+        let response = encode_message(&ChainSyncMessage::MsgRollBackward {
+            point: point.clone(),
+            tip_slot: tip.slot,
+            tip_hash: tip.hash,
+            tip_block_number: tip.block_number,
+        });
+        channel.send(response).await.map_err(ProtocolError::from)?;
+
+        // Rewind cursor to the rollback point.
+        self.cursor_slot = rb.slot;
+        self.cursor_hash = rb.hash;
+        self.cursor_at_origin = matches!(point, Point::Origin);
+
+        Ok(())
+    }
+}
+
+/// Test-only mock `BlockProvider` implementations shared by the N2N
+/// (`chainsync::server`) and N2C (`local_chainsync::server`) test suites, so
+/// both wirings exercise the exact same `BlockProvider` semantics against
+/// the shared [`ServeCore`].
+#[cfg(test)]
+pub(crate) mod test_support {
+    use crate::{BlockProvider, TipInfo};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// Flat block store with no fork tracking — every stored block is
+    /// considered on-chain.  Matches the assumption of most ChainSync tests,
+    /// which don't model competing forks.
+    pub(crate) struct MockBlockProvider {
+        pub(crate) blocks: Vec<(u64, [u8; 32], Vec<u8>)>,
+    }
+
+    impl BlockProvider for MockBlockProvider {
+        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
+            self.blocks
+                .iter()
+                .find(|(_, h, _)| h == hash)
+                .map(|(_, _, cbor)| cbor.clone())
+        }
+
+        fn has_block(&self, hash: &[u8; 32]) -> bool {
+            self.blocks.iter().any(|(_, h, _)| h == hash)
+        }
+
+        fn get_tip(&self) -> TipInfo {
+            if let Some((slot, hash, _)) = self.blocks.last() {
+                TipInfo {
+                    slot: *slot,
+                    hash: *hash,
+                    block_number: self.blocks.len() as u64,
+                }
+            } else {
+                TipInfo {
+                    slot: 0,
+                    hash: [0; 32],
+                    block_number: 0,
+                }
+            }
+        }
+
+        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            self.blocks
+                .iter()
+                .find(|(s, _, _)| *s > after_slot)
+                .cloned()
+        }
+
+        fn get_next_block_after_point(
+            &self,
+            slot: u64,
+            hash: &[u8; 32],
+        ) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            if let Some(pos) = self
+                .blocks
+                .iter()
+                .position(|(s, h, _)| *s == slot && h == hash)
+            {
+                return self.blocks.get(pos + 1).cloned();
+            }
+            self.get_next_block_after_slot(slot)
+        }
+
+        fn get_block_at_or_after_slot(&self, slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            // Inclusive `>=` lookup — the default trait impl is exclusive at
+            // slot 0 and would silently skip a genesis-EBB-style block sitting
+            // exactly at slot 0 (issue #868).
+            self.blocks.iter().find(|(s, _, _)| *s >= slot).cloned()
+        }
+
+        fn is_on_chain(&self, hash: &[u8; 32]) -> bool {
+            self.blocks.iter().any(|(_, h, _)| h == hash)
+        }
+
+        fn find_chain_ancestor(&self, start_hash: &[u8; 32]) -> Option<(u64, [u8; 32], u64)> {
+            self.blocks
+                .iter()
+                .enumerate()
+                .find(|(_, (_, h, _))| h == start_hash)
+                .map(|(i, (s, h, _))| (*s, *h, (i + 1) as u64))
+        }
+    }
+
+    /// Block slot, hash, and CBOR data — the elements stored in mutable mock providers.
+    pub(crate) type BlockEntry = (u64, [u8; 32], Vec<u8>);
+
+    /// Mock block provider that supports mutation for simulating rollback scenarios.
+    ///
+    /// Wraps blocks in an `Arc<Mutex<_>>` so both the server task and the test
+    /// can modify the block set concurrently (simulating ChainDB changes during
+    /// a fork switch).  Like [`MockBlockProvider`], every stored block is
+    /// considered on-chain — "removal" of a block from the vector IS the
+    /// rollback simulation.
+    pub(crate) struct MutableMockBlockProvider {
+        pub(crate) blocks: Arc<Mutex<Vec<BlockEntry>>>,
+    }
+
+    impl MutableMockBlockProvider {
+        pub(crate) fn new(blocks: Vec<BlockEntry>) -> Self {
+            Self {
+                blocks: Arc::new(Mutex::new(blocks)),
+            }
+        }
+    }
+
+    impl BlockProvider for MutableMockBlockProvider {
+        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
+            self.blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(_, h, _)| h == hash)
+                .map(|(_, _, cbor)| cbor.clone())
+        }
+
+        fn has_block(&self, hash: &[u8; 32]) -> bool {
+            self.blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, h, _)| h == hash)
+        }
+
+        fn get_tip(&self) -> TipInfo {
+            let blocks = self.blocks.lock().unwrap();
+            if let Some((slot, hash, _)) = blocks.last() {
+                TipInfo {
+                    slot: *slot,
+                    hash: *hash,
+                    block_number: blocks.len() as u64,
+                }
+            } else {
+                TipInfo {
+                    slot: 0,
+                    hash: [0; 32],
+                    block_number: 0,
+                }
+            }
+        }
+
+        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            self.blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(s, _, _)| *s > after_slot)
+                .cloned()
+        }
+
+        fn get_block_at_or_after_slot(&self, slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            self.blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(s, _, _)| *s >= slot)
+                .cloned()
+        }
+
+        fn is_on_chain(&self, hash: &[u8; 32]) -> bool {
+            self.blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, h, _)| h == hash)
+        }
+
+        fn find_chain_ancestor(&self, start_hash: &[u8; 32]) -> Option<(u64, [u8; 32], u64)> {
+            self.blocks
+                .lock()
+                .unwrap()
+                .iter()
+                .enumerate()
+                .find(|(_, (_, h, _))| h == start_hash)
+                .map(|(i, (s, h, _))| (*s, *h, (i + 1) as u64))
+        }
+    }
+
+    /// Fork-aware mock that distinguishes blocks on the *canonical chain*
+    /// from blocks merely stored as forks — required to exercise cursor
+    /// revalidation (Bug J) and `MsgFindIntersect` fork/slot validation (#876).
+    pub(crate) type StoredBlock = (u64, u64, [u8; 32], Vec<u8>); // (slot, block_no, prev_hash, cbor)
+
+    pub(crate) struct ForkAwareMockProvider {
+        /// Hashes on the current canonical chain, oldest → newest.
+        pub(crate) chain: Arc<Mutex<Vec<[u8; 32]>>>,
+        /// Every stored block keyed by hash.
+        pub(crate) store: Arc<Mutex<HashMap<[u8; 32], StoredBlock>>>,
+    }
+
+    impl ForkAwareMockProvider {
+        pub(crate) fn new() -> Self {
+            Self {
+                chain: Arc::new(Mutex::new(Vec::new())),
+                store: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        /// Append a block to the canonical chain.
+        pub(crate) fn push_on_chain(
+            &self,
+            slot: u64,
+            hash: [u8; 32],
+            prev_hash: [u8; 32],
+            block_no: u64,
+            cbor: Vec<u8>,
+        ) {
+            self.store
+                .lock()
+                .unwrap()
+                .insert(hash, (slot, block_no, prev_hash, cbor));
+            self.chain.lock().unwrap().push(hash);
+        }
+
+        /// Store a block as a fork (not on canonical chain).
+        pub(crate) fn put_fork(
+            &self,
+            slot: u64,
+            hash: [u8; 32],
+            prev_hash: [u8; 32],
+            block_no: u64,
+            cbor: Vec<u8>,
+        ) {
+            self.store
+                .lock()
+                .unwrap()
+                .insert(hash, (slot, block_no, prev_hash, cbor));
+        }
+
+        /// Replace the canonical chain wholesale (simulates a fork switch).
+        /// All previously-on-chain blocks not in `new_chain` become forks.
+        pub(crate) fn replace_chain(&self, new_chain: Vec<[u8; 32]>) {
+            *self.chain.lock().unwrap() = new_chain;
+        }
+    }
+
+    impl BlockProvider for ForkAwareMockProvider {
+        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
+            self.store
+                .lock()
+                .unwrap()
+                .get(hash)
+                .map(|(_, _, _, cbor)| cbor.clone())
+        }
+
+        fn has_block(&self, hash: &[u8; 32]) -> bool {
+            self.store.lock().unwrap().contains_key(hash)
+        }
+
+        fn get_tip(&self) -> TipInfo {
+            let chain = self.chain.lock().unwrap();
+            let store = self.store.lock().unwrap();
+            if let Some(tip_hash) = chain.last() {
+                if let Some((slot, block_no, _, _)) = store.get(tip_hash) {
+                    return TipInfo {
+                        slot: *slot,
+                        hash: *tip_hash,
+                        block_number: *block_no,
+                    };
+                }
+            }
+            TipInfo {
+                slot: 0,
+                hash: [0; 32],
+                block_number: 0,
+            }
+        }
+
+        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            // Walk the canonical chain in order looking for the first block
+            // with slot > after_slot.  Mirrors VolatileDB's behaviour.
+            let chain = self.chain.lock().unwrap();
+            let store = self.store.lock().unwrap();
+            for hash in chain.iter() {
+                if let Some((slot, _, _, cbor)) = store.get(hash) {
+                    if *slot > after_slot {
+                        return Some((*slot, *hash, cbor.clone()));
+                    }
+                }
+            }
+            None
+        }
+
+        fn get_block_at_or_after_slot(&self, slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
+            let chain = self.chain.lock().unwrap();
+            let store = self.store.lock().unwrap();
+            for hash in chain.iter() {
+                if let Some((s, _, _, cbor)) = store.get(hash) {
+                    if *s >= slot {
+                        return Some((*s, *hash, cbor.clone()));
+                    }
+                }
+            }
+            None
+        }
+
+        fn is_on_chain(&self, hash: &[u8; 32]) -> bool {
+            self.chain.lock().unwrap().iter().any(|h| h == hash)
+        }
+
+        fn find_chain_ancestor(&self, start_hash: &[u8; 32]) -> Option<(u64, [u8; 32], u64)> {
+            let chain: std::collections::HashSet<[u8; 32]> =
+                self.chain.lock().unwrap().iter().copied().collect();
+            let store = self.store.lock().unwrap();
+            let mut current = *start_hash;
+            let mut visited = std::collections::HashSet::new();
+            loop {
+                if !visited.insert(current) {
+                    return None;
+                }
+                if chain.contains(&current) {
+                    let (slot, block_no, _, _) = store.get(&current)?;
+                    return Some((*slot, current, *block_no));
+                }
+                let (_, _, prev_hash, _) = store.get(&current)?;
+                current = *prev_hash;
+            }
+        }
+    }
+}

--- a/crates/dugite-network/src/protocol/chainsync/server.rs
+++ b/crates/dugite-network/src/protocol/chainsync/server.rs
@@ -28,15 +28,19 @@ use std::time::Duration;
 use minicbor::{Decoder, Encoder};
 use tokio::sync::broadcast;
 
-use crate::codec::Point;
 use crate::error::ProtocolError;
 use crate::mux::channel::MuxChannel;
 use crate::BlockProvider;
 
-use super::{decode_message, encode_message, ChainSyncMessage};
+use super::serve_core::ServeCore;
 
 // Re-use shared HFC helpers from the protocol module.
 use crate::protocol::{storage_era_tag_to_hfc_index, CBOR_TAG_EMBEDDED};
+
+#[cfg(test)]
+use super::{decode_message, encode_message, ChainSyncMessage};
+#[cfg(test)]
+use crate::codec::Point;
 
 /// Extract the block header from raw HFC-wrapped block CBOR and encode it as
 /// `[hfc_index, #6.24(bstr(header_cbor))]` ready for inlining into MsgRollForward.
@@ -150,20 +154,27 @@ pub const CHAINSYNC_MUST_REPLY_TIMEOUT_MIN: Duration = Duration::from_secs(601);
 /// [`CHAINSYNC_MUST_REPLY_TIMEOUT_MIN`]).  Issue #701.
 pub const CHAINSYNC_MUST_REPLY_TIMEOUT_MAX: Duration = Duration::from_secs(911);
 
+/// Encode the `MsgRollForward` payload for N2N ChainSync: extract just the
+/// block header and HFC-wrap it.  Wraps [`extract_header_for_chainsync`]'s
+/// `String` error into a [`ProtocolError::CborDecode`] to match the
+/// `PayloadEncoder` signature used by the shared serve core (issue #881).
+fn n2n_payload_encoder(block_cbor: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+    extract_header_for_chainsync(block_cbor).map_err(|reason| ProtocolError::CborDecode {
+        protocol: "ChainSync",
+        reason: format!("header extraction failed: {reason}"),
+    })
+}
+
 /// ChainSync server that serves headers to a single downstream peer.
+///
+/// A thin wrapper around the shared `ServeCore` (issue #881) — all protocol
+/// logic (cursor tracking, `MsgFindIntersect`/`MsgRequestNext` handling,
+/// rollback propagation, `StMustReply` retry loop) lives in the shared core.
+/// This type only supplies the N2N-specific payload encoder
+/// ([`n2n_payload_encoder`]: HFC-wrapped header, not the full block) and the
+/// `"ChainSync"` protocol label.
 pub struct ChainSyncServer {
-    /// Current cursor: the last point served to this peer.
-    cursor_slot: u64,
-    cursor_hash: [u8; 32],
-    /// Whether the cursor has been initialized (via intersection or genesis).
-    cursor_initialized: bool,
-    /// True when the cursor is at Origin — meaning no block has been served
-    /// yet and we must include blocks at slot 0 (e.g. Byron genesis EBB).
-    cursor_at_origin: bool,
-    /// Per-connection `StMustReply` timeout, drawn once at construction
-    /// uniformly from `[CHAINSYNC_MUST_REPLY_TIMEOUT_MIN, CHAINSYNC_MUST_REPLY_TIMEOUT_MAX]`.
-    /// Mirrors Haskell's per-connection timeout draw (#701).
-    must_reply_timeout: Duration,
+    core: ServeCore,
 }
 
 impl ChainSyncServer {
@@ -173,7 +184,9 @@ impl ChainSyncServer {
     /// `[601 s, 911 s]` to match Haskell's `ouroboros-network` ChainSync
     /// codec timeout policy.
     pub fn new() -> Self {
-        Self::new_with_timeout(Self::draw_must_reply_timeout())
+        Self {
+            core: ServeCore::new(n2n_payload_encoder, "ChainSync"),
+        }
     }
 
     /// Test/explicit-timeout constructor.  Production code should call
@@ -182,28 +195,13 @@ impl ChainSyncServer {
     #[doc(hidden)]
     pub fn new_with_timeout(must_reply_timeout: Duration) -> Self {
         Self {
-            cursor_slot: 0,
-            cursor_hash: [0; 32],
-            cursor_initialized: false,
-            cursor_at_origin: false,
-            must_reply_timeout,
+            core: ServeCore::new_with_timeout(must_reply_timeout, n2n_payload_encoder, "ChainSync"),
         }
-    }
-
-    /// Draw a fresh `StMustReply` timeout uniformly in
-    /// `[CHAINSYNC_MUST_REPLY_TIMEOUT_MIN, CHAINSYNC_MUST_REPLY_TIMEOUT_MAX]`.
-    fn draw_must_reply_timeout() -> Duration {
-        use rand::Rng;
-        let span = CHAINSYNC_MUST_REPLY_TIMEOUT_MAX - CHAINSYNC_MUST_REPLY_TIMEOUT_MIN;
-        let span_ms = span.as_millis() as u64;
-        let mut rng = rand::rng();
-        let offset_ms = rng.random_range(0..=span_ms);
-        CHAINSYNC_MUST_REPLY_TIMEOUT_MIN + Duration::from_millis(offset_ms)
     }
 
     /// Configured `StMustReply` timeout (exposed for diagnostics / tests).
     pub fn must_reply_timeout(&self) -> Duration {
-        self.must_reply_timeout
+        self.core.must_reply_timeout()
     }
 
     /// Run the ChainSync server loop.
@@ -216,495 +214,23 @@ impl ChainSyncServer {
         &mut self,
         channel: &mut MuxChannel,
         block_provider: &B,
-        mut announcement_rx: broadcast::Receiver<BlockAnnouncement>,
-        mut rollback_rx: broadcast::Receiver<RollbackAnnouncement>,
+        announcement_rx: broadcast::Receiver<BlockAnnouncement>,
+        rollback_rx: broadcast::Receiver<RollbackAnnouncement>,
     ) -> Result<(), ProtocolError> {
-        let task_id = self as *const _ as usize;
-        tracing::info!(task_id, "chainsync server: task started");
-        loop {
-            tracing::debug!(
-                task_id,
-                cursor_slot = self.cursor_slot,
-                cursor_at_origin = self.cursor_at_origin,
-                "chainsync server: awaiting next client message"
-            );
-            let msg_bytes = channel.recv().await.map_err(|e| {
-                tracing::info!(
-                    task_id,
-                    error = %e,
-                    cursor_slot = self.cursor_slot,
-                    "chainsync server: channel.recv() failed — task exiting"
-                );
-                ProtocolError::from(e)
-            })?;
-            let msg = decode_message(&msg_bytes).map_err(|e| ProtocolError::CborDecode {
-                protocol: "ChainSync",
-                reason: e,
-            })?;
-
-            match msg {
-                ChainSyncMessage::MsgFindIntersect(points) => {
-                    self.handle_find_intersect(channel, block_provider, &points)
-                        .await?;
-                }
-                ChainSyncMessage::MsgRequestNext => {
-                    self.handle_request_next(
-                        channel,
-                        block_provider,
-                        &mut announcement_rx,
-                        &mut rollback_rx,
-                    )
-                    .await?;
-                }
-                ChainSyncMessage::MsgDone => {
-                    tracing::debug!("chainsync server: client sent MsgDone");
-                    return Ok(());
-                }
-                other => {
-                    return Err(ProtocolError::AgencyViolation {
-                        protocol: "ChainSync",
-                        state: "StIdle".to_string(),
-                        received_tag: format!("{other:?}")
-                            .as_bytes()
-                            .first()
-                            .copied()
-                            .unwrap_or(0),
-                    });
-                }
-            }
-        }
-    }
-
-    /// Handle MsgFindIntersect: walk the client's points to find the best match.
-    async fn handle_find_intersect<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-        points: &[Point],
-    ) -> Result<(), ProtocolError> {
-        let tip = block_provider.get_tip();
-
-        // Walk points in order (most recent first), find the first one we have
-        for point in points {
-            match point {
-                Point::Origin => {
-                    // We always have genesis
-                    self.cursor_slot = 0;
-                    self.cursor_hash = [0; 32];
-                    self.cursor_initialized = true;
-                    self.cursor_at_origin = true;
-
-                    let response = encode_message(&ChainSyncMessage::MsgIntersectFound {
-                        point: Point::Origin,
-                        tip_slot: tip.slot,
-                        tip_hash: tip.hash,
-                        tip_block_number: tip.block_number,
-                    });
-                    channel.send(response).await.map_err(ProtocolError::from)?;
-                    return Ok(());
-                }
-                Point::Specific(slot, hash) => {
-                    if block_provider.has_block(hash) {
-                        self.cursor_slot = *slot;
-                        self.cursor_hash = *hash;
-                        self.cursor_initialized = true;
-                        self.cursor_at_origin = false;
-
-                        let response = encode_message(&ChainSyncMessage::MsgIntersectFound {
-                            point: point.clone(),
-                            tip_slot: tip.slot,
-                            tip_hash: tip.hash,
-                            tip_block_number: tip.block_number,
-                        });
-                        channel.send(response).await.map_err(ProtocolError::from)?;
-                        return Ok(());
-                    }
-                }
-            }
-        }
-
-        // No intersection found
-        let response = encode_message(&ChainSyncMessage::MsgIntersectNotFound {
-            tip_slot: tip.slot,
-            tip_hash: tip.hash,
-            tip_block_number: tip.block_number,
-        });
-        channel.send(response).await.map_err(ProtocolError::from)?;
-        Ok(())
-    }
-
-    /// Handle MsgRequestNext: serve the next header, propagate rollback, or wait
-    /// for an announcement.
-    ///
-    /// When a rollback is detected (either because the cursor points beyond the
-    /// rollback point, or a `RollbackAnnouncement` arrives while waiting at the
-    /// tip), the server sends `MsgRollBackward` to rewind the downstream peer's
-    /// cursor.
-    async fn handle_request_next<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-        announcement_rx: &mut broadcast::Receiver<BlockAnnouncement>,
-        rollback_rx: &mut broadcast::Receiver<RollbackAnnouncement>,
-    ) -> Result<(), ProtocolError> {
-        // ── Check for pending rollbacks before serving ──────────────────────
-        // Drain any rollback announcements that arrived between the last
-        // MsgRequestNext and now.  If the cursor is beyond the rollback point,
-        // we must send MsgRollBackward instead of the next block.
-        if let Some(rb) = Self::drain_rollback(rollback_rx) {
-            if self.cursor_slot > rb.slot
-                || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
-            {
-                return self.send_rollback(channel, block_provider, &rb).await;
-            }
-        }
-
-        // ── Drain buffered block announcements ──────────────────────────────
-        // Block announcements are broadcast as dugite forges blocks, and are
-        // buffered in the receiver.  The direct `next_block` lookup below is
-        // authoritative — dugite commits each block to ChainDB before
-        // broadcasting the announcement, so any block we need to serve is
-        // already reachable via the block provider.  Drain all buffered
-        // announcements here so that the MsgAwaitReply loop only wakes on
-        // genuinely fresh post-drain forging events; otherwise a stale
-        // announcement for an already-served block would be re-served and
-        // rejected by the downstream peer with `UnexpectedBlockNo`.
-        loop {
-            match announcement_rx.try_recv() {
-                Ok(_) => continue,
-                Err(broadcast::error::TryRecvError::Empty) => break,
-                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
-                Err(broadcast::error::TryRecvError::Closed) => break,
-            }
-        }
-
-        // Try to find and serve the next block after our cursor.
-        let task_id = self as *const _ as usize;
-        let pre_lookup_cursor = self.cursor_slot;
-        if self.try_serve_next_block(channel, block_provider).await? {
-            tracing::debug!(
-                task_id,
-                pre_lookup_cursor,
-                post_serve_cursor = self.cursor_slot,
-                "chainsync server: direct serve path produced a message"
-            );
-            return Ok(());
-        }
-
-        // We're at the tip — send MsgAwaitReply and wait for announcement.
-        tracing::info!(
-            task_id,
-            cursor_slot = self.cursor_slot,
-            "chainsync server: no next block — sending MsgAwaitReply, entering StMustReply"
-        );
-        let await_msg = encode_message(&ChainSyncMessage::MsgAwaitReply);
-        channel.send(await_msg).await.map_err(|e| {
-            tracing::warn!(
-                task_id,
-                error = %e,
-                "chainsync server: MsgAwaitReply send failed"
-            );
-            ProtocolError::from(e)
-        })?;
-
-        // Wait for a block announcement OR rollback.  Timeout is the
-        // per-connection random draw in [601 s, 911 s] — matches Haskell's
-        // `minChainSyncTimeout`/`maxChainSyncTimeout` for non-trustable peers
-        // and prevents re-poll synchronization across a population of peers.
-        // Issue #701.
-        let timeout = self.must_reply_timeout;
-
-        // Bug J fix (2026-05-16): biased select so rollback_rx is always
-        // checked first when both arms are ready.  Combined with the cursor
-        // revalidation in `try_serve_next_block`, this eliminates the race
-        // where an announcement arriving simultaneously with a rollback
-        // would advance the cursor past the new chain's earlier blocks.
-        tokio::select! {
-            biased;
-
-            // ── Rollback received while waiting at tip ──────────────────────
-            // This is the critical path for issue #299: a follower in
-            // MsgAwaitReply (StMustReply) must receive MsgRollBackward when
-            // the chain switches to a better fork.
-            rollback = rollback_rx.recv() => {
-                match rollback {
-                    Ok(rb) => {
-                        // Only send rollback if cursor is at or beyond the rollback point.
-                        // If cursor is behind, the peer hasn't seen the rolled-back blocks
-                        // yet and will naturally follow the new fork.
-                        if self.cursor_slot > rb.slot
-                            || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
-                        {
-                            self.send_rollback(channel, block_provider, &rb).await
-                        } else {
-                            // Cursor is behind the rollback point — route through
-                            // `try_serve_next_block` so cursor revalidation (Bug J)
-                            // still applies on the post-rollback chain.
-                            self.try_serve_next_block(channel, block_provider).await?;
-                            Ok(())
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        // Missed rollback events — send rollback to current tip.
-                        let tip = block_provider.get_tip();
-                        let rb = RollbackAnnouncement {
-                            slot: tip.slot,
-                            hash: tip.hash,
-                        };
-                        self.send_rollback(channel, block_provider, &rb).await
-                    }
-                    Err(broadcast::error::RecvError::Closed) => Ok(()),
-                }
-            }
-            announcement = announcement_rx.recv() => {
-                tracing::info!(
-                    task_id,
-                    cursor_slot = self.cursor_slot,
-                    "chainsync server: woke from StMustReply on announcement"
-                );
-                match announcement {
-                    Ok(_ann) => {
-                        // The announcement is used only as a wake signal — the
-                        // block_provider is authoritative, and we MUST re-use
-                        // the same cursor-aware lookup as the direct-serve path
-                        // so that (a) slot-0 blocks at Origin are handled via
-                        // the inclusive `>=` lookup and (b) `cursor_at_origin`
-                        // is reliably cleared after the first serve.  Trusting
-                        // `ann.hash`/`ann.slot` directly skips the `cursor_at_origin
-                        // = false` transition and causes the next
-                        // MsgRequestNext to re-serve the first block, which
-                        // Haskell rejects with `UnexpectedBlockNo`.
-                        //
-                        // Bug J fix (2026-05-16): defence-in-depth — drain any
-                        // queued rollback first so the announcement-first race
-                        // is closed even if `try_serve_next_block`'s cursor
-                        // revalidation somehow missed (e.g., the cursor was
-                        // still on the old chain but the rollback queue had a
-                        // pending event).
-                        if let Some(rb) = Self::drain_rollback(rollback_rx) {
-                            if self.cursor_slot > rb.slot
-                                || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
-                            {
-                                return self.send_rollback(channel, block_provider, &rb).await;
-                            }
-                        }
-                        self.try_serve_next_block(channel, block_provider).await?;
-                        Ok(())
-                    }
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!(
-                            n,
-                            "chainsync server: announcement channel lagged; catching up from tip"
-                        );
-                        // Route through `try_serve_next_block` so cursor
-                        // revalidation still applies after the lag.
-                        self.try_serve_next_block(channel, block_provider).await?;
-                        Ok(())
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        // Broadcast sender dropped — node is shutting down.
-                        Ok(())
-                    }
-                }
-            }
-            _ = tokio::time::sleep(timeout) => {
-                tracing::warn!(
-                    task_id,
-                    cursor_slot = self.cursor_slot,
-                    timeout_seconds = timeout.as_secs(),
-                    "chainsync server: StMustReply timed out — re-polling block provider for next block"
-                );
-                self.try_serve_next_block(channel, block_provider).await?;
-                Ok(())
-            }
-        }
-    }
-
-    /// Look up the next block after the cursor and send it as `MsgRollForward`.
-    ///
-    /// This is the single authoritative serve path used by every wake-up site
-    /// in `handle_request_next` (direct path, announcement wake-up, timeout
-    /// poll). It respects `cursor_at_origin` by using the inclusive `>=`
-    /// lookup so a block at slot 0 (e.g. Byron genesis EBB) is not skipped,
-    /// and it unconditionally clears `cursor_at_origin` after a successful
-    /// serve.
-    ///
-    /// # Cursor revalidation (Bug J fix, 2026-05-16)
-    ///
-    /// Before serving, validate that the cursor's block is still on the
-    /// canonical chain.  If a fork switch has displaced it, send
-    /// `MsgRollBackward` to the most recent ancestor still on chain
-    /// instead of `MsgRollForward`.  This matches the Haskell ChainSync
-    /// server's behaviour: the follower's cursor anchor must always be
-    /// on the chain that the server is currently serving.
-    ///
-    /// Without this check, `get_next_block_after_slot(cursor_slot)`
-    /// silently skips any new-chain blocks whose slots fall ≤ `cursor_slot`
-    /// after a chain switch — the empirical Bug J failure mode.
-    ///
-    /// Returns `Ok(true)` if a message was sent (either `MsgRollForward` or
-    /// `MsgRollBackward`), `Ok(false)` if there is no next block to serve
-    /// (caller should continue waiting at the tip).
-    async fn try_serve_next_block<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-    ) -> Result<bool, ProtocolError> {
-        let task_id = self as *const _ as usize;
-        // ── Cursor revalidation (Bug J) ─────────────────────────────────────
-        // Skip when the cursor is at Origin — the all-zero hash is by design
-        // not a stored block, so `is_on_chain` would always be false and we'd
-        // emit a redundant Origin → Origin rollback.
-        if !self.cursor_at_origin && !block_provider.is_on_chain(&self.cursor_hash) {
-            let rb = match block_provider.find_chain_ancestor(&self.cursor_hash) {
-                Some((slot, hash, _bn)) => RollbackAnnouncement { slot, hash },
-                // No ancestor reachable on chain — rewind all the way to
-                // Origin and let the peer resync from genesis.
-                None => RollbackAnnouncement {
-                    slot: 0,
-                    hash: [0u8; 32],
-                },
-            };
-            tracing::info!(
-                task_id,
-                cursor_slot = self.cursor_slot,
-                rewind_slot = rb.slot,
-                "chainsync server: cursor rolled off chain; \
-                 sending MsgRollBackward to ancestor"
-            );
-            self.send_rollback(channel, block_provider, &rb).await?;
-            return Ok(true);
-        }
-
-        // When cursor_at_origin is true, use the inclusive `>=` lookup so that
-        // a block at slot 0 is not skipped.  The strict `>` lookup would miss
-        // it since cursor_slot is 0.
-        //
-        // Otherwise advance by POINT, not by slot: a Byron EBB shares its
-        // absolute slot with the first main block of the epoch, and a
-        // slot-only advance from the EBB would skip that main block,
-        // serving the peer a chain with a hole in it.
-        let lookup_start = std::time::Instant::now();
-        let next_block = if self.cursor_at_origin {
-            block_provider.get_block_at_or_after_slot(0)
-        } else {
-            block_provider.get_next_block_after_point(self.cursor_slot, &self.cursor_hash)
-        };
-        let lookup_elapsed = lookup_start.elapsed();
-        if lookup_elapsed.as_millis() > 50 {
-            tracing::warn!(
-                task_id,
-                cursor_slot = self.cursor_slot,
-                elapsed_ms = lookup_elapsed.as_millis() as u64,
-                "chainsync server: block_provider lookup slow"
-            );
-        }
-
-        let Some((slot, hash, block_cbor)) = next_block else {
-            return Ok(false);
-        };
-
-        // Extract the block header and encode it as the HFC-wrapped header
-        // payload expected by N2N ChainSync: [era_id, #6.24(bstr(header_cbor))].
-        let hfc_header = extract_header_for_chainsync(&block_cbor).map_err(|reason| {
-            ProtocolError::CborDecode {
-                protocol: "ChainSync",
-                reason: format!("header extraction failed for block at slot {slot}: {reason}"),
-            }
-        })?;
-
-        let tip = block_provider.get_tip();
-        let response = encode_message(&ChainSyncMessage::MsgRollForward {
-            header: hfc_header,
-            tip_slot: tip.slot,
-            tip_hash: tip.hash,
-            tip_block_number: tip.block_number,
-        });
-        let send_start = std::time::Instant::now();
-        let send_result = channel.send(response).await;
-        let send_elapsed = send_start.elapsed();
-        if send_elapsed.as_millis() > 100 {
-            tracing::warn!(
-                task_id,
-                cursor_slot = self.cursor_slot,
-                serve_slot = slot,
-                send_elapsed_ms = send_elapsed.as_millis() as u64,
-                ok = send_result.is_ok(),
-                "chainsync server: MsgRollForward send slow"
-            );
-        }
-        send_result.map_err(ProtocolError::from)?;
-        tracing::info!(
-            task_id,
-            cursor_slot = self.cursor_slot,
-            serve_slot = slot,
-            "chainsync server: served MsgRollForward"
-        );
-
-        // Advance cursor and — critically — clear cursor_at_origin so the
-        // next MsgRequestNext uses the strict `>` lookup and does not
-        // re-serve the same block.
-        self.cursor_slot = slot;
-        self.cursor_hash = hash;
-        self.cursor_at_origin = false;
-        Ok(true)
+        self.core
+            .run(channel, block_provider, announcement_rx, rollback_rx)
+            .await
     }
 
     /// Drain any pending rollback announcements, returning the most recent one.
     ///
     /// Multiple rollbacks may have queued up between calls — only the latest
     /// matters because each successive rollback supersedes the previous one.
-    fn drain_rollback(
+    #[doc(hidden)]
+    pub fn drain_rollback(
         rollback_rx: &mut broadcast::Receiver<RollbackAnnouncement>,
     ) -> Option<RollbackAnnouncement> {
-        let mut latest: Option<RollbackAnnouncement> = None;
-        loop {
-            match rollback_rx.try_recv() {
-                Ok(rb) => latest = Some(rb),
-                Err(broadcast::error::TryRecvError::Lagged(_)) => {
-                    // Missed some — continue draining to get latest.
-                    continue;
-                }
-                Err(_) => break,
-            }
-        }
-        latest
-    }
-
-    /// Send `MsgRollBackward` to the downstream peer and rewind the cursor.
-    async fn send_rollback<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-        rb: &RollbackAnnouncement,
-    ) -> Result<(), ProtocolError> {
-        let tip = block_provider.get_tip();
-        let point = if rb.slot == 0 && rb.hash == [0u8; 32] {
-            Point::Origin
-        } else {
-            Point::Specific(rb.slot, rb.hash)
-        };
-
-        tracing::info!(
-            rollback_slot = rb.slot,
-            cursor_slot = self.cursor_slot,
-            "chainsync server: sending MsgRollBackward to downstream peer"
-        );
-
-        let response = encode_message(&ChainSyncMessage::MsgRollBackward {
-            point: point.clone(),
-            tip_slot: tip.slot,
-            tip_hash: tip.hash,
-            tip_block_number: tip.block_number,
-        });
-        channel.send(response).await.map_err(ProtocolError::from)?;
-
-        // Rewind cursor to the rollback point.
-        self.cursor_slot = rb.slot;
-        self.cursor_hash = rb.hash;
-        self.cursor_at_origin = matches!(point, Point::Origin);
-
-        Ok(())
+        ServeCore::drain_rollback(rollback_rx)
     }
 }
 
@@ -716,8 +242,10 @@ impl Default for ChainSyncServer {
 
 #[cfg(test)]
 mod tests {
+    use super::super::serve_core::test_support::{
+        ForkAwareMockProvider, MockBlockProvider, MutableMockBlockProvider,
+    };
     use super::*;
-    use crate::TipInfo;
     use bytes::Bytes;
     use minicbor::Encoder;
     use tokio::sync::mpsc;
@@ -779,62 +307,6 @@ mod tests {
         // (this is what tag24 wraps — the CBOR serialisation of the header).
         enc.bytes(header_cbor).unwrap();
         buf
-    }
-
-    /// Mock block provider that stores (slot, hash, block_cbor) triples.
-    struct MockBlockProvider {
-        blocks: Vec<(u64, [u8; 32], Vec<u8>)>,
-    }
-
-    impl BlockProvider for MockBlockProvider {
-        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
-            self.blocks
-                .iter()
-                .find(|(_, h, _)| h == hash)
-                .map(|(_, _, cbor)| cbor.clone())
-        }
-
-        fn has_block(&self, hash: &[u8; 32]) -> bool {
-            self.blocks.iter().any(|(_, h, _)| h == hash)
-        }
-
-        fn get_tip(&self) -> TipInfo {
-            if let Some((slot, hash, _)) = self.blocks.last() {
-                TipInfo {
-                    slot: *slot,
-                    hash: *hash,
-                    block_number: self.blocks.len() as u64,
-                }
-            } else {
-                TipInfo {
-                    slot: 0,
-                    hash: [0; 32],
-                    block_number: 0,
-                }
-            }
-        }
-
-        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
-            self.blocks
-                .iter()
-                .find(|(s, _, _)| *s > after_slot)
-                .cloned()
-        }
-
-        fn get_next_block_after_point(
-            &self,
-            slot: u64,
-            hash: &[u8; 32],
-        ) -> Option<(u64, [u8; 32], Vec<u8>)> {
-            if let Some(pos) = self
-                .blocks
-                .iter()
-                .position(|(s, h, _)| *s == slot && h == hash)
-            {
-                return self.blocks.get(pos + 1).cloned();
-            }
-            self.get_next_block_after_slot(slot)
-        }
     }
 
     fn make_test_channel() -> (
@@ -1141,71 +613,6 @@ mod tests {
 
     // ─── rollback propagation tests ─────────────────────────────────────────────
 
-    /// Block slot, hash, and CBOR data — the elements stored in mock providers.
-    type BlockEntry = (u64, [u8; 32], Vec<u8>);
-
-    /// Mock block provider that supports mutation for simulating rollback scenarios.
-    ///
-    /// Wraps blocks in an `Arc<Mutex<_>>` so both the server task and the test
-    /// can modify the block set concurrently (simulating ChainDB changes during
-    /// a fork switch).
-    struct MutableMockBlockProvider {
-        blocks: std::sync::Arc<std::sync::Mutex<Vec<BlockEntry>>>,
-    }
-
-    impl MutableMockBlockProvider {
-        fn new(blocks: Vec<BlockEntry>) -> Self {
-            Self {
-                blocks: std::sync::Arc::new(std::sync::Mutex::new(blocks)),
-            }
-        }
-    }
-
-    impl BlockProvider for MutableMockBlockProvider {
-        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
-            self.blocks
-                .lock()
-                .unwrap()
-                .iter()
-                .find(|(_, h, _)| h == hash)
-                .map(|(_, _, cbor)| cbor.clone())
-        }
-
-        fn has_block(&self, hash: &[u8; 32]) -> bool {
-            self.blocks
-                .lock()
-                .unwrap()
-                .iter()
-                .any(|(_, h, _)| h == hash)
-        }
-
-        fn get_tip(&self) -> TipInfo {
-            let blocks = self.blocks.lock().unwrap();
-            if let Some((slot, hash, _)) = blocks.last() {
-                TipInfo {
-                    slot: *slot,
-                    hash: *hash,
-                    block_number: blocks.len() as u64,
-                }
-            } else {
-                TipInfo {
-                    slot: 0,
-                    hash: [0; 32],
-                    block_number: 0,
-                }
-            }
-        }
-
-        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
-            self.blocks
-                .lock()
-                .unwrap()
-                .iter()
-                .find(|(s, _, _)| *s > after_slot)
-                .cloned()
-        }
-    }
-
     #[tokio::test]
     async fn rollback_sends_msg_roll_backward() {
         // Scenario: serve 3 blocks (slots 10, 20, 30), then trigger a 2-block
@@ -1437,153 +844,6 @@ mod tests {
         let done = encode_message(&ChainSyncMessage::MsgDone);
         ingress_tx.send(Bytes::from(done)).await.unwrap();
         handle.await.unwrap().unwrap();
-    }
-
-    // ─── Bug J: cursor revalidation after fork switch (2026-05-16) ───────────
-
-    /// Fork-aware mock that distinguishes blocks on the *canonical chain*
-    /// from blocks merely stored as forks.  This is required to exercise
-    /// the Bug J fix in the ChainSync server: `try_serve_next_block` must
-    /// detect when the cursor's block has been displaced by a fork switch
-    /// (off-chain) and send `MsgRollBackward` rather than skipping over
-    /// the new chain's earlier-slot blocks.
-    type StoredBlock = (u64, u64, [u8; 32], Vec<u8>); // (slot, block_no, prev_hash, cbor)
-
-    struct ForkAwareMockProvider {
-        /// Hashes on the current canonical chain, oldest → newest.
-        chain: std::sync::Arc<std::sync::Mutex<Vec<[u8; 32]>>>,
-        /// Every stored block keyed by hash.
-        store: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<[u8; 32], StoredBlock>>>,
-    }
-
-    impl ForkAwareMockProvider {
-        fn new() -> Self {
-            Self {
-                chain: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
-                store: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-            }
-        }
-
-        /// Append a block to the canonical chain.
-        fn push_on_chain(
-            &self,
-            slot: u64,
-            hash: [u8; 32],
-            prev_hash: [u8; 32],
-            block_no: u64,
-            cbor: Vec<u8>,
-        ) {
-            self.store
-                .lock()
-                .unwrap()
-                .insert(hash, (slot, block_no, prev_hash, cbor));
-            self.chain.lock().unwrap().push(hash);
-        }
-
-        /// Store a block as a fork (not on canonical chain).
-        fn put_fork(
-            &self,
-            slot: u64,
-            hash: [u8; 32],
-            prev_hash: [u8; 32],
-            block_no: u64,
-            cbor: Vec<u8>,
-        ) {
-            self.store
-                .lock()
-                .unwrap()
-                .insert(hash, (slot, block_no, prev_hash, cbor));
-        }
-
-        /// Replace the canonical chain wholesale (simulates a fork switch).
-        /// All previously-on-chain blocks not in `new_chain` become forks.
-        fn replace_chain(&self, new_chain: Vec<[u8; 32]>) {
-            *self.chain.lock().unwrap() = new_chain;
-        }
-    }
-
-    impl BlockProvider for ForkAwareMockProvider {
-        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
-            self.store
-                .lock()
-                .unwrap()
-                .get(hash)
-                .map(|(_, _, _, cbor)| cbor.clone())
-        }
-
-        fn has_block(&self, hash: &[u8; 32]) -> bool {
-            self.store.lock().unwrap().contains_key(hash)
-        }
-
-        fn get_tip(&self) -> TipInfo {
-            let chain = self.chain.lock().unwrap();
-            let store = self.store.lock().unwrap();
-            if let Some(tip_hash) = chain.last() {
-                if let Some((slot, block_no, _, _)) = store.get(tip_hash) {
-                    return TipInfo {
-                        slot: *slot,
-                        hash: *tip_hash,
-                        block_number: *block_no,
-                    };
-                }
-            }
-            TipInfo {
-                slot: 0,
-                hash: [0; 32],
-                block_number: 0,
-            }
-        }
-
-        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
-            // Walk the canonical chain in order looking for the first block
-            // with slot > after_slot.  Mirrors VolatileDB's behaviour.
-            let chain = self.chain.lock().unwrap();
-            let store = self.store.lock().unwrap();
-            for hash in chain.iter() {
-                if let Some((slot, _, _, cbor)) = store.get(hash) {
-                    if *slot > after_slot {
-                        return Some((*slot, *hash, cbor.clone()));
-                    }
-                }
-            }
-            None
-        }
-
-        fn get_block_at_or_after_slot(&self, slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
-            let chain = self.chain.lock().unwrap();
-            let store = self.store.lock().unwrap();
-            for hash in chain.iter() {
-                if let Some((s, _, _, cbor)) = store.get(hash) {
-                    if *s >= slot {
-                        return Some((*s, *hash, cbor.clone()));
-                    }
-                }
-            }
-            None
-        }
-
-        fn is_on_chain(&self, hash: &[u8; 32]) -> bool {
-            self.chain.lock().unwrap().iter().any(|h| h == hash)
-        }
-
-        fn find_chain_ancestor(&self, start_hash: &[u8; 32]) -> Option<(u64, [u8; 32], u64)> {
-            let chain: std::collections::HashSet<[u8; 32]> =
-                self.chain.lock().unwrap().iter().copied().collect();
-            let store = self.store.lock().unwrap();
-            let mut current = *start_hash;
-            let mut visited = std::collections::HashSet::new();
-            loop {
-                if !visited.insert(current) {
-                    return None;
-                }
-                if chain.contains(&current) {
-                    let (slot, block_no, _, _) = store.get(&current)?;
-                    return Some((*slot, current, *block_no));
-                }
-                let (_, _, prev_hash, _) = store.get(&current)?;
-                current = *prev_hash;
-            }
-        }
     }
 
     /// **Bug J regression** (issue #500, 2026-05-16):
@@ -2348,6 +1608,249 @@ mod tests {
         }
 
         // Clean up.
+        let done = encode_message(&ChainSyncMessage::MsgDone);
+        ingress_tx.send(Bytes::from(done)).await.unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    // ─── #869: StMustReply silent no-reply ───────────────────────────────────
+
+    /// Regression test for #869: a spurious announcement wake (nothing new
+    /// past the cursor) must NOT cause `handle_request_next` to return
+    /// without sending a message.
+    ///
+    /// Per the Ouroboros ChainSync state machine, once `MsgAwaitReply` has
+    /// been sent the client is in `StMustReply` and will not send another
+    /// `MsgRequestNext` until it receives a reply.  Pre-fix, a spurious wake
+    /// (e.g. an announcement whose content doesn't correspond to anything
+    /// new past the cursor) caused the server to silently return `Ok(())`
+    /// without sending anything — the outer loop would then block on
+    /// `channel.recv()` waiting for a client message that, per protocol,
+    /// will never arrive.  This test drives that exact sequence without ever
+    /// sending a second `MsgRequestNext`, proving the server keeps waiting
+    /// on the SAME `handle_request_next` call until it has something to send.
+    #[tokio::test]
+    async fn spurious_announcement_wake_does_not_return_agency_without_reply() {
+        let block_a = make_hfc_block(7, &[0x0A]);
+        let provider = MutableMockBlockProvider::new(vec![(10, [0x01; 32], block_a)]);
+        let blocks_ref = provider.blocks.clone();
+
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel::<BlockAnnouncement>(16);
+        let (rb_tx, _) = broadcast::channel::<RollbackAnnouncement>(16);
+        let ann_rx = ann_tx.subscribe();
+        let rb_rx = rb_tx.subscribe();
+
+        let mut server = ChainSyncServer::new();
+        let handle =
+            tokio::spawn(async move { server.run(&mut channel, &provider, ann_rx, rb_rx).await });
+
+        // Intersect at origin, serve the only block — cursor now at slot 10.
+        let find = encode_message(&ChainSyncMessage::MsgFindIntersect(vec![Point::Origin]));
+        ingress_tx.send(Bytes::from(find)).await.unwrap();
+        let _ = egress_rx.recv().await.unwrap(); // MsgIntersectFound
+
+        let req = encode_message(&ChainSyncMessage::MsgRequestNext);
+        ingress_tx.send(Bytes::from(req)).await.unwrap();
+        let (_, _, resp) = egress_rx.recv().await.unwrap();
+        assert!(matches!(
+            decode_message(&resp).unwrap(),
+            ChainSyncMessage::MsgRollForward { .. }
+        ));
+
+        // Request next again — at tip, enters StMustReply.
+        let req = encode_message(&ChainSyncMessage::MsgRequestNext);
+        ingress_tx.send(Bytes::from(req)).await.unwrap();
+        let (_, _, resp) = egress_rx.recv().await.unwrap();
+        assert!(matches!(
+            decode_message(&resp).unwrap(),
+            ChainSyncMessage::MsgAwaitReply
+        ));
+
+        // Fire a SPURIOUS announcement: nothing new is added to the block
+        // store, so `try_serve_next_block` finds nothing to serve.
+        ann_tx
+            .send(BlockAnnouncement {
+                slot: 10,
+                hash: [0x01; 32],
+                block_number: 1,
+            })
+            .unwrap();
+
+        // Give the server a moment to process the spurious wake.  Pre-fix,
+        // this would cause `handle_request_next` to return without sending
+        // anything, wedging the connection.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), egress_rx.recv())
+                .await
+                .is_err(),
+            "server must not send anything on a spurious wake with nothing new to serve"
+        );
+
+        // Now push a genuine new block and announce it — the SAME
+        // `handle_request_next` call (no second MsgRequestNext from the
+        // client) must eventually deliver it.
+        let block_b = make_hfc_block(7, &[0x0B]);
+        blocks_ref.lock().unwrap().push((20, [0x02; 32], block_b));
+        ann_tx
+            .send(BlockAnnouncement {
+                slot: 20,
+                hash: [0x02; 32],
+                block_number: 2,
+            })
+            .unwrap();
+
+        let (_, _, resp) = tokio::time::timeout(Duration::from_secs(5), egress_rx.recv())
+            .await
+            .expect("server must eventually reply once a real block is available")
+            .unwrap();
+        assert!(
+            matches!(
+                decode_message(&resp).unwrap(),
+                ChainSyncMessage::MsgRollForward { .. }
+            ),
+            "server must serve the genuine block without a second MsgRequestNext"
+        );
+
+        handle.abort();
+    }
+
+    // ─── #876: MsgFindIntersect fork/slot validation ─────────────────────────
+
+    /// #876: a client claiming the wrong slot for a real on-chain hash must
+    /// NOT get `MsgIntersectFound` — accepting it would poison the follower
+    /// cursor with a `(claimed_slot, real_hash)` pair that doesn't correspond
+    /// to any actual chain point (e.g. `(u64::MAX, real_hash)` would wedge
+    /// every subsequent `try_serve_next_block` lookup).
+    #[tokio::test]
+    async fn find_intersect_wrong_claimed_slot_rejected() {
+        let provider = ForkAwareMockProvider::new();
+        let genesis = [0u8; 32];
+        let a_hash = [0x0A; 32];
+        provider.push_on_chain(10, a_hash, genesis, 1, make_hfc_block(7, &[0xA1]));
+
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel(16);
+        let (rb_tx, _) = broadcast::channel(16);
+        let mut server = ChainSyncServer::new();
+
+        let handle = tokio::spawn(async move {
+            server
+                .run(
+                    &mut channel,
+                    &provider,
+                    ann_tx.subscribe(),
+                    rb_tx.subscribe(),
+                )
+                .await
+        });
+
+        // a_hash is real and on-chain, but at slot 10 — not the claimed 999.
+        let find = encode_message(&ChainSyncMessage::MsgFindIntersect(vec![Point::Specific(
+            999, a_hash,
+        )]));
+        ingress_tx.send(Bytes::from(find)).await.unwrap();
+
+        let (_, _, resp) = egress_rx.recv().await.unwrap();
+        let msg = decode_message(&resp).unwrap();
+        assert!(
+            matches!(msg, ChainSyncMessage::MsgIntersectNotFound { .. }),
+            "wrong claimed slot for a real hash must be rejected, got {msg:?}"
+        );
+
+        let done = encode_message(&ChainSyncMessage::MsgDone);
+        ingress_tx.send(Bytes::from(done)).await.unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    /// #876: a hash that exists in storage but is NOT on the canonical chain
+    /// (a fork block) must not be accepted as an intersection point — only
+    /// `is_on_chain` hashes may become the follower cursor.
+    #[tokio::test]
+    async fn find_intersect_fork_only_hash_rejected() {
+        let provider = ForkAwareMockProvider::new();
+        let genesis = [0u8; 32];
+        let a_hash = [0x0A; 32];
+        provider.push_on_chain(10, a_hash, genesis, 1, make_hfc_block(7, &[0xA1]));
+        let fork_hash = [0xF0; 32];
+        provider.put_fork(15, fork_hash, a_hash, 2, make_hfc_block(7, &[0xF1]));
+
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel(16);
+        let (rb_tx, _) = broadcast::channel(16);
+        let mut server = ChainSyncServer::new();
+
+        let handle = tokio::spawn(async move {
+            server
+                .run(
+                    &mut channel,
+                    &provider,
+                    ann_tx.subscribe(),
+                    rb_tx.subscribe(),
+                )
+                .await
+        });
+
+        let find = encode_message(&ChainSyncMessage::MsgFindIntersect(vec![Point::Specific(
+            15, fork_hash,
+        )]));
+        ingress_tx.send(Bytes::from(find)).await.unwrap();
+
+        let (_, _, resp) = egress_rx.recv().await.unwrap();
+        let msg = decode_message(&resp).unwrap();
+        assert!(
+            matches!(msg, ChainSyncMessage::MsgIntersectNotFound { .. }),
+            "fork-only hash must not be accepted as an intersection point, got {msg:?}"
+        );
+
+        let done = encode_message(&ChainSyncMessage::MsgDone);
+        ingress_tx.send(Bytes::from(done)).await.unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    /// #876: a correct canonical point (real on-chain hash + matching slot)
+    /// must still be accepted — the fix must not be overly strict.
+    #[tokio::test]
+    async fn find_intersect_correct_canonical_point_found() {
+        let provider = ForkAwareMockProvider::new();
+        let genesis = [0u8; 32];
+        let a_hash = [0x0A; 32];
+        let b_hash = [0x0B; 32];
+        provider.push_on_chain(10, a_hash, genesis, 1, make_hfc_block(7, &[0xA1]));
+        provider.push_on_chain(20, b_hash, a_hash, 2, make_hfc_block(7, &[0xB1]));
+
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel(16);
+        let (rb_tx, _) = broadcast::channel(16);
+        let mut server = ChainSyncServer::new();
+
+        let handle = tokio::spawn(async move {
+            server
+                .run(
+                    &mut channel,
+                    &provider,
+                    ann_tx.subscribe(),
+                    rb_tx.subscribe(),
+                )
+                .await
+        });
+
+        let find = encode_message(&ChainSyncMessage::MsgFindIntersect(vec![Point::Specific(
+            10, a_hash,
+        )]));
+        ingress_tx.send(Bytes::from(find)).await.unwrap();
+
+        let (_, _, resp) = egress_rx.recv().await.unwrap();
+        let msg = decode_message(&resp).unwrap();
+        match msg {
+            ChainSyncMessage::MsgIntersectFound { point, .. } => {
+                assert_eq!(point, Point::Specific(10, a_hash));
+            }
+            other => {
+                panic!("expected MsgIntersectFound for correct canonical point, got {other:?}")
+            }
+        }
+
         let done = encode_message(&ChainSyncMessage::MsgDone);
         ingress_tx.send(Bytes::from(done)).await.unwrap();
         handle.await.unwrap().unwrap();

--- a/crates/dugite-network/src/protocol/local_chainsync/server.rs
+++ b/crates/dugite-network/src/protocol/local_chainsync/server.rs
@@ -3,16 +3,30 @@
 //! Uses the same ChainSync message wire format (tags 0-7) but wraps block data
 //! in `Serialised` encoding: `tag(24)(bytes(block_cbor))` (CBOR-in-CBOR).
 //! This matches the Haskell `SerialiseNodeToClient` encoding for `Serialised blk`.
+//!
+//! Delegates all protocol logic to the shared `ServeCore` (issue #881) —
+//! see `crate::protocol::chainsync::serve_core` for the state machine.  This
+//! server differs from N2N `ChainSyncServer` in exactly one respect: the
+//! `MsgRollForward` payload is the full `Serialised`-wrapped block
+//! ([`wrap_serialised`]) rather than an HFC-wrapped header.  Before this
+//! extraction the two servers had drifted — this server was missing the
+//! duplicate-serve dedup, the `biased` rollback-first `select!` ordering,
+//! the `StMustReply` retry loop (#869), `cursor_at_origin` genesis-EBB
+//! handling, and lagged-rollback safety (Bug J) that N2N already had (#868).
+
+use std::time::Duration;
 
 use minicbor::Encoder;
 use tokio::sync::broadcast;
 
-use crate::codec::Point;
 use crate::error::ProtocolError;
 use crate::mux::channel::MuxChannel;
+use crate::protocol::chainsync::serve_core::ServeCore;
 use crate::protocol::chainsync::server::{BlockAnnouncement, RollbackAnnouncement};
-use crate::protocol::chainsync::{decode_message, encode_message, ChainSyncMessage};
 use crate::BlockProvider;
+
+#[cfg(test)]
+use crate::codec::Point;
 
 /// Wrap raw block CBOR in `Serialised` encoding: `tag(24)(bytes(block_cbor))`.
 ///
@@ -27,24 +41,54 @@ fn wrap_serialised(block_cbor: &[u8]) -> Vec<u8> {
     buf
 }
 
+/// Encode the `MsgRollForward` payload for N2C LocalChainSync: wrap the full
+/// block CBOR in `Serialised` encoding.  Infallible — no parsing required —
+/// matching the `PayloadEncoder` signature used by the shared serve core.
+fn n2c_payload_encoder(block_cbor: &[u8]) -> Result<Vec<u8>, ProtocolError> {
+    Ok(wrap_serialised(block_cbor))
+}
+
 /// LocalChainSync server that serves full blocks to N2C clients.
 ///
-/// Reuses the ChainSync message codec but wraps block bodies in HFC era encoding
-/// instead of sending just headers.
+/// A thin wrapper around the shared `ServeCore` (issue #881) — all protocol
+/// logic (cursor tracking, `MsgFindIntersect`/`MsgRequestNext` handling,
+/// rollback propagation, `StMustReply` retry loop) lives in the shared core.
+/// This type only supplies the N2C-specific payload encoder
+/// ([`n2c_payload_encoder`]: full `Serialised`-wrapped block, not just the
+/// header) and the `"LocalChainSync"` protocol label.
 pub struct LocalChainSyncServer {
-    /// Current cursor: last slot served to this client.
-    cursor_slot: u64,
-    /// Current cursor: last hash served to this client.
-    cursor_hash: [u8; 32],
+    core: ServeCore,
 }
 
 impl LocalChainSyncServer {
     /// Create a new server with no cursor.
+    ///
+    /// Draws a per-connection `StMustReply` timeout uniformly at random in
+    /// `[601 s, 911 s]`, matching N2N ChainSync and Haskell's
+    /// `ouroboros-network` ChainSync codec timeout policy.
     pub fn new() -> Self {
         Self {
-            cursor_slot: 0,
-            cursor_hash: [0; 32],
+            core: ServeCore::new(n2c_payload_encoder, "LocalChainSync"),
         }
+    }
+
+    /// Test/explicit-timeout constructor.  Production code should call
+    /// [`Self::new`] to get the random per-connection draw; tests use this to
+    /// pin the timeout to a known small value.
+    #[doc(hidden)]
+    pub fn new_with_timeout(must_reply_timeout: Duration) -> Self {
+        Self {
+            core: ServeCore::new_with_timeout(
+                must_reply_timeout,
+                n2c_payload_encoder,
+                "LocalChainSync",
+            ),
+        }
+    }
+
+    /// Configured `StMustReply` timeout (exposed for diagnostics / tests).
+    pub fn must_reply_timeout(&self) -> Duration {
+        self.core.must_reply_timeout()
     }
 
     /// Run the LocalChainSync server loop.
@@ -55,274 +99,20 @@ impl LocalChainSyncServer {
         &mut self,
         channel: &mut MuxChannel,
         block_provider: &B,
-        mut announcement_rx: broadcast::Receiver<BlockAnnouncement>,
-        mut rollback_rx: broadcast::Receiver<RollbackAnnouncement>,
+        announcement_rx: broadcast::Receiver<BlockAnnouncement>,
+        rollback_rx: broadcast::Receiver<RollbackAnnouncement>,
     ) -> Result<(), ProtocolError> {
-        loop {
-            let msg_bytes = channel.recv().await.map_err(ProtocolError::from)?;
-            let msg = decode_message(&msg_bytes).map_err(|e| ProtocolError::CborDecode {
-                protocol: "LocalChainSync",
-                reason: e,
-            })?;
-
-            match msg {
-                ChainSyncMessage::MsgFindIntersect(points) => {
-                    self.handle_find_intersect(channel, block_provider, &points)
-                        .await?;
-                }
-                ChainSyncMessage::MsgRequestNext => {
-                    self.handle_request_next(
-                        channel,
-                        block_provider,
-                        &mut announcement_rx,
-                        &mut rollback_rx,
-                    )
-                    .await?;
-                }
-                ChainSyncMessage::MsgDone => {
-                    tracing::debug!("local chainsync server: client sent MsgDone");
-                    return Ok(());
-                }
-                other => {
-                    return Err(ProtocolError::AgencyViolation {
-                        protocol: "LocalChainSync",
-                        state: "StIdle".to_string(),
-                        received_tag: format!("{other:?}")
-                            .as_bytes()
-                            .first()
-                            .copied()
-                            .unwrap_or(0),
-                    });
-                }
-            }
-        }
-    }
-
-    /// Handle MsgFindIntersect — identical to N2N ChainSync.
-    async fn handle_find_intersect<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-        points: &[Point],
-    ) -> Result<(), ProtocolError> {
-        let tip = block_provider.get_tip();
-
-        for point in points {
-            match point {
-                Point::Origin => {
-                    self.cursor_slot = 0;
-                    self.cursor_hash = [0; 32];
-                    let response = encode_message(&ChainSyncMessage::MsgIntersectFound {
-                        point: Point::Origin,
-                        tip_slot: tip.slot,
-                        tip_hash: tip.hash,
-                        tip_block_number: tip.block_number,
-                    });
-                    channel.send(response).await.map_err(ProtocolError::from)?;
-                    return Ok(());
-                }
-                Point::Specific(slot, hash) => {
-                    if block_provider.has_block(hash) {
-                        self.cursor_slot = *slot;
-                        self.cursor_hash = *hash;
-                        let response = encode_message(&ChainSyncMessage::MsgIntersectFound {
-                            point: point.clone(),
-                            tip_slot: tip.slot,
-                            tip_hash: tip.hash,
-                            tip_block_number: tip.block_number,
-                        });
-                        channel.send(response).await.map_err(ProtocolError::from)?;
-                        return Ok(());
-                    }
-                }
-            }
-        }
-
-        let response = encode_message(&ChainSyncMessage::MsgIntersectNotFound {
-            tip_slot: tip.slot,
-            tip_hash: tip.hash,
-            tip_block_number: tip.block_number,
-        });
-        channel.send(response).await.map_err(ProtocolError::from)?;
-        Ok(())
-    }
-
-    /// Handle MsgRequestNext — sends full blocks (not headers) with HFC wrapping,
-    /// or sends MsgRollBackward if a rollback has occurred.
-    async fn handle_request_next<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-        announcement_rx: &mut broadcast::Receiver<BlockAnnouncement>,
-        rollback_rx: &mut broadcast::Receiver<RollbackAnnouncement>,
-    ) -> Result<(), ProtocolError> {
-        // ── Check for pending rollbacks before serving ──────────────────────
-        if let Some(rb) = Self::drain_rollback(rollback_rx) {
-            if self.cursor_slot > rb.slot
-                || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
-            {
-                return self.send_rollback(channel, block_provider, &rb).await;
-            }
-        }
-
-        // Advance by POINT, not by slot: a Byron EBB shares its absolute
-        // slot with the first main block of the epoch, and a slot-only
-        // advance from the EBB would skip that main block.  For the origin
-        // cursor (all-zero hash, not a stored block) the point lookup falls
-        // back to the slot-based behavior.
-        if let Some((slot, hash, block_cbor)) =
-            block_provider.get_next_block_after_point(self.cursor_slot, &self.cursor_hash)
-        {
-            let tip = block_provider.get_tip();
-
-            // N2C sends full blocks wrapped in Serialised encoding: tag(24)(bytes(block_cbor)).
-            let response = encode_message(&ChainSyncMessage::MsgRollForward {
-                header: wrap_serialised(&block_cbor),
-                tip_slot: tip.slot,
-                tip_hash: tip.hash,
-                tip_block_number: tip.block_number,
-            });
-            channel.send(response).await.map_err(ProtocolError::from)?;
-            self.cursor_slot = slot;
-            self.cursor_hash = hash;
-            return Ok(());
-        }
-
-        // At tip — wait for announcement or rollback.
-        let await_msg = encode_message(&ChainSyncMessage::MsgAwaitReply);
-        channel.send(await_msg).await.map_err(ProtocolError::from)?;
-
-        tokio::select! {
-            // ── Rollback while waiting at tip ───────────────────────────────
-            rollback = rollback_rx.recv() => {
-                match rollback {
-                    Ok(rb) => {
-                        if self.cursor_slot > rb.slot
-                            || (self.cursor_slot == rb.slot && self.cursor_hash != rb.hash)
-                        {
-                            self.send_rollback(channel, block_provider, &rb).await
-                        } else {
-                            // Cursor behind rollback — serve next block from new fork.
-                            if let Some((slot, hash, block_cbor)) = block_provider
-                                .get_next_block_after_point(self.cursor_slot, &self.cursor_hash)
-                            {
-                                let tip = block_provider.get_tip();
-                                let response = encode_message(&ChainSyncMessage::MsgRollForward {
-                                    header: wrap_serialised(&block_cbor),
-                                    tip_slot: tip.slot,
-                                    tip_hash: tip.hash,
-                                    tip_block_number: tip.block_number,
-                                });
-                                channel.send(response).await.map_err(ProtocolError::from)?;
-                                self.cursor_slot = slot;
-                                self.cursor_hash = hash;
-                            }
-                            Ok(())
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        let tip = block_provider.get_tip();
-                        let rb = RollbackAnnouncement {
-                            slot: tip.slot,
-                            hash: tip.hash,
-                        };
-                        self.send_rollback(channel, block_provider, &rb).await
-                    }
-                    Err(broadcast::error::RecvError::Closed) => Ok(()),
-                }
-            }
-            announcement = announcement_rx.recv() => {
-                match announcement {
-                    Ok(ann) => {
-                        if let Some(block_cbor) = block_provider.get_block(&ann.hash) {
-                            let tip = block_provider.get_tip();
-                            let response = encode_message(&ChainSyncMessage::MsgRollForward {
-                                header: wrap_serialised(&block_cbor),
-                                tip_slot: tip.slot,
-                                tip_hash: tip.hash,
-                                tip_block_number: tip.block_number,
-                            });
-                            channel.send(response).await.map_err(ProtocolError::from)?;
-                            self.cursor_slot = ann.slot;
-                            self.cursor_hash = ann.hash;
-                        }
-                        Ok(())
-                    }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        // Try to catch up from current position.
-                        if let Some((slot, hash, block_cbor)) = block_provider
-                            .get_next_block_after_point(self.cursor_slot, &self.cursor_hash)
-                        {
-                            let tip = block_provider.get_tip();
-                            let response = encode_message(&ChainSyncMessage::MsgRollForward {
-                                header: wrap_serialised(&block_cbor),
-                                tip_slot: tip.slot,
-                                tip_hash: tip.hash,
-                                tip_block_number: tip.block_number,
-                            });
-                            channel.send(response).await.map_err(ProtocolError::from)?;
-                            self.cursor_slot = slot;
-                            self.cursor_hash = hash;
-                        }
-                        Ok(())
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        // Node shutting down.
-                        Ok(())
-                    }
-                }
-            }
-        }
+        self.core
+            .run(channel, block_provider, announcement_rx, rollback_rx)
+            .await
     }
 
     /// Drain any pending rollback announcements, returning the most recent one.
-    fn drain_rollback(
+    #[doc(hidden)]
+    pub fn drain_rollback(
         rollback_rx: &mut broadcast::Receiver<RollbackAnnouncement>,
     ) -> Option<RollbackAnnouncement> {
-        let mut latest: Option<RollbackAnnouncement> = None;
-        loop {
-            match rollback_rx.try_recv() {
-                Ok(rb) => latest = Some(rb),
-                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
-                Err(_) => break,
-            }
-        }
-        latest
-    }
-
-    /// Send `MsgRollBackward` to the N2C client and rewind the cursor.
-    async fn send_rollback<B: BlockProvider>(
-        &mut self,
-        channel: &mut MuxChannel,
-        block_provider: &B,
-        rb: &RollbackAnnouncement,
-    ) -> Result<(), ProtocolError> {
-        let tip = block_provider.get_tip();
-        let point = if rb.slot == 0 && rb.hash == [0u8; 32] {
-            Point::Origin
-        } else {
-            Point::Specific(rb.slot, rb.hash)
-        };
-
-        tracing::info!(
-            rollback_slot = rb.slot,
-            cursor_slot = self.cursor_slot,
-            "local chainsync server: sending MsgRollBackward to N2C client"
-        );
-
-        let response = encode_message(&ChainSyncMessage::MsgRollBackward {
-            point,
-            tip_slot: tip.slot,
-            tip_hash: tip.hash,
-            tip_block_number: tip.block_number,
-        });
-        channel.send(response).await.map_err(ProtocolError::from)?;
-
-        // Rewind cursor to the rollback point.
-        self.cursor_slot = rb.slot;
-        self.cursor_hash = rb.hash;
-
-        Ok(())
+        ServeCore::drain_rollback(rollback_rx)
     }
 }
 
@@ -335,6 +125,9 @@ impl Default for LocalChainSyncServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::chainsync::serve_core::test_support::{
+        ForkAwareMockProvider, MockBlockProvider, MutableMockBlockProvider,
+    };
     use crate::protocol::chainsync::server::{BlockAnnouncement, RollbackAnnouncement};
     use crate::protocol::chainsync::{decode_message, encode_message, ChainSyncMessage};
     use crate::TipInfo;
@@ -359,49 +152,10 @@ mod tests {
         buf
     }
 
-    /// Mock block provider for LocalChainSync tests.
-    ///
-    /// Stores (slot, hash, block_cbor) tuples. The CBOR is raw block bytes —
-    /// LocalChainSync passes them through without header extraction (unlike N2N
-    /// ChainSync which extracts headers).
-    struct MockBlockProvider {
-        blocks: Vec<(u64, [u8; 32], Vec<u8>)>,
-    }
-
-    impl BlockProvider for MockBlockProvider {
-        fn get_block(&self, hash: &[u8; 32]) -> Option<Vec<u8>> {
-            self.blocks
-                .iter()
-                .find(|(_, h, _)| h == hash)
-                .map(|(_, _, cbor)| cbor.clone())
-        }
-
-        fn has_block(&self, hash: &[u8; 32]) -> bool {
-            self.blocks.iter().any(|(_, h, _)| h == hash)
-        }
-
-        fn get_tip(&self) -> TipInfo {
-            self.blocks
-                .last()
-                .map(|(s, h, _)| TipInfo {
-                    slot: *s,
-                    hash: *h,
-                    block_number: self.blocks.len() as u64,
-                })
-                .unwrap_or(TipInfo {
-                    slot: 0,
-                    hash: [0; 32],
-                    block_number: 0,
-                })
-        }
-
-        fn get_next_block_after_slot(&self, after_slot: u64) -> Option<(u64, [u8; 32], Vec<u8>)> {
-            self.blocks
-                .iter()
-                .find(|(s, _, _)| *s > after_slot)
-                .cloned()
-        }
-    }
+    // `MockBlockProvider` (flat, no-fork block store) is shared with the N2N
+    // ChainSync test suite via `serve_core::test_support` (issue #881) — both
+    // wirings exercise the exact same `BlockProvider` semantics against the
+    // shared `ServeCore`.
 
     /// Create a test MuxChannel with egress receiver and ingress sender.
     fn make_test_channel() -> (
@@ -889,7 +643,18 @@ mod tests {
             "expected MsgAwaitReply at tip, got {msg:?}"
         );
 
-        // Send announcement to unblock the server.
+        // Fire a SPURIOUS announcement — the provider does not actually have
+        // this block, so `try_serve_next_block` finds nothing to serve.
+        //
+        // #869 fix: this must NOT cause the server to return without a
+        // reply.  Per the Ouroboros ChainSync state machine, the client is
+        // in StMustReply and will never send another MsgRequestNext, so a
+        // silent return would wedge the connection.  Before the shared-core
+        // extraction, N2C's `select!` was NOT looped and returned
+        // immediately here — this test used to rely on that bug to
+        // terminate; now it asserts the fixed behaviour (no reply, no
+        // early return) and aborts the task to clean up rather than
+        // waiting on a `handle.await` that would never resolve.
         ann_tx
             .send(BlockAnnouncement {
                 slot: 20,
@@ -898,10 +663,14 @@ mod tests {
             })
             .unwrap();
 
-        // The server won't be able to serve the block (provider doesn't have it),
-        // but the select loop will complete. Drop channels to clean up.
-        drop(ingress_tx);
-        let _ = handle.await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), egress_rx.recv())
+                .await
+                .is_err(),
+            "server must not send anything on a spurious wake with nothing new to serve"
+        );
+
+        handle.abort();
     }
 
     #[tokio::test]
@@ -1238,7 +1007,252 @@ mod tests {
     #[test]
     fn default_creates_zero_cursor() {
         let server = LocalChainSyncServer::default();
-        assert_eq!(server.cursor_slot, 0);
-        assert_eq!(server.cursor_hash, [0; 32]);
+        assert_eq!(server.core.cursor_slot, 0);
+        assert_eq!(server.core.cursor_hash, [0; 32]);
+    }
+
+    // ─── #868: N2C now exercises the shared ServeCore — parity with N2N ──────
+    //
+    // Before the shared-core extraction (#881), `LocalChainSyncServer` had its
+    // own hand-rolled `handle_request_next` that was missing several fixes
+    // already present in N2N `ChainSyncServer`: cursor revalidation after a
+    // fork switch (Bug J), `cursor_at_origin` genesis-EBB handling, and the
+    // `StMustReply` retry loop (#869) / timeout arm.  These tests drive the
+    // N2C wiring through the same scenarios as the N2N test suite in
+    // `chainsync::server` and assert identical protocol-level behaviour.
+
+    /// #868 parity with N2N's `fork_switch_to_lower_slot_chain_sends_rollback_then_serves_new_blocks`
+    /// (Bug J): after a fork switch displaces the follower cursor's block,
+    /// the server must send `MsgRollBackward` to the most recent on-chain
+    /// ancestor, then deliver the new chain's blocks in slot order —
+    /// including blocks at slots at or below the old cursor slot.
+    #[tokio::test]
+    async fn fork_switch_sends_rollback_then_serves_new_blocks() {
+        let provider = ForkAwareMockProvider::new();
+        let genesis = [0u8; 32];
+        let a_hash = [0x0A; 32];
+        let b_hash = [0x0B; 32];
+        let c_hash = [0x0C; 32];
+        let d_hash = [0x0D; 32];
+
+        // Original chain: A@10 → B@20 → C@30 → D@40.
+        provider.push_on_chain(10, a_hash, genesis, 1, make_block_cbor(&[0xA1]));
+        provider.push_on_chain(20, b_hash, a_hash, 2, make_block_cbor(&[0xB1]));
+        provider.push_on_chain(30, c_hash, b_hash, 3, make_block_cbor(&[0xC1]));
+        provider.push_on_chain(40, d_hash, c_hash, 4, make_block_cbor(&[0xD1]));
+
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel::<BlockAnnouncement>(16);
+        let (rb_tx, _) = broadcast::channel::<RollbackAnnouncement>(16);
+        let ann_rx = ann_tx.subscribe();
+        let rb_rx = rb_tx.subscribe();
+
+        let mut server = LocalChainSyncServer::new();
+        let handle = {
+            let provider_handle = ForkAwareMockProvider {
+                chain: provider.chain.clone(),
+                store: provider.store.clone(),
+            };
+            tokio::spawn(async move {
+                server
+                    .run(&mut channel, &provider_handle, ann_rx, rb_rx)
+                    .await
+            })
+        };
+
+        // Intersect at origin and serve A, B, C, D.
+        send_msg(
+            &ingress_tx,
+            &ChainSyncMessage::MsgFindIntersect(vec![Point::Origin]),
+        )
+        .await;
+        let _ = recv_msg(&mut egress_rx).await;
+
+        for _ in 0..4 {
+            let msg = recv_msg_after(&ingress_tx, &mut egress_rx).await;
+            assert!(matches!(msg, ChainSyncMessage::MsgRollForward { .. }));
+        }
+        // Cursor now at D@40.
+
+        // Fork switch: A → X@15 → Y@25 → Z@35 → W@50 — intermediate blocks
+        // sit at slots BELOW the cursor (40).
+        let x_hash = [0x1A; 32];
+        let y_hash = [0x2A; 32];
+        let z_hash = [0x3A; 32];
+        let w_hash = [0x4A; 32];
+        provider.put_fork(15, x_hash, a_hash, 2, make_block_cbor(&[0xAA]));
+        provider.put_fork(25, y_hash, x_hash, 3, make_block_cbor(&[0xBB]));
+        provider.put_fork(35, z_hash, y_hash, 4, make_block_cbor(&[0xCC]));
+        provider.put_fork(50, w_hash, z_hash, 5, make_block_cbor(&[0xDD]));
+        provider.replace_chain(vec![a_hash, x_hash, y_hash, z_hash, w_hash]);
+
+        ann_tx
+            .send(BlockAnnouncement {
+                slot: 50,
+                hash: w_hash,
+                block_number: 5,
+            })
+            .unwrap();
+
+        let msg = recv_msg_after(&ingress_tx, &mut egress_rx).await;
+        match msg {
+            ChainSyncMessage::MsgRollBackward { point, .. } => {
+                assert_eq!(
+                    point,
+                    Point::Specific(10, a_hash),
+                    "must rewind to most recent on-chain ancestor"
+                );
+            }
+            other => panic!("expected MsgRollBackward to A@10, got {other:?}"),
+        }
+
+        // The entire new chain past A must be delivered, in order, including
+        // slots BELOW the old cursor (40).
+        for _ in 0..4 {
+            let msg = recv_msg_after(&ingress_tx, &mut egress_rx).await;
+            match msg {
+                ChainSyncMessage::MsgRollForward { tip_slot, .. } => {
+                    assert_eq!(tip_slot, 50);
+                }
+                other => panic!("expected MsgRollForward on new chain, got {other:?}"),
+            }
+        }
+
+        send_msg(&ingress_tx, &ChainSyncMessage::MsgDone).await;
+        handle.await.unwrap().unwrap();
+    }
+
+    /// #868 parity: a block sitting exactly at slot 0 (e.g. a Byron genesis
+    /// EBB) must be served when intersecting at Origin.  Before the
+    /// shared-core extraction, N2C never tracked `cursor_at_origin` and used
+    /// a strict point-cursor lookup that silently skipped a slot-0 block.
+    #[tokio::test]
+    async fn genesis_block_at_slot_zero_served_from_origin() {
+        let (channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel(16);
+        let (rb_tx, _) = broadcast::channel(16);
+
+        let ebb_cbor = make_block_cbor(&[0xEB]);
+        let provider = MockBlockProvider {
+            blocks: vec![
+                (0, [0xEB; 32], ebb_cbor.clone()),
+                (1, [0x01; 32], make_block_cbor(&[0x01])),
+            ],
+        };
+
+        let handle = spawn_server(channel, provider, ann_tx.subscribe(), rb_tx.subscribe());
+
+        send_msg(
+            &ingress_tx,
+            &ChainSyncMessage::MsgFindIntersect(vec![Point::Origin]),
+        )
+        .await;
+        let _ = recv_msg(&mut egress_rx).await; // MsgIntersectFound
+
+        // First MsgRequestNext must serve the slot-0 block, not skip it.
+        send_msg(&ingress_tx, &ChainSyncMessage::MsgRequestNext).await;
+        let msg = recv_msg(&mut egress_rx).await;
+        match msg {
+            ChainSyncMessage::MsgRollForward { header, .. } => {
+                assert_eq!(
+                    header,
+                    wrap_serialised(&ebb_cbor),
+                    "genesis block at slot 0 must be served, not skipped"
+                );
+            }
+            other => panic!("expected MsgRollForward for slot-0 block, got {other:?}"),
+        }
+
+        // Second request must advance past slot 0 to slot 1 (cursor_at_origin
+        // must have been cleared — otherwise the slot-0 block is re-served).
+        send_msg(&ingress_tx, &ChainSyncMessage::MsgRequestNext).await;
+        let msg = recv_msg(&mut egress_rx).await;
+        match msg {
+            ChainSyncMessage::MsgRollForward { tip_slot, .. } => {
+                assert_eq!(
+                    tip_slot, 1,
+                    "must advance past the slot-0 block, not re-serve it"
+                );
+            }
+            other => panic!("expected MsgRollForward for slot 1, got {other:?}"),
+        }
+
+        send_msg(&ingress_tx, &ChainSyncMessage::MsgDone).await;
+        handle.await.unwrap().unwrap();
+    }
+
+    /// #868 parity with N2N's `spurious_announcement_wake_does_not_return_agency_without_reply`
+    /// (#869): once `MsgAwaitReply` has been sent, a spurious wake with
+    /// nothing new to serve must not cause the server to return without a
+    /// reply — and the periodic `StMustReply` timeout re-poll (which N2C
+    /// never had before the shared-core extraction) must eventually deliver
+    /// a block that arrives after the timeout has already fired once.
+    #[tokio::test]
+    async fn idle_timeout_repolls_and_eventually_serves() {
+        let block_a = make_block_cbor(&[0x0A]);
+        let provider = MutableMockBlockProvider::new(vec![(10, [0x01; 32], block_a)]);
+        let blocks_ref = provider.blocks.clone();
+
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let (ann_tx, _) = broadcast::channel::<BlockAnnouncement>(16);
+        let (rb_tx, _) = broadcast::channel::<RollbackAnnouncement>(16);
+        let ann_rx = ann_tx.subscribe();
+        let rb_rx = rb_tx.subscribe();
+
+        // Pin a short StMustReply timeout so the timeout arm fires quickly.
+        let mut server = LocalChainSyncServer::new_with_timeout(Duration::from_millis(100));
+        let handle =
+            tokio::spawn(async move { server.run(&mut channel, &provider, ann_rx, rb_rx).await });
+
+        send_msg(
+            &ingress_tx,
+            &ChainSyncMessage::MsgFindIntersect(vec![Point::Origin]),
+        )
+        .await;
+        let _ = recv_msg(&mut egress_rx).await;
+
+        send_msg(&ingress_tx, &ChainSyncMessage::MsgRequestNext).await;
+        let msg = recv_msg(&mut egress_rx).await;
+        assert!(matches!(msg, ChainSyncMessage::MsgRollForward { .. }));
+
+        // At tip — enters StMustReply.
+        send_msg(&ingress_tx, &ChainSyncMessage::MsgRequestNext).await;
+        let msg = recv_msg(&mut egress_rx).await;
+        assert!(matches!(msg, ChainSyncMessage::MsgAwaitReply));
+
+        // Nothing new yet — let the 100ms timeout fire at least once with
+        // nothing to serve.  The server must keep waiting (not wedge, not
+        // return early) rather than requiring a second MsgRequestNext.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert!(
+            egress_rx.try_recv().is_err(),
+            "server must not send anything while there is still nothing new to serve"
+        );
+
+        // Now push a genuine block — no announcement this time, proving the
+        // timeout re-poll (not just the announcement wake) picks it up.
+        let block_b = make_block_cbor(&[0x0B]);
+        blocks_ref.lock().unwrap().push((20, [0x02; 32], block_b));
+
+        let (_, _, resp) = tokio::time::timeout(Duration::from_secs(5), egress_rx.recv())
+            .await
+            .expect("server must eventually reply once a real block is available")
+            .unwrap();
+        assert!(matches!(
+            decode_message(&resp).unwrap(),
+            ChainSyncMessage::MsgRollForward { .. }
+        ));
+
+        handle.abort();
+    }
+
+    /// Helper: send `MsgRequestNext` and receive the next reply.  Used by the
+    /// fork-switch parity test where the same request/response idiom repeats.
+    async fn recv_msg_after(
+        ingress_tx: &mpsc::Sender<Bytes>,
+        egress_rx: &mut mpsc::Receiver<(u16, crate::mux::Direction, Bytes)>,
+    ) -> ChainSyncMessage {
+        send_msg(ingress_tx, &ChainSyncMessage::MsgRequestNext).await;
+        recv_msg(egress_rx).await
     }
 }

--- a/crates/dugite-network/src/protocol/local_state_query/server.rs
+++ b/crates/dugite-network/src/protocol/local_state_query/server.rs
@@ -24,6 +24,27 @@ use super::{
 ///
 /// Implemented by the node integration layer, which has access to the ledger state.
 pub trait QueryHandler: Send + Sync {
+    /// Opaque handle produced by [`acquire`](QueryHandler::acquire) and threaded
+    /// back into every dispatch method for the lifetime of a single acquisition.
+    ///
+    /// This is how the server pins a consistent ledger-state snapshot at
+    /// MsgAcquire time (issue #867): the handler resolves the acquire target to a
+    /// concrete state handle ONCE, and every subsequent MsgQuery in that
+    /// acquisition dispatches against the SAME handle -- even if the node's live
+    /// tip advances mid-session. Without this, two queries issued back-to-back
+    /// under one acquisition (e.g. cardano-cli/ogmios pulling tip + pparams +
+    /// utxo + account state) could observe different ledger states (a "torn
+    /// read") if a block lands between them.
+    type Acquired: Send + Sync;
+
+    /// Resolve an acquire target to a pinned state handle.
+    ///
+    /// Returns `Ok(handle)` if the target can be acquired, or `Err(AcquireFailure)`
+    /// if the point is invalid. The returned handle must be cheap to produce
+    /// (typically an `Arc` clone of the current state) and MUST represent a
+    /// fixed point in time -- it must not silently track later state updates.
+    fn acquire(&self, target: &AcquireTarget) -> Result<Self::Acquired, AcquireFailure>;
+
     /// Handle a raw query from the MsgQuery payload.
     ///
     /// `query_cbor` is the raw CBOR after the MsgQuery tag (i.e. the consensus-level
@@ -32,9 +53,14 @@ pub trait QueryHandler: Send + Sync {
     /// HFC-level (QueryIfCurrent/QueryAnytime/QueryHardFork), and era-level dispatch.
     ///
     /// Returns the fully-encoded MsgResult payload bytes (WITHOUT the `[4, ...]`
-    /// envelope — the server adds that). For BlockQuery QueryIfCurrent results,
+    /// envelope -- the server adds that). For BlockQuery QueryIfCurrent results,
     /// wrap in HFC success `[1, result]`. For other query types, return unwrapped.
-    fn handle_query(&self, query_cbor: &[u8], n2c_version: u16) -> Result<Vec<u8>, String>;
+    fn handle_query(
+        &self,
+        acquired: &Self::Acquired,
+        query_cbor: &[u8],
+        n2c_version: u16,
+    ) -> Result<Vec<u8>, String>;
 
     /// Handle a Shelley BlockQuery by tag number.
     ///
@@ -43,19 +69,28 @@ pub trait QueryHandler: Send + Sync {
     ///
     /// Returns the CBOR-encoded result, which will be wrapped in the HFC
     /// success envelope `[1, result]` by the server.
-    fn handle_block_query(&self, tag: u64, query_cbor: &[u8]) -> Result<Vec<u8>, String>;
+    fn handle_block_query(
+        &self,
+        acquired: &Self::Acquired,
+        tag: u64,
+        query_cbor: &[u8],
+    ) -> Result<Vec<u8>, String>;
 
     /// Handle a QueryAnytime query (e.g., GetEraStart).
     /// Returns unwrapped CBOR result.
-    fn handle_query_anytime(&self, query_cbor: &[u8]) -> Result<Vec<u8>, String>;
+    fn handle_query_anytime(
+        &self,
+        acquired: &Self::Acquired,
+        query_cbor: &[u8],
+    ) -> Result<Vec<u8>, String>;
 
     /// Handle a QueryHardFork query (e.g., GetInterpreter).
     /// Returns unwrapped CBOR result.
-    fn handle_query_hard_fork(&self, query_cbor: &[u8]) -> Result<Vec<u8>, String>;
-
-    /// Validate an acquire target. Returns `Ok(())` if the target can be acquired,
-    /// or `Err(AcquireFailure)` if the point is invalid.
-    fn validate_acquire(&self, target: &AcquireTarget) -> Result<(), AcquireFailure>;
+    fn handle_query_hard_fork(
+        &self,
+        acquired: &Self::Acquired,
+        query_cbor: &[u8],
+    ) -> Result<Vec<u8>, String>;
 }
 
 /// LocalStateQuery server.
@@ -71,7 +106,7 @@ impl LocalStateQueryServer {
         handler: &H,
         n2c_version: u16,
     ) -> Result<(), ProtocolError> {
-        let mut acquired = false;
+        let mut acquired: Option<H::Acquired> = None;
 
         loop {
             let msg_bytes = channel.recv().await.map_err(ProtocolError::from)?;
@@ -96,9 +131,9 @@ impl LocalStateQueryServer {
                 // MsgAcquire: [0, point] / [8] / [10]
                 TAG_ACQUIRE_SPECIFIC | TAG_ACQUIRE_VOLATILE | TAG_ACQUIRE_IMMUTABLE => {
                     let target = decode_acquire_target(tag, &mut dec)?;
-                    match handler.validate_acquire(&target) {
-                        Ok(()) => {
-                            acquired = true;
+                    match handler.acquire(&target) {
+                        Ok(handle) => {
+                            acquired = Some(handle);
                             // MsgAcquired = [1]
                             let mut buf = Vec::new();
                             let mut enc = Encoder::new(&mut buf);
@@ -133,9 +168,9 @@ impl LocalStateQueryServer {
                 | super::TAG_REACQUIRE_IMMUTABLE => {
                     // Release old state, acquire new
                     let target = decode_acquire_target(tag, &mut dec)?;
-                    match handler.validate_acquire(&target) {
-                        Ok(()) => {
-                            acquired = true;
+                    match handler.acquire(&target) {
+                        Ok(handle) => {
+                            acquired = Some(handle);
                             let mut buf = Vec::new();
                             let mut enc = Encoder::new(&mut buf);
                             enc.array(1).expect("infallible");
@@ -143,7 +178,7 @@ impl LocalStateQueryServer {
                             channel.send(buf).await.map_err(ProtocolError::from)?;
                         }
                         Err(failure) => {
-                            acquired = false; // Old state is also lost
+                            acquired = None; // Old state is also lost
                             let mut buf = Vec::new();
                             let mut enc = Encoder::new(&mut buf);
                             enc.array(2).expect("infallible");
@@ -164,19 +199,30 @@ impl LocalStateQueryServer {
                 }
 
                 // MsgRelease = [5]
+                //
+                // Issue #880: MsgRelease is only valid from StAcquired. A client
+                // that sends MsgRelease from StIdle (never acquired, or already
+                // released) is violating the protocol state machine.
                 TAG_RELEASE => {
-                    acquired = false;
-                }
-
-                // MsgQuery = [3, query]
-                TAG_QUERY => {
-                    if !acquired {
+                    if acquired.is_none() {
                         return Err(ProtocolError::StateViolation {
                             protocol: "LocalStateQuery",
                             expected: "StAcquired".to_string(),
                             actual: "StIdle (not acquired)".to_string(),
                         });
                     }
+                    acquired = None;
+                }
+
+                // MsgQuery = [3, query]
+                TAG_QUERY => {
+                    let Some(acquired_handle) = acquired.as_ref() else {
+                        return Err(ProtocolError::StateViolation {
+                            protocol: "LocalStateQuery",
+                            expected: "StAcquired".to_string(),
+                            actual: "StIdle (not acquired)".to_string(),
+                        });
+                    };
 
                     // Pass the full consensus-level query CBOR to the handler.
                     // The handler dispatches BlockQuery/GetSystemStart/GetChainBlockNo/
@@ -202,12 +248,11 @@ impl LocalStateQueryServer {
                         });
                     }
 
-                    let result_cbor =
-                        handler.handle_query(query_cbor, n2c_version).map_err(|e| {
-                            ProtocolError::CborDecode {
-                                protocol: "LocalStateQuery",
-                                reason: format!("query dispatch: {e}"),
-                            }
+                    let result_cbor = handler
+                        .handle_query(acquired_handle, query_cbor, n2c_version)
+                        .map_err(|e| ProtocolError::CborDecode {
+                            protocol: "LocalStateQuery",
+                            reason: format!("query dispatch: {e}"),
                         })?;
 
                     // MsgResult = [4, result]
@@ -272,7 +317,28 @@ mod tests {
     struct MockQueryHandler;
 
     impl QueryHandler for MockQueryHandler {
-        fn handle_query(&self, query_cbor: &[u8], _n2c_version: u16) -> Result<Vec<u8>, String> {
+        type Acquired = ();
+
+        fn acquire(&self, target: &AcquireTarget) -> Result<(), AcquireFailure> {
+            match target {
+                AcquireTarget::VolatileTip | AcquireTarget::ImmutableTip => Ok(()),
+                AcquireTarget::SpecificPoint(codec::Point::Origin) => Ok(()),
+                AcquireTarget::SpecificPoint(codec::Point::Specific(slot, _)) => {
+                    if *slot > 1000 {
+                        Err(AcquireFailure::PointNotOnChain)
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        }
+
+        fn handle_query(
+            &self,
+            acquired: &(),
+            query_cbor: &[u8],
+            _n2c_version: u16,
+        ) -> Result<Vec<u8>, String> {
             // Simple mock: decode the consensus-level query and return a
             // canned response. For BlockQuery(QueryIfCurrent), return the
             // shelley tag wrapped in HFC success [1, tag].
@@ -281,15 +347,15 @@ mod tests {
             let outer_tag = dec.u64().unwrap_or(999);
             match outer_tag {
                 0 => {
-                    // BlockQuery → parse HFC inner
+                    // BlockQuery -> parse HFC inner
                     let _ = dec.array();
                     let hfc_tag = dec.u64().unwrap_or(999);
                     match hfc_tag {
                         0 => {
-                            // QueryIfCurrent → parse shelley tag
+                            // QueryIfCurrent -> parse shelley tag
                             let _ = dec.array();
                             let shelley_tag = dec.u64().unwrap_or(999);
-                            let result = self.handle_block_query(shelley_tag, &[])?;
+                            let result = self.handle_block_query(acquired, shelley_tag, &[])?;
                             // Wrap in HFC success: [1, result]
                             let mut buf = Vec::new();
                             let mut enc = Encoder::new(&mut buf);
@@ -313,7 +379,12 @@ mod tests {
             }
         }
 
-        fn handle_block_query(&self, tag: u64, _query_cbor: &[u8]) -> Result<Vec<u8>, String> {
+        fn handle_block_query(
+            &self,
+            _acquired: &(),
+            tag: u64,
+            _query_cbor: &[u8],
+        ) -> Result<Vec<u8>, String> {
             // Return a simple response: the tag as a CBOR integer
             let mut buf = Vec::new();
             let mut enc = Encoder::new(&mut buf);
@@ -321,32 +392,103 @@ mod tests {
             Ok(buf)
         }
 
-        fn handle_query_anytime(&self, _query_cbor: &[u8]) -> Result<Vec<u8>, String> {
+        fn handle_query_anytime(
+            &self,
+            _acquired: &(),
+            _query_cbor: &[u8],
+        ) -> Result<Vec<u8>, String> {
             let mut buf = Vec::new();
             let mut enc = Encoder::new(&mut buf);
             enc.str("anytime").expect("infallible");
             Ok(buf)
         }
 
-        fn handle_query_hard_fork(&self, _query_cbor: &[u8]) -> Result<Vec<u8>, String> {
+        fn handle_query_hard_fork(
+            &self,
+            _acquired: &(),
+            _query_cbor: &[u8],
+        ) -> Result<Vec<u8>, String> {
             let mut buf = Vec::new();
             let mut enc = Encoder::new(&mut buf);
             enc.str("hardfork").expect("infallible");
             Ok(buf)
         }
+    }
 
-        fn validate_acquire(&self, target: &AcquireTarget) -> Result<(), AcquireFailure> {
-            match target {
-                AcquireTarget::VolatileTip | AcquireTarget::ImmutableTip => Ok(()),
-                AcquireTarget::SpecificPoint(codec::Point::Origin) => Ok(()),
-                AcquireTarget::SpecificPoint(codec::Point::Specific(slot, _)) => {
-                    if *slot > 1000 {
-                        Err(AcquireFailure::PointNotOnChain)
-                    } else {
-                        Ok(())
-                    }
-                }
+    /// A stateful mock handler whose "current tip" can be mutated after an
+    /// acquire has already pinned a handle -- used to prove that queries
+    /// within one acquisition observe a consistent (non-torn) snapshot even
+    /// as the live state moves underneath (issue #867).
+    struct TornReadMockHandler {
+        /// The handler's live "current tip" value. Mutated by the test to
+        /// simulate a concurrent `update_state()` swap between two queries.
+        live_tip: std::sync::atomic::AtomicU64,
+    }
+
+    impl TornReadMockHandler {
+        fn new(initial_tip: u64) -> Self {
+            Self {
+                live_tip: std::sync::atomic::AtomicU64::new(initial_tip),
             }
+        }
+
+        fn set_live_tip(&self, tip: u64) {
+            self.live_tip
+                .store(tip, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    /// Query tag used by [`TornReadMockHandler`] to report the tip value
+    /// pinned in the `Acquired` handle (NOT the handler's live tip).
+    const GET_PINNED_TIP_TAG: u64 = 100;
+
+    impl QueryHandler for TornReadMockHandler {
+        /// The handle pins a copy of the live tip value AT acquire time.
+        type Acquired = u64;
+
+        fn acquire(&self, _target: &AcquireTarget) -> Result<u64, AcquireFailure> {
+            Ok(self.live_tip.load(std::sync::atomic::Ordering::SeqCst))
+        }
+
+        fn handle_query(
+            &self,
+            acquired: &u64,
+            query_cbor: &[u8],
+            _n2c_version: u16,
+        ) -> Result<Vec<u8>, String> {
+            let mut dec = Decoder::new(query_cbor);
+            let _ = dec.array();
+            let tag = dec.u64().unwrap_or(999);
+            self.handle_block_query(acquired, tag, &[])
+        }
+
+        fn handle_block_query(
+            &self,
+            acquired: &u64,
+            _tag: u64,
+            _query_cbor: &[u8],
+        ) -> Result<Vec<u8>, String> {
+            // Always echo the PINNED value, never the live one.
+            let mut buf = Vec::new();
+            let mut enc = Encoder::new(&mut buf);
+            enc.u64(*acquired).expect("infallible");
+            Ok(buf)
+        }
+
+        fn handle_query_anytime(
+            &self,
+            _acquired: &u64,
+            _query_cbor: &[u8],
+        ) -> Result<Vec<u8>, String> {
+            Ok(Vec::new())
+        }
+
+        fn handle_query_hard_fork(
+            &self,
+            _acquired: &u64,
+            _query_cbor: &[u8],
+        ) -> Result<Vec<u8>, String> {
+            Ok(Vec::new())
         }
     }
 
@@ -922,5 +1064,142 @@ mod tests {
 
         ingress_tx.send(Bytes::from(encode_done())).await.unwrap();
         handle.await.unwrap().unwrap();
+    }
+
+    // ── Issue #867: pinned-snapshot / torn-read tests ──────────────────────
+
+    /// Regression for issue #867: two queries issued within the SAME
+    /// acquisition must observe the SAME pinned state, even if the handler's
+    /// live state is mutated between them (simulating a concurrent
+    /// `update_state()` swap as new blocks are applied). Before the fix, each
+    /// MsgQuery read live state directly, so the second query would see the
+    /// post-swap value -- a torn read.
+    #[tokio::test]
+    async fn torn_read_regression_pinned_snapshot_survives_live_update() {
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let handler = std::sync::Arc::new(TornReadMockHandler::new(100));
+        let handler_for_task = handler.clone();
+
+        let handle = tokio::spawn(async move {
+            LocalStateQueryServer::run(&mut channel, handler_for_task.as_ref(), 16).await
+        });
+
+        // Acquire while live_tip == 100. The handle must pin 100.
+        ingress_tx
+            .send(Bytes::from(encode_acquire_volatile()))
+            .await
+            .unwrap();
+        let _ = egress_rx.recv().await.unwrap(); // MsgAcquired
+
+        // First query: expect the pinned value (100).
+        ingress_tx
+            .send(Bytes::from(encode_block_query(GET_PINNED_TIP_TAG)))
+            .await
+            .unwrap();
+        let (_, _, result1) = egress_rx.recv().await.unwrap();
+        let mut dec = Decoder::new(&result1);
+        dec.array().unwrap();
+        assert_eq!(dec.u64().unwrap(), TAG_RESULT);
+        let pinned1 = dec.u64().unwrap();
+        assert_eq!(pinned1, 100, "first query must see the pinned snapshot");
+
+        // Simulate a live tip advance (e.g. a new block landing) BETWEEN the
+        // two queries of this acquisition. A correctly pinned handler must
+        // NOT observe this.
+        handler.set_live_tip(999);
+
+        // Second query: must STILL return 100, not 999.
+        ingress_tx
+            .send(Bytes::from(encode_block_query(GET_PINNED_TIP_TAG)))
+            .await
+            .unwrap();
+        let (_, _, result2) = egress_rx.recv().await.unwrap();
+        let mut dec = Decoder::new(&result2);
+        dec.array().unwrap();
+        assert_eq!(dec.u64().unwrap(), TAG_RESULT);
+        let pinned2 = dec.u64().unwrap();
+        assert_eq!(
+            pinned2, 100,
+            "second query in the same acquisition must still see the \
+             ORIGINAL pinned snapshot (100), not the live tip that changed \
+             mid-acquisition (999) -- a torn read"
+        );
+
+        ingress_tx
+            .send(Bytes::from(encode_release()))
+            .await
+            .unwrap();
+        ingress_tx.send(Bytes::from(encode_done())).await.unwrap();
+        handle.await.unwrap().unwrap();
+    }
+
+    /// Regression for issue #880: MsgRelease sent from StIdle (before any
+    /// successful acquire) must be rejected with a StateViolation, mirroring
+    /// the existing MsgQuery-without-acquire rejection.
+    #[tokio::test]
+    async fn release_without_acquire_returns_state_violation() {
+        let (mut channel, _egress_rx, ingress_tx) = make_test_channel();
+        let handler = MockQueryHandler;
+
+        let handle =
+            tokio::spawn(
+                async move { LocalStateQueryServer::run(&mut channel, &handler, 16).await },
+            );
+
+        // Send MsgRelease without acquiring first.
+        ingress_tx
+            .send(Bytes::from(encode_release()))
+            .await
+            .unwrap();
+
+        let result = handle.await.unwrap();
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::ProtocolError::StateViolation { .. })
+            ),
+            "expected StateViolation for release without acquire, got: {result:?}"
+        );
+    }
+
+    /// A second MsgRelease immediately after a valid release (i.e. release
+    /// while already released) must also be rejected -- StIdle is StIdle
+    /// regardless of history.
+    #[tokio::test]
+    async fn double_release_returns_state_violation() {
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+        let handler = MockQueryHandler;
+
+        let handle =
+            tokio::spawn(
+                async move { LocalStateQueryServer::run(&mut channel, &handler, 16).await },
+            );
+
+        ingress_tx
+            .send(Bytes::from(encode_acquire_volatile()))
+            .await
+            .unwrap();
+        let _ = egress_rx.recv().await.unwrap(); // MsgAcquired
+
+        // First release: valid (StAcquired -> StIdle).
+        ingress_tx
+            .send(Bytes::from(encode_release()))
+            .await
+            .unwrap();
+
+        // Second release: invalid (StIdle -> StIdle is not a legal MsgRelease).
+        ingress_tx
+            .send(Bytes::from(encode_release()))
+            .await
+            .unwrap();
+
+        let result = handle.await.unwrap();
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::ProtocolError::StateViolation { .. })
+            ),
+            "expected StateViolation for double release, got: {result:?}"
+        );
     }
 }

--- a/crates/dugite-network/src/protocol/local_tx_monitor/server.rs
+++ b/crates/dugite-network/src/protocol/local_tx_monitor/server.rs
@@ -153,7 +153,10 @@ impl LocalTxMonitorServer {
 
                         // Try to get the tx CBOR + era from mempool.
                         let tx_hash_obj = dugite_primitives::Hash::from_bytes(*tx_hash);
-                        match (mempool.get_tx_cbor(&tx_hash_obj), mempool.get_tx(&tx_hash_obj)) {
+                        match (
+                            mempool.get_tx_cbor(&tx_hash_obj),
+                            mempool.get_tx(&tx_hash_obj),
+                        ) {
                             (Some(tx_cbor), Some(tx)) => {
                                 // #874: MsgReplyNextTx present = [6, <GenTx>] where
                                 // <GenTx> is the era-tagged CBOR-in-CBOR form
@@ -570,9 +573,10 @@ mod tests {
     async fn release_before_acquire_is_state_violation() {
         let mempool = MockMempool::new(100);
         let (mut channel, _egress_rx, ingress_tx) = make_test_channel();
-        let handle = tokio::spawn(async move {
-            LocalTxMonitorServer::run(&mut channel, &mempool, || 0).await
-        });
+        let handle =
+            tokio::spawn(
+                async move { LocalTxMonitorServer::run(&mut channel, &mempool, || 0).await },
+            );
 
         send_raw(&ingress_tx, encode_tag_only(TAG_RELEASE)).await;
 

--- a/crates/dugite-network/src/protocol/local_tx_monitor/server.rs
+++ b/crates/dugite-network/src/protocol/local_tx_monitor/server.rs
@@ -123,6 +123,17 @@ impl LocalTxMonitorServer {
                     channel.send(buf).await.map_err(ProtocolError::from)?;
                 }
                 TAG_RELEASE => {
+                    // #880: MsgRelease has client agency only in StAcquired.
+                    // Reject it from StIdle (no snapshot held) with a
+                    // StateViolation, mirroring the strict MsgNextTx handling —
+                    // Haskell only permits MsgRelease from StAcquired.
+                    if snapshot.is_none() {
+                        return Err(ProtocolError::StateViolation {
+                            protocol: "LocalTxMonitor",
+                            expected: "StAcquired".to_string(),
+                            actual: "StIdle (no snapshot)".to_string(),
+                        });
+                    }
                     // Release the snapshot, return to StIdle
                     snapshot = None;
                 }
@@ -140,17 +151,32 @@ impl LocalTxMonitorServer {
                         let tx_hash = &snap.tx_hashes[snap.next_tx_index];
                         snap.next_tx_index += 1;
 
-                        // Try to get the tx CBOR from mempool
+                        // Try to get the tx CBOR + era from mempool.
                         let tx_hash_obj = dugite_primitives::Hash::from_bytes(*tx_hash);
-                        if let Some(tx_cbor) = mempool.get_tx_cbor(&tx_hash_obj) {
-                            // MsgReplyNextTx with tx = [6, [era_id, tx_bytes]]
-                            enc.array(2).expect("infallible");
-                            enc.u64(TAG_REPLY_NEXT_TX).expect("infallible");
-                            enc.bytes(&tx_cbor).expect("infallible");
-                        } else {
-                            // Tx was removed from mempool since snapshot — skip
-                            enc.array(1).expect("infallible");
-                            enc.u64(TAG_REPLY_NEXT_TX).expect("infallible");
+                        match (mempool.get_tx_cbor(&tx_hash_obj), mempool.get_tx(&tx_hash_obj)) {
+                            (Some(tx_cbor), Some(tx)) => {
+                                // #874: MsgReplyNextTx present = [6, <GenTx>] where
+                                // <GenTx> is the era-tagged CBOR-in-CBOR form
+                                // cardano-node uses (byte-identical to MsgSubmitTx),
+                                // so ogmios and other Haskell mempool monitors can
+                                // decode it:
+                                //   [6, [era_index, tag(24) bstr(tx_cbor)]]
+                                // The HFC era index is 0-based (Conway=6); the
+                                // per-era Shelley GenTx ToCBOR wraps the tx in
+                                // tag(24). Previously we emitted a bare bytestring
+                                // [6, bstr(tx)] which no Haskell decoder accepts.
+                                enc.array(2).expect("infallible");
+                                enc.u64(TAG_REPLY_NEXT_TX).expect("infallible");
+                                enc.array(2).expect("infallible");
+                                enc.u32(tx.era.to_era_index()).expect("infallible");
+                                enc.tag(minicbor::data::Tag::new(24)).expect("infallible");
+                                enc.bytes(&tx_cbor).expect("infallible");
+                            }
+                            _ => {
+                                // Tx was removed from mempool since snapshot — skip
+                                enc.array(1).expect("infallible");
+                                enc.u64(TAG_REPLY_NEXT_TX).expect("infallible");
+                            }
                         }
                     } else {
                         // No more transactions — MsgReplyNextTx with no tx
@@ -285,8 +311,15 @@ mod tests {
         fn contains(&self, tx_hash: &Hash<32>) -> bool {
             self.txs.contains_key(&tx_hash.0)
         }
-        fn get_tx(&self, _: &Hash<32>) -> Option<Transaction> {
-            None
+        fn get_tx(&self, tx_hash: &Hash<32>) -> Option<Transaction> {
+            // #874: the monitor server now needs the tx era to emit the
+            // era-tagged GenTx. The mock stores Conway-era txs; return a
+            // minimal Transaction carrying the era so the encoder can index it.
+            self.txs.get(&tx_hash.0).map(|_| {
+                let mut tx = Transaction::empty_with_hash(*tx_hash);
+                tx.era = dugite_primitives::era::Era::Conway;
+                tx
+            })
         }
         fn get_tx_size(&self, tx_hash: &Hash<32>) -> Option<usize> {
             self.txs.get(&tx_hash.0).map(|(_, s)| *s)
@@ -486,6 +519,7 @@ mod tests {
         let _ = recv_raw(&mut egress_rx).await;
 
         // Iterate: should get 2 transactions, then empty.
+        // #874: each present reply is [6, [era_index, tag(24) bstr(tx_cbor)]].
         let mut received_cbors = Vec::new();
         for _ in 0..2 {
             send_raw(&ingress_tx, encode_tag_only(TAG_NEXT_TX)).await;
@@ -495,12 +529,27 @@ mod tests {
             let tag = dec.u64().unwrap();
             assert_eq!(tag, TAG_REPLY_NEXT_TX);
             if arr_len == Some(2) {
-                // Has tx CBOR.
+                // GenTx = array(2) [era_index, tag(24) bstr(tx_cbor)].
+                assert_eq!(dec.array().unwrap(), Some(2), "GenTx must be array(2)");
+                assert_eq!(
+                    dec.u32().unwrap(),
+                    dugite_primitives::era::Era::Conway.to_era_index(),
+                    "era index must be the HFC index (Conway=6)"
+                );
+                assert_eq!(
+                    dec.tag().unwrap().as_u64(),
+                    24,
+                    "tx must be CBOR-in-CBOR tag(24)"
+                );
                 let cbor = dec.bytes().unwrap().to_vec();
                 received_cbors.push(cbor);
             }
         }
         assert_eq!(received_cbors.len(), 2, "should receive 2 transactions");
+        assert!(
+            received_cbors.contains(&tx1_cbor) && received_cbors.contains(&tx2_cbor),
+            "delivered tx CBORs must round-trip verbatim inside tag(24)"
+        );
 
         // Third NextTx → empty (array len 1, no tx body).
         send_raw(&ingress_tx, encode_tag_only(TAG_NEXT_TX)).await;
@@ -512,6 +561,32 @@ mod tests {
 
         send_raw(&ingress_tx, encode_tag_only(TAG_DONE)).await;
         handle.await.unwrap().unwrap();
+    }
+
+    /// #880: MsgRelease has client agency only in StAcquired — sending it from
+    /// StIdle (before any MsgAcquire) must be a protocol StateViolation, not a
+    /// silent no-op.
+    #[tokio::test]
+    async fn release_before_acquire_is_state_violation() {
+        let mempool = MockMempool::new(100);
+        let (mut channel, _egress_rx, ingress_tx) = make_test_channel();
+        let handle = tokio::spawn(async move {
+            LocalTxMonitorServer::run(&mut channel, &mempool, || 0).await
+        });
+
+        send_raw(&ingress_tx, encode_tag_only(TAG_RELEASE)).await;
+
+        let result = handle.await.unwrap();
+        assert!(
+            matches!(
+                result,
+                Err(ProtocolError::StateViolation {
+                    protocol: "LocalTxMonitor",
+                    ..
+                })
+            ),
+            "MsgRelease from StIdle must be a StateViolation, got: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/dugite-network/src/protocol/peersharing/client.rs
+++ b/crates/dugite-network/src/protocol/peersharing/client.rs
@@ -28,6 +28,20 @@ impl PeerSharingClient {
 
         match response {
             PeerSharingMessage::MsgSharePeers(addrs) => {
+                // #880: a well-behaved peer never returns more addresses than the
+                // `amount` we requested. Reject an over-count reply as a protocol
+                // violation (adversarial posture: convict over silently tolerate)
+                // — the MAX_SHARED_ADDRS decode cap alone lets a peer send up to
+                // 255 regardless of what we asked for.
+                if addrs.len() > amount as usize {
+                    return Err(ProtocolError::BoundsExceeded {
+                        protocol: "PeerSharing",
+                        reason: format!(
+                            "peer returned {} addresses but only {amount} were requested",
+                            addrs.len()
+                        ),
+                    });
+                }
                 // B10: Filter addresses on the CLIENT side before returning to the
                 // PeerManager.  A malicious peer can send private/loopback/link-local
                 // addresses (127.0.0.1, 169.254.169.254, 10.0.0.0/8) to cause dugite

--- a/crates/dugite-network/src/protocol/txsubmission/mod.rs
+++ b/crates/dugite-network/src/protocol/txsubmission/mod.rs
@@ -54,6 +54,28 @@ pub struct TxIdAndSize {
     pub size_in_bytes: u32,
 }
 
+/// Outcome of handing a received transaction body to the admission callback.
+///
+/// The N2N inbound tx path must reconcile the txid a peer *attests* (in
+/// `MsgReplyTxIds`) against the canonical id `blake2b_256(raw_body_cbor)` of the
+/// body it later delivers (in `MsgReplyTxs`). A mismatch is a protocol
+/// integrity violation, not a mere validation failure, so it is distinguished
+/// from an ordinary rejection: the server converts [`Self::Convict`] into a
+/// fatal [`crate::error::ProtocolError::IntegrityViolation`] that drops the
+/// connection (#864).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxAdmission {
+    /// Tx passed validation and was admitted to the mempool (or already present).
+    Accepted,
+    /// Tx failed validation / mempool admission — NOT a protocol violation; the
+    /// connection stays up.
+    Rejected,
+    /// The peer committed a protocol integrity violation (e.g. the delivered
+    /// body's canonical id does not match the txid it attested). Convict the
+    /// peer: the server returns a fatal error and the connection is dropped.
+    Convict,
+}
+
 /// TxSubmission2 protocol messages.
 #[derive(Debug, Clone)]
 pub enum TxSubmissionMessage {

--- a/crates/dugite-network/src/protocol/txsubmission/server.rs
+++ b/crates/dugite-network/src/protocol/txsubmission/server.rs
@@ -16,7 +16,7 @@ use std::collections::{HashSet, VecDeque};
 use crate::error::ProtocolError;
 use crate::mux::channel::MuxChannel;
 
-use super::{decode_message, encode_message, TxIdAndSize, TxSubmissionMessage};
+use super::{decode_message, encode_message, TxAdmission, TxIdAndSize, TxSubmissionMessage};
 
 /// Maximum number of tx IDs to request in a single MsgRequestTxIds.
 const MAX_TX_IDS_PER_REQUEST: u16 = 10;
@@ -37,13 +37,17 @@ impl TxSubmissionServer {
     ///
     /// Drives the protocol by requesting tx IDs and bodies from the remote peer.
     /// Each received transaction is passed to `on_tx` for validation and mempool
-    /// admission. The callback returns `true` if the tx was accepted, `false` if rejected.
+    /// admission. `on_tx` receives the **attested** txid the peer advertised and
+    /// the raw tx body, and returns a [`TxAdmission`]: `Accepted`/`Rejected` keep
+    /// the connection open, while `Convict` (e.g. the delivered body's canonical
+    /// id does not match the attested txid, #864) is a fatal integrity violation
+    /// that disconnects the peer.
     pub async fn run<F>(
         channel: &mut MuxChannel,
         mut on_tx: F,
     ) -> Result<TxSubmissionStats, ProtocolError>
     where
-        F: FnMut([u8; 32], Vec<u8>) -> bool + Send,
+        F: FnMut([u8; 32], Vec<u8>) -> TxAdmission + Send,
     {
         let mut stats = TxSubmissionStats::default();
 
@@ -207,11 +211,23 @@ impl TxSubmissionServer {
                                     [0; 32]
                                 };
 
-                                // Pass raw tx bytes (era wrapper stripped) to the callback.
-                                if on_tx(tx_id, tx_bytes) {
-                                    stats.txs_accepted += 1;
-                                } else {
-                                    stats.txs_rejected += 1;
+                                // Pass raw tx bytes (era wrapper stripped) to the
+                                // callback along with the txid the PEER ATTESTED.
+                                // The callback recomputes blake2b_256(body) and
+                                // convicts the peer on mismatch (#864).
+                                match on_tx(tx_id, tx_bytes) {
+                                    TxAdmission::Accepted => stats.txs_accepted += 1,
+                                    TxAdmission::Rejected => stats.txs_rejected += 1,
+                                    TxAdmission::Convict => {
+                                        return Err(ProtocolError::IntegrityViolation {
+                                            protocol: "TxSubmission2",
+                                            reason: format!(
+                                                "delivered tx body's canonical id \
+                                                 blake2b_256(body) != attested txid {}",
+                                                hex::encode(tx_id)
+                                            ),
+                                        });
+                                    }
                                 }
 
                                 // Remove from inflight using the hash component.
@@ -287,7 +303,7 @@ mod tests {
         let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
 
         let handle = tokio::spawn(async move {
-            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| true).await
+            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| TxAdmission::Accepted).await
         });
 
         // Send MsgInit
@@ -346,7 +362,7 @@ mod tests {
         let handle = tokio::spawn(async move {
             TxSubmissionServer::run(&mut channel, move |tx_id, tx_bytes| {
                 accepted_clone.lock().unwrap().push((tx_id, tx_bytes));
-                true // accept all
+                TxAdmission::Accepted // accept all
             })
             .await
         });
@@ -431,7 +447,7 @@ mod tests {
         let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
 
         let handle = tokio::spawn(async move {
-            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| true).await
+            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| TxAdmission::Accepted).await
         });
 
         // MsgInit
@@ -468,7 +484,7 @@ mod tests {
         let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
 
         let handle = tokio::spawn(async move {
-            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| true).await
+            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| TxAdmission::Accepted).await
         });
 
         // MsgInit
@@ -520,13 +536,64 @@ mod tests {
         );
     }
 
+    /// #864: when the callback convicts the peer (the delivered body's canonical
+    /// id != the attested txid), the server must return a fatal
+    /// `IntegrityViolation` that drops the connection — not silently continue.
+    #[tokio::test]
+    async fn server_convicts_peer_on_txid_mismatch() {
+        let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
+
+        let handle = tokio::spawn(async move {
+            // Callback simulates the node's blake2b(body) check failing.
+            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| TxAdmission::Convict).await
+        });
+
+        ingress_tx
+            .send(Bytes::from(encode_message(&TxSubmissionMessage::MsgInit)))
+            .await
+            .unwrap();
+        let _ = egress_rx.recv().await.unwrap();
+
+        // Advertise one txid so the server requests the body.
+        let reply = encode_message(&TxSubmissionMessage::MsgReplyTxIds(vec![TxIdAndSize {
+            era_id: 6,
+            tx_id: [0xAB; 32],
+            size_in_bytes: 100,
+        }]));
+        ingress_tx.send(Bytes::from(reply)).await.unwrap();
+
+        // Read MsgRequestTxs.
+        let (_, _, req_txs) = egress_rx.recv().await.unwrap();
+        assert!(matches!(
+            decode_message(&req_txs).unwrap(),
+            TxSubmissionMessage::MsgRequestTxs(_)
+        ));
+
+        // Deliver a body — the callback will convict regardless of content.
+        let reply_txs =
+            encode_message(&TxSubmissionMessage::MsgReplyTxs(vec![(6u8, vec![0x01, 0x02])]));
+        ingress_tx.send(Bytes::from(reply_txs)).await.unwrap();
+
+        let result = handle.await.unwrap();
+        assert!(
+            matches!(
+                result,
+                Err(ProtocolError::IntegrityViolation {
+                    protocol: "TxSubmission2",
+                    ..
+                })
+            ),
+            "txid mismatch must convict the peer with IntegrityViolation, got: {result:?}"
+        );
+    }
+
     #[tokio::test]
     async fn server_normal_flow_within_bounds() {
         // Normal flow: peer sends exactly MAX_TX_IDS_PER_REQUEST IDs, all accepted.
         let (mut channel, mut egress_rx, ingress_tx) = make_test_channel();
 
         let handle = tokio::spawn(async move {
-            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| true).await
+            TxSubmissionServer::run(&mut channel, |_tx_id, _tx_bytes| TxAdmission::Accepted).await
         });
 
         // MsgInit

--- a/crates/dugite-network/src/protocol/txsubmission/server.rs
+++ b/crates/dugite-network/src/protocol/txsubmission/server.rs
@@ -152,12 +152,14 @@ impl TxSubmissionServer {
                     }
 
                     // Track new tx IDs, dedup against inflight.
-                    // to_fetch carries (era_id, tx_hash) pairs for MsgRequestTxs.
-                    let mut to_fetch: Vec<(u8, [u8; 32])> = Vec::new();
+                    // to_fetch carries (era_id, tx_hash, advertised_size) triples
+                    // for MsgRequestTxs; the advertised size lets us reject a peer
+                    // that later delivers a body larger than it declared (#880).
+                    let mut to_fetch: Vec<(u8, [u8; 32], u32)> = Vec::new();
                     for id in &ids {
                         if !inflight.contains(&id.tx_id) {
                             inflight.insert(id.tx_id);
-                            to_fetch.push((id.era_id, id.tx_id));
+                            to_fetch.push((id.era_id, id.tx_id, id.size_in_bytes));
                         }
                         unacked.push_back(id.clone());
                     }
@@ -182,8 +184,9 @@ impl TxSubmissionServer {
                     }
 
                     // Request full tx bodies — MsgRequestTxs carries (era_id, tx_hash) pairs.
-                    let req_txs =
-                        encode_message(&TxSubmissionMessage::MsgRequestTxs(to_fetch.clone()));
+                    let req_pairs: Vec<(u8, [u8; 32])> =
+                        to_fetch.iter().map(|(e, h, _)| (*e, *h)).collect();
+                    let req_txs = encode_message(&TxSubmissionMessage::MsgRequestTxs(req_pairs));
                     channel.send(req_txs).await.map_err(ProtocolError::from)?;
 
                     let txs_bytes = channel.recv().await.map_err(ProtocolError::from)?;
@@ -210,6 +213,24 @@ impl TxSubmissionServer {
                                 } else {
                                     [0; 32]
                                 };
+
+                                // #880: the delivered body must not exceed the
+                                // size the peer advertised in MsgReplyTxIds (which
+                                // includes the ~4-byte HFC envelope, so the
+                                // era-stripped body is always <= it). A larger body
+                                // is a flow-control / attribution violation —
+                                // convict the peer.
+                                if i < to_fetch.len() && tx_bytes.len() as u64 > to_fetch[i].2 as u64
+                                {
+                                    return Err(ProtocolError::BoundsExceeded {
+                                        protocol: "TxSubmission2",
+                                        reason: format!(
+                                            "delivered tx body is {} bytes but peer advertised {}",
+                                            tx_bytes.len(),
+                                            to_fetch[i].2
+                                        ),
+                                    });
+                                }
 
                                 // Pass raw tx bytes (era wrapper stripped) to the
                                 // callback along with the txid the PEER ATTESTED.

--- a/crates/dugite-network/src/protocol/txsubmission/server.rs
+++ b/crates/dugite-network/src/protocol/txsubmission/server.rs
@@ -220,7 +220,8 @@ impl TxSubmissionServer {
                                 // era-stripped body is always <= it). A larger body
                                 // is a flow-control / attribution violation —
                                 // convict the peer.
-                                if i < to_fetch.len() && tx_bytes.len() as u64 > to_fetch[i].2 as u64
+                                if i < to_fetch.len()
+                                    && tx_bytes.len() as u64 > to_fetch[i].2 as u64
                                 {
                                     return Err(ProtocolError::BoundsExceeded {
                                         protocol: "TxSubmission2",
@@ -591,8 +592,10 @@ mod tests {
         ));
 
         // Deliver a body — the callback will convict regardless of content.
-        let reply_txs =
-            encode_message(&TxSubmissionMessage::MsgReplyTxs(vec![(6u8, vec![0x01, 0x02])]));
+        let reply_txs = encode_message(&TxSubmissionMessage::MsgReplyTxs(vec![(
+            6u8,
+            vec![0x01, 0x02],
+        )]));
         ingress_tx.send(Bytes::from(reply_txs)).await.unwrap();
 
         let result = handle.await.unwrap();

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -2995,6 +2995,18 @@ impl ConnectionLifecycleManager {
                                     CodecPoint::Specific(s, _) => *s,
                                     CodecPoint::Origin => 0,
                                 };
+                                // #875: the lower bound of the requested range.
+                                // A BlockFetch server must only stream blocks whose
+                                // point falls in the requested [from, to] span; any
+                                // block outside it is an unrequested block the peer
+                                // has no business delivering (Haskell raises
+                                // BlockFetchProtocolFailure). We reject it as a peer
+                                // fault BEFORE it is decoded into `decoded_blocks`
+                                // and pushed toward VolatileDB/apply.
+                                let range_from_slot = match &ranges[range_idx].0 {
+                                    CodecPoint::Specific(s, _) => *s,
+                                    CodecPoint::Origin => 0,
+                                };
 
                                 // Collect decoded blocks in a local Vec inside the
                                 // sync callback, then send them via `.send().await`
@@ -3053,6 +3065,24 @@ impl ConnectionLifecycleManager {
                                         ) {
                                             Ok(block) => {
                                                 let slot = block.slot().0;
+                                                // #875: reject blocks outside the
+                                                // requested [from, to] slot span —
+                                                // an adversarial server otherwise
+                                                // rides arbitrary blocks into the
+                                                // apply loop before higher layers
+                                                // drop them. Convict the peer.
+                                                if slot < range_from_slot || slot > range_to_slot {
+                                                    warn!(
+                                                        %addr, slot, range_from_slot, range_to_slot,
+                                                        "BlockFetch: peer delivered a block outside the requested range — rejecting"
+                                                    );
+                                                    return Err(dugite_network::error::ProtocolError::IntegrityViolation {
+                                                        protocol: "BlockFetch",
+                                                        reason: format!(
+                                                            "delivered block at slot {slot} outside requested range [{range_from_slot}, {range_to_slot}]"
+                                                        ),
+                                                    });
+                                                }
                                                 debug!(%addr, slot, block_no = block.block_number().0, "BlockFetch: block decoded");
                                                 decoded_blocks.push(FetchedBlock {
                                                     peer,

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -1635,17 +1635,21 @@ impl ConnectionLifecycleManager {
             peer_manager.mark_terminating(&addr);
 
             // Close ALL connections to this remote (covers duplex pairs).
+            // #870: offload the shutdown `.await` (see demote_to_cold) so the
+            // held peer_manager write lock is not blocked on a stalled peer.
             let cids: Vec<ConnectionId> = self
                 .connections
                 .keys()
                 .filter(|c| c.remote == addr)
                 .copied()
                 .collect();
+            let mut closing: Vec<PeerConnection> = Vec::with_capacity(cids.len());
             for close_cid in &cids {
-                if let Some(mut conn) = self.connections.remove(close_cid) {
-                    conn.shutdown().await;
+                if let Some(conn) = self.connections.remove(close_cid) {
+                    closing.push(conn);
                 }
             }
+            Self::spawn_shutdown(closing);
 
             {
                 let mut chains = self.candidate_chains.write().await;
@@ -1658,6 +1662,25 @@ impl ConnectionLifecycleManager {
         }
 
         Ok(())
+    }
+
+    /// Shut down owned connections on a detached task (#870).
+    ///
+    /// `conn.shutdown()` aborts the mux + protocol tasks and can take up to
+    /// PROTOCOL_SHUTDOWN_TIMEOUT (5 s) if a protocol task is wedged behind a
+    /// stalled peer. Callers that hold the global `peer_manager` write lock must
+    /// NOT await it inline (it would freeze the connection manager for an
+    /// adversary-controlled duration); they remove the connections from the map
+    /// synchronously and hand the owned values here instead.
+    fn spawn_shutdown(mut conns: Vec<PeerConnection>) {
+        if conns.is_empty() {
+            return;
+        }
+        tokio::spawn(async move {
+            for conn in &mut conns {
+                conn.shutdown().await;
+            }
+        });
     }
 
     /// Demote a warm peer to cold: stop all protocols, close connection.
@@ -1693,11 +1716,21 @@ impl ConnectionLifecycleManager {
         // Mark connection as terminating before shutdown (for metrics).
         peer_manager.mark_terminating(&addr);
 
+        // #870: remove the connections from the map synchronously (O(1)) and
+        // OFFLOAD the shutdown `.await` to a detached task. The governor tick
+        // holds the global `peer_manager` write lock across this call, and
+        // `conn.shutdown()` can block up to PROTOCOL_SHUTDOWN_TIMEOUT (5 s) when
+        // an adversarial peer stalls its mux close — holding that lock for
+        // seconds would freeze the whole connection manager (connect results,
+        // inbound accepts, ledger discovery, metrics). Detaching the shutdown
+        // keeps the lock hold to the fast map removal + pm state update.
+        let mut closing: Vec<PeerConnection> = Vec::with_capacity(cids.len());
         for cid in &cids {
-            if let Some(mut conn) = self.connections.remove(cid) {
-                conn.shutdown().await;
+            if let Some(conn) = self.connections.remove(cid) {
+                closing.push(conn);
             }
         }
+        Self::spawn_shutdown(closing);
 
         // Clear candidate chain state.
         {
@@ -1761,11 +1794,24 @@ impl ConnectionLifecycleManager {
             GovernorAction::DemoteToWarm(addr) => {
                 if let Err(e) = self.demote_to_warm(addr, peer_manager).await {
                     warn!(%addr, error = %e, "failed to demote hot -> warm");
+                    // #880: on NotConnected the peer is Hot in the manager with
+                    // no backing connection; without reconciling, hot_count
+                    // inflates permanently and the governor re-emits DemoteToWarm
+                    // every tick while never promoting. There is genuinely no
+                    // socket, so move the peer to cold.
+                    if matches!(e, LifecycleError::NotConnected(_)) {
+                        peer_manager.peer_disconnected(&addr);
+                    }
                 }
             }
             GovernorAction::DemoteToCold(addr) => {
                 if let Err(e) = self.demote_to_cold(addr, peer_manager).await {
                     warn!(%addr, error = %e, "failed to demote warm -> cold");
+                    // #880: same reconciliation — a warm peer with no connection
+                    // must be moved to cold rather than left dangling.
+                    if matches!(e, LifecycleError::NotConnected(_)) {
+                        peer_manager.peer_disconnected(&addr);
+                    }
                 }
             }
             GovernorAction::DiscoverMore => {
@@ -1782,11 +1828,14 @@ impl ConnectionLifecycleManager {
                     .filter(|c| c.remote == addr)
                     .copied()
                     .collect();
+                // #870: offload the shutdown awaits off the held pm write lock.
+                let mut closing: Vec<PeerConnection> = Vec::with_capacity(cids.len());
                 for cid in cids {
-                    if let Some(mut conn) = self.connections.remove(&cid) {
-                        conn.shutdown().await;
+                    if let Some(conn) = self.connections.remove(&cid) {
+                        closing.push(conn);
                     }
                 }
+                Self::spawn_shutdown(closing);
                 peer_manager.inner.remove_peer(&addr);
             }
             GovernorAction::PeerShareRequest(addr) => {
@@ -1855,6 +1904,23 @@ impl ConnectionLifecycleManager {
     /// Check if any connection (inbound or outbound) exists for the given remote.
     pub fn has_connection(&self, addr: &SocketAddr) -> bool {
         self.has_any_to(*addr)
+    }
+
+    /// Number of currently-ESTABLISHED inbound connections (#865).
+    ///
+    /// The accept-side semaphore + ConnectionManager slot bound only concurrent
+    /// in-flight handshakes; they are released the instant a handshake completes.
+    /// This counts live registered inbound connections so the caller can enforce
+    /// a hard cap on established inbound connections (matching Haskell's
+    /// `AcceptedConnectionsLimit`, which holds for the whole connection lifetime)
+    /// — otherwise an attacker who completes handshakes from a botnet can hold an
+    /// unbounded number of live inbound connections (each a mux task + five
+    /// responder channels + keepalive) → memory / FD exhaustion.
+    pub fn inbound_connection_count(&self) -> usize {
+        self.connections
+            .values()
+            .filter(|p| p.direction == PeerConnectionDirection::Inbound)
+            .count()
     }
 
     /// Returns true if we have at least one outbound connection to `remote`.

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -3551,7 +3551,8 @@ impl ConnectionLifecycleManager {
                     let tx_mempool = mempool;
                     let tx_metrics = metrics;
                     let validator = tx_validator;
-                    move |tx_hash: [u8; 32], tx_bytes: Vec<u8>| -> bool {
+                    move |tx_hash: [u8; 32], tx_bytes: Vec<u8>| -> dugite_network::TxAdmission {
+                        use dugite_network::TxAdmission;
                         // Track every transaction received from peers in real-time.
                         tx_metrics
                             .transactions_received
@@ -3570,7 +3571,7 @@ impl ConnectionLifecycleManager {
                             tx_metrics
                                 .transactions_rejected
                                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            return false;
+                            return TxAdmission::Rejected;
                         }
 
                         // Run full Phase-1 + Phase-2 validation (including IsValid
@@ -3583,31 +3584,60 @@ impl ConnectionLifecycleManager {
                             if let Ok(tx) =
                                 dugite_serialization::decode_transaction(era_id, &tx_bytes)
                             {
+                                // #864: reconcile the CANONICAL txid — the decoder
+                                // computes `tx.hash = blake2b_256(raw_body_cbor)`
+                                // over the body span — against the txid the peer
+                                // ATTESTED in MsgReplyTxIds. A mismatch means the
+                                // peer delivered a valid body under a key that is
+                                // NOT its hash, breaking the mempool invariant
+                                // `key == blake2b(body)` (a censorship /
+                                // propagation-poisoning lever). This is a protocol
+                                // integrity violation, not a validation failure:
+                                // convict the peer and drop the connection.
+                                // `tx.hash` is era-independent (the body-span bytes
+                                // are the same regardless of which era schema
+                                // interprets them), so a first-decode mismatch is
+                                // authoritative.
+                                if tx.hash.as_bytes() != &tx_hash {
+                                    debug!(
+                                        %addr,
+                                        attested = %dugite_primitives::hash::Hash32::from_bytes(tx_hash).to_hex(),
+                                        computed = %tx.hash.to_hex(),
+                                        "N2N peer attested a txid != blake2b(body) — convicting"
+                                    );
+                                    tx_metrics
+                                        .transactions_rejected
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    return TxAdmission::Convict;
+                                }
+
                                 // Phase-1 + Phase-2 validation via LedgerTxValidator.
                                 if let Err(e) = validator.validate_tx(era_id, &tx_bytes) {
                                     debug!(
                                         %addr,
-                                        tx_hash = %dugite_primitives::hash::Hash32::from_bytes(tx_hash).to_hex(),
+                                        tx_hash = %tx.hash.to_hex(),
                                         reason = ?e,
                                         "N2N tx rejected by validator"
                                     );
                                     tx_metrics
                                         .transactions_rejected
                                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    return false;
+                                    return TxAdmission::Rejected;
                                 }
 
-                                let hash = dugite_primitives::hash::Hash32::from_bytes(tx_hash);
+                                // Key the mempool on the verified canonical hash
+                                // (== attested txid) rather than trusting the wire.
+                                let hash = tx.hash;
                                 if tx_mempool.add_tx(hash, tx, size_bytes).is_ok() {
                                     tx_metrics
                                         .transactions_validated
                                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    return true;
+                                    return TxAdmission::Accepted;
                                 } else {
                                     tx_metrics
                                         .transactions_rejected
                                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    return false;
+                                    return TxAdmission::Rejected;
                                 }
                             }
                         }
@@ -3615,7 +3645,7 @@ impl ConnectionLifecycleManager {
                         tx_metrics
                             .transactions_rejected
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        false
+                        TxAdmission::Rejected
                     }
                 };
 

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -8011,6 +8011,14 @@ impl Node {
         // periodic `update_state()` write lock until the client disconnected.
         // Instead, use a per-query wrapper that acquires and releases the read lock
         // inside each dispatch method — the lock is never held across an .await point.
+        //
+        // Issue #867: `acquire()` additionally pins the CURRENT `Arc<NodeStateSnapshot>`
+        // at MsgAcquire time (a single cheap Arc clone under a momentary
+        // `blocking_read()` — the guard is dropped immediately after, preserving the
+        // C3 invariant). Every MsgQuery within that acquisition then dispatches
+        // against the pinned Arc directly (no lock at all), so multiple queries in
+        // one acquisition see a consistent ledger-state view even if `update_state()`
+        // swaps the live snapshot mid-session.
         let lsq_handler = query_handler;
         let lsq_task = tokio::spawn(async move {
             // Per-query read-lock wrapper: acquires a blocking_read() guard for each
@@ -8018,38 +8026,68 @@ impl Node {
             // update_state() can always acquire its write lock between queries.
             struct PerQueryHandler(Arc<RwLock<QueryHandler>>);
             impl dugite_network::QueryHandler for PerQueryHandler {
+                /// Pinned ledger-state snapshot for a single acquisition (#867).
+                type Acquired = Arc<n2c_query::types::NodeStateSnapshot>;
+
+                fn acquire(
+                    &self,
+                    target: &dugite_network::protocol::local_state_query::AcquireTarget,
+                ) -> Result<
+                    Self::Acquired,
+                    dugite_network::protocol::local_state_query::AcquireFailure,
+                > {
+                    // Momentary read guard: run the existing on-chain validation,
+                    // then Arc-clone the current state and drop the guard. No lock
+                    // is held once this call returns — the returned Arc is then used
+                    // for every MsgQuery in this acquisition, lock-free.
+                    let guard = tokio::task::block_in_place(|| self.0.blocking_read());
+                    dugite_network::QueryHandler::acquire(&*guard, target)
+                }
                 fn handle_query(
                     &self,
+                    acquired: &Self::Acquired,
                     query_cbor: &[u8],
                     n2c_version: u16,
                 ) -> Result<Vec<u8>, String> {
                     // Acquire read guard for this single query dispatch, then release.
                     let guard = tokio::task::block_in_place(|| self.0.blocking_read());
-                    guard.handle_query(query_cbor, n2c_version)
+                    dugite_network::QueryHandler::handle_query(
+                        &*guard,
+                        acquired,
+                        query_cbor,
+                        n2c_version,
+                    )
                 }
                 fn handle_block_query(
                     &self,
+                    acquired: &Self::Acquired,
                     tag: u64,
                     query_cbor: &[u8],
                 ) -> Result<Vec<u8>, String> {
                     let guard = tokio::task::block_in_place(|| self.0.blocking_read());
-                    guard.handle_block_query(tag, query_cbor)
+                    dugite_network::QueryHandler::handle_block_query(
+                        &*guard, acquired, tag, query_cbor,
+                    )
                 }
-                fn handle_query_anytime(&self, query_cbor: &[u8]) -> Result<Vec<u8>, String> {
-                    let guard = tokio::task::block_in_place(|| self.0.blocking_read());
-                    guard.handle_query_anytime(query_cbor)
-                }
-                fn handle_query_hard_fork(&self, query_cbor: &[u8]) -> Result<Vec<u8>, String> {
-                    let guard = tokio::task::block_in_place(|| self.0.blocking_read());
-                    guard.handle_query_hard_fork(query_cbor)
-                }
-                fn validate_acquire(
+                fn handle_query_anytime(
                     &self,
-                    target: &dugite_network::protocol::local_state_query::AcquireTarget,
-                ) -> Result<(), dugite_network::protocol::local_state_query::AcquireFailure>
-                {
+                    acquired: &Self::Acquired,
+                    query_cbor: &[u8],
+                ) -> Result<Vec<u8>, String> {
                     let guard = tokio::task::block_in_place(|| self.0.blocking_read());
-                    guard.validate_acquire(target)
+                    dugite_network::QueryHandler::handle_query_anytime(
+                        &*guard, acquired, query_cbor,
+                    )
+                }
+                fn handle_query_hard_fork(
+                    &self,
+                    acquired: &Self::Acquired,
+                    query_cbor: &[u8],
+                ) -> Result<Vec<u8>, String> {
+                    let guard = tokio::task::block_in_place(|| self.0.blocking_read());
+                    dugite_network::QueryHandler::handle_query_hard_fork(
+                        &*guard, acquired, query_cbor,
+                    )
                 }
             }
             let wrapper = PerQueryHandler(lsq_handler);

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -4517,10 +4517,15 @@ impl Node {
                     // BLP classification per resolved socket address.
                     let mut resolved: Vec<(SocketAddr, bool)> = Vec::new();
                     for r in &sample {
-                        if let Ok(mut addrs) =
+                        if let Ok(addrs) =
                             tokio::net::lookup_host(format!("{}:{}", r.host, r.port)).await
                         {
-                            if let Some(socket_addr) = addrs.next() {
+                            // #879: keep ALL resolved addresses, not just the
+                            // first — a BLP relay commonly has multiple A/AAAA
+                            // records; taking `.next()` biased toward whatever
+                            // the resolver happened to order first and dropped
+                            // the rest of the relay set.
+                            for socket_addr in addrs {
                                 resolved.push((socket_addr, r.is_blp));
                             }
                         }
@@ -4528,6 +4533,10 @@ impl Node {
 
                     if !resolved.is_empty() {
                         let mut pm_w = pm.write().await;
+                        // #879: rebuild the BLP set from scratch each pass so it
+                        // stays a faithful snapshot of the current top-stake
+                        // relays instead of accumulating stale/duplicate entries.
+                        pm_w.clear_big_ledger_peers();
                         let mut blp_count = 0usize;
                         for (socket_addr, is_blp) in &resolved {
                             pm_w.add_ledger_peer(*socket_addr);
@@ -5340,6 +5349,16 @@ impl Node {
                                     if lifecycle.has_connection(addr)
                                         || in_flight_connects.contains(addr)
                                     {
+                                        // #880: the connect is skipped, so no
+                                        // connect_result will ever fire for this
+                                        // peer — release the governor's in-flight
+                                        // marker now. Otherwise in_progress_promote_cold
+                                        // leaks the addr and the governor
+                                        // permanently excludes it from future
+                                        // cold->warm promotion. (Harmless if the
+                                        // pending connect later completes: the
+                                        // second clear is a no-op.)
+                                        governor.promotion_cold_completed(addr);
                                         continue;
                                     }
                                     // Look up the per-peer initiator_only flag computed
@@ -5462,18 +5481,42 @@ impl Node {
                 // starts server protocol tasks on the duplex channels.
                 Some(result) = inbound_accept_rx.recv() => {
                     match result {
-                        Ok((addr, conn, rtt_ms)) => {
+                        Ok((addr, mut conn, rtt_ms)) => {
+                            // #865: enforce a hard cap on ESTABLISHED inbound
+                            // connections, not merely concurrent handshakes. The
+                            // accept semaphore/ConnectionManager slot are freed the
+                            // instant the handshake completes, so a botnet that
+                            // completes handshakes could otherwise hold unbounded
+                            // live inbound connections and exhaust memory/FDs. The
+                            // cap is the same `accepted_connections_limit.hard_limit`
+                            // the handshake window uses. Computed before the
+                            // `self.connection_lifecycle` mutable borrow below.
+                            let inbound_cap = self
+                                .config
+                                .accepted_connections_limit
+                                .unwrap_or_default()
+                                .hard_limit as usize;
                             if let Some(ref mut lifecycle) = self.connection_lifecycle {
-                                let mut pm = peer_manager.write().await;
-                                match lifecycle.register_inbound_connection(addr, conn, rtt_ms, &mut pm).await {
-                                    Ok(()) => {
-                                        info!(%addr, rtt_ms = format_args!("{rtt_ms:.0}"), "inbound connection registered");
-                                        // Update all peer metrics (including n2n_connections_active)
-                                        // via the derived-read helper rather than a bare fetch_add.
-                                        self.update_peer_metrics(&pm);
-                                    }
-                                    Err(e) => {
-                                        warn!(%addr, "inbound registration failed: {e}");
+                                if lifecycle.inbound_connection_count() >= inbound_cap {
+                                    warn!(
+                                        %addr,
+                                        max = inbound_cap,
+                                        established = lifecycle.inbound_connection_count(),
+                                        "established inbound connection cap reached — rejecting"
+                                    );
+                                    conn.shutdown().await;
+                                } else {
+                                    let mut pm = peer_manager.write().await;
+                                    match lifecycle.register_inbound_connection(addr, conn, rtt_ms, &mut pm).await {
+                                        Ok(()) => {
+                                            info!(%addr, rtt_ms = format_args!("{rtt_ms:.0}"), "inbound connection registered");
+                                            // Update all peer metrics (including n2n_connections_active)
+                                            // via the derived-read helper rather than a bare fetch_add.
+                                            self.update_peer_metrics(&pm);
+                                        }
+                                        Err(e) => {
+                                            warn!(%addr, "inbound registration failed: {e}");
+                                        }
                                     }
                                 }
                             }

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -3716,8 +3716,7 @@ impl Node {
                         Ok(r) => Box::new(r),
                         Err(_) => Box::new(NoopDnsResolver),
                     };
-                    let mut interval =
-                        tokio::time::interval(std::time::Duration::from_secs(300));
+                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
                     interval.tick().await; // skip the immediate first tick
                     loop {
                         tokio::select! {
@@ -3743,11 +3742,10 @@ impl Node {
                         for (gi, group) in re_groups.iter().enumerate() {
                             let hot_val = usize::from(group.effective_hot_valency());
                             let warm_val = usize::from(group.effective_warm_valency());
-                            let diffusion_mode =
-                                group.diffusion_mode.as_deref().map(|s| match s {
-                                    "InitiatorOnly" => networking::DiffusionMode::InitiatorOnly,
-                                    _ => networking::DiffusionMode::InitiatorAndResponder,
-                                });
+                            let diffusion_mode = group.diffusion_mode.as_deref().map(|s| match s {
+                                "InitiatorOnly" => networking::DiffusionMode::InitiatorOnly,
+                                _ => networking::DiffusionMode::InitiatorAndResponder,
+                            });
                             let mut group_addrs = Vec::new();
                             for ap in &group.access_points {
                                 let addrs =

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -3647,6 +3647,7 @@ impl Node {
             // Each entry carries resolved addresses plus all topology metadata so
             // `add_local_root_group` can be called with fully-populated info.
             struct ResolvedGroup {
+                orig_index: usize,
                 addrs: Vec<std::net::SocketAddr>,
                 hot_valency: usize,
                 warm_valency: usize,
@@ -3655,7 +3656,7 @@ impl Node {
                 advertise: bool,
             }
             let mut resolved_groups: Vec<ResolvedGroup> = Vec::new();
-            for group in &self.topology.local_roots {
+            for (orig_index, group) in self.topology.local_roots.iter().enumerate() {
                 let hot_val = usize::from(group.effective_hot_valency());
                 let warm_val = usize::from(group.effective_warm_valency());
                 let diffusion_mode = group.diffusion_mode.as_deref().map(|s| match s {
@@ -3677,6 +3678,7 @@ impl Node {
                 }
                 if !group_addrs.is_empty() {
                     resolved_groups.push(ResolvedGroup {
+                        orig_index,
                         addrs: group_addrs,
                         hot_valency: hot_val,
                         warm_valency: warm_val,
@@ -3685,6 +3687,90 @@ impl Node {
                         advertise: group.advertise,
                     });
                 }
+            }
+
+            // #871: periodic DNS re-resolution of topology / local-root names.
+            //
+            // Topology and local-root DNS names were resolved exactly ONCE at
+            // startup, so a block producer whose relay's A/AAAA record rotated
+            // silently lost its relay (the governor retried the stale IP forever
+            // at the 160s backoff cap), and a transient DNS failure at startup
+            // dropped a local-root group with no retry. This loop re-resolves
+            // both sets periodically, re-registering resolved addresses
+            // (idempotent by SocketAddr — inner add_peer never overwrites) and
+            // upserting each local-root group by its stable `local-root-{index}`
+            // name. On an EMPTY resolution it keeps the previous addresses (never
+            // forgets a group / bootstrap set on a transient failure — this fixes
+            // the startup-drop). A fixed 5-minute interval approximates
+            // cardano-node's TTL-driven DNSActions; resolve_with_srv does not yet
+            // surface record TTLs. (Stale rotated-out IPs linger as Topology cold
+            // peers rather than being pruned; connectivity is restored via the
+            // freshly-resolved address.)
+            {
+                let re_pm = peer_manager.clone();
+                let re_peers = detailed_peers.clone();
+                let re_groups = self.topology.local_roots.clone();
+                let mut re_shutdown = shutdown_rx.clone();
+                tokio::spawn(async move {
+                    let resolver: Box<dyn DnsResolver> = match HickoryDnsResolver::new() {
+                        Ok(r) => Box::new(r),
+                        Err(_) => Box::new(NoopDnsResolver),
+                    };
+                    let mut interval =
+                        tokio::time::interval(std::time::Duration::from_secs(300));
+                    interval.tick().await; // skip the immediate first tick
+                    loop {
+                        tokio::select! {
+                            _ = interval.tick() => {}
+                            _ = re_shutdown.changed() => break,
+                        }
+                        // Re-resolve bootstrap / config peers.
+                        for peer in &re_peers {
+                            let addrs =
+                                resolve_with_srv(resolver.as_ref(), &peer.address, peer.port).await;
+                            if addrs.is_empty() {
+                                continue; // keep previous on transient failure
+                            }
+                            let mut w = re_pm.write().await;
+                            for a in &addrs {
+                                w.add_config_peer(*a);
+                                if peer.trustable {
+                                    w.add_bootstrap_peer(*a);
+                                }
+                            }
+                        }
+                        // Re-resolve local-root groups, upserting by stable name.
+                        for (gi, group) in re_groups.iter().enumerate() {
+                            let hot_val = usize::from(group.effective_hot_valency());
+                            let warm_val = usize::from(group.effective_warm_valency());
+                            let diffusion_mode =
+                                group.diffusion_mode.as_deref().map(|s| match s {
+                                    "InitiatorOnly" => networking::DiffusionMode::InitiatorOnly,
+                                    _ => networking::DiffusionMode::InitiatorAndResponder,
+                                });
+                            let mut group_addrs = Vec::new();
+                            for ap in &group.access_points {
+                                let addrs =
+                                    resolve_with_srv(resolver.as_ref(), &ap.address, ap.port).await;
+                                group_addrs.extend(addrs);
+                            }
+                            if group_addrs.is_empty() {
+                                continue; // keep previous group on transient failure
+                            }
+                            let mut w = re_pm.write().await;
+                            w.add_local_root_group(networking::LocalRootGroupInfo {
+                                name: format!("local-root-{gi}"),
+                                addrs: group_addrs,
+                                hot_valency: hot_val,
+                                warm_valency: warm_val,
+                                diffusion_mode,
+                                behind_firewall: group.is_behind_firewall(),
+                                advertise: group.advertise,
+                            });
+                        }
+                    }
+                    tracing::debug!("DNS re-resolution loop exiting (shutdown)");
+                });
             }
 
             let mut pm = peer_manager.write().await;
@@ -3698,9 +3784,11 @@ impl Node {
             }
             // Register per-group valency targets.  This must happen AFTER
             // add_config_peer() calls so the peer table contains the members.
-            for rg in resolved_groups {
+            // #871: give each group a stable name (its topology index) so the
+            // periodic DNS re-resolution loop can upsert it in place.
+            for rg in resolved_groups.into_iter() {
                 pm.add_local_root_group(networking::LocalRootGroupInfo {
-                    name: String::new(),
+                    name: format!("local-root-{}", rg.orig_index),
                     addrs: rg.addrs,
                     hot_valency: rg.hot_valency,
                     warm_valency: rg.warm_valency,

--- a/crates/dugite-node/src/node/n2c_query/mod.rs
+++ b/crates/dugite-node/src/node/n2c_query/mod.rs
@@ -107,6 +107,31 @@ impl QueryHandler {
         self.state = Arc::new(snapshot);
     }
 
+    /// Build a lightweight "shadow" handler that shares everything with `self`
+    /// via cheap `Arc`/`Copy` fields, except its `state` is pinned to
+    /// `pinned_state` instead of the live `self.state`.
+    ///
+    /// This is how LocalStateQuery snapshot pinning (issue #867) is implemented:
+    /// rather than threading an explicit `state: &NodeStateSnapshot` parameter
+    /// through every internal dispatch method (~40 call sites across
+    /// `dispatch_query_with_version`, `handle_shelley_query`, and friends — all
+    /// of which are also exercised directly by unit tests in this module), we
+    /// construct a throwaway `QueryHandler` whose `state` Arc points at the
+    /// snapshot pinned at MsgAcquire time, and delegate to the SAME unmodified
+    /// internal methods on that shadow. No lock is touched here and no ledger
+    /// data is deep-cloned — only `Arc`/`Option<Arc<_>>` pointers are cloned.
+    fn with_pinned_state(&self, pinned_state: Arc<NodeStateSnapshot>) -> QueryHandler {
+        QueryHandler {
+            state: pinned_state,
+            utxo_provider: self.utxo_provider.clone(),
+            n2c_version: std::sync::atomic::AtomicU16::new(
+                self.n2c_version.load(std::sync::atomic::Ordering::Relaxed),
+            ),
+            max_major_prot_ver: self.max_major_prot_ver,
+            chain_db: self.chain_db.clone(),
+        }
+    }
+
     /// Get a reference to the current node state snapshot
     #[allow(dead_code)] // used in tests
     pub fn state(&self) -> &NodeStateSnapshot {
@@ -614,93 +639,149 @@ fn encode_result_value(result: &QueryResult) -> Vec<u8> {
 }
 
 impl dugite_network::QueryHandler for QueryHandler {
-    fn handle_query(&self, query_cbor: &[u8], n2c_version: u16) -> Result<Vec<u8>, String> {
+    /// Pinned ledger-state snapshot for a single MsgAcquire..MsgRelease session
+    /// (issue #867): `acquire()` resolves the target to one of these ONCE, and
+    /// every MsgQuery dispatch method below receives the SAME `Arc` for the
+    /// lifetime of that acquisition — guaranteeing a consistent (non-torn)
+    /// view even if `update_state()` swaps the live snapshot mid-session.
+    type Acquired = Arc<NodeStateSnapshot>;
+
+    fn acquire(
+        &self,
+        target: &dugite_network::protocol::local_state_query::AcquireTarget,
+    ) -> Result<Self::Acquired, dugite_network::protocol::local_state_query::AcquireFailure> {
+        use dugite_network::codec::Point as CodecPoint;
+        use dugite_network::protocol::local_state_query::{AcquireFailure, AcquireTarget};
+
+        match target {
+            // VolatileTip and ImmutableTip always refer to the CURRENT chain
+            // tip — pin the current state snapshot (a cheap Arc clone).
+            AcquireTarget::VolatileTip | AcquireTarget::ImmutableTip => Ok(Arc::clone(&self.state)),
+
+            // SpecificPoint: the client has requested a point. There is no
+            // machinery to rewind ledger state to an arbitrary past point
+            // (only destructive rollbacks), so the only point we can honestly
+            // materialise a snapshot for is the CURRENT tip. If the requested
+            // point equals the current tip, pin the current state. Otherwise:
+            // mirror Haskell `ouroboros-consensus` by checking whether the
+            // point exists anywhere on our chain (VolatileDB/ImmutableDB) to
+            // choose the right failure — `PointTooOld` (it exists, but we
+            // cannot rewind to it) vs `PointNotOnChain` (it never existed on
+            // our chain at all).
+            AcquireTarget::SpecificPoint(point) => match point {
+                CodecPoint::Origin => {
+                    if matches!(
+                        self.state.tip.point,
+                        dugite_primitives::block::Point::Origin
+                    ) {
+                        Ok(Arc::clone(&self.state))
+                    } else {
+                        debug!(
+                            "acquire: SpecificPoint(Origin) requested but current tip has \
+                             moved past genesis — cannot materialise a non-tip snapshot"
+                        );
+                        Err(AcquireFailure::PointTooOld)
+                    }
+                }
+                CodecPoint::Specific(slot, hash_arr) => {
+                    let block_hash = dugite_primitives::hash::Hash32::from_bytes(*hash_arr);
+                    let matches_current_tip = matches!(
+                        &self.state.tip.point,
+                        dugite_primitives::block::Point::Specific(tip_slot, tip_hash)
+                            if tip_slot.0 == *slot && tip_hash == &block_hash
+                    );
+                    if matches_current_tip {
+                        return Ok(Arc::clone(&self.state));
+                    }
+
+                    match &self.chain_db {
+                        None => {
+                            // No ChainDB wired (tests without storage) — refuse specific-point
+                            // acquires defensively rather than silently accepting a fabricated point.
+                            debug!("acquire: no chain_db wired, refusing SpecificPoint");
+                            Err(AcquireFailure::PointNotOnChain)
+                        }
+                        Some(chain_db) => {
+                            let on_chain = tokio::task::block_in_place(|| {
+                                let db = chain_db.blocking_read();
+                                db.has_block(&block_hash)
+                            });
+                            if on_chain {
+                                debug!(
+                                    hash = hex::encode(hash_arr),
+                                    "acquire: SpecificPoint is on chain but not the current tip \
+                                     — cannot materialise a historical snapshot (PointTooOld)"
+                                );
+                                Err(AcquireFailure::PointTooOld)
+                            } else {
+                                debug!(
+                                    hash = hex::encode(hash_arr),
+                                    "acquire: SpecificPoint not on chain — refusing"
+                                );
+                                Err(AcquireFailure::PointNotOnChain)
+                            }
+                        }
+                    }
+                }
+            },
+        }
+    }
+
+    fn handle_query(
+        &self,
+        acquired: &Self::Acquired,
+        query_cbor: &[u8],
+        n2c_version: u16,
+    ) -> Result<Vec<u8>, String> {
+        let shadow = self.with_pinned_state(Arc::clone(acquired));
         let mut decoder = minicbor::Decoder::new(query_cbor);
-        let result = self.dispatch_query_with_version(&mut decoder, n2c_version);
+        let result = shadow.dispatch_query_with_version(&mut decoder, n2c_version);
         match result {
             QueryResult::Error(msg) => Err(msg),
             _ => Ok(encoding::encode_query_result_payload(&result)),
         }
     }
 
-    fn handle_block_query(&self, tag: u64, query_cbor: &[u8]) -> Result<Vec<u8>, String> {
-        let mut decoder = minicbor::Decoder::new(query_cbor);
-        let result = self.handle_shelley_query(tag as u32, &mut decoder);
-        match result {
-            QueryResult::Error(msg) => Err(msg),
-            _ => Ok(encode_result_value(&result)),
-        }
-    }
-
-    fn handle_query_anytime(&self, query_cbor: &[u8]) -> Result<Vec<u8>, String> {
-        let mut decoder = minicbor::Decoder::new(query_cbor);
-        let result = self.handle_query_anytime_inner(&mut decoder);
-        match result {
-            QueryResult::Error(msg) => Err(msg),
-            _ => Ok(encode_result_value(&result)),
-        }
-    }
-
-    fn handle_query_hard_fork(&self, query_cbor: &[u8]) -> Result<Vec<u8>, String> {
-        let mut decoder = minicbor::Decoder::new(query_cbor);
-        let result = self.handle_hard_fork_query(&mut decoder);
-        match result {
-            QueryResult::Error(msg) => Err(msg),
-            _ => Ok(encode_result_value(&result)),
-        }
-    }
-
-    fn validate_acquire(
+    fn handle_block_query(
         &self,
-        target: &dugite_network::protocol::local_state_query::AcquireTarget,
-    ) -> Result<(), dugite_network::protocol::local_state_query::AcquireFailure> {
-        use dugite_network::codec::Point as CodecPoint;
-        use dugite_network::protocol::local_state_query::{AcquireFailure, AcquireTarget};
+        acquired: &Self::Acquired,
+        tag: u64,
+        query_cbor: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let shadow = self.with_pinned_state(Arc::clone(acquired));
+        let mut decoder = minicbor::Decoder::new(query_cbor);
+        let result = shadow.handle_shelley_query(tag as u32, &mut decoder);
+        match result {
+            QueryResult::Error(msg) => Err(msg),
+            _ => Ok(encode_result_value(&result)),
+        }
+    }
 
-        match target {
-            // VolatileTip and ImmutableTip always refer to the current chain
-            // tip — they are always valid acquire targets.
-            AcquireTarget::VolatileTip | AcquireTarget::ImmutableTip => Ok(()),
+    fn handle_query_anytime(
+        &self,
+        acquired: &Self::Acquired,
+        query_cbor: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let shadow = self.with_pinned_state(Arc::clone(acquired));
+        let mut decoder = minicbor::Decoder::new(query_cbor);
+        let result = shadow.handle_query_anytime_inner(&mut decoder);
+        match result {
+            QueryResult::Error(msg) => Err(msg),
+            _ => Ok(encode_result_value(&result)),
+        }
+    }
 
-            // SpecificPoint: the client has requested a historical point.
-            // Mirror Haskell `ouroboros-consensus`: the point must exist in
-            // either the VolatileDB (recent blocks) or the ImmutableDB (finalized
-            // blocks). If it is not found on any chain, return PointNotOnChain.
-            //
-            // Note: we do NOT distinguish PointTooOld from PointNotOnChain here
-            // because ImmutableDB already contains all finalized blocks — if a
-            // block is in ImmutableDB it is still addressable. A point before the
-            // immutable tip that is truly absent simply was never on our chain.
-            AcquireTarget::SpecificPoint(point) => match point {
-                CodecPoint::Origin => {
-                    // Origin is always a valid acquire target.
-                    Ok(())
-                }
-                CodecPoint::Specific(_slot, hash_arr) => match &self.chain_db {
-                    None => {
-                        // No ChainDB wired (tests without storage) — refuse specific-point
-                        // acquires defensively rather than silently accepting a fabricated point.
-                        debug!("validate_acquire: no chain_db wired, refusing SpecificPoint");
-                        Err(AcquireFailure::PointNotOnChain)
-                    }
-                    Some(chain_db) => {
-                        let block_hash = dugite_primitives::hash::Hash32::from_bytes(*hash_arr);
-                        let on_chain = tokio::task::block_in_place(|| {
-                            let db = chain_db.blocking_read();
-                            db.has_block(&block_hash)
-                        });
-                        if on_chain {
-                            Ok(())
-                        } else {
-                            debug!(
-                                hash = hex::encode(hash_arr),
-                                "validate_acquire: SpecificPoint not on chain — refusing"
-                            );
-                            Err(AcquireFailure::PointNotOnChain)
-                        }
-                    }
-                },
-            },
+    fn handle_query_hard_fork(
+        &self,
+        acquired: &Self::Acquired,
+        query_cbor: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        let shadow = self.with_pinned_state(Arc::clone(acquired));
+        let mut decoder = minicbor::Decoder::new(query_cbor);
+        let result = shadow.handle_hard_fork_query(&mut decoder);
+        match result {
+            QueryResult::Error(msg) => Err(msg),
+            _ => Ok(encode_result_value(&result)),
         }
     }
 }
@@ -1670,8 +1751,11 @@ mod tests {
         use dugite_network::QueryHandler as TraitQueryHandler;
 
         let handler = super::QueryHandler::new(11);
+        let acquired = handler
+            .acquire(&AcquireTarget::VolatileTip)
+            .expect("VolatileTip acquire must succeed");
         // Tag 1 = GetEpochNo (no params needed)
-        let result = handler.handle_block_query(1, &[]);
+        let result = handler.handle_block_query(&acquired, 1, &[]);
         assert!(result.is_ok());
         // The result should be CBOR-encoded epoch number (0)
         let cbor = result.unwrap();
@@ -1684,16 +1768,19 @@ mod tests {
         use dugite_network::QueryHandler as TraitQueryHandler;
 
         let handler = super::QueryHandler::new(11);
+        let acquired = handler
+            .acquire(&AcquireTarget::VolatileTip)
+            .expect("VolatileTip acquire must succeed");
         // Sub-tag 1 = GetCurrentEra, encoded as [1]
         let mut buf = Vec::new();
         let mut enc = minicbor::Encoder::new(&mut buf);
         enc.array(1).unwrap();
         enc.u32(1).unwrap();
-        let result = handler.handle_query_hard_fork(&buf);
+        let result = handler.handle_query_hard_fork(&acquired, &buf);
         assert!(result.is_ok());
     }
 
-    // ── C1 tests: validate_acquire point-on-chain checks ─────────────────────
+    // ── C1 / #867 tests: acquire() point-on-chain + snapshot-pinning checks ──
 
     use dugite_network::codec::Point as CodecPoint;
     use dugite_network::protocol::local_state_query::{AcquireFailure, AcquireTarget};
@@ -1703,20 +1790,14 @@ mod tests {
     fn c1_volatile_tip_always_succeeds() {
         use dugite_network::QueryHandler as _;
         let handler = super::QueryHandler::new(11); // no chain_db
-        assert_eq!(
-            handler.validate_acquire(&AcquireTarget::VolatileTip),
-            Ok(())
-        );
+        assert!(handler.acquire(&AcquireTarget::VolatileTip).is_ok());
     }
 
     #[test]
     fn c1_immutable_tip_always_succeeds() {
         use dugite_network::QueryHandler as _;
         let handler = super::QueryHandler::new(11); // no chain_db
-        assert_eq!(
-            handler.validate_acquire(&AcquireTarget::ImmutableTip),
-            Ok(())
-        );
+        assert!(handler.acquire(&AcquireTarget::ImmutableTip).is_ok());
     }
 
     /// C1: SpecificPoint with no chain_db must return PointNotOnChain (defensive default).
@@ -1725,23 +1806,159 @@ mod tests {
         use dugite_network::QueryHandler as _;
         let handler = super::QueryHandler::new(11); // no chain_db
         let point = AcquireTarget::SpecificPoint(CodecPoint::Specific(1000, [0xAA; 32]));
-        assert_eq!(
-            handler.validate_acquire(&point),
-            Err(AcquireFailure::PointNotOnChain),
+        assert!(
+            matches!(
+                handler.acquire(&point),
+                Err(AcquireFailure::PointNotOnChain)
+            ),
             "SpecificPoint with no chain_db must refuse (defensive default)"
         );
     }
 
-    /// C1: Origin point is always valid even without chain_db.
+    /// C1: Origin point is valid when the current tip IS Origin (default state).
     #[test]
-    fn c1_origin_point_always_valid() {
+    fn c1_origin_point_valid_at_genesis() {
         use dugite_network::QueryHandler as _;
-        let handler = super::QueryHandler::new(11); // no chain_db
+        let handler = super::QueryHandler::new(11); // no chain_db, default state == Origin tip
         let point = AcquireTarget::SpecificPoint(CodecPoint::Origin);
+        assert!(
+            handler.acquire(&point).is_ok(),
+            "Origin point must be a valid acquire target when the current tip is Origin"
+        );
+    }
+
+    /// #867: Origin point is REJECTED (PointTooOld) once the chain has moved
+    /// past genesis, because there is no machinery to rewind ledger state
+    /// back to Origin — we can only materialise a snapshot of the CURRENT tip.
+    #[test]
+    fn issue_867_origin_point_too_old_once_tip_advances() {
+        use dugite_network::QueryHandler as _;
+        let mut handler = super::QueryHandler::new(11);
+        handler.update_state(NodeStateSnapshot {
+            tip: Tip {
+                point: Point::Specific(SlotNo(500), Hash32::from_bytes([0x33; 32])),
+                block_number: BlockNo(10),
+            },
+            ..Default::default()
+        });
+        let point = AcquireTarget::SpecificPoint(CodecPoint::Origin);
+        assert!(
+            matches!(handler.acquire(&point), Err(AcquireFailure::PointTooOld)),
+            "Origin acquire must fail with PointTooOld once the tip has advanced past genesis"
+        );
+    }
+
+    /// #867: a SpecificPoint that IS the current tip pins that tip's snapshot.
+    #[test]
+    fn issue_867_specific_point_matching_current_tip_succeeds() {
+        use dugite_network::QueryHandler as _;
+        let mut handler = super::QueryHandler::new(11);
+        let tip_hash = Hash32::from_bytes([0x44; 32]);
+        handler.update_state(NodeStateSnapshot {
+            tip: Tip {
+                point: Point::Specific(SlotNo(777), tip_hash),
+                block_number: BlockNo(20),
+            },
+            ..Default::default()
+        });
+        let point = AcquireTarget::SpecificPoint(CodecPoint::Specific(777, tip_hash.0));
+        assert!(
+            handler.acquire(&point).is_ok(),
+            "SpecificPoint matching the current tip must always succeed"
+        );
+    }
+
+    /// #867: a SpecificPoint that IS on our chain (VolatileDB/ImmutableDB) but
+    /// is NOT the current tip must return `PointTooOld` — we have no way to
+    /// rewind ledger state to serve that historical snapshot.
+    #[test]
+    fn issue_867_specific_point_on_chain_but_not_tip_returns_point_too_old() {
+        use dugite_network::QueryHandler as _;
+
+        let tmp_dir = tempfile::tempdir().expect("tempdir");
+        let mut chain_db = dugite_storage::ChainDB::open(tmp_dir.path()).expect("open chain_db");
+        let old_hash = Hash32::from_bytes([0x11; 32]);
+        chain_db
+            .add_block(
+                old_hash,
+                SlotNo(50),
+                BlockNo(1),
+                Hash32::from_bytes([0u8; 32]),
+                vec![0xAAu8; 4],
+            )
+            .expect("add_block");
+
+        let mut handler = super::QueryHandler::new(11);
+        // Advance the handler's current tip PAST that block, so the point is
+        // on-chain but no longer the tip.
+        handler.update_state(NodeStateSnapshot {
+            tip: Tip {
+                point: Point::Specific(SlotNo(999), Hash32::from_bytes([0x22; 32])),
+                block_number: BlockNo(2),
+            },
+            ..Default::default()
+        });
+        handler.set_chain_db(Arc::new(RwLock::new(chain_db)));
+
+        let point = AcquireTarget::SpecificPoint(CodecPoint::Specific(50, old_hash.0));
+        let result = handler.acquire(&point);
+        assert!(
+            matches!(result, Err(AcquireFailure::PointTooOld)),
+            "on-chain point that is not the current tip must return PointTooOld, got {result:?}"
+        );
+    }
+
+    /// #867: torn-read regression at the node QueryHandler level. Two queries
+    /// dispatched against the SAME pinned `Acquired` handle must answer from
+    /// the SAME snapshot, even after `update_state()` swaps the live state.
+    #[test]
+    fn issue_867_torn_read_regression_pinned_handle_survives_update_state() {
+        use dugite_network::QueryHandler as _;
+
+        let mut handler = super::QueryHandler::new(11);
+        handler.update_state(NodeStateSnapshot {
+            epoch: EpochNo(100),
+            ..Default::default()
+        });
+
+        // Pin a snapshot at epoch 100.
+        let acquired = handler
+            .acquire(&AcquireTarget::VolatileTip)
+            .expect("acquire must succeed");
+
+        // Simulate a live update landing BETWEEN two queries of one acquisition.
+        handler.update_state(NodeStateSnapshot {
+            epoch: EpochNo(200),
+            ..Default::default()
+        });
+
+        // Both queries against the PINNED handle must still see epoch 100.
+        // Tag 1 = GetEpochNo (no query-CBOR arguments needed).
+        for _ in 0..2 {
+            let result = handler
+                .handle_block_query(&acquired, 1, &[])
+                .expect("handle_block_query must succeed");
+            let mut dec = minicbor::Decoder::new(&result);
+            assert_eq!(
+                dec.u64().unwrap(),
+                100,
+                "query against the pinned handle must see epoch 100, not the \
+                 live epoch 200 set by the concurrent update_state() call"
+            );
+        }
+
+        // A FRESH acquire (new session) must see the NEW live state.
+        let acquired2 = handler
+            .acquire(&AcquireTarget::VolatileTip)
+            .expect("acquire must succeed");
+        let result = handler
+            .handle_block_query(&acquired2, 1, &[])
+            .expect("handle_block_query must succeed");
+        let mut dec = minicbor::Decoder::new(&result);
         assert_eq!(
-            handler.validate_acquire(&point),
-            Ok(()),
-            "Origin point must always be a valid acquire target"
+            dec.u64().unwrap(),
+            200,
+            "a NEW acquire must observe the latest live state"
         );
     }
 

--- a/crates/dugite-node/src/node/networking.rs
+++ b/crates/dugite-node/src/node/networking.rs
@@ -548,6 +548,11 @@ impl NodePeerManager {
         if is_non_public_ip(addr.ip()) {
             return;
         }
+        // #880: reject port 0 — an undialable address the governor would
+        // otherwise burn a connect attempt on every promotion tick.
+        if addr.port() == 0 {
+            return;
+        }
         self.inner.add_peer(addr, PeerSource::Ledger);
     }
 
@@ -568,12 +573,29 @@ impl NodePeerManager {
         if is_non_public_ip(addr.ip()) {
             return;
         }
+        // #880: reject port 0 — an undialable address the governor would
+        // otherwise burn a connect attempt on.
+        if addr.port() == 0 {
+            return;
+        }
         self.inner.add_peer(addr, PeerSource::PeerSharing);
     }
 
     /// Mark a peer as a big ledger peer.
     pub fn add_big_ledger_peer(&mut self, addr: SocketAddr) {
         self.big_ledger_peers.insert(addr);
+    }
+
+    /// Clear the big-ledger-peer set so the next ledger-discovery pass can
+    /// rebuild it from scratch (#879).
+    ///
+    /// The BLP set was previously insert-only, so cold-churn/`peer_failed`
+    /// forgets and rotating-DNS re-adds under fresh `SocketAddr`s left it
+    /// growing unbounded with stale/duplicate membership that distorted
+    /// governor decisions. Rebuilding each pass keeps it a faithful snapshot of
+    /// the current top-stake relays.
+    pub fn clear_big_ledger_peers(&mut self) {
+        self.big_ledger_peers.clear();
     }
 
     /// Mark a peer as a bootstrap peer (topology `bootstrapPeers`). Bootstrap
@@ -694,6 +716,12 @@ impl NodePeerManager {
             // Non-root peer exceeded max retries — remove from known set entirely.
             // It will only re-appear if re-discovered via ledger or peer sharing.
             self.inner.remove_peer(addr);
+            // #879: keep the BLP/bootstrap address sets in sync with the peer
+            // table. Leaving a forgotten peer in `big_ledger_peers` bloats the
+            // set with stale entries that mis-feed `is_big_ledger_peer` and the
+            // demote-exclusion set.
+            self.big_ledger_peers.remove(addr);
+            self.bootstrap_peer_addrs.remove(addr);
         } else {
             self.inner.demote_to_cold(addr);
         }

--- a/crates/dugite-node/src/node/networking.rs
+++ b/crates/dugite-node/src/node/networking.rs
@@ -514,6 +514,19 @@ impl NodePeerManager {
         for &addr in &group.addrs {
             self.add_config_peer(addr);
         }
+        // #871: upsert by (non-empty) name so periodic DNS re-resolution can
+        // refresh a group's resolved addresses in place instead of pushing a
+        // duplicate every pass. A blank name (legacy callers) always appends.
+        if !group.name.is_empty() {
+            if let Some(existing) = self
+                .local_root_groups
+                .iter_mut()
+                .find(|g| g.name == group.name)
+            {
+                *existing = group;
+                return;
+            }
+        }
         self.local_root_groups.push(group);
     }
 
@@ -1116,6 +1129,60 @@ impl std::fmt::Display for PeerManagerStats {
 mod tests {
     use super::*;
     use std::net::SocketAddr;
+
+    /// #871: re-adding a named local-root group (periodic DNS re-resolution)
+    /// must UPSERT it in place — refreshing its addresses — not push a
+    /// duplicate. A blank-named group always appends (legacy behaviour).
+    #[test]
+    fn add_local_root_group_upserts_by_name() {
+        let mut pm = NodePeerManager::new(PeerManagerConfig::default());
+        let a1: SocketAddr = "203.0.113.1:3001".parse().unwrap();
+        let a2: SocketAddr = "203.0.113.2:3001".parse().unwrap();
+
+        pm.add_local_root_group(LocalRootGroupInfo {
+            name: "local-root-0".into(),
+            addrs: vec![a1],
+            hot_valency: 1,
+            warm_valency: 1,
+            diffusion_mode: None,
+            behind_firewall: false,
+            advertise: false,
+        });
+        assert_eq!(pm.local_root_groups().len(), 1);
+
+        // Re-resolution returns a rotated address for the SAME group name.
+        pm.add_local_root_group(LocalRootGroupInfo {
+            name: "local-root-0".into(),
+            addrs: vec![a2],
+            hot_valency: 1,
+            warm_valency: 1,
+            diffusion_mode: None,
+            behind_firewall: false,
+            advertise: false,
+        });
+        assert_eq!(
+            pm.local_root_groups().len(),
+            1,
+            "same-named group must be replaced, not duplicated"
+        );
+        assert_eq!(
+            pm.local_root_groups()[0].addrs,
+            vec![a2],
+            "group addresses must be refreshed to the newly-resolved set"
+        );
+
+        // A distinct name is a distinct group.
+        pm.add_local_root_group(LocalRootGroupInfo {
+            name: "local-root-1".into(),
+            addrs: vec![a1],
+            hot_valency: 1,
+            warm_valency: 1,
+            diffusion_mode: None,
+            behind_firewall: false,
+            advertise: false,
+        });
+        assert_eq!(pm.local_root_groups().len(), 2);
+    }
 
     #[test]
     fn test_haa_satisfied_via_trusted_local_roots() {

--- a/crates/dugite-node/src/node/peer_connection.rs
+++ b/crates/dugite-node/src/node/peer_connection.rs
@@ -573,6 +573,18 @@ impl PeerConnection {
             .await
             .map_err(|e| PeerConnectionError::Handshake(addr, e.to_string()))?;
 
+        // #880: a query-mode handshake enumerated our versions (we already sent
+        // MsgQueryReply) and the peer closes — no mini-protocols run on it, so
+        // drop the connection instead of spinning up protocol tasks against a
+        // socket the peer is closing.
+        if handshake_result.query {
+            info!(%addr, "N2N query-mode handshake — closing connection (no protocols)");
+            return Err(PeerConnectionError::Handshake(
+                addr,
+                "query-mode connection (version enumeration only)".to_string(),
+            ));
+        }
+
         let version = handshake_result.version;
         info!(%addr, version, "N2N handshake complete (inbound)");
 


### PR DESCRIPTION
Resolves the entire `dugite-network` review roundup — **18 issues (#864–#881)**.
All fixes land with tests; `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, and the full `dugite-network` (620) + `dugite-node` (1058) test suites are green, and the workspace builds clean.

## High-severity (security / correctness / DoS)
- **Closes #864** — TxSubmission2 verifies `blake2b(body) == attested txid`; a mismatch convicts the peer (new `TxAdmission::Convict` → `ProtocolError::IntegrityViolation`), and the mempool is keyed on the verified canonical hash.
- **Closes #865** — hard cap on *established* inbound N2N connections (not just concurrent handshakes).
- **Closes #866** — mux teardown aborts (not detaches) its reader/writer/ingress/egress tasks via an abort-on-drop guard, closing the socket → no FD leak under churn.
- **Closes #867** — LocalStateQuery pins an `Arc<NodeStateSnapshot>` at Acquire (no torn reads); a non-tip `SpecificPoint` returns `AcquireFailure::PointTooOld`. Preserves the C3 no-lock-across-await invariant.
- **Closes #868 / #869 / #876 / #881** — the N2N and N2C ChainSync servers are collapsed onto one shared `serve_core.rs` (parameterised over the payload encoder), which fixes the `StMustReply` silent-no-reply wedge (#869), ports every N2N fix to N2C (#868), and adds `is_on_chain` + slot-match validation to `MsgFindIntersect` on both (#876). #881 dedup is the vehicle.
- **Closes #870** — demote/forget offload `conn.shutdown()` to a detached task so the global `peer_manager` write lock isn't held across an adversary-controlled teardown.
- **Closes #871** — periodic DNS re-resolution of topology/local-root names (a BP no longer loses its relay on DNS rotation; transient startup failures no longer drop a group).

## Medium-severity
- **Closes #872** — mux egress applies true back-pressure at the 8 MB per-channel cap instead of dropping a queued message.
- **Closes #873** — n2c_client bounds attacker-declared CBOR array/map lengths against remaining input (no hang/OOM vs a malicious node).
- **Closes #874** — LocalTxMonitor `MsgReplyNextTx` emits the era-tagged CBOR-in-CBOR `GenTx` (`[6,[era_index,tag(24) tx]]`) cardano-node/ogmios expect; verified against ouroboros-network/-consensus. Client decodes it and derives the canonical body-span tx id.
- **Closes #875** — BlockFetch client rejects delivered blocks outside the requested `[from,to]` range.
- **Closes #877** — mux `resubscribe()` resets `bytes_in_flight` + swaps the sender under the same lock as the ingress critical section (no underflow → no spurious overrun disconnect).
- **Closes #878** — BlockFetch server streams a range in bounded look-ahead chunks (O(chunk) memory, was ~180 MB/conn), advancing the cursor by point-hash to keep same-slot EBB/main semantics exact.
- **Closes #879** — big-ledger peers excluded from cold-churn eviction; the BLP set is rebuilt each discovery pass and pruned on forget; ledger discovery keeps all resolved A/AAAA records.

## Low-severity roundup
- **Closes #880** — peersharing count clamp; ChainSync outer-array arity assertion; tx-size-vs-advertised check; handshake simultaneous-open skip-unknown + cap; MsgAcceptVersion magic re-check (N2N + N2C); MsgRelease-in-StIdle rejection (LSQ + LocalTxMonitor); N2N **query mode** implemented (MsgQueryReply); PipelinedChainSyncClient rejects unsolicited responses + server MsgDone; CSJ bisection-continue transitions. `weighted_shuffle`'s RFC 2782 weight-0 ordering is intentionally left (cosmetic, non-security, per the issue).

## Known residual limitations (documented in-code, not regressions)
- #871: rotated-out stale IPs linger as Topology cold peers (connectivity is restored via the fresh address); exact TTL honouring needs `resolve_with_srv` to surface TTLs.
- #870: the graceful hot→warm *recover* path still awaits under the lock (bounded, non-adversarial); only the peer-controlled *close* path was offloaded.
- #875: only slot-range membership is enforced in-protocol; in-range junk is still dropped by chain selection.
- PipelinedChainSyncClient's rollback-depth (k) bound belongs at its (currently unused) integration point.
