### PR TITLE
fix(ledger): refresh cert-derived Phase-1 registries per-tx within a block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/config/bp-pair/haskell-relay.config.json
+++ b/config/bp-pair/haskell-relay.config.json
@@ -3,7 +3,7 @@
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
   "ByronGenesisFile": "../preview/byron-genesis.json",
   "ByronGenesisHash": "83de1d7302569ad56cf9139a41e2e11346d4cb4a31c00142557b6ab3fa550761",
-  "ConsensusMode": "Praos",
+  "ConsensusMode": "PraosMode",
   "ConwayGenesisFile": "../preview/conway-genesis.json",
   "ConwayGenesisHash": "9cc5084f02e27210eacba47af0872e3dba8946ad9460b6072d793e1d2f3987ef",
   "ExperimentalHardForksEnabled": false,
@@ -38,7 +38,7 @@
       "backends": [
         "EKGBackend",
         "Forwarder",
-        "PrometheusSimple suffix 127.0.0.1 12796",
+        "PrometheusSimple suffix 127.0.0.1 12799",
         "Stdout HumanFormatColoured"
       ],
       "detail": "DNormal",

--- a/crates/dugite-ledger/Cargo.toml
+++ b/crates/dugite-ledger/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { workspace = true }
 proptest = { workspace = true }
 criterion = { workspace = true }
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [[bench]]
 name = "ledger_bench"

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -835,12 +835,12 @@ impl LedgerState {
         // hoist + Arc share collapses that to micro-seconds per block.
         #[allow(clippy::type_complexity)]
         let (
-            block_registered_pool_ids,
-            block_registered_drep_ids,
-            block_registered_vrf_keys,
+            mut block_registered_pool_ids,
+            mut block_registered_drep_ids,
+            mut block_registered_vrf_keys,
             block_committee_member_keys,
-            block_committee_resigned_keys,
-            block_vote_delegation_keys,
+            mut block_committee_resigned_keys,
+            mut block_vote_delegation_keys,
             // `block_active_proposals` is `mut` so we can update it after each
             // proposal-containing tx.  Haskell's `LEDGER` rule processes txs
             // sequentially with updating state, so a vote in tx[j] on a proposal
@@ -849,8 +849,8 @@ impl LedgerState {
             // Without this update dugite logs spurious `GovActionsDoNotExist`
             // warnings for cross-tx same-block proposal+vote patterns.
             mut block_active_proposals,
-            block_committee_authorized_hot_keys,
-            block_committee_authorized_elected_hot_keys,
+            mut block_committee_authorized_hot_keys,
+            mut block_committee_authorized_elected_hot_keys,
             // Retained for registry-builder signature compatibility; the
             // per-tx ValidationContext now clones the LIVE deposits map
             // (sequential LEDGERS semantics — see the reward-accounts note).
@@ -1659,6 +1659,74 @@ impl LedgerState {
                         }
                     }
                     block_active_proposals = std::sync::Arc::new(updated_proposals);
+                }
+
+                // ── Step 8b-post: refresh cert-derived validation registries ──
+                //
+                // After a cert-containing tx applies (Step 8b inserts/removes
+                // into the live pool / DRep / committee / vote-delegation maps),
+                // a later tx in the SAME block that acts on those changes must
+                // see them: Haskell's LEDGERS rule folds LEDGER over the block's
+                // txs sequentially, threading CertState (Shelley `Ledgers.hs`
+                // `foldM`), so Conway GOVCERT `UnRegDRep` reads the *mutated*
+                // `vsDReps` — a same-block RegDRep→UnRegDRep succeeds and a
+                // same-block double-RegDRep is rejected. A pre-block snapshot
+                // gets both wrong (observed: spurious `DRepNotRegistered` on
+                // preview block 4456609 — a RegDRep then UnRegDRep of the same
+                // credential one tx apart). Mirror the `reward_accounts` /
+                // `block_active_proposals` sequential refresh for every
+                // cert-mutated registry. Guarded on cert presence so the common
+                // (payment) tx keeps the O(1) pre-block-snapshot fast path.
+                // `block_committee_member_keys` is intentionally excluded — it
+                // changes via governance ratification / `UpdateCommittee`
+                // proposals, not certificates.
+                if mode == BlockValidationMode::ValidateAll && !tx.body.certificates.is_empty() {
+                    block_registered_pool_ids =
+                        std::sync::Arc::new(self.certs.pool_params.keys().copied().collect());
+                    block_registered_vrf_keys = std::sync::Arc::new(
+                        self.certs
+                            .pool_params
+                            .values()
+                            .map(|reg| (reg.vrf_keyhash, reg.pool_id))
+                            .collect(),
+                    );
+                    block_registered_drep_ids =
+                        std::sync::Arc::new(self.gov.governance.dreps.keys().copied().collect());
+                    block_vote_delegation_keys = std::sync::Arc::new(
+                        self.gov
+                            .governance
+                            .vote_delegations
+                            .keys()
+                            .copied()
+                            .collect(),
+                    );
+                    block_committee_resigned_keys = std::sync::Arc::new(
+                        self.gov
+                            .governance
+                            .committee_resigned
+                            .keys()
+                            .copied()
+                            .collect(),
+                    );
+                    block_committee_authorized_hot_keys = std::sync::Arc::new(
+                        self.gov
+                            .governance
+                            .committee_hot_keys
+                            .values()
+                            .copied()
+                            .collect(),
+                    );
+                    block_committee_authorized_elected_hot_keys = std::sync::Arc::new(
+                        self.gov
+                            .governance
+                            .committee_hot_keys
+                            .iter()
+                            .filter(|(cold, _)| {
+                                self.gov.governance.committee_expiration.contains_key(*cold)
+                            })
+                            .map(|(_, hot)| *hot)
+                            .collect(),
+                    );
                 }
 
                 // ── Step 8c: Pre-Conway PP update proposals ───────────────
@@ -2998,6 +3066,124 @@ mod tests {
         assert!(
             reward_accounts.contains_key(&key2),
             "cred2 must be registered in reward_accounts"
+        );
+    }
+
+    // ── Test 15b: same-block DRep register→deregister (intra-block registry
+    //    staleness regression, issue #13 / preview block 4456609) ────────────
+    //
+    // A `RegDRep` in tx[i] followed by an `UnregDRep` of the SAME credential in
+    // tx[j] (j>i) of the SAME block must NOT be reported `DRepNotRegistered`.
+    // Haskell's LEDGERS rule threads CertState sequentially (Shelley
+    // `Ledgers.hs` `foldM`; Conway `GovCert.hs` `UnRegDRep` reads the mutated
+    // `vsDReps`), so the registration is visible to the later tx. Before the
+    // Step-8b-post registry refresh in `apply_block`, dugite validated tx[j]
+    // against a stale pre-block DRep snapshot and logged a spurious Phase-1
+    // divergence (`DRep unregistration rejected: ... is not registered`).
+    //
+    // The block is applied in `ValidateAll` (the only mode that builds the
+    // per-block registry snapshot). We capture WARN-level tracing output and
+    // assert the DRep-not-registered divergence is absent. Value is fully
+    // conserved so the only difference between the buggy and fixed code is the
+    // DRep check — verified to FAIL before the fix and PASS after.
+    #[test]
+    fn test_same_block_drep_register_then_deregister_no_spurious_divergence() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl Write for BufWriter {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(BufWriter(Arc::clone(&buf)))
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let mut params = ProtocolParameters::mainnet_defaults();
+            params.protocol_version_major = 9;
+            let deposit = params.drep_deposit.0;
+            let mut state = LedgerState::new(params);
+            state.era = Era::Conway;
+
+            let drep_cred = Credential::VerificationKey(Hash28::from_bytes([0x7Du8; 28]));
+
+            // Seed the UTxO tx1 spends.
+            let in0 = TransactionInput {
+                transaction_id: Hash32::from_bytes([0xC0u8; 32]),
+                index: 0,
+            };
+            seed_utxo(&mut state, in0.clone(), make_output(2_000_000_000));
+
+            // tx1: spend in0 (2 ADA·10³), register the DRep (500 ADA deposit),
+            // output the change. Value is conserved: in = out + fee + deposit.
+            let mut tx1 = make_simple_tx(
+                0xD1,
+                vec![in0],
+                vec![make_output(2_000_000_000 - deposit - 1_000_000)],
+                1_000_000,
+            );
+            tx1.body.certificates = vec![Certificate::RegDRep {
+                credential: drep_cred.clone(),
+                deposit: Lovelace(deposit),
+                anchor: None,
+            }];
+
+            // tx2: spend tx1's change, deregister the SAME DRep (matching
+            // refund), output. Value conserved: in + refund = out + fee.
+            let tx1_out = TransactionInput {
+                transaction_id: tx1.hash,
+                index: 0,
+            };
+            let mut tx2 = make_simple_tx(
+                0xD2,
+                vec![tx1_out],
+                vec![make_output(2_000_000_000 - 2_000_000)],
+                1_000_000,
+            );
+            tx2.body.certificates = vec![Certificate::UnregDRep {
+                credential: drep_cred.clone(),
+                refund: Lovelace(deposit),
+            }];
+
+            let block = make_test_block(Era::Conway, 1_000, 1, 9, 0, vec![tx1, tx2]);
+            // Best-effort apply — must not panic; divergence handling is
+            // warn-and-continue, so a spurious rejection surfaces only in logs.
+            let _ = state.apply_block(&block, BlockValidationMode::ValidateAll);
+
+            // The DRep must end up correctly deregistered regardless.
+            assert!(
+                !state
+                    .gov
+                    .governance
+                    .dreps
+                    .contains_key(&drep_cred.to_typed_hash32()),
+                "DRep must be deregistered after the same-block reg→unreg pair"
+            );
+        });
+
+        let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            !logs.contains("DRepNotRegistered") && !logs.contains("is not registered"),
+            "same-block RegDRep→UnregDRep must not produce a spurious DRep-not-registered \
+             Phase-1 divergence; captured WARN logs:\n{logs}"
         );
     }
 

--- a/crates/dugite-ledger/src/state/certificates.rs
+++ b/crates/dugite-ledger/src/state/certificates.rs
@@ -217,22 +217,9 @@ impl LedgerState {
             self.certs.pointer_map.insert(pointer, key);
         }
         // Also handle combined registration certificates
-        if let Certificate::RegStakeDeleg {
-            credential,
-            pool_hash: _,
-            ..
-        }
-        | Certificate::RegStakeVoteDeleg {
-            credential,
-            pool_hash: _,
-            drep: _,
-            ..
-        }
-        | Certificate::VoteRegDeleg {
-            credential,
-            drep: _,
-            ..
-        } = cert
+        if let Certificate::RegStakeDeleg { credential, .. }
+        | Certificate::RegStakeVoteDeleg { credential, .. }
+        | Certificate::VoteRegDeleg { credential, .. } = cert
         {
             let key = credential_to_hash(credential);
             let pointer = dugite_primitives::credentials::Pointer {

--- a/crates/dugite-ledger/src/validation/conway.rs
+++ b/crates/dugite-ledger/src/validation/conway.rs
@@ -737,7 +737,7 @@ pub(super) fn treasury_withdrawal_network_mismatches(
     };
     let expected = expected_net.to_u8();
     let mut out: Vec<(String, u8)> = Vec::new();
-    for (addr, _coin) in withdrawals.iter() {
+    for addr in withdrawals.keys() {
         // Empty address → skip (decoder-shape error, not this predicate's
         // concern; mirrors `is_proposal_return_addr_wrong_network`).
         let Some(&header) = addr.first() else {


### PR DESCRIPTION
## Summary
Fixes a Phase-1 validation staleness bug (a whole registry class) found during a preview block-producer Mithril catch-up, then validated on the local devnet.

Phase-1 validation fed every transaction a **pre-block `Arc<HashSet>` snapshot** of the DRep set and 5 sibling cert registries (pool-ids, vrf-keys, committee resigned / authorized-hot, vote-delegations). But Haskell's `LEDGERS` rule folds `LEDGER` over a block's txs **sequentially**, threading `CertState` (Shelley `Ledgers.hs` `foldM`), so a same-block `RegDRep`(tx *i*) → `UnRegDRep`(tx *j*, *j*>*i*) must succeed (Conway `GovCert.hs` `UnRegDRep` reads the *mutated* `vsDReps`).

The stale snapshot diverges **bidirectionally**:
- wrongly **rejects** same-block reg→unreg (`ConwayDRepNotRegistered`) — observed once on preview block `4456609`
- would wrongly **accept** same-block double-reg (misses `ConwayDRepAlreadyRegistered`)

Non-corrupting on confirmed blocks (Step 8b applies the real cert regardless → warn-and-trust), but a wrong Phase-1 verdict would reject/accept a valid/invalid tx at mempool admission.

## Fix
Mirrors the existing `block_active_proposals` / `reward_accounts` sequential refresh: rebuild the 7 cert-derived registries from live state after any cert-containing tx, guarded on `!tx.body.certificates.is_empty()` so payment txs keep the O(1) fast path. `committee_member_keys` is excluded (proposal/ratification-driven, not cert-driven).

## Verification
- **Haskell source**: confirmed vs `cardano-ledger-conway-1.22.1.0` — `Ledgers.hs:185-201` (`foldM`), `Ledger.hs:381-468`, `Certs.hs:247-251`, `GovCert.hs:213-244`, `Deleg.hs:223-229`.
- **Regression test** (`test_same_block_drep_register_then_deregister_no_spurious_divergence`): captures WARN logs, asserts no `DRepNotRegistered`. **Proven to fail without the fix** (reproduces the exact `7d7d…00000000` credential-form divergence) and pass with it.
- **1663/1663** ledger tests pass; fmt + workspace clippy `--all-targets -D warnings` clean.
- **Devnet re-validated** (3-node dugite ↔ cardano-node 11.0.1): tx-zoo 80/0, tip-parity 100%, **0 DRep divergence, 0 invalid blocks**, Haskell adopts every dugite block.

## Also included (devnet bp-pair rig config)
- `ConsensusMode "Praos" → "PraosMode"` (cardano-node 11.0.1 rejects the old spelling; relay wouldn't start).
- Relay PrometheusSimple exporter `127.0.0.1:12796 → 12799` — it collided with the dugite BP metrics port, shadowing it on loopback so `dugite-monitor`'s discovery probe hit cardano-node and dropped the BP from the attach list.