### PR TITLE
fix(consensus): KES forge-loop enforces genesis maxKESEvolutions (#1054) + hardfork/kes round harness fixes

### DIFF
--- a/crates/dugite-node/src/forge.rs
+++ b/crates/dugite-node/src/forge.rs
@@ -230,6 +230,19 @@ pub struct BlockProducerConfig {
     pub era: Era,
     /// Slots per KES period (from genesis config)
     pub slots_per_kes_period: u64,
+    /// Maximum number of KES key evolutions permitted for one operational
+    /// certificate (genesis `maxKESEvolutions`), i.e. the policy bound
+    /// `[opcert_kes_period, opcert_kes_period + max_kes_evolutions)`.
+    ///
+    /// This is a GENESIS-SOURCED policy value, not the Sum6Kes structural
+    /// depth (`dugite_crypto::kes` supports exactly 62 evolutions regardless
+    /// of genesis — see `dugite-crypto/src/kes.rs`). Real networks can and do
+    /// configure a smaller policy bound than the structural ceiling (e.g. a
+    /// short-KES devnet overlay with `maxKESEvolutions=10`), and this field
+    /// must reflect whatever the chain's genesis actually declares so the
+    /// forge-side bound matches `dugite_consensus::praos::validate_kes_period`
+    /// exactly (issue #1054).
+    pub max_kes_evolutions: u64,
 }
 
 impl Default for BlockProducerConfig {
@@ -247,6 +260,12 @@ impl Default for BlockProducerConfig {
             _max_txs_per_block: 500,
             era: Era::Conway,
             slots_per_kes_period: 129600,
+            // Matches the checked-in devnet genesis default AND the Sum6Kes
+            // structural ceiling, so tests/defaults that don't care about a
+            // custom policy bound keep working unchanged. Production forging
+            // always overrides this from `self.consensus.max_kes_evolutions`
+            // (genesis-sourced) — see `node/mod.rs`.
+            max_kes_evolutions: 62,
         }
     }
 }
@@ -337,18 +356,21 @@ pub fn forge_block(
     let current_slot_kes_period = slot.0 / config.slots_per_kes_period;
     let kes_period_offset = current_slot_kes_period.saturating_sub(creds.opcert_kes_period);
 
-    // Validate KES period offset is within bounds (Sum6Kes supports 62 evolutions)
-    const MAX_KES_EVOLUTIONS: u64 = 62;
-    // Sum6Kes supports periods 0..=61 (62 evolutions). Period 62 is expired.
-    // Using >= to match consensus validation at praos.rs which also uses >=.
-    if kes_period_offset >= MAX_KES_EVOLUTIONS {
+    // Validate KES period offset is within the genesis-configured policy bound
+    // (`config.max_kes_evolutions`), NOT the Sum6Kes structural ceiling of 62.
+    // Using >= to match consensus validation at praos.rs
+    // (`validate_kes_period`), which also uses >= against the same
+    // genesis-sourced `max_kes_evolutions` — the forge side and the receive
+    // side must reject at the identical boundary or a block forged here could
+    // be one dugite (and Haskell) would reject (issue #1054).
+    if kes_period_offset >= config.max_kes_evolutions {
         anyhow::bail!(
             "KES key expired: current period {} - opcert period {} = offset {} > max {}. \
              Rotate your KES key and issue a new operational certificate.",
             current_slot_kes_period,
             creds.opcert_kes_period,
             kes_period_offset,
-            MAX_KES_EVOLUTIONS
+            config.max_kes_evolutions
         );
     }
 
@@ -1012,6 +1034,122 @@ mod tests {
             result.is_ok(),
             "forge_block must succeed with a 608-byte (cardano-cli) KES key file: {:?}",
             result.err()
+        );
+    }
+
+    // ─── Issue #1054: forge-side KES bound must be genesis-configured ────────
+    //
+    // forge_block() previously bounded the KES period offset against a
+    // hardcoded `MAX_KES_EVOLUTIONS: u64 = 62` (the Sum6Kes STRUCTURAL
+    // ceiling), instead of `config.max_kes_evolutions` (the GENESIS policy
+    // bound). Under any genesis with `maxKESEvolutions < 62` — e.g. a
+    // short-KES devnet overlay with `maxKESEvolutions=10` — the forge path
+    // would keep signing blocks for 52 periods past the point cardano-node
+    // poisons its KES key and stops forging entirely.
+
+    /// forge_block must reject once the offset reaches the CONFIGURED
+    /// `max_kes_evolutions` (10), even though that offset (15) is
+    /// comfortably below the old hardcoded structural ceiling of 62 — i.e.
+    /// it must no longer "wait for 62".
+    #[test]
+    fn test_forge_block_rejects_past_configured_max_not_structural_62() {
+        let creds = make_test_credentials(); // opcert_kes_period = 0
+        let config = BlockProducerConfig {
+            slots_per_kes_period: 100,
+            max_kes_evolutions: 10,
+            ..BlockProducerConfig::default()
+        };
+        let epoch_nonce = Hash32::from_bytes([0x07u8; 32]);
+
+        // current_slot_kes_period = 1500 / 100 = 15: >= configured max (10)
+        // and < the structural ceiling (62).
+        let result = forge_block(
+            &creds,
+            &config,
+            SlotNo(1500),
+            BlockNo(1),
+            Hash32::ZERO,
+            &epoch_nonce,
+            vec![],
+        );
+        assert!(
+            result.is_err(),
+            "forge_block must bail at offset 15 once max_kes_evolutions=10 is \
+             configured, even though 15 < the Sum6Kes structural ceiling of 62"
+        );
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("KES key expired"),
+            "error must be the KES-expired diagnostic (got: {err})"
+        );
+        assert!(
+            err.contains("max 10"),
+            "error must report the ACTUAL configured limit (10), not the old \
+             hardcoded 62 (got: {err})"
+        );
+    }
+
+    /// Boundary: offset == max-1 must still be forgeable; offset == max must
+    /// bail. Same `>=` comparison as
+    /// `dugite_consensus::praos::validate_kes_period` — the forge side and
+    /// the receive side must reject at the identical boundary.
+    #[test]
+    fn test_forge_block_kes_evolution_boundary_at_configured_max() {
+        let creds = make_test_credentials(); // opcert_kes_period = 0
+        let config = BlockProducerConfig {
+            slots_per_kes_period: 100,
+            max_kes_evolutions: 10,
+            ..BlockProducerConfig::default()
+        };
+        let epoch_nonce = Hash32::from_bytes([0x09u8; 32]);
+
+        // offset = 9 (== max - 1) — must succeed.
+        let ok_result = forge_block(
+            &creds,
+            &config,
+            SlotNo(900),
+            BlockNo(1),
+            Hash32::ZERO,
+            &epoch_nonce,
+            vec![],
+        );
+        assert!(
+            ok_result.is_ok(),
+            "offset 9 (max_kes_evolutions - 1) must still be forgeable: {:?}",
+            ok_result.err()
+        );
+
+        // offset = 10 (== max) — must bail.
+        let bail_result = forge_block(
+            &creds,
+            &config,
+            SlotNo(1000),
+            BlockNo(2),
+            Hash32::ZERO,
+            &epoch_nonce,
+            vec![],
+        );
+        assert!(
+            bail_result.is_err(),
+            "offset 10 (== max_kes_evolutions) must be rejected as KES-expired"
+        );
+        let err = bail_result.err().unwrap().to_string();
+        assert!(
+            err.contains("KES key expired"),
+            "error must be the KES-expired diagnostic (got: {err})"
+        );
+    }
+
+    /// `BlockProducerConfig::default()` must keep `max_kes_evolutions = 62`
+    /// so callers that don't care about a custom genesis policy bound (most
+    /// existing tests) are unaffected by this field's addition.
+    #[test]
+    fn test_default_block_producer_config_max_kes_evolutions_is_62() {
+        let config = BlockProducerConfig::default();
+        assert_eq!(
+            config.max_kes_evolutions, 62,
+            "default max_kes_evolutions must match the checked-in devnet \
+             genesis default and the Sum6Kes structural ceiling"
         );
     }
 }

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -9842,6 +9842,39 @@ impl Node {
             return;
         }
 
+        // ── Step 5c: TraceNodeCannotForge (KES key expired) ───────────────────
+        // Upper-bound mirror of the 5b gate above (issue #1054). Haskell's
+        // `HotKey.evolveKey` classifies the target period against
+        // `[c0, c0 + maxKESEvolutions)`; once the wall clock moves past the
+        // end of that window it POISONS the key (`forgetSignKeyKES`) and
+        // every subsequent `checkShouldForge` call short-circuits
+        // `KESKeyAlreadyPoisoned` — zero further blocks, permanently, without
+        // even attempting VRF leader election. Checking here — before the VRF
+        // leader check and before calling `forge_block` — matches that: a
+        // wedged forger fails fast every slot instead of only when a VRF-won
+        // slot happens to reach `forge_block`'s own bounds check.
+        //
+        // `self.consensus.max_kes_evolutions` is the SAME genesis-sourced
+        // value threaded into `BlockProducerConfig::max_kes_evolutions` below
+        // and used by `dugite_consensus::praos::validate_kes_period` on the
+        // receiving side — same bound, same `>=` comparison, so a block
+        // dugite forges is exactly one dugite (and Haskell) would accept.
+        let kes_evolutions = current_slot_kes_period.saturating_sub(creds.opcert_kes_period);
+        if kes_evolutions >= self.consensus.max_kes_evolutions {
+            warn!(
+                target: "forge",
+                current_slot,
+                wall_clock_kes_period = current_slot_kes_period,
+                opcert_kes_period = creds.opcert_kes_period,
+                kes_evolutions,
+                max_kes_evolutions = self.consensus.max_kes_evolutions,
+                pool_id = %creds.pool_id,
+                "TraceNodeCannotForge: KES key expired — cannot forge until the KES key is \
+                 rotated and a new operational certificate is issued",
+            );
+            return;
+        }
+
         // ── Extract ledger values needed for the forge attempt ────────────────
         // Use epoch_nonce_for_slot to handle first slot of new epoch correctly.
         // At epoch boundaries, the TICKN transition hasn't been applied yet, so
@@ -10010,6 +10043,11 @@ impl Node {
             _max_txs_per_block: 500,
             era: current_era,
             slots_per_kes_period,
+            // Genesis-sourced policy bound (issue #1054) — must match the
+            // exact value `dugite_consensus::praos::validate_kes_period` uses
+            // on the receiving side, so forge-side rejects at the same
+            // boundary a peer (dugite or Haskell) would.
+            max_kes_evolutions: self.consensus.max_kes_evolutions,
         };
 
         // ── Step 9: Block.forgeBlock — TraceForgedBlock ───────────────────────
@@ -11493,6 +11531,54 @@ mod tests {
         assert!(
             wall_clock_kes_period >= opcert_kes_period,
             "TraceNodeCannotForge gate must NOT fire when wall-clock period > opcert start"
+        );
+    }
+
+    /// CannotForge upper-bound gate (issue #1054): forge must be skipped once
+    /// the KES key has evolved past the GENESIS-configured `max_kes_evolutions`
+    /// policy bound, not the Sum6Kes structural ceiling of 62. Mirrors
+    /// `forge_gate_cannot_forge_key_not_usable_yet` above but for the upper
+    /// edge of the `[opcert_kes_period, opcert_kes_period + max_kes_evolutions)`
+    /// window, and matches the SAME `>=` comparison as
+    /// `dugite_consensus::praos::validate_kes_period` on the receiving side.
+    #[test]
+    fn forge_gate_kes_expired_uses_configured_max_not_structural_ceiling() {
+        let slots_per_kes_period: u64 = 120; // short-KES devnet overlay value
+        let max_kes_evolutions: u64 = 10; // genesis-configured, NOT 62
+        let opcert_kes_period: u64 = 0;
+
+        // offset 9 (< max 10, well under the 62 structural ceiling too):
+        // gate must NOT fire.
+        let current_slot: u64 = 9 * slots_per_kes_period;
+        let wall_clock_kes_period = current_slot / slots_per_kes_period;
+        let kes_evolutions = wall_clock_kes_period.saturating_sub(opcert_kes_period);
+        assert!(
+            kes_evolutions < max_kes_evolutions,
+            "gate must NOT fire below the configured max"
+        );
+
+        // offset 10 (== configured max 10, but still well under the
+        // structural ceiling of 62 — the regression this issue fixes: the
+        // OLD hardcoded-62 bound would have let this slot through):
+        // gate MUST fire.
+        let current_slot: u64 = 10 * slots_per_kes_period;
+        let wall_clock_kes_period = current_slot / slots_per_kes_period;
+        let kes_evolutions = wall_clock_kes_period.saturating_sub(opcert_kes_period);
+        assert!(
+            kes_evolutions >= max_kes_evolutions,
+            "gate must fire at offset == configured max (10), not wait for 62"
+        );
+
+        // offset 15 (comfortably between the configured max and the
+        // structural ceiling): gate MUST fire. This is exactly the #1054
+        // symptom — dugite-bp forged 40 blocks in this window before the fix.
+        let current_slot: u64 = 15 * slots_per_kes_period;
+        let wall_clock_kes_period = current_slot / slots_per_kes_period;
+        let kes_evolutions = wall_clock_kes_period.saturating_sub(opcert_kes_period);
+        assert!(
+            kes_evolutions >= max_kes_evolutions && kes_evolutions < 62,
+            "gate must fire between the configured max and the structural \
+             ceiling — this is the exact window #1054 leaked blocks through"
         );
     }
 

--- a/testnet/local-devnet/hardfork-round.sh
+++ b/testnet/local-devnet/hardfork-round.sh
@@ -605,13 +605,25 @@ step "5. re-run 16e post-HF — expect the PV11 constructor"
 run_16e "5-16e-post-hf" 11 "$EVID/16e-post-hf.csv"
 
 # ─────────────────────────────────────────────────────────────────────────
-step "6. post-HF zoo smoke (01-bookkeeping, 08-negative, 16-cert-negatives) — both sockets"
+step "6. post-HF zoo smoke (01-bookkeeping, 08-negative, 16-cert-negatives)"
 # ─────────────────────────────────────────────────────────────────────────
 # 18-plutus-edges is deliberately excluded: 18f's BabbageNonDisjointRefInputs
 # constructor arm INVERTS at PV11 (pre-flight finding 3) and would need its
 # own expectation flip before it belongs in a post-HF smoke.
-run_zoo_smoke "6-zoo-smoke-relay"   "$LD_RELAY_SOCK"      "$EVID/zoo-smoke-relay.csv"
-run_zoo_smoke "6-zoo-smoke-haskell" "$LD_CARDANO_BP_SOCK" "$EVID/zoo-smoke-haskell.csv"
+#
+# ONE run, against the relay (dugite) socket. An earlier revision ran the
+# same scripts a SECOND time against the cardano-bp socket for "both-socket
+# parity", but both runs draw from the same funder wallet — the first run's
+# positives (01i/01j fan-out, 08t's accept arm) consume it, so the second run
+# failed with fanout-not-included / submit / drained-wallet cascades (5 false
+# FAILs), NOT a PV11 divergence. Cross-node parity is already covered without
+# a second submit: every positive script calls zoo_wait_all_observers, which
+# fails unless the tx reaches BOTH dugite-bp AND cardano-bp with the same
+# verdict, and the bidirectional-parity round (1p) runs these exact
+# categories through both sockets with disjoint per-batch wallets. So the
+# post-HF smoke asserts dugite accepts/rejects correctly at PV11; it does not
+# re-submit the identical bytes to a second socket on a shared wallet.
+run_zoo_smoke "6-zoo-smoke" "$LD_RELAY_SOCK" "$EVID/zoo-smoke.csv"
 
 # ─────────────────────────────────────────────────────────────────────────
 step "SUMMARY"

--- a/testnet/local-devnet/hardfork-round.sh
+++ b/testnet/local-devnet/hardfork-round.sh
@@ -50,25 +50,22 @@
 # shipping PV11 support: treat any FAIL from step 4 (the PV flip assertion)
 # as blocking, not as a harness flake.
 #
-# CONFIG INJECTION — RENDERED CONFIGS, NOT TEMPLATES
+# NO CONFIG INJECTION — PV11 IS NATIVE ON cardano-node 11.0.1
 # ----------------------------------------------------
-# config/templates/cardano-bp.config.tmpl.json and
-# config/templates/cardano-arbiter.config.tmpl.json both ship with
-# "ExperimentalHardForksEnabled": false. This round does NOT edit those
-# templates (every other round renders from them and must keep getting
-# false-by-default). Instead, after ./setup.sh has rendered them to
-# $LD_CONFIG/cardano-bp.config.json (and cardano-arbiter.config.json, which
-# setup.sh always renders even though only two-forger mode starts that
-# node), this round flips the flag to `true` in the RENDERED copies with
-# `jq`, in place, before ./run.sh reads them.
+# PRE-FLIGHT RESOLVED (issue #1042 step 2): PV10->PV11 is an INTRA-Conway
+# HardForkInitiation (PV11 is still the Conway era), which cardano-node 11.0.1
+# enacts natively — preview mainnet has run PV11 on 11.0.1 since before this
+# round was written.
 #
-# Belt-and-braces note: preview mainnet has been running PV11 on
-# cardano-node 11.0.1 since before this issue was filed, and 11.0.1
-# arguably does not gate a same-major-line hard fork behind this flag at
-# all in the way older testnet-only forks did. This round sets it anyway
-# — it costs nothing, and if a future cardano-node release DOES gate PV11
-# behind it, this round silently keeps working instead of silently NO-OP
-# ratifying nothing.
+# An earlier revision of this round flipped ExperimentalHardForksEnabled to
+# `true` in the rendered cardano configs as "belt-and-braces". That is WRONG on
+# 11.0.1 and was caught on the first live run: enabling experimental hard forks
+# makes cardano-node require a DijkstraGenesisFile (the NEXT, experimental era
+# after Conway) and refuse to start with `key "DijkstraGenesisFile" not found`.
+# The flag gates the *next* era, not an intra-Conway PV bump. So this round now
+# leaves the rendered configs at their template default
+# (ExperimentalHardForksEnabled=false) — the exact config every other round
+# starts cardano-bp with.
 #
 # WHAT THIS ROUND REUSES, AND FROM WHERE
 # ---------------------------------------
@@ -130,7 +127,7 @@ bad()  { printf '\033[0;31m[FAIL]\033[0m %s: %s\n' "$1" "${*:2}"; record "$1" FA
 note() { printf '\033[0;33m[NOTE]\033[0m %s: %s\n' "$1" "${*:2}"; record "$1" NOTE "${*:2}"; }
 
 # ─────────────────────────────────────────────────────────────────────────
-step "0. fresh devnet + inject ExperimentalHardForksEnabled=true"
+step "0. fresh devnet (no config injection — PV11 HFI is native on cardano-node 11.0.1)"
 # ─────────────────────────────────────────────────────────────────────────
 if [ "$SKIP_SETUP" -eq 0 ]; then
     ./stop.sh  >/dev/null 2>&1
@@ -146,19 +143,17 @@ CSV="$EVID/hardfork-round.csv"
 echo "ts,step,outcome,detail" > "$CSV"
 
 if [ "$SKIP_SETUP" -eq 0 ]; then
-    note "0-inject-flag" "preview mainnet is already PV11 on cardano-node 11.0.1 — this injection is belt-and-braces, see header"
-    INJECT_OK=1
-    for f in "$LD_CONFIG/cardano-bp.config.json" "$LD_CONFIG/cardano-arbiter.config.json"; do
-        [ -f "$f" ] || continue
-        TMP=$(mktemp)
-        if jq '.ExperimentalHardForksEnabled = true' "$f" > "$TMP" && mv "$TMP" "$f"; then
-            note "0-inject-flag" "$f: ExperimentalHardForksEnabled -> true"
-        else
-            bad "0-inject-flag" "jq injection failed for $f"
-            INJECT_OK=0
-        fi
-    done
-    [ "$INJECT_OK" -eq 1 ] && ok "0-inject-flag" "rendered configs patched before ./run.sh"
+    # PRE-FLIGHT RESOLVED (issue #1042 step 2): PV10->PV11 is an INTRA-Conway
+    # HardForkInitiation — PV11 is still the Conway era, not a new one — and
+    # cardano-node 11.0.1 enacts it NATIVELY (preview mainnet has run PV11 on
+    # 11.0.1 since before this round was written). ExperimentalHardForksEnabled
+    # is NOT needed and is actively HARMFUL on 11.0.1: setting it true makes
+    # cardano-node require a DijkstraGenesisFile (the NEXT, experimental era)
+    # and refuse to start ("key DijkstraGenesisFile not found"). So the round
+    # leaves the rendered configs at their template default (flag=false) — the
+    # same config every other round starts cardano-bp with.
+    note "0-inject-flag" "no config injection — PV11 HFI is intra-Conway and native on cardano-node 11.0.1 (ExperimentalHardForksEnabled would pull in the Dijkstra era and break startup)"
+    ok "0-inject-flag" "rendered configs left at template default (ExperimentalHardForksEnabled=false)"
 
     ./run.sh >/dev/null 2>&1 || { bad "0-run" "RUN FAILED"; exit 2; }
 fi
@@ -377,8 +372,16 @@ classify_sampler() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────
-step "1. assert current PV=10 on both sockets; run 16e pre-HF"
+step "1. zoo setup, then assert PV=10 on both sockets + run 16e pre-HF"
 # ─────────────────────────────────────────────────────────────────────────
+# The zoo --setup (keys + on-chain funding for wallet-a) MUST run before the
+# pre-HF 16e: 16e builds a stake-registration tx from wallet-a, so without
+# funding it fails at build time (`build-failed`) rather than reaching the
+# IncorrectDepositDELEG constructor it asserts. An earlier revision ran the
+# setup in step 2, after this 16e call — caught on the first live run.
+if [ "$SKIP_SETUP" -eq 0 ]; then
+    ./tx-zoo/run-all.sh --setup >/dev/null 2>&1
+fi
 PVD=$(pv_major "$LD_RELAY_SOCK")
 PVH=$(pv_major "$LD_CARDANO_BP_SOCK")
 echo "  protocolVersion.major: dugite(relay)=$PVD haskell(cardano-bp)=$PVH"
@@ -394,10 +397,9 @@ fi
 run_16e "1-16e-pre-hf" 10 "$EVID/16e-pre-hf.csv"
 
 # ─────────────────────────────────────────────────────────────────────────
-step "2. zoo setup + DRep power + propose/vote HardForkInitiation PV11"
+step "2. DRep power + propose/vote HardForkInitiation PV11"
 # ─────────────────────────────────────────────────────────────────────────
 if [ "$SKIP_SETUP" -eq 0 ]; then
-    ./tx-zoo/run-all.sh --setup >/dev/null 2>&1
     ZOO_SOCKET="$LD_RELAY_SOCK" bash ./tx-zoo/04-stake/04a-stake-register.sh 2>&1 | tail -2
     ZOO_SOCKET="$LD_RELAY_SOCK" bash ./tx-zoo/05-governance-certs/05a-drep-register.sh 2>&1 | tail -1
     ZOO_SOCKET="$LD_RELAY_SOCK" bash ./tx-zoo/05-governance-certs/05g-cc-hot-key-authorization.sh 2>&1 | tail -1

--- a/testnet/local-devnet/kes-round.sh
+++ b/testnet/local-devnet/kes-round.sh
@@ -359,13 +359,17 @@ else
     bad "cardano-bp forged 0 blocks in the same window — cannot distinguish KES-expiry from a stalled devnet"
 fi
 
-# Pinned diagnostic: crates/dugite-node/src/forge.rs:344-351 bails with this
-# exact text once kes_period_offset >= MAX_KES_EVOLUTIONS; the Err(e) is
-# logged at ERROR by crates/dugite-node/src/node/mod.rs (the
-# "TraceForgeStateUpdateError: block forging failed: {e}" wrapper around the
-# forge_block() match, ~line 10560). Only reachable when dugite-bp is VRF-
-# elected leader for a slot after expiry — see the risk note in the header.
-KES_EXPIRED_PATTERN='TraceForgeStateUpdateError: block forging failed: KES key expired'
+# Pinned diagnostic. After the #1054 fix, the per-slot upper-bound gate in
+# try_forge_block_at fires BEFORE the VRF leader check and skips forging once
+# expired (matching Haskell's HotKey poison-once-then-short-circuit), logging
+# `TraceNodeCannotForge: KES key expired` at WARN. That gate short-circuits
+# before forge_block is ever called, so the OLDER
+# `TraceForgeStateUpdateError: block forging failed: KES key expired` wrapper
+# (forge.rs bail -> node/mod.rs Err(e), only reachable when dugite-bp was
+# VRF-elected leader at/after expiry) no longer fires. Match EITHER form so
+# the assertion holds both before and after the fix: the anchored phrase
+# `KES key expired` appears in both.
+KES_EXPIRED_PATTERN='KES key expired'
 if expect_log_errors "$LD_LOGS/dugite-bp.log" "$MARK_DBP" "$KES_EXPIRED_PATTERN"; then
     ok "dugite-bp.log carries the KES-expiry diagnostic"
 else
@@ -521,13 +525,20 @@ else
 fi
 
 note "kes-period-info parity across both sockets (cardano-cli against both, per the 09-cli-parity convention — this measures the NODE, not the CLI)"
+# `query kes-period-info` prints a HUMAN-READABLE report to stdout; JSON is
+# only emitted via --out-file. Piping stdout to jq yielded empty on BOTH
+# sockets (including the unmodified Haskell arbiter) — a harness bug, not a
+# dugite gap. Write to a file and read that.
 KPI_FILTER='del(.qKesRemainingSlotsInKesPeriod)'
-KPI_DBP=$(cardano-cli conway query kes-period-info --testnet-magic "$LD_MAGIC" \
-    --socket-path "$LD_RELAY_SOCK" --op-cert-file "$LD_KEYS/pool1/opcert.cert" 2>/dev/null \
-    | jq -S "$KPI_FILTER" 2>/dev/null)
-KPI_ARB=$(cardano-cli conway query kes-period-info --testnet-magic "$LD_MAGIC" \
-    --socket-path "$LD_CARDANO_ARBITER_SOCK" --op-cert-file "$LD_KEYS/pool1/opcert.cert" 2>/dev/null \
-    | jq -S "$KPI_FILTER" 2>/dev/null)
+_kpi() { # _kpi <socket>
+    local out; out="$WORK/kpi-$(basename "$1").json"
+    cardano-cli conway query kes-period-info --testnet-magic "$LD_MAGIC" \
+        --socket-path "$1" --op-cert-file "$LD_KEYS/pool1/opcert.cert" \
+        --out-file "$out" >/dev/null 2>&1
+    [ -s "$out" ] && jq -S "$KPI_FILTER" "$out" 2>/dev/null
+}
+KPI_DBP=$(_kpi "$LD_RELAY_SOCK")
+KPI_ARB=$(_kpi "$LD_CARDANO_ARBITER_SOCK")
 if [ -n "$KPI_DBP" ] && [ -n "$KPI_ARB" ] && [ "$KPI_DBP" = "$KPI_ARB" ]; then
     ok "kes-period-info parity: dugite (via relay) matches the Haskell arbiter"
 elif [ -z "$KPI_DBP" ] || [ -z "$KPI_ARB" ]; then


### PR DESCRIPTION
Follow-up to #1052 (the #1031 e2e-coverage adoption). During live validation of the new devnet rounds, the KES round (#1037) caught a real consensus-behavioral defect, and two rounds needed harness corrections found only by running them.

## Product fix
- **#1054** — `fix(consensus)`: dugite-bp's forge loop hardcoded `MAX_KES_EVOLUTIONS=62` (the Sum6Kes structural depth) as the *policy* bound, so with any real genesis `maxKESEvolutions` it forged blocks past KES expiry — blocks cardano-node rejects at ChainSync header validation (`KESAfterEndOCERT`). `BlockProducerConfig` now carries the genesis-sourced `max_kes_evolutions`; `forge_block`'s check reads it, and a new per-slot upper-bound gate in `try_forge_block_at` mirrors the working lower-bound gate (fires before the leader check, matching Haskell's HotKey poison-then-skip). Forge-side and the receive-side `praos.rs::validate_kes_period` now use the identical genesis bound + `>=` comparison. Oracle-verified against ouroboros-consensus f06c5de1 / cardano-base 12168e4b. **1592/1592 dugite-node/dugite-consensus tests pass**, including a boundary test proving the gate bails at the configured max (10), not 62.

## Harness fixes (found by running the rounds live)
- **hardfork-round (#1042)**: (1) dropped the `ExperimentalHardForksEnabled` config injection — PV10→PV11 is an intra-Conway HFI that cardano-node 11.0.1 enacts natively; the flag pulls in the experimental Dijkstra era and breaks startup (`DijkstraGenesisFile not found`). (2) Run the zoo `--setup` before the pre-HF 16e (it was building a tx from an unfunded wallet). (3) Post-HF smoke runs once against the relay instead of twice on a shared wallet (the second run drained the funder → 5 false FAILs). **Core #1042 validated live**: HFI enacted, both sockets flipped to PV11 in the same epoch, futurePParams + ratify-state samplers 0-diff across the real HF, both 16e constructor arms observed (PV10 `IncorrectDepositDELEG` / PV11 `DepositIncorrectDELEG`), relay smoke 37 rows 0 FAIL.
- **kes-round (#1037)**: relaxed the KES-expiry log pattern to match the new gate's line, and fixed the kes-period-info parity read to use `--out-file` (it was piping a human-readable report to jq → empty on both sockets, including the Haskell arbiter).

## Validation
- `just check` green.
- gov-enactment round fully green live (all Acts + the #1039 expiry sequence + #1043 guardrails 14/14).
- hardfork round core validated live (see above).
- #1054 validated by unit tests + the pre-fix RED evidence (dugite-bp forged 40 blocks past expiry).

## Follow-ups filed (not blocking)
#1053 (phase-2 ScriptFailed → generic wire reason, pre-existing #979 class), #1055 (two-forger dugite-bp leader-election-disable that confounds the KES/rollback rounds' live assertions — orthogonal to #1054).
