### PR TITLE
fix(redeemers/datums): PV12 list-reject (#885), CLI script_data_hash dedup (#884), canonical witness encoding (#887)

### DIFF
--- a/crates/dugite-cli/src/commands/transaction.rs
+++ b/crates/dugite-cli/src/commands/transaction.rs
@@ -1115,50 +1115,6 @@ pub(crate) fn parse_execution_units(s: &str) -> Result<ExUnits> {
     Ok(ExUnits { mem, steps })
 }
 
-/// Encode a single `Redeemer` to CBOR `[tag, index, data, [mem, steps]]`.
-///
-/// Self-contained implementation that avoids depending on the `pub(crate)`
-/// helper in `dugite-serialization`, keeping the CLI crate independent.
-fn encode_redeemer_to_cbor(r: &Redeemer) -> Vec<u8> {
-    // Redeemer = [tag, index, data, ex_units]
-    // Tag: Spend=0, Mint=1, Cert=2, Reward=3, Vote=4, Propose=5, Guarding=6
-    // (Guarding is Dijkstra-only — issue #475 Phase 3.5).
-    let tag_num: u64 = match r.tag {
-        RedeemerTag::Spend => 0,
-        RedeemerTag::Mint => 1,
-        RedeemerTag::Cert => 2,
-        RedeemerTag::Reward => 3,
-        RedeemerTag::Vote => 4,
-        RedeemerTag::Propose => 5,
-        RedeemerTag::Guarding => 6,
-    };
-
-    // Build header (array(4), tag, index) in a block so the encoder borrow ends
-    // before we extend with the data and ex_units bytes.
-    let mut header = Vec::new();
-    {
-        let mut enc = minicbor::Encoder::new(&mut header);
-        enc.array(4).unwrap();
-        enc.u64(tag_num).unwrap();
-        enc.u64(r.index as u64).unwrap();
-    }
-
-    // ex_units: [mem, steps]
-    let mut ex_units = Vec::new();
-    {
-        let mut enc = minicbor::Encoder::new(&mut ex_units);
-        enc.array(2).unwrap();
-        enc.u64(r.ex_units.mem).unwrap();
-        enc.u64(r.ex_units.steps).unwrap();
-    }
-
-    // Concatenate: header || data_cbor || ex_units
-    let mut buf = header;
-    buf.extend_from_slice(&encode_plutus_data_to_cbor(&r.data));
-    buf.extend_from_slice(&ex_units);
-    buf
-}
-
 /// Encode a `PlutusData` value to CBOR using the Cardano wire encoding.
 ///
 /// Self-contained implementation that mirrors `dugite_serialization::cbor::encode_plutus_data`
@@ -1280,13 +1236,14 @@ fn encode_plutus_data_to_cbor(data: &PlutusData) -> Vec<u8> {
 /// re-validates this hash during submission using the actual cost models.
 ///
 /// Returns `None` when no Plutus scripts are attached to the transaction.
-pub(crate) fn compute_script_data_hash_offline(witnesses: &[ScriptWitness]) -> Option<Hash32> {
-    if witnesses.is_empty() {
-        return None;
-    }
-
-    // Redeemers: one per witness, indexed by witness position (= sorted tx-input position)
-    let redeemers: Vec<Redeemer> = witnesses
+/// Build the `Redeemer` list for a set of script witnesses.
+///
+/// One `Spend` redeemer per witness, indexed by witness position (= sorted
+/// tx-input position). Shared by [`build_plutus_witness_set_cbor`] (key 5) and
+/// [`compute_script_data_hash_offline`] so the redeemers term in the witness
+/// set and the one fed into the script-integrity hash are built identically.
+fn conway_redeemers(witnesses: &[ScriptWitness]) -> Vec<Redeemer> {
+    witnesses
         .iter()
         .enumerate()
         .map(|(idx, w)| {
@@ -1299,37 +1256,71 @@ pub(crate) fn compute_script_data_hash_offline(witnesses: &[ScriptWitness]) -> O
                 ex_units: w.ex_units,
             }
         })
-        .collect();
+        .collect()
+}
 
-    // Encode redeemers as an array
-    let mut redeemer_bytes = Vec::new();
+/// Encode the datums witness term (key 4) as a bare `array(n)` of the
+/// pre-encoded per-witness datum CBOR, matching what the witness-set builder
+/// emits so the script-integrity hash preimage is byte-identical to the wire
+/// witness set (the ledger recomputes the hash from those bytes).
+fn conway_datums_term(witnesses: &[ScriptWitness]) -> Vec<u8> {
+    let mut buf = Vec::new();
     {
-        let mut enc = minicbor::Encoder::new(&mut redeemer_bytes);
-        enc.array(redeemers.len() as u64).unwrap();
-    }
-    for r in &redeemers {
-        redeemer_bytes.extend_from_slice(&encode_redeemer_to_cbor(r));
-    }
-
-    // Encode datums as an array
-    let mut datum_bytes = Vec::new();
-    {
-        let mut enc = minicbor::Encoder::new(&mut datum_bytes);
+        let mut enc = minicbor::Encoder::new(&mut buf);
         enc.array(witnesses.len() as u64).unwrap();
     }
     for w in witnesses {
-        datum_bytes.extend_from_slice(&w.datum_cbor);
+        buf.extend_from_slice(&w.datum_cbor);
+    }
+    buf
+}
+
+/// Compute the `script_data_hash` (tx body field 11) for a set of Plutus
+/// witnesses, offline (no ledger state).
+///
+/// Delegates the preimage assembly to the canonical
+/// [`dugite_serialization::compute_script_data_hash`] rather than hand-rolling
+/// it, so byte-exact fixes (era-gated empty-redeemers sentinel, empty-datums
+/// omission, language-views layout) stay in one place (#884). The redeemers
+/// term is Conway **map** form (era-correct; the legacy array form is
+/// hard-rejected from PV12 — #885) and byte-matches key 5 of the witness set
+/// built by [`build_plutus_witness_set_cbor`]. Language views are empty
+/// (`0xa0`): the offline builder carries no cost models, so it hashes as though
+/// none apply — the same behavior as before.
+pub(crate) fn compute_script_data_hash_offline(witnesses: &[ScriptWitness]) -> Option<Hash32> {
+    if witnesses.is_empty() {
+        return None;
     }
 
-    // Empty language views map: `a0`
-    let language_views: Vec<u8> = vec![0xa0];
+    // Redeemers: Conway map form, shared byte-for-byte with witness-set key 5.
+    let redeemers = conway_redeemers(witnesses);
+    let redeemers_term =
+        dugite_serialization::encode_redeemers(&redeemers, /*map_form=*/ true);
 
-    let mut preimage = Vec::new();
-    preimage.extend_from_slice(&redeemer_bytes);
-    preimage.extend_from_slice(&datum_bytes);
-    preimage.extend_from_slice(&language_views);
+    // Datums: bare array of the raw per-witness datum bytes, shared with key 4.
+    let datums_term = conway_datums_term(witnesses);
+    // Decoded datums only serve to satisfy the "datums present" gate in
+    // `compute_script_data_hash`; the raw `datums_term` bytes drive the hash so
+    // the original datum encoding (and therefore each datum hash) is preserved.
+    let plutus_data: Vec<PlutusData> = witnesses
+        .iter()
+        .map(|w| decode_plutus_data_cbor(&w.datum_cbor).unwrap_or(PlutusData::Bytes(vec![])))
+        .collect();
 
-    Some(dugite_primitives::hash::blake2b_256(&preimage))
+    // No cost models offline → empty language views (`0xa0`).
+    let cost_models = dugite_primitives::transaction::CostModels::default();
+
+    Some(dugite_serialization::compute_script_data_hash(
+        &[],
+        &plutus_data,
+        &cost_models,
+        false,
+        false,
+        false,
+        Some(&redeemers_term),
+        Some(&datums_term),
+        /*redeemers_map_form=*/ true,
+    ))
 }
 
 /// Build the Plutus witness set CBOR for inclusion in the signed transaction.
@@ -1398,37 +1389,30 @@ pub(crate) fn build_plutus_witness_set_cbor(witnesses: &[ScriptWitness]) -> Vec<
         }
     }
 
-    // Key 4: datums — array of PlutusData; each datum_cbor is a pre-encoded item
+    // Key 4: datums — bare `array(n)` of the pre-encoded per-witness datum CBOR.
+    // Shares `conway_datums_term` with the script_data_hash preimage so the two
+    // are byte-identical.
     if datum_count > 0 {
         {
             let mut enc = minicbor::Encoder::new(&mut buf);
             enc.u32(4).unwrap();
-            enc.array(datum_count as u64).unwrap();
         }
-        for w in witnesses {
-            // datum_cbor is the encoding of one PlutusData item — inject raw bytes.
-            buf.extend_from_slice(&w.datum_cbor);
-        }
+        buf.extend_from_slice(&conway_datums_term(witnesses));
     }
 
-    // Key 5: redeemers — array of [tag, index, data, ex_units]
+    // Key 5: redeemers — Conway **map** form `{ [tag, index] => [data, ex_units] }`
+    // (era-correct; the legacy array form is hard-rejected from PV12, #885).
+    // Encoded via the canonical `dugite_serialization::encode_redeemers`, shared
+    // byte-for-byte with the script_data_hash preimage (#884).
     if redeemer_count > 0 {
         {
             let mut enc = minicbor::Encoder::new(&mut buf);
             enc.u32(5).unwrap();
-            enc.array(redeemer_count as u64).unwrap();
         }
-        for (idx, w) in witnesses.iter().enumerate() {
-            let data =
-                decode_plutus_data_cbor(&w.redeemer_data_cbor).unwrap_or(PlutusData::Bytes(vec![]));
-            let r = Redeemer {
-                tag: RedeemerTag::Spend,
-                index: idx as u32,
-                data,
-                ex_units: w.ex_units,
-            };
-            buf.extend_from_slice(&encode_redeemer_to_cbor(&r));
-        }
+        let redeemers = conway_redeemers(witnesses);
+        buf.extend_from_slice(&dugite_serialization::encode_redeemers(
+            &redeemers, /*map_form=*/ true,
+        ));
     }
 
     // Key 6: PlutusV2 scripts
@@ -4856,6 +4840,82 @@ mod tests {
         let h1 = compute_script_data_hash_offline(std::slice::from_ref(&w));
         let h2 = compute_script_data_hash_offline(std::slice::from_ref(&w));
         assert_eq!(h1, h2, "Hash must be deterministic");
+    }
+
+    /// #884: the offline script_data_hash must byte-match the actual witness-set
+    /// bytes — the ledger recomputes the hash from key 4 (datums) + key 5
+    /// (redeemers) as they appear on the wire, so a divergence here would make
+    /// every CLI-built Plutus tx fail with ScriptDataHashMismatch. This locks
+    /// the two encoders (witness-set builder + hash preimage) together and
+    /// pins the redeemers to Conway **map** form.
+    #[test]
+    fn test_offline_hash_matches_witness_set_bytes() {
+        let datum = PlutusData::Constr(0, vec![PlutusData::Integer(7i64.into())]);
+        let redeemer = PlutusData::Integer(num_bigint::BigInt::from(1i64));
+        let mk = |v| ScriptWitness {
+            version: v,
+            script_bytes: vec![0xaa, 0xbb],
+            datum_cbor: encode_plutus_data_to_cbor(&datum),
+            redeemer_data_cbor: encode_plutus_data_to_cbor(&redeemer),
+            ex_units: ExUnits {
+                mem: 1234,
+                steps: 5678,
+            },
+        };
+        let witnesses = vec![mk(PlutusVersion::V3), mk(PlutusVersion::V2)];
+
+        // Redeemers term (key 5) must be Conway map form: `a2` (map(2)) header.
+        let redeemers = conway_redeemers(&witnesses);
+        let redeemers_term = dugite_serialization::encode_redeemers(&redeemers, true);
+        assert_eq!(
+            redeemers_term[0], 0xa2,
+            "Conway redeemers must be a map(2), got {:#x}",
+            redeemers_term[0]
+        );
+
+        // Rebuild the preimage the ledger would hash: extract key 4 and key 5
+        // values straight out of the witness-set CBOR the CLI emits, then append
+        // the empty language views (`0xa0`), and confirm the hash matches.
+        let ws_cbor = build_plutus_witness_set_cbor(&witnesses);
+        let entries = collect_plutus_witness_entries(Some(&hex::encode(&ws_cbor)))
+            .expect("witness set must parse");
+        let mut redeemers_from_ws = None;
+        let mut datums_from_ws = None;
+        for (key, entry) in &entries {
+            // `entry` is the raw key+value CBOR; strip the 1-byte uint key.
+            let value = &entry[1..];
+            match key {
+                4 => datums_from_ws = Some(value.to_vec()),
+                5 => redeemers_from_ws = Some(value.to_vec()),
+                _ => {}
+            }
+        }
+        let redeemers_from_ws = redeemers_from_ws.expect("key 5 present");
+        let datums_from_ws = datums_from_ws.expect("key 4 present");
+
+        // The hash's redeemers/datums terms are exactly the witness-set bytes.
+        assert_eq!(
+            redeemers_from_ws, redeemers_term,
+            "witness-set key 5 must equal the hash's redeemers term"
+        );
+        assert_eq!(
+            datums_from_ws,
+            conway_datums_term(&witnesses),
+            "witness-set key 4 must equal the hash's datums term"
+        );
+
+        let mut preimage = Vec::new();
+        preimage.extend_from_slice(&redeemers_from_ws);
+        preimage.extend_from_slice(&datums_from_ws);
+        preimage.push(0xa0); // empty language views
+        let expected = dugite_primitives::hash::blake2b_256(&preimage);
+
+        let actual = compute_script_data_hash_offline(&witnesses).expect("hash present");
+        assert_eq!(
+            actual.as_bytes(),
+            expected.as_bytes(),
+            "offline hash must equal blake2b(key5 || key4 || 0xa0)"
+        );
     }
 
     // ── Plutus witness set CBOR tests ────────────────────────────────────────

--- a/crates/dugite-serialization/src/decode/era_conway.rs
+++ b/crates/dugite-serialization/src/decode/era_conway.rs
@@ -187,7 +187,7 @@ fn decode_conway_block_mode(
     let mut parsed_witnesses: Vec<Option<TransactionWitnessSet>> = Vec::new();
     r.for_each_array_item(|r| {
         if mode == DecodeMode::Full {
-            let ws = KeepRaw::parse_with(r, decode_conway_witness_set)?;
+            let ws = KeepRaw::parse_with(r, |r| decode_conway_witness_set(r, era))?;
             raw_witnesses.push(ws.raw.to_vec());
             parsed_witnesses.push(Some(ws.value));
         } else {
@@ -2349,6 +2349,7 @@ fn read_drep_voting_thresholds(
 /// - Key 7: plutus_v3_scripts
 fn decode_conway_witness_set(
     r: &mut Reader<'_>,
+    era: Era,
 ) -> Result<TransactionWitnessSet, SerializationError> {
     let mut vkey_witnesses: Vec<VKeyWitness> = Vec::new();
     let mut native_scripts = Vec::new();
@@ -2442,7 +2443,7 @@ fn decode_conway_witness_set(
             5 => {
                 // redeemers: map form (Conway) or array form (pre-Conway) — NOT a set
                 let rd_start = r.position();
-                redeemers = read_redeemers(r)?;
+                redeemers = read_redeemers(r, era)?;
                 raw_redeemers_cbor = Some(r.slice_from(rd_start).to_vec());
             }
             6 => {
@@ -2483,15 +2484,32 @@ fn decode_conway_witness_set(
 }
 
 /// Read redeemers — supports both Conway map form and pre-Conway array form.
-fn read_redeemers(r: &mut Reader<'_>) -> Result<Vec<Redeemer>, SerializationError> {
-    read_redeemers_raw(r).map(crate::decode::helpers::dedup_redeemers_last_wins)
+///
+/// `era` selects the decoder version: from Dijkstra (PV12) on, the legacy
+/// list/array encoding is a hard decode failure (see [`read_redeemers_raw`]).
+fn read_redeemers(r: &mut Reader<'_>, era: Era) -> Result<Vec<Redeemer>, SerializationError> {
+    read_redeemers_raw(r, era).map(crate::decode::helpers::dedup_redeemers_last_wins)
 }
 
 /// Wire-form reader without the Haskell `Map.fromList` dedup — every caller
 /// must go through [`read_redeemers`]. Duplicate (tag, index) entries occur
 /// on-chain (mainnet block 8,826,011, #753); Haskell collapses them
 /// (last-wins) in BOTH the map and array wire forms.
-fn read_redeemers_raw(r: &mut Reader<'_>) -> Result<Vec<Redeemer>, SerializationError> {
+///
+/// From PV12 (Dijkstra) the list/array wire form is rejected outright, matching
+/// cardano-ledger `DecCBOR (Annotator RedeemersRaw)` in `Alonzo/TxWits.hs`:
+///
+/// ```haskell
+/// ifDecoderVersionAtLeast (natVersion @12)
+///   (fail "List encoding of redeemers not supported starting with PV 12")
+///   decodeListRedeemers
+/// ```
+///
+/// The decoder version equals the protocol major version, and PV12 is the
+/// Dijkstra hard fork, so `era == Dijkstra` is the exact proxy for the gate.
+/// The whole list branch fails (empty `0x80` included) — only the Conway map
+/// form is accepted at PV12+.
+fn read_redeemers_raw(r: &mut Reader<'_>, era: Era) -> Result<Vec<Redeemer>, SerializationError> {
     let ty = r.peek_major()?;
     match ty {
         Type::Map | Type::MapIndef => {
@@ -2535,6 +2553,14 @@ fn read_redeemers_raw(r: &mut Reader<'_>) -> Result<Vec<Redeemer>, Serialization
                 })
                 .collect();
             Ok(out)
+        }
+        Type::Array | Type::ArrayIndef if era == Era::Dijkstra => {
+            // PV12 (Dijkstra) hard-rejects the legacy list encoding — matches
+            // Haskell's `fail` branch. Reject before reading any element so an
+            // empty `0x80` list is refused too.
+            Err(SerializationError::CborDecode(
+                "List encoding of redeemers not supported starting with PV 12".to_string(),
+            ))
         }
         Type::Array | Type::ArrayIndef => {
             // Pre-Conway array form: [* [tag, index, data, ex_units]]
@@ -3028,7 +3054,7 @@ pub(crate) fn decode_conway_tx_standalone(
     let body = body_raw.value;
 
     // 2. Witness set
-    let ws_raw = KeepRaw::parse_with(&mut r, decode_conway_witness_set)?;
+    let ws_raw = KeepRaw::parse_with(&mut r, |r| decode_conway_witness_set(r, era))?;
     let raw_witness_cbor = ws_raw.raw.to_vec();
     let witness_set = ws_raw.value;
 
@@ -3126,7 +3152,7 @@ pub(crate) fn decode_dijkstra_tx_standalone(
     let body = body_raw.value;
 
     // 2. Witness set.
-    let ws_raw = KeepRaw::parse_with(&mut r, decode_conway_witness_set)?;
+    let ws_raw = KeepRaw::parse_with(&mut r, |r| decode_conway_witness_set(r, Era::Dijkstra))?;
     let raw_witness_cbor = ws_raw.raw.to_vec();
     let witness_set = ws_raw.value;
 
@@ -3552,7 +3578,7 @@ mod tests {
         data.extend(&value_arr);
 
         let mut r = Reader::new(&data);
-        let redeemers = read_redeemers(&mut r).unwrap();
+        let redeemers = read_redeemers(&mut r, Era::Conway).unwrap();
         assert_eq!(redeemers.len(), 1);
         assert_eq!(redeemers[0].tag, RedeemerTag::Spend);
         assert_eq!(redeemers[0].index, 0);
@@ -3575,10 +3601,64 @@ mod tests {
         data.extend(&redeemer);
 
         let mut r = Reader::new(&data);
-        let redeemers = read_redeemers(&mut r).unwrap();
+        let redeemers = read_redeemers(&mut r, Era::Conway).unwrap();
         assert_eq!(redeemers.len(), 1);
         assert_eq!(redeemers[0].tag, RedeemerTag::Spend);
         assert_eq!(redeemers[0].ex_units.mem, 50);
+    }
+
+    /// #885: the legacy list/array redeemers encoding is accepted through
+    /// Conway (PV9/10/11) but hard-rejected from Dijkstra (PV12) on, mirroring
+    /// cardano-ledger's `ifDecoderVersionAtLeast (natVersion @12) (fail …)`.
+    #[test]
+    fn test_redeemers_list_form_rejected_from_pv12() {
+        // Same array-form bytes as `test_read_redeemers_array_form`:
+        // [[0, 0, #6.121([]), [50, 100]]] — Alonzo/Babbage list form.
+        let constr_data = {
+            let mut v = cbor_tag(121);
+            v.extend(vec![0x80]);
+            v
+        };
+        let ex_units = cbor_arr(&[&cbor_uint(50), &cbor_uint(100)]);
+        let redeemer = cbor_arr(&[&cbor_uint(0), &cbor_uint(0), &constr_data, &ex_units]);
+        let mut list_bytes = vec![0x81]; // array(1)
+        list_bytes.extend(&redeemer);
+
+        // Conway (PV11): accepted.
+        let mut r = Reader::new(&list_bytes);
+        let redeemers = read_redeemers(&mut r, Era::Conway).expect("Conway accepts list form");
+        assert_eq!(redeemers.len(), 1);
+
+        // Dijkstra (PV12): the identical bytes are a decode failure.
+        let mut r = Reader::new(&list_bytes);
+        let err = read_redeemers(&mut r, Era::Dijkstra)
+            .expect_err("Dijkstra must reject list-encoded redeemers");
+        assert!(
+            matches!(&err, SerializationError::CborDecode(m) if m.contains("PV 12")),
+            "unexpected error for PV12 list redeemers: {err:?}"
+        );
+
+        // The EMPTY list `0x80` is rejected too (whole list branch fails).
+        let empty_list = vec![0x80];
+        let mut r = Reader::new(&empty_list);
+        assert!(read_redeemers(&mut r, Era::Dijkstra).is_err());
+        // …but Conway still accepts an empty list as zero redeemers.
+        let mut r = Reader::new(&empty_list);
+        assert_eq!(read_redeemers(&mut r, Era::Conway).unwrap().len(), 0);
+
+        // The Conway MAP form is accepted in BOTH eras (only the list form is
+        // gated). { [0,0] => [#6.121([]), [50,100]] }
+        let value_arr = cbor_arr(&[&constr_data, &ex_units]);
+        let key_arr = cbor_arr(&[&cbor_uint(0), &cbor_uint(0)]);
+        let mut map_bytes = vec![0xa1]; // map(1)
+        map_bytes.extend(&key_arr);
+        map_bytes.extend(&value_arr);
+        for era in [Era::Conway, Era::Dijkstra] {
+            let mut r = Reader::new(&map_bytes);
+            let rs = read_redeemers(&mut r, era).expect("map form accepted in every era");
+            assert_eq!(rs.len(), 1);
+            assert_eq!(rs[0].ex_units.mem, 50);
+        }
     }
 
     // ── Plutus V3 script ──────────────────────────────────────────────────────
@@ -3597,7 +3677,7 @@ mod tests {
         data.extend(&scripts_arr);
 
         let mut r = Reader::new(&data);
-        let ws = decode_conway_witness_set(&mut r).unwrap();
+        let ws = decode_conway_witness_set(&mut r, Era::Conway).unwrap();
         assert_eq!(ws.plutus_v3_scripts.len(), 1);
         assert_eq!(ws.plutus_v3_scripts[0], vec![0xde, 0xad, 0xbe, 0xef]);
     }
@@ -3621,7 +3701,7 @@ mod tests {
         data.extend(cbor_uint(0));
 
         let mut r = Reader::new(&data);
-        let result = decode_conway_witness_set(&mut r);
+        let result = decode_conway_witness_set(&mut r, Era::Conway);
         assert!(
             matches!(result, Err(SerializationError::CborDecode(_))),
             "unknown witness-set key must be rejected, got {result:?}"
@@ -3643,7 +3723,7 @@ mod tests {
         data.extend(&empty_set);
 
         let mut r = Reader::new(&data);
-        let result = decode_conway_witness_set(&mut r);
+        let result = decode_conway_witness_set(&mut r, Era::Conway);
         assert!(
             matches!(result, Err(SerializationError::CborDecode(_))),
             "duplicate witness-set field key must be rejected, got {result:?}"
@@ -3818,7 +3898,7 @@ mod tests {
         data.extend(&set);
 
         let mut r = Reader::new(&data);
-        let ws = decode_conway_witness_set(&mut r)
+        let ws = decode_conway_witness_set(&mut r, Era::Conway)
             .expect("duplicate vkey witness must decode Ok at PV9-11 (Haskell accepts)");
         assert_eq!(
             ws.vkey_witnesses.len(),
@@ -3846,7 +3926,7 @@ mod tests {
         data.extend(&set);
 
         let mut r = Reader::new(&data);
-        let ws = decode_conway_witness_set(&mut r)
+        let ws = decode_conway_witness_set(&mut r, Era::Conway)
             .expect("duplicate native script must decode Ok at PV9-11 (Haskell accepts)");
         assert_eq!(
             ws.native_scripts.len(),
@@ -3879,7 +3959,7 @@ mod tests {
         data.extend(&set);
 
         let mut r = Reader::new(&data);
-        let ws = decode_conway_witness_set(&mut r)
+        let ws = decode_conway_witness_set(&mut r, Era::Conway)
             .expect("duplicate bootstrap witness must decode Ok at PV9-11 (Haskell accepts)");
         assert_eq!(
             ws.bootstrap_witnesses.len(),
@@ -3907,7 +3987,7 @@ mod tests {
         data.extend(&set);
 
         let mut r = Reader::new(&data);
-        let ws = decode_conway_witness_set(&mut r)
+        let ws = decode_conway_witness_set(&mut r, Era::Conway)
             .expect("duplicate plutus datum must decode Ok at PV9-11 (Haskell accepts)");
         assert_eq!(
             ws.plutus_data.len(),
@@ -3955,7 +4035,7 @@ mod tests {
         data.extend(&set);
 
         let mut r = Reader::new(&data);
-        let ws = decode_conway_witness_set(&mut r).expect("unique vkeys decode");
+        let ws = decode_conway_witness_set(&mut r, Era::Conway).expect("unique vkeys decode");
         assert_eq!(ws.vkey_witnesses.len(), 2);
         assert_eq!(ws.vkey_witnesses[0].vkey, vec![0x44; 32]);
         assert_eq!(ws.vkey_witnesses[1].vkey, vec![0x66; 32]);
@@ -4994,7 +5074,7 @@ mod tests {
         let mut def = vec![0xA1];
         def.extend_from_slice(&body);
         let mut rd = Reader::new(&def);
-        let rs = read_redeemers(&mut rd).expect("definite map redeemers must decode");
+        let rs = read_redeemers(&mut rd, Era::Conway).expect("definite map redeemers must decode");
         assert_eq!(rs.len(), 1);
         assert_eq!(rs[0].tag, RedeemerTag::Spend);
         assert_eq!(rs[0].index, 0);
@@ -5005,7 +5085,8 @@ mod tests {
         indef.extend_from_slice(&body);
         indef.push(0xFF);
         let mut ri = Reader::new(&indef);
-        let rs2 = read_redeemers(&mut ri).expect("indefinite map redeemers must decode");
+        let rs2 =
+            read_redeemers(&mut ri, Era::Conway).expect("indefinite map redeemers must decode");
         assert_eq!(rs2.len(), 1);
         assert_eq!(rs2[0].tag, RedeemerTag::Spend);
         assert_eq!(rs2[0].index, 0);

--- a/crates/dugite-serialization/src/encode/mod.rs
+++ b/crates/dugite-serialization/src/encode/mod.rs
@@ -32,7 +32,7 @@ pub use script::{
 };
 pub use transaction::{
     compute_transaction_hash, compute_transaction_hash_from_tx, encode_auxiliary_data,
-    encode_dijkstra_transaction, encode_transaction, encode_transaction_body,
+    encode_dijkstra_transaction, encode_redeemers, encode_transaction, encode_transaction_body,
     encode_transaction_output, encode_witness_set,
 };
 pub use value::encode_value;

--- a/crates/dugite-serialization/src/encode/mod.rs
+++ b/crates/dugite-serialization/src/encode/mod.rs
@@ -32,8 +32,8 @@ pub use script::{
 };
 pub use transaction::{
     compute_transaction_hash, compute_transaction_hash_from_tx, encode_auxiliary_data,
-    encode_dijkstra_transaction, encode_redeemers, encode_transaction, encode_transaction_body,
-    encode_transaction_output, encode_witness_set,
+    encode_datums, encode_dijkstra_transaction, encode_redeemers, encode_transaction,
+    encode_transaction_body, encode_transaction_output, encode_witness_set,
 };
 pub use value::encode_value;
 

--- a/crates/dugite-serialization/src/encode/script.rs
+++ b/crates/dugite-serialization/src/encode/script.rs
@@ -224,12 +224,14 @@ pub fn compute_script_data_hash(
         if let Some(raw) = raw_datums_cbor {
             preimage.extend_from_slice(raw);
         } else {
-            let mut datums_buf = encode_tag(258);
-            datums_buf.extend(encode_array_header(plutus_data.len()));
-            for d in plutus_data {
-                datums_buf.extend(encode_plutus_data(d));
-            }
-            preimage.extend(&datums_buf);
+            // Canonical datums term, shared with the witness-set builder so a
+            // synthetic tx's script_data_hash always matches its own witnesses.
+            // The set-tag gate is the same PV≥9 boundary as `redeemers_map_form`
+            // (tag 258 from Conway on, bare array pre-Conway).
+            preimage.extend(crate::encode::encode_datums(
+                plutus_data,
+                redeemers_map_form,
+            ));
         }
     }
 

--- a/crates/dugite-serialization/src/encode/script.rs
+++ b/crates/dugite-serialization/src/encode/script.rs
@@ -203,35 +203,15 @@ pub fn compute_script_data_hash(
     // `hashScriptIntegrity` which encodes the era's `Redeemers` type verbatim.
     if let Some(raw) = raw_redeemers_cbor {
         preimage.extend_from_slice(raw);
-    } else if redeemers.is_empty() {
-        preimage.push(if redeemers_map_form { 0xa0 } else { 0x80 });
-    } else if redeemers_map_form {
-        // Conway map format: { [tag, index] => [data, ex_units] }
-        let mut redeemers_buf = encode_map_header(redeemers.len());
-        for r in redeemers {
-            redeemers_buf.extend(encode_array_header(2));
-            redeemers_buf.extend(encode_redeemer_tag(&r.tag));
-            redeemers_buf.extend(encode_uint(r.index as u64));
-            redeemers_buf.extend(encode_array_header(2));
-            redeemers_buf.extend(encode_plutus_data(&r.data));
-            redeemers_buf.extend(encode_array_header(2));
-            redeemers_buf.extend(encode_uint(r.ex_units.mem));
-            redeemers_buf.extend(encode_uint(r.ex_units.steps));
-        }
-        preimage.extend(&redeemers_buf);
     } else {
-        // Alonzo/Babbage list format: [ [tag, index, data, ex_units], ... ]
-        let mut redeemers_buf = encode_array_header(redeemers.len());
-        for r in redeemers {
-            redeemers_buf.extend(encode_array_header(4));
-            redeemers_buf.extend(encode_redeemer_tag(&r.tag));
-            redeemers_buf.extend(encode_uint(r.index as u64));
-            redeemers_buf.extend(encode_plutus_data(&r.data));
-            redeemers_buf.extend(encode_array_header(2));
-            redeemers_buf.extend(encode_uint(r.ex_units.mem));
-            redeemers_buf.extend(encode_uint(r.ex_units.steps));
-        }
-        preimage.extend(&redeemers_buf);
+        // Single canonical redeemers encoder — `encode_redeemers` yields the
+        // era's empty container (`0xa0` map / `0x80` list) for an empty slice,
+        // which is exactly the empty-redeemers sentinel, so no special-casing
+        // is needed here.
+        preimage.extend(crate::encode::encode_redeemers(
+            redeemers,
+            redeemers_map_form,
+        ));
     }
 
     // 2. Datums: per Haskell `SafeToHash (ScriptIntegrity era)` the datums term

--- a/crates/dugite-serialization/src/encode/transaction.rs
+++ b/crates/dugite-serialization/src/encode/transaction.rs
@@ -201,12 +201,25 @@ pub fn encode_witness_set(ws: &TransactionWitnessSet) -> Vec<u8> {
 /// (see [`crate::compute_script_data_hash`]). This is the single canonical
 /// redeemers encoder, shared by the witness-set builder, the script-data-hash
 /// preimage, and `dugite-cli`'s offline tx builder so the three never diverge.
+///
+/// The redeemers are emitted in canonical order — ascending `(tag, index)` —
+/// matching cardano-ledger, whose `Redeemers` is a `Map (PlutusPurpose AsIx)
+/// (Data, ExUnits)` serialized via `Map.toAscList`. The `Ord` on the key is
+/// `(purpose-constructor, index)`, and the purpose constructors are numbered
+/// exactly as the redeemer tags (Spend=0, Mint=1, Cert=2, Reward=3, Vote=4,
+/// Propose=5, Guarding=6), so `(tag, index)` reproduces it (#887).
 pub fn encode_redeemers(redeemers: &[Redeemer], map_form: bool) -> Vec<u8> {
+    // Canonical ascending `(tag, index)` order via an index permutation, so we
+    // never clone the (potentially large) redeemer `data`.
+    let mut order: Vec<usize> = (0..redeemers.len()).collect();
+    order.sort_by_key(|&i| (redeemer_tag_ord(&redeemers[i].tag), redeemers[i].index));
+
     let mut buf = Vec::new();
     if map_form {
         // Conway/Dijkstra map: { [tag, index] => [data, ex_units], … }
         buf.extend(encode_map_header(redeemers.len()));
-        for r in redeemers {
+        for &i in &order {
+            let r = &redeemers[i];
             // Key: [tag, index]
             buf.extend(encode_array_header(2));
             buf.extend(encode_redeemer_tag(&r.tag));
@@ -221,7 +234,8 @@ pub fn encode_redeemers(redeemers: &[Redeemer], map_form: bool) -> Vec<u8> {
     } else {
         // Pre-Conway list: [* [tag, index, data, ex_units]]
         buf.extend(encode_array_header(redeemers.len()));
-        for r in redeemers {
+        for &i in &order {
+            let r = &redeemers[i];
             buf.extend(encode_array_header(4));
             buf.extend(encode_redeemer_tag(&r.tag));
             buf.extend(encode_uint(r.index as u64));
@@ -230,6 +244,53 @@ pub fn encode_redeemers(redeemers: &[Redeemer], map_form: bool) -> Vec<u8> {
             buf.extend(encode_uint(r.ex_units.mem));
             buf.extend(encode_uint(r.ex_units.steps));
         }
+    }
+    buf
+}
+
+/// Numeric ordering of a redeemer tag, matching both the CBOR tag value and the
+/// `PlutusPurpose` constructor order in cardano-ledger (used to sort redeemers
+/// and the redeemers map into canonical ascending-key order).
+fn redeemer_tag_ord(tag: &RedeemerTag) -> u8 {
+    match tag {
+        RedeemerTag::Spend => 0,
+        RedeemerTag::Mint => 1,
+        RedeemerTag::Cert => 2,
+        RedeemerTag::Reward => 3,
+        RedeemerTag::Vote => 4,
+        RedeemerTag::Propose => 5,
+        RedeemerTag::Guarding => 6,
+    }
+}
+
+/// Encode the `plutus_data` witness term (witness-set key 4 / the datums term
+/// of the script-integrity preimage) as CBOR.
+///
+/// Canonicalizes to match cardano-ledger's `TxDats = Map DataHash (Data era)`,
+/// serialized as `encodeWithSetTag . Map.elems`:
+/// - The datums are ordered by ascending `DataHash` (`blake2b_256` of each
+///   datum's encoding) — `Map.elems` yields ascending-key order.
+/// - `use_set_tag` (true from Conway/PV9 on) prepends the set tag 258
+///   (`encodeWithSetTag`); pre-Conway emits a bare array.
+///
+/// The caller must ensure `plutus_data` is non-empty — an empty `TxDats`
+/// contributes nothing to the preimage and is omitted by the callers (#887).
+pub fn encode_datums(plutus_data: &[PlutusData], use_set_tag: bool) -> Vec<u8> {
+    // Order by ascending datum hash via an index permutation.
+    let hashes: Vec<[u8; 32]> = plutus_data
+        .iter()
+        .map(|d| *blake2b_256(&encode_plutus_data(d)).as_bytes())
+        .collect();
+    let mut order: Vec<usize> = (0..plutus_data.len()).collect();
+    order.sort_by(|&a, &b| hashes[a].cmp(&hashes[b]));
+
+    let mut buf = Vec::new();
+    if use_set_tag {
+        buf.extend(encode_tag(258));
+    }
+    buf.extend(encode_array_header(plutus_data.len()));
+    for &i in &order {
+        buf.extend(encode_plutus_data(&plutus_data[i]));
     }
     buf
 }
@@ -303,10 +364,12 @@ pub(super) fn encode_witness_set_for_era(ws: &TransactionWitnessSet, era: Era) -
 
     if !ws.plutus_data.is_empty() {
         buf.extend(encode_uint(4));
-        buf.extend(encode_array_header(ws.plutus_data.len()));
-        for d in &ws.plutus_data {
-            buf.extend(encode_plutus_data(d));
-        }
+        // Canonical datums term — hash-sorted, tag-258 wrapped from Conway on.
+        // Shared with the script-data-hash preimage so the two stay identical.
+        buf.extend(encode_datums(
+            &ws.plutus_data,
+            matches!(era, Era::Conway | Era::Dijkstra),
+        ));
     }
 
     if !ws.redeemers.is_empty() {
@@ -943,6 +1006,7 @@ pub fn compute_transaction_hash_from_tx(tx: &Transaction) -> Hash32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encode::compute_script_data_hash;
     use dugite_primitives::{
         address::{Address, EnterpriseAddress},
         credentials::Credential,
@@ -1361,6 +1425,136 @@ mod tests {
         assert_eq!(encoded[1], 0x05, "redeemer key must be 5");
         // Babbage array: array(1) = 0x81 for one redeemer
         assert_eq!(encoded[2], 0x81, "Babbage redeemers encoded as array(1)");
+    }
+
+    // ── #887: canonical redeemers / datums ordering + tag-258 ────────────────
+
+    fn rdmr(tag: RedeemerTag, index: u32) -> Redeemer {
+        Redeemer {
+            tag,
+            index,
+            data: PlutusData::Integer(num_bigint::BigInt::from(index as i64)),
+            ex_units: ExUnits { mem: 1, steps: 2 },
+        }
+    }
+
+    /// #887: `encode_redeemers` emits the map in canonical ascending
+    /// `(tag, index)` order regardless of input order (matches Haskell's
+    /// `Map.toAscList` over `PlutusPurpose`).
+    #[test]
+    fn encode_redeemers_sorts_by_tag_then_index() {
+        // Deliberately unsorted input: (Mint,0), (Spend,3), (Spend,1).
+        let unsorted = vec![
+            rdmr(RedeemerTag::Mint, 0),
+            rdmr(RedeemerTag::Spend, 3),
+            rdmr(RedeemerTag::Spend, 1),
+        ];
+        let sorted = vec![
+            rdmr(RedeemerTag::Spend, 1),
+            rdmr(RedeemerTag::Spend, 3),
+            rdmr(RedeemerTag::Mint, 0),
+        ];
+        assert_eq!(
+            encode_redeemers(&unsorted, true),
+            encode_redeemers(&sorted, true),
+            "map form must be canonical-ordered"
+        );
+        assert_eq!(
+            encode_redeemers(&unsorted, false),
+            encode_redeemers(&sorted, false),
+            "list form must be canonical-ordered too"
+        );
+        // Empty slice → era's empty container (the sentinel).
+        assert_eq!(encode_redeemers(&[], true), vec![0xa0]);
+        assert_eq!(encode_redeemers(&[], false), vec![0x80]);
+    }
+
+    /// #887: `encode_datums` sorts by datum hash and applies the tag-258 set
+    /// wrapper from Conway on (bare array pre-Conway).
+    #[test]
+    fn encode_datums_sorts_by_hash_and_tags_conway() {
+        let a = PlutusData::Bytes(vec![0x01]);
+        let b = PlutusData::Bytes(vec![0x02, 0x03]);
+        let c = PlutusData::Integer(num_bigint::BigInt::from(9i64));
+        let forward = vec![a.clone(), b.clone(), c.clone()];
+        let shuffled = vec![c, a, b];
+
+        // Order-independent (canonical hash order).
+        assert_eq!(
+            encode_datums(&forward, true),
+            encode_datums(&shuffled, true),
+            "datums must sort by hash regardless of input order"
+        );
+
+        // Conway/Dijkstra: tag 258 prefix (0xd9 0x01 0x02).
+        let conway = encode_datums(&forward, true);
+        assert_eq!(
+            &conway[..3],
+            &[0xd9, 0x01, 0x02],
+            "Conway datums must be tag-258"
+        );
+        assert_eq!(conway[3], 0x83, "…wrapping an array(3)");
+
+        // Pre-Conway: bare array, no tag.
+        let pre = encode_datums(&forward, false);
+        assert_eq!(pre[0], 0x83, "pre-Conway datums are a bare array(3)");
+    }
+
+    /// #887 core invariant: a synthetic Conway tx built via the witness-set
+    /// builder has key-4 (datums) and key-5 (redeemers) bytes identical to the
+    /// terms the script-integrity hash re-encodes — so its `script_data_hash`
+    /// matches its own witnesses. Previously the two diverged (witness datums
+    /// were a bare array while the hash used tag-258).
+    #[test]
+    fn witness_set_and_script_data_hash_agree_on_terms() {
+        use crate::encode::{encode_datums, encode_redeemers};
+        let mut ws = empty_witness_set();
+        ws.redeemers = vec![rdmr(RedeemerTag::Mint, 0), rdmr(RedeemerTag::Spend, 2)];
+        ws.plutus_data = vec![
+            PlutusData::Bytes(vec![0xaa]),
+            PlutusData::Integer(num_bigint::BigInt::from(1i64)),
+        ];
+
+        let wire = encode_witness_set_for_era(&ws, Era::Conway);
+
+        // Extract key-4 and key-5 raw values out of the witness-set map.
+        let mut dec = minicbor::Decoder::new(&wire);
+        let n = dec.map().unwrap().unwrap();
+        let mut key4 = None;
+        let mut key5 = None;
+        for _ in 0..n {
+            let k = dec.u32().unwrap();
+            let start = dec.position();
+            dec.skip().unwrap();
+            let val = wire[start..dec.position()].to_vec();
+            match k {
+                4 => key4 = Some(val),
+                5 => key5 = Some(val),
+                _ => {}
+            }
+        }
+        // The builder's terms equal the canonical primitives …
+        assert_eq!(key4.unwrap(), encode_datums(&ws.plutus_data, true));
+        assert_eq!(key5.unwrap(), encode_redeemers(&ws.redeemers, true));
+
+        // … and the hash re-encodes the *same* bytes (raw = None path), so a
+        // self-built tx's script_data_hash matches its own witness set.
+        let cm = CostModels::default();
+        let via_slices = compute_script_data_hash(
+            &ws.redeemers,
+            &ws.plutus_data,
+            &cm,
+            false,
+            false,
+            false,
+            None,
+            None,
+            true,
+        );
+        let mut preimage = encode_redeemers(&ws.redeemers, true);
+        preimage.extend(encode_datums(&ws.plutus_data, true));
+        preimage.push(0xa0); // empty langviews
+        assert_eq!(via_slices.as_bytes(), blake2b_256(&preimage).as_bytes());
     }
 
     // ── transaction body ─────────────────────────────────────────────────────

--- a/crates/dugite-serialization/src/encode/transaction.rs
+++ b/crates/dugite-serialization/src/encode/transaction.rs
@@ -188,6 +188,52 @@ pub fn encode_witness_set(ws: &TransactionWitnessSet) -> Vec<u8> {
     encode_witness_set_for_era(ws, Era::Conway)
 }
 
+/// Encode the `redeemers` witness term (witness-set key 5) as CBOR.
+///
+/// The wire form is era-dependent and `map_form` selects it:
+/// - Conway/Dijkstra (`map_form = true`): MAP `{ [tag, index] => [data, ex_units], … }`
+///   (Conway CDDL `nonempty_map<redeemer_key, redeemer_value>`).
+/// - Alonzo/Babbage (`map_form = false`): LIST `[* [tag, index, data, ex_units]]`.
+///
+/// An empty slice therefore encodes as the era's empty container — `0xa0`
+/// (empty map) in Conway/Dijkstra, `0x80` (empty list) pre-Conway — which is
+/// exactly the empty-redeemers sentinel used by the script-integrity preimage
+/// (see [`crate::compute_script_data_hash`]). This is the single canonical
+/// redeemers encoder, shared by the witness-set builder, the script-data-hash
+/// preimage, and `dugite-cli`'s offline tx builder so the three never diverge.
+pub fn encode_redeemers(redeemers: &[Redeemer], map_form: bool) -> Vec<u8> {
+    let mut buf = Vec::new();
+    if map_form {
+        // Conway/Dijkstra map: { [tag, index] => [data, ex_units], … }
+        buf.extend(encode_map_header(redeemers.len()));
+        for r in redeemers {
+            // Key: [tag, index]
+            buf.extend(encode_array_header(2));
+            buf.extend(encode_redeemer_tag(&r.tag));
+            buf.extend(encode_uint(r.index as u64));
+            // Value: [data, ex_units]
+            buf.extend(encode_array_header(2));
+            buf.extend(encode_plutus_data(&r.data));
+            buf.extend(encode_array_header(2));
+            buf.extend(encode_uint(r.ex_units.mem));
+            buf.extend(encode_uint(r.ex_units.steps));
+        }
+    } else {
+        // Pre-Conway list: [* [tag, index, data, ex_units]]
+        buf.extend(encode_array_header(redeemers.len()));
+        for r in redeemers {
+            buf.extend(encode_array_header(4));
+            buf.extend(encode_redeemer_tag(&r.tag));
+            buf.extend(encode_uint(r.index as u64));
+            buf.extend(encode_plutus_data(&r.data));
+            buf.extend(encode_array_header(2));
+            buf.extend(encode_uint(r.ex_units.mem));
+            buf.extend(encode_uint(r.ex_units.steps));
+        }
+    }
+    buf
+}
+
 /// Encode a transaction witness set using era-specific encoding rules.
 ///
 /// - Conway: redeemers use map format `{ [tag, index] => [data, ex_units] }`
@@ -265,37 +311,12 @@ pub(super) fn encode_witness_set_for_era(ws: &TransactionWitnessSet, era: Era) -
 
     if !ws.redeemers.is_empty() {
         buf.extend(encode_uint(5));
-        if matches!(era, Era::Conway | Era::Dijkstra) {
-            // Conway/Dijkstra map format: { [tag, index] => [data, ex_units], ... }
-            // Per Conway CDDL (also inherited by Dijkstra):
-            //   redeemers = nonempty_map<redeemer_key, redeemer_value>
-            buf.extend(encode_map_header(ws.redeemers.len()));
-            for r in &ws.redeemers {
-                // Key: [tag, index]
-                buf.extend(encode_array_header(2));
-                buf.extend(encode_redeemer_tag(&r.tag));
-                buf.extend(encode_uint(r.index as u64));
-                // Value: [data, ex_units]
-                buf.extend(encode_array_header(2));
-                buf.extend(encode_plutus_data(&r.data));
-                buf.extend(encode_array_header(2));
-                buf.extend(encode_uint(r.ex_units.mem));
-                buf.extend(encode_uint(r.ex_units.steps));
-            }
-        } else {
-            // Pre-Conway (Alonzo/Babbage) array format:
-            //   [* [tag, index, data, ex_units]]
-            buf.extend(encode_array_header(ws.redeemers.len()));
-            for r in &ws.redeemers {
-                buf.extend(encode_array_header(4));
-                buf.extend(encode_redeemer_tag(&r.tag));
-                buf.extend(encode_uint(r.index as u64));
-                buf.extend(encode_plutus_data(&r.data));
-                buf.extend(encode_array_header(2));
-                buf.extend(encode_uint(r.ex_units.mem));
-                buf.extend(encode_uint(r.ex_units.steps));
-            }
-        }
+        // Single canonical redeemers encoder — map form in Conway/Dijkstra,
+        // list form pre-Conway. Shared with the script-data-hash preimage.
+        buf.extend(encode_redeemers(
+            &ws.redeemers,
+            matches!(era, Era::Conway | Era::Dijkstra),
+        ));
     }
 
     if !ws.plutus_v2_scripts.is_empty() {


### PR DESCRIPTION
Resolves three related items in the redeemers / script-integrity / witness-encoding area. #884 and #885 are the open follow-ups from #883; #887 was discovered while doing #884 and filed as a tracking issue. Byte-exact semantics confirmed against `IntersectMBO/cardano-ledger` via the cardano-ledger-oracle.

## #885 — PV12 hard-reject of list-encoded redeemers
`DecCBOR (Annotator RedeemersRaw)` (`Alonzo/TxWits.hs`) gates the legacy list encoding on decoder version ≥ 12:
```haskell
ifDecoderVersionAtLeast (natVersion @12)
  (fail "List encoding of redeemers not supported starting with PV 12")
  decodeListRedeemers
```
Decoder version == protocol major version, and PV12 is the Dijkstra hard fork (Conway = PV9/10/11), so `era == Dijkstra` is a byte-exact proxy. Threaded `era` through `decode_conway_witness_set → read_redeemers`; the list branch is rejected on token type (so empty `0x80` is refused too). Map form stays accepted at every era.

## #884 — CLI `compute_script_data_hash_offline` dedup + era-correct redeemers
The CLI had a hand-rolled preimage (always-array redeemers, hard-coded langviews, no code sharing → #883-class fixes didn't propagate).
- Extracted a single canonical `encode_redeemers(&[Redeemer], map_form)`, reused by the witness builder, the `script_data_hash` preimage, and the CLI. Empty slice → the era's empty container (`0xa0`/`0x80`) = the empty-redeemers sentinel.
- `compute_script_data_hash_offline` now delegates to `dugite_serialization::compute_script_data_hash`, sharing the witness-set's own redeemer/datum bytes so hash == wire witnesses.
- CLI redeemers now use Conway **map** form (era-correct + future-proof against #885).

## #887 — canonical witness datums/redeemers encoding
`encode_witness_set_for_era` emitted bare-array, insertion-order datums while `compute_script_data_hash` already emitted tag-258 — a latent self-mismatch for synthetic Conway txs. Centralized both terms in canonical primitives shared by the builder and the preimage:
- `encode_redeemers` → ascending `(tag, index)` (`Map.toAscList`).
- new `encode_datums` → sorted by `blake2b` datum hash + tag-258 from Conway on (`encodeWithSetTag . Map.elems`).

Safe for sync: `compute_script_data_hash` prefers `raw_*_cbor` (always populated when the term is present), so the re-encode branch is synthetic-only.

## Verification
- `cargo nextest run --workspace` → **7386 passed**, 0 failed
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

The `encode_redeemers` extraction is a pure refactor (byte-identical for already-ordered/empty inputs; all existing byte-exact tests unchanged). New tests pin PV12 rejection, canonical ordering, the tag-258 gate, and the witness==preimage invariant.

Closes #884
Closes #885
Closes #887