### PR TITLE
v2.7.0: genesis is an anchor, and eras are checked at the wire (#1057, #1058 + 10 backlog issues)

### DIFF
--- a/.claude/skills/devnet-validate/SKILL.md
+++ b/.claude/skills/devnet-validate/SKILL.md
@@ -461,6 +461,51 @@ Two-forger + arbiter devnet. Case 1: ~30s firewall partition (port-pair pfctl/ip
 
 Actually enacts a HardForkInitiation PV 11.0 (DRep + SPO + CC votes; `ExperimentalHardForksEnabled` injected into the RENDERED cardano configs only). Runs 16e pre-HF (PV10 constructor `IncorrectDepositDELEG`) and post-HF (PV11 `DepositIncorrectDELEG` Mismatch form) — both inversion arms in one round; the futurePParams and ratify-state samplers run across the ratification + enactment boundaries (their first exercise over a REAL hard fork); both sockets must flip to PV11 in the SAME epoch; then a 01/08/16 zoo smoke at PV11 (18-plutus-edges deliberately excluded — 18f's constructor inverts at PV11). **Terminal**, and deliberately absent from the preset manifests: when it runs, read `hardfork-round.csv` directly.
 
+### Round 11 — Restart endurance (~20 min, needs a RUNNING devnet) — #1044
+
+```bash
+./restart-endurance-round.sh                       # 30 iterations
+RE_ITERATIONS=3 ./restart-endurance-round.sh       # shakedown
+```
+
+30 SIGTERM/restart cycles of **dugite-relay**, with per-iteration recovery
+assertions. Adapted from upstream `test_reconnect.py::test_metrics_reconnect`
+(200 upstream, adopted at 30 — at devnet scale the metric assertions saturate
+long before 200, which adds wall-time, not signal).
+
+The subject under test is **dugite-bp — the PEER of the restarted node.** Leak
+classes need repetition to surface and are invisible in the gate's single Round-3
+restart: fd-per-reconnect (#924 — dropping a tokio `JoinHandle` DETACHES, leaking
+the socket for the process lifetime), task-per-reconnect (#980's responder re-arm),
+and peer-registry growth. One cycle cannot distinguish "recovered" from
+"recovered while leaking a socket each time".
+
+Per iteration: SIGTERM (**never SIGKILL** — kill -9 corrupts the ImmutableDB;
+the chaos suite owns that scenario separately), confirm exit by POLLING rather
+than trusting `kill`'s exit status, restart with run.sh's flags, then require the
+relay's tip to be **advancing** (a socket that accepts a connection is not a node
+that rejoined the chain) and `dugite_peers_connected` to be readable and ≥ 1. A
+missing metric FAILS rather than defaulting — the #987 shape was a verdict column
+that was always 0.
+
+End of round: all 30 recovered; dugite-bp fd and thread counts flat within budget;
+no unexpected error-class lines in either log via `lib/expect-log-errors.sh` +
+the checked-in `restart-endurance-round.allowed-errors` (kept deliberately narrow
+— an allowlist matching `WARN` would swallow the very regressions this round
+exists to catch). **Not terminal**: it leaves the devnet running.
+
+RED cases, runnable rather than claimed:
+
+```bash
+RE_RED_CASE=down  ./restart-endurance-round.sh   # assert recovery, never restart
+RE_RED_CASE=peers ./restart-endurance-round.sh   # require peers_connected > 999
+```
+
+Both must FAIL the round; in RED mode the script inverts its exit status, so a
+RED case that *passes* is reported as the failure it is.
+
+Evidence: `restart-endurance.csv`; denominator `restart_endurance.expected_cases: 30`.
+
 ## Final report
 
 After all rounds complete, generate a machine-parseable + GitHub-release-ready report:

--- a/.claude/skills/devnet-validate/schemas/denominators.json
+++ b/.claude/skills/devnet-validate/schemas/denominators.json
@@ -4,7 +4,7 @@
     "",
     "WHY THIS FILE EXISTS (#953, same class as #945/#923): every suite in this",
     "harness reports N/N by counting the rows it produced. A stimulus that never",
-    "fires produces no row, so N/N is tautological — '26/26 adversarial' said",
+    "fires produces no row, so N/N is tautological \u2014 '26/26 adversarial' said",
     "nothing about whether 26 cases ran. A denominator is only meaningful when it",
     "comes from OUTSIDE the run that produces the numerator.",
     "",
@@ -49,12 +49,12 @@
   "n2n_adversarial": {
     "expected_scripts": 7,
     "expected_cases": 26,
-    "$comment": "Rows in n2n-trace.csv. NOT the same as the count of adv_record call sites (28) — two sites are mutually-exclusive branches. Confirmed live: see the closing evidence on #953."
+    "$comment": "Rows in n2n-trace.csv. NOT the same as the count of adv_record call sites (28) \u2014 two sites are mutually-exclusive branches. Confirmed live: see the closing evidence on #953."
   },
   "chaos": {
     "expected_cases_standard": 5,
     "expected_cases_extended": 6,
-    "_comment": "expected_scripts = scenario .sh files on disk (excluding lib.sh/run.sh). expected_cases_* = terminal ROWS a given preset produces, which is preset-dependent: the STANDARD set runs 4 scenarios for 5 rows; EXTENDED adds network-partition + disk-full for 6. Pinning a single `expected_cases: 6` from the extended set made every standard run fail gate integrity with 'chaos recorded 5 rows, below the pinned 6' — a denominator no standard run could ever satisfy. ENV-SKIP is a counted class, never silence (#959).",
+    "_comment": "expected_scripts = scenario .sh files on disk (excluding lib.sh/run.sh). expected_cases_* = terminal ROWS a given preset produces, which is preset-dependent: the STANDARD set runs 4 scenarios for 5 rows; EXTENDED adds network-partition + disk-full for 6. Pinning a single `expected_cases: 6` from the extended set made every standard run fail gate integrity with 'chaos recorded 5 rows, below the pinned 6' \u2014 a denominator no standard run could ever satisfy. ENV-SKIP is a counted class, never silence (#959).",
     "expected_scripts": 6
   },
   "parity_matrix": {
@@ -75,12 +75,12 @@
     "excluded_categories": {
       "10-gov-lifecycle": "Chain-global governance lifecycle: propose -> 3-role vote -> assert enactment. Two batches would create two proposals in the same lane and both vote; ratification is a property of the whole chain, not of a batch, so the second batch's enactment assertion is not independent. Covered on path B only.",
       "12-post-enactment": "Only meaningful once a governance action has actually ENACTED, so it depends on 10 having run and on global chain state. Same reason as 10.",
-      "13-script-purposes": "The guarding scripts are fixed (always-true/false V3, one native), so their hashes are deterministic and BOTH parity batches would share one stake credential and one DRep credential. Batch 1 registers and then deregisters it, so batch 2 acts on state batch 1 already mutated — the same class as 05g/05h. These scripts instead demand Haskell confirmation directly: they use wait_all_strict, which requires all three observers and never soft-passes on 'cbp lagging'.",
-      "14-gov-negatives": "Governance negatives assert rejection CLASSES against chain-global gov state (live actions, registered DReps). Both batches would target the same actions, so batch 2's result depends on what batch 1 did — same class as 10/12. The rejection class is already compared against cardano-node directly by each script.",
+      "13-script-purposes": "The guarding scripts are fixed (always-true/false V3, one native), so their hashes are deterministic and BOTH parity batches would share one stake credential and one DRep credential. Batch 1 registers and then deregisters it, so batch 2 acts on state batch 1 already mutated \u2014 the same class as 05g/05h. These scripts instead demand Haskell confirmation directly: they use wait_all_strict, which requires all three observers and never soft-passes on 'cbp lagging'.",
+      "14-gov-negatives": "Governance negatives assert rejection CLASSES against chain-global gov state (live actions, registered DReps). Both batches would target the same actions, so batch 2's result depends on what batch 1 did \u2014 same class as 10/12. The rejection class is already compared against cardano-node directly by each script.",
       "15-asset-lattice": "Mint policies are derived from the batch's own payment key, so the two parity batches mint under DIFFERENT policy ids and the resulting values are not comparable cell-for-cell. The properties under test (encodeMap definite/indefinite boundaries at 23/24/256, multi-policy values, mint+burn, the maxTxSize lattice, the `after` timelock and nested native combinators) are wire-shape properties already checked against cardano-node by zoo_wait_all_observers on every script.",
       "16-cert-negatives": "Reject-REASON negatives asserted directly against the constructor name by expect_cert_rejection, which is a stronger check than the parity oracle's accept/reject cell. They also mutate shared credential state (16a/16d depend on wallet-a's stake key and drep-1 already being registered), so a second parity batch would act on state the first batch already changed - the same class as 05g/05h.",
       "17-context-inspecting": "Context-inspecting validators (#969). Each script locks its own UTxO at a script address and spends it, so a second batch is independent and the category WOULD be runnable through both sockets. It is excluded for cost, not correctness: 17f alone submits three transactions and does two cardano-cli builds, and the oracle already re-executes its set twice. Revisit if the parity round gets its own budget.",
-      "19-era-negatives": "Decode/era-level negatives asserted against BOTH sockets in-script (each script submits to relay AND cardano-bp itself). Haskell may drop the bearer on a decode failure (#925 class), which makes the oracle reject-REASON cell structurally CLASSDIFF — noise, not signal. The both-socket agreement the oracle would measure is already asserted, stronger, inside every script."
+      "19-era-negatives": "Decode/era-level negatives asserted against BOTH sockets in-script (each script submits to relay AND cardano-bp itself). Haskell may drop the bearer on a decode failure (#925 class), which makes the oracle reject-REASON cell structurally CLASSDIFF \u2014 noise, not signal. The both-socket agreement the oracle would measure is already asserted, stronger, inside every script."
     },
     "excluded_scripts": {
       "05g-cc-hot-key-authorization": "Constitutional committee is seated at genesis and is devnet-global. Batch 1 resigns cc-1, so batch 2 correctly receives ConwayCommitteeHasPreviouslyResigned. Giving batch 2 its own committee requires an UpdateCommittee governance action (2+ epoch boundaries). Verified live 2026-08-02, not a dugite defect.",
@@ -93,5 +93,9 @@
   "rpc": {
     "expected_checks": 27,
     "_comment": "Rows written by rpc/run.sh: 1 service-discovery + 8 service-present + 1 relay-reachable + 2 read-params + 2 cost-models + 2 read-tip + 2 read-utxos + 2 submit-tx + 2 malformed-cbor + 1 oversized + 1 empty-tx + 1 garbage-txoref + 1 duplicate-concurrent-submit + 1 mempool-hygiene = 27. Pinned from OUTSIDE the run so 27/27 is not tautological; a suite that silently stops emitting rows fails the gate instead of reporting a smaller clean sweep."
+  },
+  "restart_endurance": {
+    "expected_cases": 30,
+    "_comment": "Rows in restart-endurance.csv: one terminal row per SIGTERM/restart iteration of dugite-relay (#1044, #1031 P2-3). EXTENDED preset only. Adopted at 30, not upstream's 200 (test_reconnect.py::test_metrics_reconnect) \u2014 at devnet scale the metric assertions saturate long before 200, which adds wall-time, not signal. Overridable via RE_ITERATIONS for a shakedown, but the GATE pins 30: a run that quietly lowers the iteration count would weaken exactly the repetition this round exists for, since the leak classes it targets (#924 fd-per-reconnect, #980 task-per-reconnect) are invisible in a single cycle. The round's own RED cases are RE_RED_CASE=down (assert recovery without restarting) and RE_RED_CASE=peers (require peers_connected > 999); both must FAIL the round."
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ dugite-lsm (LSM-tree on-disk storage for UTxO-HD)
 - 28-byte hash types (DRep keys, pool voter keys, required signers) must be padded to 32 bytes via `Hash28::to_hash32_padded()` — do not use `Hash<32>::from()` directly on 28-byte hashes
 
 ## Current Focus
-**v2.7.0 (2026-08-06) — genesis is an anchor, and eras are checked at the wire.**
+**v2.7.0 (2026-08-06) — eras are checked at the wire.**
 Drop-in from v2.6.0, **SNAPSHOT unchanged at 37**. Closes #1015, #1026, #1028,
 #1046, #1047, #1048, #1050, #1051, #1054, #1055, #1031, #1044, plus **#1058**
 found during the sweep. Open: **#1057** (P0, fully diagnosed below — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,141 @@ dugite-lsm (LSM-tree on-disk storage for UTxO-HD)
 - 28-byte hash types (DRep keys, pool voter keys, required signers) must be padded to 32 bytes via `Hash28::to_hash32_padded()` — do not use `Hash<32>::from()` directly on 28-byte hashes
 
 ## Current Focus
-**v2.6.0 (2026-08-04) — the DRep pulser becomes one mechanism.**
+**v2.7.0 (2026-08-06) — genesis is an anchor, and eras are checked at the wire.**
+Drop-in from v2.6.0, **SNAPSHOT unchanged at 37**. Closes #1015, #1026, #1028,
+#1046, #1047, #1048, #1050, #1051, #1054, #1055, plus **#1057** and **#1058**
+found during the sweep. Open: #1008 (CLI surface backlog), #1053 (typed phase-2
+wire class), #1030 items 4-6, #1031/#1044 (round landed, awaiting a live run).
+
+### #1057 — a node with any block of its own never rejoins (P0, strands a BP)
+
+**The most serious find.** A node whose local chain must be replaced from Origin
+never adopted the canonical chain: BlockFetch declined the peer's block 0
+forever, the ledger never advanced, ChainSync's forecast-horizon park timed out,
+and **every** peer was disconnected in an endless reconnect loop — no
+self-healing, for the process lifetime.
+
+Live evidence from a two-forger devnet: dugite-bp forged blocks 0..8 (slots
+4-21) on Origin, then froze at its own tip while the Haskell chain reached block
+240+, dying at the *same* header slot 345 on every peer, every reconnect, with
+6m15s of total log silence after slot 30. Controlled comparison, same binary and
+devnet: **dugite-relay reached epoch 2, dugite-bp stayed at epoch 0** — the only
+difference being whether the ChainDB was non-empty when the Origin adoption was
+required.
+
+One blind spot in two independent layers — **genesis/Origin was not recognised
+as an anchor**, only a stored block or the ImmutableDB tip:
+
+- `connection_lifecycle.rs` (the branch that fired): the #735 gross-request
+  invariant exempted only a completely EMPTY ChainDB. Genesis is never a stored
+  block, so `has_block(&genesis)` is always false. The guard's own comment
+  documents the same wedge one case earlier (the relay declining block 1) and
+  its `is_none()` escape hatch is the bug's twin.
+- `volatile_db.rs::switch_chain`: accepted a non-intersecting fork only when its
+  root's prev_hash equalled the ImmutableDB tip. With nothing flushed yet
+  (9 blocks, k=40) that anchor is `None`, so a genesis-rooted fork was
+  "unreachable".
+
+`Hash32::ZERO` was already dugite's canonical Origin parent (the encoder maps it
+to CBOR `null` == Haskell `PrevHash = GenesisHash`), so both layers now
+recognise it. Upstream needs no such guard because `AnchorGenesis` is a
+first-class constructor of `Anchor blk`, matched by `Paths.hs::isReachable`.
+The `k` cap is untouched — the new arm makes a genesis rollback *expressible*,
+not permitted.
+
+**An existing test PINNED the storage half.**
+`test_switch_chain_reachable_via_immutable_anchor` used `h(0)` as its "immutable
+tip", and `h(0)` is `[0u8; 32]` == `Hash32::ZERO` == the genesis sentinel — so it
+was really asserting that a genesis-rooted fork stays unreachable. The #948
+trap: assert on the payload, not just the shape.
+
+### #1015 — Babbage folded extraEntropy; Praos has 2 terms, not 3
+
+`babbage.rs` delegated wholesale to `ShelleyRules::process_epoch_transition`,
+which folds the TPraos TICKN 3-term nonce. Babbage is **Praos**:
+`tickChainDepState` folds two terms and `extraEntropy` does not exist for Praos
+at all (`Praos.hs` has zero occurrences; `hkdExtraEntropyL =
+notSupportedInThisEraL` for Babbage/Conway/Dijkstra). Dormant — extra_entropy is
+`ZERO` by the time Babbage runs on every known network — but nonce evolution has
+no self-correcting mechanism, so a chain carrying a non-neutral value across
+Alonzo→Babbage would split via the VRF leader schedule forever.
+
+THREE implementations existed and the duplication WAS the mechanism: Conway had
+the right formula, Babbage reused the wrong era's code. Now one
+`compute_epoch_boundary_nonce` + an `EpochNonceMode` derived from `ctx.era` via
+`Era::uses_tpraos()` (#985's predicate), so no caller can select the wrong one.
+
+**The third copy was in `state/epoch.rs`** — the `#[doc(hidden)]` test-only
+`LedgerState::process_epoch_transition`, i.e. *exactly the path #977's fix landed
+in while production did nothing*, and the path every unit test drives. Fixing
+only the era-rules path would have left the tests exercising the old formula.
+
+### #1046 — the invented default PlutusV2 cost model
+
+dugite injected a hardcoded `defaultV2CostModel` whenever genesis supplied no
+V2, so `curPParams.costModels` reported `[V1,V2,V3]` where cardano-node reports
+`[V1,V3]` on mainnet/preview/preprod. Latent accept-where-Haskell-rejects: a V2
+script executes on dugite and fails upstream with
+`CollectErrors [NoCostModel PlutusV2]`.
+
+The issue supposed the devnet/preview disagreement came from different *paths
+into Conway*. It does not — it is the **genesis file**:
+
+| genesis | `costModels` | `extraConfig.costModels` |
+|---|---|---|
+| devnet (`create-testnet-data`) | V1 | V1, **V2** |
+| preview/preprod/mainnet | V1 | *absent* |
+
+`alonzoInjectCostModels` (`Alonzo/Transition.hs`) applies
+`agExtraConfig.aecCostModels` via `curPParamsEpochStateL` — **cur-only**, and
+`updateCostModels` is a **per-language** update. cardano-ledger has no default
+V2 anywhere; `defaultV2CostModel` lives in **cardano-api** as a value written
+INTO a generated genesis file. dugite's constant was copied from that same
+source, so it matched on the devnet by coincidence while being wrong everywhere
+real. Reading only the top-level `costModels` key is what produced #994's wrong
+conclusion — and #994's claim that real alonzo-genesis files "DO define
+PlutusV2" is false; none ever has.
+
+### #1058 — script-integrity mismatch used tag 13 at every PV (#1030 item 3)
+
+`checkScriptIntegrityHash` picks by PV: `< 11` ⇒ `PPViewHashesDontMatch` (UTXOW
+**13**, `ToGroup` = Mismatch FLATTENED); `>= 11` ⇒ `ScriptIntegrityHashMismatch`
+(UTXOW **18**, Mismatch NESTED + a `StrictMaybe ByteString` preimage field).
+dugite emitted 13 unconditionally — wrong at PV11, **which preview runs**, so
+the reachable case was the wrong one. #978's inversion. Found only because
+#1030 item 3 said the split had "not been independently re-verified against
+dugite's encoder" — it was worth re-verifying.
+
+### #1047 / #1026 / #1028 — three accept-where-Haskell-rejects gaps
+
+- **#1047**: no wire-era check on N2C submission. A legacy-era tx was rejected
+  only as an ACCIDENTAL CBOR array-length error, and that accident was
+  load-bearing: correct any legacy standalone decoder without adding an era
+  check and MIR / GenesisKeyDelegation become ACCEPTABLE on a Conway chain (MIR
+  Phase-1 is a no-op at PV>=9; GenesisKeyDelegation has era-unconditional
+  apply-time support, so the ledger would not catch it). Now
+  `HardForkApplyTxErrWrongEra` before decoding, era from
+  `EraHistory::current_era()` — **not** ledger pparams (#985).
+- **#1026**: PV9 restricts proposal SUBMISSION to
+  ParameterChange/HardForkInitiation/InfoAction. dugite had the symmetric VOTE
+  restriction but not the proposal side. `isBootstrapAction` is now SHARED by
+  both, as upstream gates both on the one predicate.
+- **#1028**: `SNothing` guardrail was treated as "anything goes". Haskell
+  compares the WHOLE `StrictMaybe`, so a guardrail-less constitution requires the
+  proposal to supply `SNothing` too. Root cause was a type that could not express
+  the distinction — `Option<Hash28>` conflated "not plumbed" with "genuinely
+  absent"; now `Option<Option<Hash28>>`.
+
+### Testing discipline this wave
+
+Every fix landed with a test **proven RED by disarming the fix**, not merely
+written. That caught the two cases that matter most here: #1026's behavioural
+tests were RED against the *wiring* (not the predicate), which is #977's exact
+failure mode; and #1028's not-plumbed-vs-SNothing test drives the same input
+through both and asserts they behave DIFFERENTLY, so the doubly-optional type
+cannot silently collapse again.
+
+### Superseded: v2.6.0 (2026-08-04) — the DRep pulser becomes one mechanism.
 **RE-SYNC RELEASE: SNAPSHOT_VERSION 32 -> 37**, so existing DBs replay chunks
 on first restart. Closes #977, #980, #969, #970 (the earlier backlog) plus
 #988, #989, #990, #991, #992, #993, #995, #996, #997. Open: #994 (devnet-only,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,51 +103,70 @@ dugite-lsm (LSM-tree on-disk storage for UTxO-HD)
 ## Current Focus
 **v2.7.0 (2026-08-06) — genesis is an anchor, and eras are checked at the wire.**
 Drop-in from v2.6.0, **SNAPSHOT unchanged at 37**. Closes #1015, #1026, #1028,
-#1046, #1047, #1048, #1050, #1051, #1054, #1055, plus **#1057** and **#1058**
-found during the sweep. Open: #1008 (CLI surface backlog), #1053 (typed phase-2
-wire class), #1030 items 4-6, #1031/#1044 (round landed, awaiting a live run).
+#1046, #1047, #1048, #1050, #1051, #1054, #1055, #1031, #1044, plus **#1058**
+found during the sweep. Open: **#1057** (P0, fully diagnosed below — the
+two-layer storage fix was attempted, verified WRONG live, and reverted), #1008
+(CLI surface backlog), #1053 (typed phase-2 wire class), #1030 items 4-6.
 
-### #1057 — a node with any block of its own never rejoins (P0, strands a BP)
+### #1057 — a node with any block of its own never rejoins (P0, OPEN)
 
-**The most serious find.** A node whose local chain must be replaced from Origin
-never adopted the canonical chain: BlockFetch declined the peer's block 0
-forever, the ledger never advanced, ChainSync's forecast-horizon park timed out,
-and **every** peer was disconnected in an endless reconnect loop — no
-self-healing, for the process lifetime.
+**Diagnosed in detail, NOT fixed — do not re-diagnose from scratch.** A node whose
+local chain must be replaced from Origin never adopts the canonical chain:
+BlockFetch declines the peer's block 0 forever, the ledger never advances,
+ChainSync's forecast-horizon park times out, and **every** peer is disconnected in
+an endless reconnect loop with no self-healing. It strands a block producer.
 
-Live evidence from a two-forger devnet: dugite-bp forged blocks 0..8 (slots
-4-21) on Origin, then froze at its own tip while the Haskell chain reached block
-240+, dying at the *same* header slot 345 on every peer, every reconnect, with
-6m15s of total log silence after slot 30. Controlled comparison, same binary and
+Live evidence: dugite-bp forged blocks 0..8 (slots 4-21) on Origin, then froze at
+its own tip while the Haskell chain reached block 240+, dying at the *same* header
+slot on every peer and every reconnect. Controlled comparison, same binary and
 devnet: **dugite-relay reached epoch 2, dugite-bp stayed at epoch 0** — the only
 difference being whether the ChainDB was non-empty when the Origin adoption was
 required.
 
-One blind spot in two independent layers — **genesis/Origin was not recognised
-as an anchor**, only a stored block or the ImmutableDB tip:
+Two layers both refuse a genesis anchor, recognising only a stored block or the
+ImmutableDB tip:
+- `connection_lifecycle.rs` — the #735 gross-request invariant exempts only a
+  COMPLETELY EMPTY ChainDB. Genesis is never a stored block, so
+  `has_block(&genesis)` is always false. **This is the branch that fires.**
+- `volatile_db.rs::switch_chain` — accepts a non-intersecting fork only when its
+  root anchors at the ImmutableDB tip; with nothing flushed yet that anchor is
+  `None`.
 
-- `connection_lifecycle.rs` (the branch that fired): the #735 gross-request
-  invariant exempted only a completely EMPTY ChainDB. Genesis is never a stored
-  block, so `has_block(&genesis)` is always false. The guard's own comment
-  documents the same wedge one case earlier (the relay declining block 1) and
-  its `is_none()` escape hatch is the bug's twin.
-- `volatile_db.rs::switch_chain`: accepted a non-intersecting fork only when its
-  root's prev_hash equalled the ImmutableDB tip. With nothing flushed yet
-  (9 blocks, k=40) that anchor is `None`, so a genesis-rooted fork was
-  "unreachable".
+**Why the obvious two-line fix is WRONG, verified live.** Teaching both layers to
+accept `prev_hash == Hash32::ZERO` was attempted and REVERTED: storage then emits a
+genesis-rooted `SwitchPlan` (`intersection = ZERO, slot 0`), chain selection asks
+the ledger to roll back to Origin, and `sync.rs` aborts —
 
-`Hash32::ZERO` was already dugite's canonical Origin parent (the encoder maps it
-to CBOR `null` == Haskell `PrevHash = GenesisHash`), so both layers now
-recognise it. Upstream needs no such guard because `AnchorGenesis` is a
-first-class constructor of `Anchor blk`, matched by `Paths.hs::isReachable`.
-The `k` cap is untouched — the new arm makes a genesis rollback *expressible*,
-not permitted.
+```
+Chain selection: fork switch at live tip — rolling back ledger to intersection
+  intersection=00000000000000000000000000000000
+ERROR Rollback target outside LedgerSeq volatile window AND no canonical
+  snapshot available. Aborting rollback
+WARN  Fork rollback failed; skipping fork replay
+```
 
-**An existing test PINNED the storage half.**
+— leaving dugite-bp at block 4 while the network was at 84. The wedge MOVES from
+BlockFetch to the ledger rollback; it does not go away. Unit tests on
+`switch_chain` in isolation all passed, because nothing drove the storage plan
+through the ledger.
+
+The complete fix needs the ledger to **re-initialise from genesis** on a
+rollback-to-Origin (a full `init_fresh_ledger`, not an in-place rewind — #989
+deleted `reset_to_origin` precisely because a partial reset cannot be correct),
+plus a LedgerSeq re-anchor (#985) and a query-state reset. That touches the code
+path that produced #985's chimera, so it needs its own focused pass with
+byte-exact validation.
+
+`Hash32::ZERO` IS dugite's canonical Origin parent (encoder → CBOR `null` ==
+Haskell `PrevHash = GenesisHash`), and upstream needs no guard at all because
+`AnchorGenesis` is a first-class constructor of `Anchor blk`, matched by
+`Paths.hs::isReachable`. Those facts are settled; the blocker is the ledger.
+
+**An existing test PINNED the storage half**:
 `test_switch_chain_reachable_via_immutable_anchor` used `h(0)` as its "immutable
-tip", and `h(0)` is `[0u8; 32]` == `Hash32::ZERO` == the genesis sentinel — so it
-was really asserting that a genesis-rooted fork stays unreachable. The #948
-trap: assert on the payload, not just the shape.
+tip", and `h(0)` is `[0u8; 32]` — the genesis sentinel. Re-pointed at a non-ZERO
+anchor so it covers the path it is named for; its `is_none()` assertion now
+documents the open wedge explicitly.
 
 ### #1015 — Babbage folded extraEntropy; Praos has 2 terms, not 3
 
@@ -229,7 +248,12 @@ dugite's encoder" — it was worth re-verifying.
 ### Testing discipline this wave
 
 Every fix landed with a test **proven RED by disarming the fix**, not merely
-written. That caught the two cases that matter most here: #1026's behavioural
+written — and the one case where that was NOT enough is the lesson of this wave:
+#1057's unit tests all passed while the fix was wrong, because they exercised
+`switch_chain` in isolation and nothing drove its output through the ledger. A
+RED-proven unit test bounds the function, not the system.
+
+Where it did work, it worked well. The two cases that matter most: #1026's behavioural
 tests were RED against the *wiring* (not the predicate), which is #977's exact
 failure mode; and #1028's not-plumbed-vs-SNothing test drives the same input
 through both and asserts they behave DIFFERENTLY, so the doubly-optional type

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-cli"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-config"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-conformance"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "cddl",
  "dugite-crypto",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-consensus"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-crypto"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "criterion",
  "curve25519-dalek 3.2.0 (git+https://github.com/iquerejeta/curve25519-dalek?branch=ietf03_vrf_compat_ell2)",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-golden-tests"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "dugite-crypto",
  "dugite-network",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-integration-tests"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "dugite-consensus",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-ledger"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bincode 1.3.3",
  "criterion",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-lsm"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-mempool"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "criterion",
  "dashmap",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-monitor"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-network"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-node"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-primitives"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bech32",
  "blake2 0.10.6",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-rpc"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-serialization"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-storage"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-uplc"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "amaru-uplc",
  "blake2 0.10.6",
@@ -7127,7 +7127,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/michaeljfazio/dugite"

--- a/charts/dugite-node/Chart.yaml
+++ b/charts/dugite-node/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: dugite-node
 description: A Helm chart for deploying Dugite, a Rust implementation of the Cardano node
 type: application
-version: 0.11.0
-appVersion: "2.6.0"
+version: 0.12.0
+appVersion: "2.7.0"
 kubeVersion: ">= 1.27.0-0"
 keywords:
   - cardano

--- a/crates/dugite-ledger/src/eras/common.rs
+++ b/crates/dugite-ledger/src/eras/common.rs
@@ -135,6 +135,116 @@ pub(crate) fn combine_nonce(a: Hash32, b: Hash32) -> Hash32 {
     }
 }
 
+/// Which epoch-boundary nonce formula an era uses.
+///
+/// **These are two different, independently hand-written Haskell functions, not
+/// a parameterised variant of one** (#1015):
+///
+/// * [`EpochNonceMode::TPraos`] — Shelley/Allegra/Mary/Alonzo. The TICKN rule
+///   (`Cardano.Protocol.TPraos.Rules.Tickn.tickTransition`) folds **three**
+///   terms:
+///   ```text
+///   ticknStateEpochNonce = ηc ⭒ ηh ⭒ extraEntropy
+///   ```
+/// * [`EpochNonceMode::Praos`] — Babbage/Conway/Dijkstra. `tickChainDepState`
+///   (`Ouroboros.Consensus.Protocol.Praos`) folds **two**, and `extraEntropy`
+///   does not exist for Praos at all:
+///   ```text
+///   praosStateEpochNonce = praosStateCandidateNonce st ⭒ praosStateLastEpochBlockNonce st
+///   ```
+///   Grepping `Praos.hs` for `extraEntropy` is zero hits; `PraosState` has no
+///   such field, and `tickChainDepState` takes no `TicknEnv`. Confirmed
+///   structurally in cardano-ledger: `hkdExtraEntropyL =
+///   notSupportedInThisEraL` for Babbage, Conway and Dijkstra — only
+///   `Alonzo/PParams.hs` carries the real field.
+///
+/// `HFEras.hs` binds the era set: `TPraos` for Shelley-Alonzo, `Praos` for
+/// Babbage+.
+///
+/// Why this matters even though it is dormant today: `extra_entropy` is only
+/// ever set from a legacy pre-Conway `ProtocolParamUpdate.extra_entropy`, and
+/// the one historical mainnet occurrence (epoch 259) was entirely inside the
+/// TPraos window, so on mainnet/preview/preprod the third term is
+/// `Hash32::ZERO` — the identity of `⭒` — by the time Babbage runs. But nonce
+/// evolution has **no self-correcting mechanism**: any chain that carried a
+/// non-neutral `extra_entropy` across the Alonzo→Babbage boundary without an
+/// intervening reset PPU would diverge from cardano-node forever, as a
+/// consensus split via the VRF leader schedule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EpochNonceMode {
+    /// Shelley through Alonzo: `candidate ⭒ prevHashNonce ⭒ extraEntropy`.
+    TPraos,
+    /// Babbage onward: `candidate ⭒ prevHashNonce` — no `extraEntropy` term.
+    Praos,
+}
+
+impl EpochNonceMode {
+    /// Select the formula from the era whose rules are executing.
+    ///
+    /// Derived from [`Era::uses_tpraos`] rather than plumbed through a
+    /// parameter, deliberately: the shared pre-Conway boundary function then has
+    /// exactly ONE code path and no caller can pass the wrong mode. This reuses
+    /// the same canonical era predicate #985 introduced to collapse the two
+    /// hand-written copies of the overlay-slot condition, and it mirrors
+    /// `HFEras.hs`, which binds `TPraos` to Shelley-Alonzo and `Praos` to
+    /// Babbage+ at the type level.
+    pub(crate) fn for_era(era: dugite_primitives::era::Era) -> Self {
+        if era.uses_tpraos() {
+            Self::TPraos
+        } else {
+            Self::Praos
+        }
+    }
+
+    /// Protocol-version fallback for the ONE call site that has no era in
+    /// scope: `LedgerState::process_epoch_transition`, the `#[doc(hidden)]`
+    /// test-only boundary helper whose own rustdoc says *"Production code MUST
+    /// go through `Self::apply_block`"*. That signature takes only an
+    /// `EpochNo`, so `ctx.era` does not exist there.
+    ///
+    /// PV → era: Shelley 2, Allegra 3, Mary 4, Alonzo 5-6, Babbage 7-8,
+    /// Conway 9+. So TPraos ⟺ `pv <= 6`.
+    ///
+    /// **Prefer [`Self::for_era`] everywhere it is available.** #985's lesson is
+    /// that an era decision keyed off ledger pparams can be fed a stale or
+    /// corrupt protocol version — that is precisely how a PV-6 chimera ran the
+    /// overlay classifier on a PV-11 Conway header. This variant is acceptable
+    /// only because the path is test-only and no block era is reachable from it;
+    /// it exists so the boundary FORMULA has a single implementation rather than
+    /// a third hand-written copy, which is the drift mechanism #977 and #985
+    /// both got caught by.
+    pub(crate) fn for_protocol_version_major(pv_major: u64) -> Self {
+        if pv_major <= 6 {
+            Self::TPraos
+        } else {
+            Self::Praos
+        }
+    }
+}
+
+/// Compute the epoch-boundary nonce for `mode`.
+///
+/// The single implementation of both formulas. Before #1015 there were three
+/// call sites with two behaviours and no shared code: `shelley.rs` folded three
+/// terms (correct for TPraos), `babbage.rs` reused that function wholesale and
+/// so folded three terms too (**wrong** — Babbage is Praos), and `conway.rs`
+/// hand-inlined a two-term fold that duplicated [`combine_nonce`]'s body. That
+/// is the recurring N-copies trap: one era's implementation had the right
+/// formula, a sibling sharing the same STS concept did not, because it reused
+/// the *other* era's code.
+pub(crate) fn compute_epoch_boundary_nonce(
+    mode: EpochNonceMode,
+    candidate_nonce: Hash32,
+    last_epoch_block_nonce: Hash32,
+    extra_entropy: Hash32,
+) -> Hash32 {
+    let two_term = combine_nonce(candidate_nonce, last_epoch_block_nonce);
+    match mode {
+        EpochNonceMode::TPraos => combine_nonce(two_term, extra_entropy),
+        EpochNonceMode::Praos => two_term,
+    }
+}
+
 // ============================================================================
 // 1. apply_utxo_changes
 // ============================================================================
@@ -2574,6 +2684,161 @@ mod tests {
             result.is_err(),
             "block ExUnits budget must count is_valid=false tx redeemers \
              (Haskell has no IsValid filter in Bbody.hs)"
+        );
+    }
+
+    // ── #1015: TPraos folds extraEntropy, Praos does NOT ──────────────────
+    //
+    // These are two independently hand-written Haskell functions:
+    //   TPraos  Tickn.tickTransition:   ηc ⭒ ηh ⭒ extraEntropy      (3 terms)
+    //   Praos   tickChainDepState:      candidate ⭒ lastEpochBlock  (2 terms)
+    // `Praos.hs` has zero occurrences of extraEntropy and `PraosState` has no
+    // such field; cardano-ledger sets `hkdExtraEntropyL = notSupportedInThisEraL`
+    // for Babbage, Conway and Dijkstra.
+    //
+    // Babbage was folding the third term because it reused Shelley's boundary
+    // function wholesale. With a non-neutral extra_entropy the two formulas give
+    // DIFFERENT nonces, and nonce evolution never self-corrects — so this was a
+    // latent consensus split via the VRF leader schedule.
+
+    /// The two modes must actually disagree when extra_entropy is non-neutral.
+    /// If they ever agree here, every other assertion in this area is vacuous.
+    #[test]
+    fn epoch_nonce_modes_differ_when_extra_entropy_is_non_neutral() {
+        let candidate = Hash32::from_bytes([1u8; 32]);
+        let prev_hash = Hash32::from_bytes([2u8; 32]);
+        let extra = Hash32::from_bytes([3u8; 32]);
+
+        let tpraos =
+            compute_epoch_boundary_nonce(EpochNonceMode::TPraos, candidate, prev_hash, extra);
+        let praos =
+            compute_epoch_boundary_nonce(EpochNonceMode::Praos, candidate, prev_hash, extra);
+
+        assert_ne!(
+            tpraos, praos,
+            "with a non-neutral extraEntropy the 3-term TPraos fold and the \
+             2-term Praos fold MUST differ — otherwise #1015 is untestable"
+        );
+        // Praos is exactly the two-term fold, extra_entropy ignored entirely.
+        assert_eq!(praos, combine_nonce(candidate, prev_hash));
+        // TPraos is that, then folded with extraEntropy.
+        assert_eq!(
+            tpraos,
+            combine_nonce(combine_nonce(candidate, prev_hash), extra)
+        );
+    }
+
+    /// Praos must ignore extra_entropy no matter what it holds.
+    #[test]
+    fn praos_epoch_nonce_ignores_extra_entropy() {
+        let candidate = Hash32::from_bytes([9u8; 32]);
+        let prev_hash = Hash32::from_bytes([8u8; 32]);
+        let expected = combine_nonce(candidate, prev_hash);
+
+        for byte in [0u8, 1, 42, 255] {
+            let extra = Hash32::from_bytes([byte; 32]);
+            assert_eq!(
+                compute_epoch_boundary_nonce(EpochNonceMode::Praos, candidate, prev_hash, extra),
+                expected,
+                "Praos must ignore extra_entropy (byte {byte})"
+            );
+        }
+    }
+
+    /// The era → mode mapping is the whole fix: Babbage must select Praos.
+    /// `HFEras.hs` binds TPraos to Shelley-Alonzo and Praos to Babbage+.
+    #[test]
+    fn epoch_nonce_mode_for_era_matches_hferas_binding() {
+        use dugite_primitives::era::Era;
+        for era in [Era::Shelley, Era::Allegra, Era::Mary, Era::Alonzo] {
+            assert_eq!(
+                EpochNonceMode::for_era(era),
+                EpochNonceMode::TPraos,
+                "{era:?} is a TPraos era and folds extraEntropy"
+            );
+        }
+        for era in [Era::Babbage, Era::Conway, Era::Dijkstra] {
+            assert_eq!(
+                EpochNonceMode::for_era(era),
+                EpochNonceMode::Praos,
+                "{era:?} is a Praos era and must NOT fold extraEntropy (#1015)"
+            );
+        }
+    }
+
+    /// Regression, stated as the bug: on a chain carrying a non-neutral
+    /// extra_entropy, the BABBAGE boundary nonce must equal the Praos 2-term
+    /// value — i.e. it must NOT equal what Shelley would produce from the same
+    /// inputs. This is the assertion that was false before #1015.
+    #[test]
+    fn babbage_epoch_nonce_is_praos_not_tpraos() {
+        use dugite_primitives::era::Era;
+        let candidate = Hash32::from_bytes([0xaau8; 32]);
+        let prev_hash = Hash32::from_bytes([0xbbu8; 32]);
+        let extra = Hash32::from_bytes([0xccu8; 32]);
+
+        let babbage = compute_epoch_boundary_nonce(
+            EpochNonceMode::for_era(Era::Babbage),
+            candidate,
+            prev_hash,
+            extra,
+        );
+        let shelley = compute_epoch_boundary_nonce(
+            EpochNonceMode::for_era(Era::Shelley),
+            candidate,
+            prev_hash,
+            extra,
+        );
+
+        assert_eq!(
+            babbage,
+            combine_nonce(candidate, prev_hash),
+            "Babbage boundary nonce must be the 2-term Praos fold"
+        );
+        assert_ne!(
+            babbage, shelley,
+            "Babbage must NOT reuse Shelley's 3-term TPraos fold (#1015)"
+        );
+    }
+
+    /// The PV fallback used by the test-only boundary path must agree with the
+    /// era mapping: Shelley 2, Allegra 3, Mary 4, Alonzo 5-6 are TPraos;
+    /// Babbage 7-8, Conway 9+ are Praos. PV 6/7 is the load-bearing boundary.
+    #[test]
+    fn epoch_nonce_mode_for_protocol_version_major_matches_era_mapping() {
+        for pv in [2u64, 3, 4, 5, 6] {
+            assert_eq!(
+                EpochNonceMode::for_protocol_version_major(pv),
+                EpochNonceMode::TPraos,
+                "PV {pv} is a TPraos era"
+            );
+        }
+        for pv in [7u64, 8, 9, 10, 11, 12] {
+            assert_eq!(
+                EpochNonceMode::for_protocol_version_major(pv),
+                EpochNonceMode::Praos,
+                "PV {pv} is a Praos era and must NOT fold extraEntropy (#1015)"
+            );
+        }
+    }
+
+    /// Neutral extra_entropy is the identity of ⭒, which is why this defect was
+    /// dormant on mainnet/preview/preprod: the two formulas coincide there.
+    /// Pinned so the dormancy argument is checked, not assumed.
+    #[test]
+    fn epoch_nonce_modes_coincide_when_extra_entropy_is_neutral() {
+        let candidate = Hash32::from_bytes([4u8; 32]);
+        let prev_hash = Hash32::from_bytes([5u8; 32]);
+        assert_eq!(
+            compute_epoch_boundary_nonce(
+                EpochNonceMode::TPraos,
+                candidate,
+                prev_hash,
+                Hash32::ZERO
+            ),
+            compute_epoch_boundary_nonce(EpochNonceMode::Praos, candidate, prev_hash, Hash32::ZERO),
+            "with NeutralNonce extraEntropy the formulas must agree — this is \
+             exactly why the Babbage bug was invisible on every live network"
         );
     }
 }

--- a/crates/dugite-ledger/src/eras/conway.rs
+++ b/crates/dugite-ledger/src/eras/conway.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 use dugite_primitives::block::{Block, BlockHeader};
 use dugite_primitives::credentials::Credential;
 use dugite_primitives::era::Era;
-use dugite_primitives::hash::{blake2b_256, Hash28, Hash32};
+use dugite_primitives::hash::{Hash28, Hash32};
 use dugite_primitives::time::EpochNo;
 use dugite_primitives::transaction::{Certificate, GovActionId, Transaction, Voter};
 use dugite_primitives::value::Lovelace;
@@ -937,23 +937,27 @@ impl EraRules for ConwayRules {
         // capture position is load-bearing for byte-exact RUPD math at
         // boundaries that enact a ParameterChange / HardForkInitiation.
 
-        // Compute new epoch nonce (TICKN rule).
+        // Compute the new epoch nonce.
+        //
+        // Conway is a **Praos** era, so `tickChainDepState` folds TWO terms and
+        // never `extraEntropy`:
+        //   praosStateEpochNonce = candidateNonce ⭒ lastEpochBlockNonce
+        //
+        // #1015: this was a hand-inlined re-implementation of
+        // `combine_nonce`'s body — correct, but a third copy of the concept.
+        // Now it shares the one `compute_epoch_boundary_nonce` with Shelley and
+        // Babbage, so the TPraos/Praos split lives in exactly one place. That
+        // duplication WAS the mechanism by which Babbage kept folding a third
+        // term: Conway had the right formula, and its sibling reused the wrong
+        // era's code wholesale instead.
         let candidate = consensus.candidate_nonce;
         let prev_hash_nonce = consensus.last_epoch_block_nonce;
-
-        let zero = Hash32::ZERO;
-        consensus.epoch_nonce = if candidate == zero && prev_hash_nonce == zero {
-            zero
-        } else if candidate == zero {
-            prev_hash_nonce
-        } else if prev_hash_nonce == zero {
-            candidate
-        } else {
-            let mut nonce_input = Vec::with_capacity(64);
-            nonce_input.extend_from_slice(candidate.as_bytes());
-            nonce_input.extend_from_slice(prev_hash_nonce.as_bytes());
-            blake2b_256(&nonce_input)
-        };
+        consensus.epoch_nonce = super::common::compute_epoch_boundary_nonce(
+            super::common::EpochNonceMode::for_era(ctx.era),
+            candidate,
+            prev_hash_nonce,
+            consensus.extra_entropy,
+        );
 
         // Update prevHashNonce to current labNonce for NEXT epoch.
         consensus.last_epoch_block_nonce = consensus.lab_nonce;

--- a/crates/dugite-ledger/src/eras/shelley.rs
+++ b/crates/dugite-ledger/src/eras/shelley.rs
@@ -845,16 +845,28 @@ impl EraRules for ShelleyRules {
             );
         }
 
-        // Compute new epoch nonce (TICKN rule):
+        // Compute the new epoch nonce.
+        //
+        // TPraos eras (Shelley/Allegra/Mary/Alonzo) run the TICKN rule
+        // (Haskell `Cardano.Protocol.TPraos.Rules.Tickn.tickTransition`):
         //   η0 = candidateNonce ⭒ prevHashNonce ⭒ extraEntropy
-        // (Haskell `Cardano.Protocol.TPraos.Rules.Tickn.tickTransition`).
         // extraEntropy is NeutralNonce on virtually every epoch, but mainnet
         // injected a non-neutral value effective epoch 259 — omitting it
         // desynchronises the epoch nonce (and thus every VRF check) from there.
+        //
+        // #1015: this function is ALSO the shared pre-Conway boundary for
+        // BABBAGE, which is a **Praos** era — `tickChainDepState` folds only
+        // TWO terms and `extraEntropy` does not exist for Praos at all. Folding
+        // the third term there was wrong. The mode is derived from `ctx.era`
+        // inside `compute_epoch_boundary_nonce`'s caller so there is one code
+        // path and no way to select the wrong formula; see `EpochNonceMode`.
         let candidate = consensus.candidate_nonce;
         let prev_hash_nonce = consensus.last_epoch_block_nonce;
-        consensus.epoch_nonce = super::common::combine_nonce(
-            super::common::combine_nonce(candidate, prev_hash_nonce),
+        let nonce_mode = super::common::EpochNonceMode::for_era(ctx.era);
+        consensus.epoch_nonce = super::common::compute_epoch_boundary_nonce(
+            nonce_mode,
+            candidate,
+            prev_hash_nonce,
             consensus.extra_entropy,
         );
 

--- a/crates/dugite-ledger/src/state/apply.rs
+++ b/crates/dugite-ledger/src/state/apply.rs
@@ -903,7 +903,9 @@ impl LedgerState {
             std::sync::Arc<std::collections::HashSet<dugite_primitives::hash::Hash32>>,
             std::sync::Arc<std::collections::HashSet<dugite_primitives::hash::Hash32>>,
             imbl::HashMap<dugite_primitives::hash::Hash32, u64>,
-            Option<dugite_primitives::hash::Hash28>,
+            // #1028: doubly-optional guardrail — outer None = no constitution
+            // enacted; Some(None) = enacted with NO guardrail (SNothing).
+            Option<Option<dugite_primitives::hash::Hash28>>,
         ) = if mode == BlockValidationMode::ValidateAll {
             use std::collections::{HashMap, HashSet};
             use std::sync::Arc;
@@ -1041,12 +1043,18 @@ impl LedgerState {
                     .map(|(_, hot)| *hot)
                     .collect(),
             );
-            let constitution_script_hash = self
+            // #1028: doubly-optional. `None` = no constitution enacted (context
+            // unknown, check skipped); `Some(None)` = constitution enacted with
+            // NO guardrail script (Haskell `SNothing`), against which a proposal
+            // must also supply `SNothing`; `Some(Some(h))` = guardrail `h`.
+            // Flattening these two `None`s is what let a guardrail-less
+            // constitution accept any `policy_hash` at all.
+            let constitution_script_hash: Option<Option<dugite_primitives::hash::Hash28>> = self
                 .gov
                 .governance
                 .constitution
                 .as_ref()
-                .and_then(|c| c.script_hash);
+                .map(|c| c.script_hash);
 
             // Refresh the cache with the (possibly rebuilt) large registries and
             // their current source keys.  RHS reads only `&self` immutably and
@@ -1333,8 +1341,11 @@ impl LedgerState {
                     if let Some(net) = self.node_network {
                         ctx = ctx.with_network(net);
                     }
-                    if let Some(h) = block_constitution_script_hash {
-                        ctx = ctx.with_constitution_script_hash(h);
+                    // #1028: `Some(guardrail)` — where `guardrail` may itself be
+                    // `None` — means a constitution IS enacted and its guardrail
+                    // (present or absent) must be matched exactly.
+                    if let Some(guardrail) = block_constitution_script_hash {
+                        ctx = ctx.with_constitution_guardrail(guardrail);
                     }
                     if let Some(start) = ctx_start {
                         t_ctx_build += start.elapsed();

--- a/crates/dugite-ledger/src/state/epoch.rs
+++ b/crates/dugite-ledger/src/state/epoch.rs
@@ -727,13 +727,31 @@ impl LedgerState {
         );
 
         // Step 1: Compute new epoch nonce using OLD prevHashNonce (ηh).
-        //   epochNonce = candidate ⭒ prevHashNonce ⭒ extraEntropy
+        //
+        // TPraos (Shelley..Alonzo): candidate ⭒ prevHashNonce ⭒ extraEntropy
+        // Praos  (Babbage onward):  candidate ⭒ prevHashNonce
+        //
         // Nonce combine (⭒) treats NeutralNonce (ZERO) as the identity.
         // extraEntropy is NeutralNonce on virtually every epoch, but mainnet
-        // injected a non-neutral value effective epoch 259 — it MUST be folded
-        // in (see `ConsensusSubState::extra_entropy`).
-        self.consensus.epoch_nonce = crate::eras::common::combine_nonce(
-            crate::eras::common::combine_nonce(candidate, prev_hash_nonce),
+        // injected a non-neutral value effective epoch 259 — on a TPraos era it
+        // MUST be folded in (see `ConsensusSubState::extra_entropy`); on a Praos
+        // era the term does not exist at all (#1015).
+        //
+        // #1015/#977: this is the THIRD site that computed a boundary nonce, and
+        // it is the `#[doc(hidden)]` test-only path that every unit test in this
+        // crate drives — exactly the path #977's fix landed in while production
+        // did nothing. It now shares the ONE
+        // `common::compute_epoch_boundary_nonce` with the era-rules paths, so the
+        // formula cannot drift between them. Only the mode SELECTION differs, and
+        // it differs because this signature has no era in scope; see
+        // `EpochNonceMode::for_protocol_version_major` for why that is the
+        // narrower choice and why production must not copy it.
+        self.consensus.epoch_nonce = crate::eras::common::compute_epoch_boundary_nonce(
+            crate::eras::common::EpochNonceMode::for_protocol_version_major(
+                self.epochs.protocol_params.protocol_version_major,
+            ),
+            candidate,
+            prev_hash_nonce,
             self.consensus.extra_entropy,
         );
 

--- a/crates/dugite-ledger/src/state/mod.rs
+++ b/crates/dugite-ledger/src/state/mod.rs
@@ -1140,8 +1140,13 @@ impl LedgerState {
         if let Some(net) = self.node_network {
             ctx = ctx.with_network(net);
         }
-        if let Some(h) = gov.constitution.as_ref().and_then(|c| c.script_hash) {
-            ctx = ctx.with_constitution_script_hash(h);
+        // #1028: pass the guardrail through INCLUDING its absence. If a
+        // constitution is enacted, `c.script_hash` is authoritative — `None`
+        // there means "no guardrail" (`SNothing`), which Haskell still enforces
+        // equality against. Only the total absence of a constitution leaves the
+        // context unset, which is the one case that skips the check.
+        if let Some(c) = gov.constitution.as_ref() {
+            ctx = ctx.with_constitution_guardrail(c.script_hash);
         }
         ctx
     }

--- a/crates/dugite-ledger/src/validation/conway.rs
+++ b/crates/dugite-ledger/src/validation/conway.rs
@@ -396,13 +396,12 @@ pub(super) fn check_pparam_update_well_formed(
 ///
 /// `hardforkConwayBootstrapPhase pv = pvMajor pv < 10` — fires at PV9 only.
 /// Callers gate on `protocol_version_major == 9` before invoking.
+///
+/// The action-type classification is shared with the proposal-side restriction
+/// via [`is_bootstrap_action`] — Haskell gates both on the identical
+/// `isBootstrapAction` predicate, so they must not be able to drift.
 pub(super) fn is_bootstrap_vote_disallowed(voter: &Voter, action: &GovAction) -> bool {
-    let is_bootstrap_action = matches!(
-        action,
-        GovAction::ParameterChange { .. }
-            | GovAction::HardForkInitiation { .. }
-            | GovAction::InfoAction
-    );
+    let is_bootstrap_action = is_bootstrap_action(action);
     match voter {
         // DRepVoter: only InfoAction is allowed during bootstrap.
         Voter::DRep(_) => !matches!(action, GovAction::InfoAction),
@@ -410,6 +409,63 @@ pub(super) fn is_bootstrap_vote_disallowed(voter: &Voter, action: &GovAction) ->
         // (ParameterChange / HardForkInitiation / InfoAction).
         Voter::ConstitutionalCommittee(_) | Voter::StakePool(_) => !is_bootstrap_action,
     }
+}
+
+/// Haskell `isBootstrapAction` — the governance-action types permitted during
+/// the Conway bootstrap phase (PV9).
+///
+/// ```haskell
+/// isBootstrapAction =
+///   \case
+///     ParameterChange {} -> True
+///     HardForkInitiation {} -> True
+///     InfoAction -> True
+///     _ -> False
+/// ```
+///
+/// Source: `eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs`
+/// (lines 633-639), pinned at `4849c13d6f70e5ab46add9af6e0ec5c537b61f69`.
+///
+/// Haskell gates BOTH bootstrap restrictions on this one predicate — votes via
+/// `checkBootstrapVotes` and proposal submission via `checkBootstrapProposal` —
+/// so dugite shares it rather than keeping two matching `matches!` arms that
+/// could drift (#1026).
+pub(super) fn is_bootstrap_action(action: &GovAction) -> bool {
+    matches!(
+        action,
+        GovAction::ParameterChange { .. }
+            | GovAction::HardForkInitiation { .. }
+            | GovAction::InfoAction
+    )
+}
+
+/// Returns `true` when a proposal may NOT be SUBMITTED during the Conway
+/// bootstrap phase.
+///
+/// Per Haskell `checkBootstrapProposal`, step 1 of the per-proposal fold in
+/// `conwayGovTransition`'s `processProposal`:
+///
+/// ```haskell
+/// checkBootstrapProposal pp proposal
+///   | hardforkConwayBootstrapPhase (pp ^. ppProtocolVersionL) =
+///       failureUnless (isBootstrapAction (pProcGovAction proposal)) $
+///         DisallowedProposalDuringBootstrap proposal
+///   | otherwise = pure ()
+/// ```
+///
+/// So at PV9 only `ParameterChange` / `HardForkInitiation` / `InfoAction` may be
+/// proposed; `NoConfidence`, `UpdateCommittee`, `NewConstitution` and
+/// `TreasuryWithdrawals` are rejected with `ConwayGovPredFailure` tag 12.
+///
+/// **Ordering is load-bearing**: `runTest $ checkBootstrapProposal pp proposal`
+/// is the FIRST test in `processProposal`, ahead of the `ProposalCantFollow`
+/// hard-fork check and `actionWellFormed`. Callers must run it before those, so
+/// a bootstrap-disallowed proposal reports tag 12 and not some later failure.
+///
+/// Callers gate on `protocol_version_major == 9` before invoking
+/// (`hardforkConwayBootstrapPhase pv = pvMajor pv == natVersion @9`).
+pub(super) fn is_bootstrap_proposal_disallowed(action: &GovAction) -> bool {
+    !is_bootstrap_action(action)
 }
 
 pub(super) fn is_voter_disallowed(voter: &Voter, action: &GovAction) -> bool {
@@ -3095,5 +3151,85 @@ mod tests {
             committee_update_invalid_expiries(&proposal, &ctx).is_empty(),
             "Predicate must skip (empty vec) when current_epoch is None"
         );
+    }
+
+    // ── #1026: PV9 bootstrap proposal-SUBMISSION restriction ──────────────
+    //
+    // Haskell `checkBootstrapProposal` (step 1 of `processProposal`) restricts
+    // PROPOSAL submission at PV9 to the same action set the VOTE side already
+    // restricted, via the identical `isBootstrapAction` predicate. dugite had
+    // only the vote side, i.e. accept-where-Haskell-rejects.
+
+    /// `isBootstrapAction` — allowed set is exactly ParameterChange /
+    /// HardForkInitiation / InfoAction.
+    #[test]
+    fn is_bootstrap_action_matches_haskell_allowed_set() {
+        assert!(is_bootstrap_action(&GovAction::InfoAction));
+        assert!(is_bootstrap_action(&GovAction::HardForkInitiation {
+            prev_action_id: None,
+            protocol_version: (10, 0),
+        }));
+
+        // Everything else is disallowed during bootstrap.
+        assert!(!is_bootstrap_action(&GovAction::NoConfidence {
+            prev_action_id: None
+        }));
+        assert!(!is_bootstrap_action(&GovAction::TreasuryWithdrawals {
+            withdrawals: std::collections::BTreeMap::new(),
+            policy_hash: None,
+        }));
+        assert!(!is_bootstrap_action(&GovAction::NewConstitution {
+            prev_action_id: None,
+            constitution: dugite_primitives::transaction::Constitution {
+                anchor: dugite_primitives::transaction::Anchor {
+                    url: "https://c".to_string(),
+                    data_hash: dugite_primitives::hash::Hash32::from_bytes([0x05; 32]),
+                },
+                script_hash: None,
+            },
+        }));
+    }
+
+    /// The proposal-side predicate is the exact negation, and — critically —
+    /// shares its classification with the vote side, so the two cannot drift.
+    /// Haskell gates both on one `isBootstrapAction`.
+    #[test]
+    fn bootstrap_proposal_and_vote_restrictions_share_one_classification() {
+        let disallowed = GovAction::TreasuryWithdrawals {
+            withdrawals: std::collections::BTreeMap::new(),
+            policy_hash: None,
+        };
+        let allowed = GovAction::InfoAction;
+
+        assert!(is_bootstrap_proposal_disallowed(&disallowed));
+        assert!(!is_bootstrap_proposal_disallowed(&allowed));
+
+        // Same action set drives the SPO/CC vote restriction: a non-bootstrap
+        // action is vote-disallowed for those voters too. If a future edit
+        // changed one side's set, this pairing fails.
+        let spo = Voter::StakePool(dugite_primitives::hash::Hash32::from_bytes([7u8; 32]));
+        assert_eq!(
+            is_bootstrap_proposal_disallowed(&disallowed),
+            is_bootstrap_vote_disallowed(&spo, &disallowed),
+            "proposal and SPO-vote restrictions must agree on a non-bootstrap action"
+        );
+        assert_eq!(
+            is_bootstrap_proposal_disallowed(&allowed),
+            is_bootstrap_vote_disallowed(&spo, &allowed),
+            "proposal and SPO-vote restrictions must agree on a bootstrap action"
+        );
+    }
+
+    /// A HardForkInitiation proposal must stay PROPOSABLE at PV9 — that is the
+    /// whole point of the bootstrap phase, and rejecting it would break the
+    /// PV9→PV10 hard fork itself. Guards against an over-broad fix.
+    #[test]
+    fn hardfork_initiation_stays_proposable_during_bootstrap() {
+        assert!(!is_bootstrap_proposal_disallowed(
+            &GovAction::HardForkInitiation {
+                prev_action_id: None,
+                protocol_version: (10, 0),
+            }
+        ));
     }
 }

--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -317,12 +317,34 @@ pub struct ValidationContext {
     ///
     /// Uses `imbl::HashMap` for the same O(1) clone reason as `reward_accounts`.
     pub stake_key_deposits: Option<ImblMap<Hash32, u64>>,
-    /// The constitution's guardrail script hash, if any.
+    /// The enacted constitution's guardrail script, as a **doubly**-optional
+    /// value. The nesting is load-bearing (#1028):
     ///
-    /// When `Some`, governance proposals of type `ParameterChange` or
-    /// `TreasuryWithdrawals` must carry a matching `policy_hash`.  When `None`,
-    /// the constitution policy-hash check is skipped.
-    pub constitution_script_hash: Option<Hash28>,
+    /// * `None` — the caller has not plumbed this context in. The guardrail
+    ///   check is SKIPPED, following the lenient-default convention the other
+    ///   GOV predicates in this module use for un-supplied context.
+    /// * `Some(None)` — the constitution is known and genuinely has **no**
+    ///   guardrail script (Haskell `SNothing`). A `ParameterChange` /
+    ///   `TreasuryWithdrawals` proposal must then supply `SNothing` too; any
+    ///   `SJust h` is REJECTED.
+    /// * `Some(Some(h))` — the guardrail is `h`; a proposal must supply exactly
+    ///   `SJust h`.
+    ///
+    /// A single `Option<Hash28>` conflated the first two, and dugite skipped the
+    /// whole check on `None` — so with a guardrail-less constitution a proposal
+    /// carrying ANY `policy_hash`, including garbage, was silently accepted
+    /// (accept-where-Haskell-rejects). Haskell compares the entire
+    /// `StrictMaybe ScriptHash`:
+    ///
+    /// ```haskell
+    /// checkGuardrailsScriptHash expectedHash actualHash =
+    ///   failureUnless (actualHash == expectedHash) $
+    ///     InvalidGuardrailsScriptHash actualHash expectedHash
+    /// ```
+    ///
+    /// `SNothing == SNothing` is required exactly as `SJust h == SJust h` is —
+    /// "the constitution has no guardrail" does NOT mean "anything goes".
+    pub constitution_script_hash: Option<Option<Hash28>>,
     /// DRep vote delegations — keys are stake credential hashes of accounts
     /// that have delegated to any DRep (including AlwaysAbstain / AlwaysNoConfidence).
     pub vote_delegations: Option<Arc<HashSet<Hash32>>>,
@@ -590,8 +612,26 @@ impl ValidationContext {
         self
     }
 
+    /// Declare the enacted constitution's guardrail, INCLUDING the case where it
+    /// has none.
+    ///
+    /// Call this whenever a constitution is enacted, passing its
+    /// `script_hash` verbatim — `None` here means "known to have no guardrail"
+    /// (`SNothing`), not "unknown". Leaving the context unset (never calling
+    /// this) is what means "unknown", and only that skips the check (#1028).
+    pub fn with_constitution_guardrail(mut self, guardrail: Option<Hash28>) -> Self {
+        self.constitution_script_hash = Some(guardrail);
+        self
+    }
+
+    /// Convenience for the common case of a constitution WITH a guardrail.
+    ///
+    /// Equivalent to `with_constitution_guardrail(Some(hash))`. Prefer
+    /// [`Self::with_constitution_guardrail`] at any site that derives the value
+    /// from a real constitution, so a guardrail-less one stays distinguishable
+    /// from missing context.
     pub fn with_constitution_script_hash(mut self, hash: Hash28) -> Self {
-        self.constitution_script_hash = Some(hash);
+        self.constitution_script_hash = Some(Some(hash));
         self
     }
 
@@ -2156,25 +2196,52 @@ pub enum ValidationError {
         /// reports the whole set (#979).
         accounts: Vec<String>,
     },
-    /// Conway GOV rule: a `ParameterChange` or `TreasuryWithdrawals` proposal's
-    /// `policy_hash` does not match the constitution's guardrail script hash.
+    /// Conway GOV rule `InvalidGuardrailsScriptHash` (`ConwayGovPredFailure`
+    /// tag 11): a `ParameterChange` or `TreasuryWithdrawals` proposal's
+    /// `policy_hash` does not equal the enacted constitution's guardrail script.
     ///
-    /// When the constitution carries a guardrail script, every governed proposal
-    /// must include a `policy_hash` that equals the constitution's script hash.
-    /// A mismatch or omission prevents the guardrail from being executed during
-    /// Phase-2, bypassing the constitutionality check.
+    /// Haskell compares the WHOLE `StrictMaybe ScriptHash`:
     ///
-    /// Reference: Haskell `ConwayGovFailure` predicate —
-    /// `GovActionsDoNotExist` / policy-hash mismatch in the GOV rule.
+    /// ```haskell
+    /// checkGuardrailsScriptHash expectedHash actualHash =
+    ///   failureUnless (actualHash == expectedHash) $
+    ///     InvalidGuardrailsScriptHash actualHash expectedHash
+    /// ```
+    ///
+    /// called as `checkGuardrailsScriptHash constitutionPolicy proposalPolicy`.
+    /// All four combinations matter, and there is no escape hatch:
+    ///
+    /// | constitution | proposal   | verdict |
+    /// |---|---|---|
+    /// | `SJust h`  | `SJust h`  | ok |
+    /// | `SJust a`  | `SJust b`  | reject (mismatch) |
+    /// | `SJust e`  | `SNothing` | reject (omitted — bypasses the guardrail) |
+    /// | `SNothing` | `SJust a`  | reject (#1028 — dugite used to skip) |
+    ///
+    /// The last row is the point of #1028: "the constitution has no guardrail"
+    /// does NOT mean "anything goes". dugite gated the whole check on
+    /// `if let Some(hash) = constitution_script_hash`, so a guardrail-less
+    /// constitution accepted a proposal carrying any `policy_hash` at all.
+    /// See [`ValidationContext::constitution_script_hash`] for how the two
+    /// meanings of `None` are now kept apart.
+    ///
+    /// Renamed from `ConstitutionPolicyMismatch` to match Haskell's own
+    /// constructor name, and the payload is now typed `Option<Hash28>` on both
+    /// sides rather than hex strings with an empty-string sentinel for absence —
+    /// the wire variant in `dugite-network` was already
+    /// `InvalidGuardrailsScriptHash { got, expected }` with `StrictMaybe`
+    /// semantics, so this removes a stringly-typed conversion in between.
+    ///
+    /// Field order follows Haskell's constructor: ACTUAL (`got`) first.
     #[error(
-        "Governance proposal policy_hash mismatch: constitution requires {expected}, \
-         proposal has {actual} (ConstitutionPolicyMismatch)"
+        "InvalidGuardrailsScriptHash: constitution guardrail is {expected:?}, \
+         proposal policy_hash is {got:?}"
     )]
-    ConstitutionPolicyMismatch {
-        /// Hex-encoded expected constitution script hash.
-        expected: String,
-        /// Hex-encoded provided policy hash, or "None" if absent.
-        actual: String,
+    InvalidGuardrailsScriptHash {
+        /// The proposal's `policy_hash` (Haskell `actualHash`).
+        got: Option<Hash28>,
+        /// The enacted constitution's guardrail script (Haskell `expectedHash`).
+        expected: Option<Hash28>,
     },
     /// Pool metadata hash exceeds the 32-byte (Blake2b-256) cap.
     ///
@@ -3543,7 +3610,7 @@ pub fn validate_transaction_with_pools(
     committee_members: Option<&HashSet<Hash32>>,
     committee_resigned: Option<&HashSet<Hash32>>,
     stake_key_deposits: Option<&ImblMap<Hash32, u64>>,
-    constitution_script_hash: Option<Hash28>,
+    constitution_script_hash: Option<Option<Hash28>>,
     vote_delegations: Option<&HashSet<Hash32>>,
 ) -> Result<(), Vec<ValidationError>> {
     trace!(
@@ -4392,29 +4459,33 @@ pub fn validate_transaction_with_pools(
     // script hash for governed governance actions.
     // ------------------------------------------------------------------
     if params.protocol_version_major >= 9 {
-        if let Some(required_hash) = constitution_script_hash {
-            for (idx, proposal) in tx.body.proposal_procedures.iter().enumerate() {
+        // #1028: the OUTER `Option` is "did the caller plumb this in?". Only
+        // that skips the check. `Some(None)` is a real, representable on-chain
+        // state — a constitution with no guardrail script — and Haskell still
+        // enforces equality there.
+        if let Some(expected_guardrail) = constitution_script_hash {
+            for proposal in tx.body.proposal_procedures.iter() {
                 let policy_hash = match &proposal.gov_action {
                     GovAction::ParameterChange { policy_hash, .. }
-                    | GovAction::TreasuryWithdrawals { policy_hash, .. } => policy_hash.as_ref(),
+                    | GovAction::TreasuryWithdrawals { policy_hash, .. } => *policy_hash,
                     _ => continue,
                 };
-                match policy_hash {
-                    Some(provided) if *provided == required_hash => {
-                        // Valid — policy hash matches constitution guardrail
-                    }
-                    Some(provided) => {
-                        errors.push(ValidationError::ConstitutionPolicyMismatch {
-                            expected: required_hash.to_hex(),
-                            actual: provided.to_hex(),
-                        });
-                    }
-                    None => {
-                        errors.push(ValidationError::ConstitutionPolicyMismatch {
-                            expected: required_hash.to_hex(),
-                            actual: format!("None (proposal index {idx})"),
-                        });
-                    }
+                // Whole-`StrictMaybe` comparison, matching
+                //   checkGuardrailsScriptHash expectedHash actualHash =
+                //     failureUnless (actualHash == expectedHash) $
+                //       InvalidGuardrailsScriptHash actualHash expectedHash
+                //
+                // so all four combinations are handled by one `!=`:
+                //   SJust h  vs SJust h  -> ok
+                //   SJust a  vs SJust b  -> reject (mismatch)
+                //   SNothing vs SJust e  -> reject (missing)
+                //   SJust a  vs SNothing -> reject  <-- the #1028 gap: dugite
+                //                                      used to skip entirely
+                if policy_hash != expected_guardrail {
+                    errors.push(ValidationError::InvalidGuardrailsScriptHash {
+                        got: policy_hash,
+                        expected: expected_guardrail,
+                    });
                 }
             }
         }

--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -1178,6 +1178,50 @@ pub enum ValidationError {
     DisallowedVotesDuringBootstrap {
         violations: Vec<(Voter, GovActionId)>,
     },
+    /// Conway bootstrap-phase (PV9) proposal-SUBMISSION restriction —
+    /// `ConwayGovPredFailure` tag 12.
+    ///
+    /// Per Haskell `checkBootstrapProposal`, step 1 of the per-proposal fold in
+    /// `conwayGovTransition`'s `processProposal`
+    /// (`eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs`, pinned at
+    /// `4849c13d6f70e5ab46add9af6e0ec5c537b61f69`):
+    ///
+    /// ```haskell
+    /// checkBootstrapProposal pp proposal
+    ///   | hardforkConwayBootstrapPhase (pp ^. ppProtocolVersionL) =
+    ///       failureUnless (isBootstrapAction (pProcGovAction proposal)) $
+    ///         DisallowedProposalDuringBootstrap proposal
+    ///   | otherwise = pure ()
+    /// ```
+    ///
+    /// Only `ParameterChange` / `HardForkInitiation` / `InfoAction` may be
+    /// proposed at PV9; `NoConfidence`, `UpdateCommittee`, `NewConstitution` and
+    /// `TreasuryWithdrawals` are rejected. dugite had the symmetric VOTE-side
+    /// restriction ([`Self::DisallowedVotesDuringBootstrap`]) but no
+    /// proposal-side one, i.e. accept-where-Haskell-rejects (#1026).
+    ///
+    /// Fires only when `pvMajor == 9`. Not reachable on mainnet/preprod/preview,
+    /// which are all past PV9 — but a fresh devnet or testnet bootstrapped at
+    /// PV9 reaches it, and historical replay through the PV9 window would too.
+    ///
+    /// Haskell's payload is the whole `ProposalProcedure`
+    /// (`DisallowedProposalDuringBootstrap (ProposalProcedure era)`), the same
+    /// one-field shape as [`Self::InvalidPrevGovActionId`]'s tag 8. `proposal`
+    /// carries it so the N2C encoder can emit a byte-exact tag-12 frame rather
+    /// than degrading to a generic `ConwayMempoolFailure` — the #979/#1050 class
+    /// this project keeps having to un-degrade. Boxed for the same reason tag 8
+    /// boxes it: `ProposalProcedure` boxes `ProtocolParamUpdate`, and an unboxed
+    /// copy would make this the largest `ValidationError` variant and bloat every
+    /// `Vec<ValidationError>` on the hot rejection path.
+    #[error(
+        "DisallowedProposalDuringBootstrap: proposal index {action_index} ({action_type}) may \
+         not be proposed during the Conway bootstrap phase (PV9)"
+    )]
+    DisallowedProposalDuringBootstrap {
+        action_index: u32,
+        action_type: &'static str,
+        proposal: Box<ProposalProcedure>,
+    },
     /// Conway GOV rule: every TreasuryWithdrawals destination address
     /// must be a registered staking credential.
     ///
@@ -3007,6 +3051,37 @@ pub fn validate_transaction_with_context(
     // a tx with no proposals).
     // -------------------------------------------------------------------
     if params.protocol_version_major >= 9 && !tx.body.proposal_procedures.is_empty() {
+        // -------------------------------------------------------------------
+        // DisallowedProposalDuringBootstrap (ConwayGovPredFailure tag 12),
+        // PV9 only.
+        //
+        // MUST be first. Haskell's `processProposal` opens with
+        //
+        //     runTest $ checkBootstrapProposal pp proposal
+        //
+        // ahead of the `ProposalCantFollow` hard-fork check and
+        // `actionWellFormed`, so a bootstrap-disallowed proposal reports tag 12
+        // rather than some later predicate's failure. Placing it after
+        // ProposalCantFollow would still reject the tx but with the wrong reason
+        // for a `HardForkInitiation`-shaped payload.
+        //
+        // dugite already had the symmetric VOTE-side restriction
+        // (`DisallowedVotesDuringBootstrap`) and shares the identical
+        // `isBootstrapAction` classification with it via
+        // `conway::is_bootstrap_action` (#1026).
+        // -------------------------------------------------------------------
+        if params.protocol_version_major == 9 {
+            for (idx, proposal) in tx.body.proposal_procedures.iter().enumerate() {
+                if conway::is_bootstrap_proposal_disallowed(&proposal.gov_action) {
+                    extra_errors.push(ValidationError::DisallowedProposalDuringBootstrap {
+                        action_index: idx as u32,
+                        action_type: gov_action_type_name(&proposal.gov_action),
+                        proposal: Box::new(proposal.clone()),
+                    });
+                }
+            }
+        }
+
         // -------------------------------------------------------------------
         // ProposalCantFollow: a HardForkInitiation proposal's target protocol
         // version must legally follow its resolved base version (Haskell

--- a/crates/dugite-ledger/src/validation/phase1.rs
+++ b/crates/dugite-ledger/src/validation/phase1.rs
@@ -727,6 +727,28 @@ pub(super) fn run_phase1_rules(
 ) {
     let body = &tx.body;
 
+    // Did every input resolve to a UTxO?
+    //
+    // #1030 item 1: the precondition for the checks that need input VALUES
+    // (Rule 3 conservation) or input ADDRESSES (Rule 9b witness completeness).
+    // Those two used to be gated on `errors.is_empty()`, which conflated "this
+    // check cannot be computed" with "something else already went wrong" and so
+    // shortened the reported failure list on any multi-failure transaction.
+    // Haskell's `?!` never short-circuits, so all applicable failures reach
+    // MsgRejectTx.
+    //
+    // Deliberately NARROW: only the variants that mean a UTxO lookup did not
+    // produce an entry. `ValueNotConserved` is not here — it is a RESULT of this
+    // check, not a precondition for it.
+    fn inputs_resolved(errors: &[ValidationError]) -> bool {
+        !errors.iter().any(|e| {
+            matches!(
+                e,
+                ValidationError::NoInputs | ValidationError::InputNotFound(_)
+            )
+        })
+    }
+
     // ------------------------------------------------------------------
     // Rule 1: Must have at least one input
     // ------------------------------------------------------------------
@@ -1171,8 +1193,22 @@ pub(super) fn run_phase1_rules(
     // Rule 3: ADA value conservation
     // consumed = Σ(inputs) + Σ(withdrawals) + Σ(refunds)
     // produced = Σ(outputs) + fee + Σ(deposits) + proposal_deposits + donation
+    //
+    // #1030 item 1: gated on INPUT RESOLUTION, not on `errors.is_empty()`.
+    //
+    // Haskell's STS `?!` never short-circuits within a rule body, so every
+    // applicable predicate failure accumulates and all of them reach
+    // `MsgRejectTx`. An `errors.is_empty()` gate silently shortens that list:
+    // a `ProposalDepositIncorrect` raised immediately above — which has nothing
+    // to do with whether ADA conservation can be computed — used to suppress the
+    // conservation failure entirely. The verdict never diverged (both
+    // implementations reject), but a client parsing the reason saw fewer causes
+    // than cardano-node reports.
+    //
+    // What this check genuinely CANNOT be computed without is resolved inputs,
+    // so that — and only that — is the precondition now.
     // ------------------------------------------------------------------
-    if errors.is_empty() {
+    if inputs_resolved(errors) {
         let output_value: u128 = body.outputs.iter().map(|o| o.value.coin.0 as u128).sum();
         let withdrawal_value: u128 = body.withdrawals.values().map(|l| l.0 as u128).sum();
 
@@ -1704,8 +1740,13 @@ pub(super) fn run_phase1_rules(
 
     // ------------------------------------------------------------------
     // Rule 9b: Witness completeness
+    //
+    // #1030 item 1: gated on INPUT RESOLUTION, not `errors.is_empty()` — see
+    // Rule 3's note. Witness completeness needs each input's ADDRESS to know
+    // which key or script must have signed, so unresolved inputs genuinely make
+    // it uncomputable; an unrelated earlier failure does not.
     // ------------------------------------------------------------------
-    if errors.is_empty() {
+    if inputs_resolved(errors) {
         // Build the set of VKey witness key hashes (blake2b-224 of each vkey).
         //
         // D9 / audit #544: Only hash vkeys that are exactly 32 bytes.

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -15868,6 +15868,175 @@ mod tests {
 
     /// At PV=9 (Conway bootstrap) the conflicting-update check is **still
     /// enforced** — there is no bootstrap skip for this rule.
+    // -------------------------------------------------------------------------
+    // #1026: DisallowedProposalDuringBootstrap (ConwayGovPredFailure tag 12)
+    //
+    // These are the tests that prove the predicate is WIRED into the live
+    // `validate_transaction_with_context` path, not merely that a helper
+    // function returns the right boolean. #977's lesson: eight unit tests were
+    // green while the production path did nothing, because they all drove a
+    // `#[doc(hidden)]` helper instead of the real dispatch.
+    // -------------------------------------------------------------------------
+
+    /// Build a bootstrap-DISALLOWED proposal (TreasuryWithdrawals).
+    fn treasury_withdrawal_proposal_for_test() -> ProposalProcedure {
+        ProposalProcedure {
+            deposit: Lovelace(1_000_000),
+            return_addr: std::iter::once(0xE1)
+                .chain(std::iter::repeat_n(0x11, 28))
+                .collect(),
+            gov_action: dugite_primitives::transaction::GovAction::TreasuryWithdrawals {
+                withdrawals: BTreeMap::new(),
+                policy_hash: None,
+            },
+            anchor: dugite_primitives::transaction::Anchor {
+                url: "https://x".to_string(),
+                data_hash: Hash32::from_bytes([0xAA; 32]),
+            },
+        }
+    }
+
+    /// Build a bootstrap-ALLOWED proposal (InfoAction).
+    fn info_action_proposal_for_test() -> ProposalProcedure {
+        ProposalProcedure {
+            deposit: Lovelace(1_000_000),
+            return_addr: std::iter::once(0xE1)
+                .chain(std::iter::repeat_n(0x11, 28))
+                .collect(),
+            gov_action: dugite_primitives::transaction::GovAction::InfoAction,
+            anchor: dugite_primitives::transaction::Anchor {
+                url: "https://x".to_string(),
+                data_hash: Hash32::from_bytes([0xAA; 32]),
+            },
+        }
+    }
+
+    /// At PV9 a `TreasuryWithdrawals` proposal MUST be rejected with
+    /// `DisallowedProposalDuringBootstrap`. Before #1026 dugite accepted it —
+    /// accept-where-Haskell-rejects.
+    #[test]
+    fn treasury_withdrawal_proposal_rejected_during_bootstrap_pv9() {
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.protocol_version_major = 9;
+        let utxo_set = UtxoSet::new();
+
+        let tx = make_gov_tx(
+            vec![treasury_withdrawal_proposal_for_test()],
+            BTreeMap::new(),
+        );
+        let context =
+            ValidationContext::new().with_network(dugite_primitives::network::NetworkId::Mainnet);
+        let errors =
+            validate_transaction_with_context(&tx, &utxo_set, &params, 100, 500, None, context)
+                .expect_err("a TreasuryWithdrawals proposal must be rejected at PV9");
+
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::DisallowedProposalDuringBootstrap { .. })),
+            "DisallowedProposalDuringBootstrap MUST fire at PV9 for TreasuryWithdrawals \
+             (#1026); got: {errors:?}"
+        );
+    }
+
+    /// The PV gate: at PV10 the same proposal must NOT raise this predicate.
+    /// `hardforkConwayBootstrapPhase pv = pvMajor pv == natVersion @9`, so an
+    /// over-broad fix that rejected TreasuryWithdrawals on live networks would
+    /// be a false-reject far worse than the gap it closed.
+    #[test]
+    fn treasury_withdrawal_proposal_allowed_post_bootstrap_pv10() {
+        let params = conway_pparams_pv10();
+        let utxo_set = UtxoSet::new();
+
+        let tx = make_gov_tx(
+            vec![treasury_withdrawal_proposal_for_test()],
+            BTreeMap::new(),
+        );
+        let context =
+            ValidationContext::new().with_network(dugite_primitives::network::NetworkId::Mainnet);
+        // The tx still fails (no inputs), so filter for THIS predicate only.
+        let errors =
+            validate_transaction_with_context(&tx, &utxo_set, &params, 100, 500, None, context)
+                .expect_err("tx has no inputs, so it fails for unrelated reasons");
+
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::DisallowedProposalDuringBootstrap { .. })),
+            "DisallowedProposalDuringBootstrap must NOT fire at PV10 — the bootstrap \
+             phase is PV9 only; got: {errors:?}"
+        );
+    }
+
+    /// An `InfoAction` proposal is bootstrap-ALLOWED and must not raise the
+    /// predicate even at PV9. Without this, a fix that rejected every proposal
+    /// during bootstrap would pass the test above.
+    #[test]
+    fn info_action_proposal_allowed_during_bootstrap_pv9() {
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.protocol_version_major = 9;
+        let utxo_set = UtxoSet::new();
+
+        let tx = make_gov_tx(vec![info_action_proposal_for_test()], BTreeMap::new());
+        let context =
+            ValidationContext::new().with_network(dugite_primitives::network::NetworkId::Mainnet);
+        let errors =
+            validate_transaction_with_context(&tx, &utxo_set, &params, 100, 500, None, context)
+                .expect_err("tx has no inputs, so it fails for unrelated reasons");
+
+        assert!(
+            !errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::DisallowedProposalDuringBootstrap { .. })),
+            "InfoAction is a bootstrap action and must stay proposable at PV9; got: {errors:?}"
+        );
+    }
+
+    /// The payload must identify WHICH proposal failed, so a tx carrying several
+    /// proposals is diagnosable — and it must carry the whole
+    /// `ProposalProcedure`, which is what lets the N2C encoder emit a byte-exact
+    /// GOV tag-12 frame instead of a generic `ConwayMempoolFailure`.
+    #[test]
+    fn disallowed_proposal_during_bootstrap_payload_identifies_the_proposal() {
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.protocol_version_major = 9;
+        let utxo_set = UtxoSet::new();
+
+        // index 0 allowed, index 1 disallowed.
+        let tx = make_gov_tx(
+            vec![
+                info_action_proposal_for_test(),
+                treasury_withdrawal_proposal_for_test(),
+            ],
+            BTreeMap::new(),
+        );
+        let context =
+            ValidationContext::new().with_network(dugite_primitives::network::NetworkId::Mainnet);
+        let errors =
+            validate_transaction_with_context(&tx, &utxo_set, &params, 100, 500, None, context)
+                .expect_err("the disallowed proposal must reject the tx");
+
+        let found = errors
+            .iter()
+            .find_map(|e| match e {
+                ValidationError::DisallowedProposalDuringBootstrap {
+                    action_index,
+                    action_type,
+                    proposal,
+                } => Some((*action_index, *action_type, proposal.clone())),
+                _ => None,
+            })
+            .expect("DisallowedProposalDuringBootstrap must be present");
+
+        assert_eq!(found.0, 1, "must name the SECOND proposal, not the first");
+        assert_eq!(found.1, "TreasuryWithdrawals");
+        assert_eq!(
+            found.2.deposit,
+            Lovelace(1_000_000),
+            "payload must carry the whole ProposalProcedure for the tag-12 encoder"
+        );
+    }
+
     #[test]
     fn test_validate_transaction_rejects_conflicting_committee_update_in_bootstrap() {
         use dugite_primitives::credentials::Credential;

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -14085,7 +14085,7 @@ mod tests {
     fn test_constitution_policy_hash_match_accepted() {
         // When the constitution has a guardrail script and the proposal provides
         // a matching policy_hash, validation should NOT produce a
-        // ConstitutionPolicyMismatch error.
+        // InvalidGuardrailsScriptHash error.
         let script_hash = Hash28::from_bytes([0xAB; 28]);
         let (utxo_set, _input, tx, params) = make_guardrail_proposal_tx(Some(script_hash));
 
@@ -14106,15 +14106,15 @@ mod tests {
             None,
             None,
             None,
-            Some(script_hash), // constitution_script_hash matches policy_hash
-            None,              // vote_delegations
+            Some(Some(script_hash)), // constitution guardrail matches policy_hash
+            None,                    // vote_delegations
         );
-        // Should not have ConstitutionPolicyMismatch (may have other errors
+        // Should not have InvalidGuardrailsScriptHash (may have other errors
         // like MissingWitness — that's fine, we only care about the policy check).
         if let Err(errors) = result {
             assert!(
-                !errors.iter().any(|e| matches!(e, ValidationError::ConstitutionPolicyMismatch { .. })),
-                "Should not have ConstitutionPolicyMismatch when policy_hash matches, got: {errors:?}"
+                !errors.iter().any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+                "Should not have InvalidGuardrailsScriptHash when policy_hash matches, got: {errors:?}"
             );
         }
     }
@@ -14123,7 +14123,7 @@ mod tests {
     fn test_constitution_policy_hash_mismatch_rejected() {
         // When the constitution has a guardrail script and the proposal provides
         // a DIFFERENT policy_hash, validation must produce a
-        // ConstitutionPolicyMismatch error.
+        // InvalidGuardrailsScriptHash error.
         let constitution_hash = Hash28::from_bytes([0xAB; 28]);
         let wrong_hash = Hash28::from_bytes([0xCD; 28]);
         let (utxo_set, _input, tx, params) = make_guardrail_proposal_tx(Some(wrong_hash));
@@ -14145,15 +14145,15 @@ mod tests {
             None,
             None,
             None,
-            Some(constitution_hash), // constitution expects 0xAB, proposal has 0xCD
-            None,                    // vote_delegations
+            Some(Some(constitution_hash)), // constitution expects 0xAB, proposal has 0xCD
+            None,                          // vote_delegations
         );
         let errors = result.expect_err("should reject mismatched policy_hash");
         assert!(
             errors
                 .iter()
-                .any(|e| matches!(e, ValidationError::ConstitutionPolicyMismatch { .. })),
-            "Should have ConstitutionPolicyMismatch, got: {errors:?}"
+                .any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+            "Should have InvalidGuardrailsScriptHash, got: {errors:?}"
         );
     }
 
@@ -14161,7 +14161,7 @@ mod tests {
     fn test_constitution_policy_hash_missing_rejected() {
         // When the constitution has a guardrail script but the proposal has
         // no policy_hash (None), validation must produce a
-        // ConstitutionPolicyMismatch error.
+        // InvalidGuardrailsScriptHash error.
         let constitution_hash = Hash28::from_bytes([0xAB; 28]);
         let (utxo_set, _input, tx, params) = make_guardrail_proposal_tx(None);
 
@@ -14182,22 +14182,167 @@ mod tests {
             None,
             None,
             None,
-            Some(constitution_hash), // constitution requires guardrail, proposal has None
-            None,                    // vote_delegations
+            Some(Some(constitution_hash)), // constitution requires guardrail, proposal has None
+            None,                          // vote_delegations
         );
         let errors = result.expect_err("should reject missing policy_hash");
         assert!(
             errors
                 .iter()
-                .any(|e| matches!(e, ValidationError::ConstitutionPolicyMismatch { .. })),
-            "Should have ConstitutionPolicyMismatch for missing policy_hash, got: {errors:?}"
+                .any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+            "Should have InvalidGuardrailsScriptHash for missing policy_hash, got: {errors:?}"
+        );
+    }
+
+    // ── #1028: SNothing-vs-not-plumbed, the full StrictMaybe matrix ────────
+    //
+    // Haskell:
+    //   checkGuardrailsScriptHash expectedHash actualHash =
+    //     failureUnless (actualHash == expectedHash) $
+    //       InvalidGuardrailsScriptHash actualHash expectedHash
+    //
+    // `SNothing == SNothing` is required exactly as `SJust h == SJust h` is.
+    // dugite gated the WHOLE check on `if let Some(hash) = ...`, so a
+    // guardrail-less constitution accepted a proposal carrying any policy_hash
+    // at all — accept-where-Haskell-rejects.
+
+    /// **The #1028 regression.** Constitution enacted with NO guardrail
+    /// (`Some(None)`), proposal supplies `SJust h` ⇒ MUST reject.
+    #[test]
+    fn guardrail_snothing_constitution_rejects_proposal_with_policy_hash() {
+        let provided = Hash28::from_bytes([0xCD; 28]);
+        let (utxo_set, _input, tx, params) = make_guardrail_proposal_tx(Some(provided));
+
+        let result = validate_transaction_with_pools(
+            &tx,
+            &utxo_set,
+            &params,
+            100,
+            300,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(None), // constitution ENACTED, guardrail SNothing
+            None,       // vote_delegations
+        );
+
+        let errors =
+            result.expect_err("a policy_hash against a guardrail-less constitution must reject");
+        let found = errors
+            .iter()
+            .find_map(|e| match e {
+                ValidationError::InvalidGuardrailsScriptHash { got, expected } => {
+                    Some((*got, *expected))
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "InvalidGuardrailsScriptHash MUST fire when the constitution has NO \
+                     guardrail but the proposal supplies one (#1028); got: {errors:?}"
+                )
+            });
+        assert_eq!(
+            found.0,
+            Some(provided),
+            "`got` is the proposal's policy_hash"
+        );
+        assert_eq!(
+            found.1, None,
+            "`expected` is the constitution's SNothing guardrail"
+        );
+    }
+
+    /// Constitution enacted with NO guardrail and proposal ALSO supplies none
+    /// ⇒ must be accepted. `SNothing == SNothing`. Without this, a fix that
+    /// rejected everything on a guardrail-less constitution would pass the test
+    /// above.
+    #[test]
+    fn guardrail_snothing_constitution_accepts_proposal_without_policy_hash() {
+        let (utxo_set, _input, tx, params) = make_guardrail_proposal_tx(None);
+
+        let result = validate_transaction_with_pools(
+            &tx,
+            &utxo_set,
+            &params,
+            100,
+            300,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(None), // constitution ENACTED, guardrail SNothing
+            None,
+        );
+
+        if let Err(errors) = result {
+            assert!(
+                !errors
+                    .iter()
+                    .any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+                "SNothing constitution + SNothing proposal must NOT raise \
+                 InvalidGuardrailsScriptHash; got: {errors:?}"
+            );
+        }
+    }
+
+    /// The two meanings of `None` must behave DIFFERENTLY on identical input.
+    /// If they ever coincide, the doubly-optional type is pointless and #1028
+    /// has regressed — this is the test that makes the distinction observable.
+    #[test]
+    fn guardrail_not_plumbed_and_snothing_are_distinguishable() {
+        let provided = Hash28::from_bytes([0xCD; 28]);
+
+        let fires = |guardrail: Option<Option<Hash28>>| -> bool {
+            let (utxo_set, _input, tx, params) = make_guardrail_proposal_tx(Some(provided));
+            let result = validate_transaction_with_pools(
+                &tx, &utxo_set, &params, 100, 300, None, None, None, None, None, None, None, None,
+                None, None, None, guardrail, None,
+            );
+            match result {
+                Err(errors) => errors
+                    .iter()
+                    .any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+                Ok(_) => false,
+            }
+        };
+
+        assert!(
+            !fires(None),
+            "outer None = context not plumbed in ⇒ check SKIPPED (lenient default)"
+        );
+        assert!(
+            fires(Some(None)),
+            "Some(None) = constitution known to have NO guardrail ⇒ check ENFORCED (#1028)"
         );
     }
 
     #[test]
     fn test_no_constitution_no_policy_required() {
-        // When the constitution has no guardrail script (None), proposals with
-        // or without policy_hash should NOT trigger ConstitutionPolicyMismatch.
+        // #1028: this covers the OUTER `None` — the caller never plumbed the
+        // guardrail context in, so the check is skipped under this module's
+        // lenient-default convention for un-supplied context.
+        //
+        // It does NOT cover "the constitution exists and has no guardrail"
+        // (`Some(None)`); the original comment here said it did, which is
+        // exactly the conflation #1028 was about. That case is a real,
+        // representable on-chain state where Haskell still enforces equality,
+        // and it has its own tests below.
         let (utxo_set, _input, tx, params) =
             make_guardrail_proposal_tx(Some(Hash28::from_bytes([0xAB; 28])));
 
@@ -14206,13 +14351,13 @@ mod tests {
             None, None, None, None, // no constitution script hash
             None, // vote_delegations
         );
-        // Should not have ConstitutionPolicyMismatch.
+        // Should not have InvalidGuardrailsScriptHash.
         if let Err(errors) = result {
             assert!(
                 !errors
                     .iter()
-                    .any(|e| matches!(e, ValidationError::ConstitutionPolicyMismatch { .. })),
-                "Should not have ConstitutionPolicyMismatch when no constitution, got: {errors:?}"
+                    .any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+                "Should not have InvalidGuardrailsScriptHash when no constitution, got: {errors:?}"
             );
         }
     }
@@ -14247,15 +14392,15 @@ mod tests {
             None,
             None,
             None,
-            Some(constitution_hash),
+            Some(Some(constitution_hash)),
             None, // vote_delegations
         );
         let errors = result.expect_err("should reject mismatched TreasuryWithdrawals policy_hash");
         assert!(
             errors
                 .iter()
-                .any(|e| matches!(e, ValidationError::ConstitutionPolicyMismatch { .. })),
-            "Should have ConstitutionPolicyMismatch for TreasuryWithdrawals, got: {errors:?}"
+                .any(|e| matches!(e, ValidationError::InvalidGuardrailsScriptHash { .. })),
+            "Should have InvalidGuardrailsScriptHash for TreasuryWithdrawals, got: {errors:?}"
         );
     }
 
@@ -14322,7 +14467,7 @@ mod tests {
             None,
             None,
             None,
-            Some(script_hash),
+            Some(Some(script_hash)),
             None, // vote_delegations
         );
         // The redeemer at index 2 should NOT trigger RedeemerIndexOutOfRange
@@ -15866,8 +16011,6 @@ mod tests {
         assert_eq!(conflicts[0], cred.to_typed_hash32().to_hex());
     }
 
-    /// At PV=9 (Conway bootstrap) the conflicting-update check is **still
-    /// enforced** — there is no bootstrap skip for this rule.
     // -------------------------------------------------------------------------
     // #1026: DisallowedProposalDuringBootstrap (ConwayGovPredFailure tag 12)
     //
@@ -16037,6 +16180,8 @@ mod tests {
         );
     }
 
+    /// At PV=9 (Conway bootstrap) the conflicting-update check is **still
+    /// enforced** — there is no bootstrap skip for this rule.
     #[test]
     fn test_validate_transaction_rejects_conflicting_committee_update_in_bootstrap() {
         use dugite_primitives::credentials::Credential;

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -13386,6 +13386,55 @@ mod tests {
         tx
     }
 
+    /// #1030 item 1: Phase-1 failures must ACCUMULATE, not short-circuit.
+    ///
+    /// Haskell's STS `?!` never short-circuits within a rule body, so every
+    /// applicable predicate failure reaches `MsgRejectTx`. dugite gated Rule 3
+    /// (ADA conservation) on `errors.is_empty()`, so an unrelated
+    /// `ProposalDepositIncorrect` raised immediately above it SUPPRESSED the
+    /// conservation failure — a client saw one cause where cardano-node reports
+    /// two. The verdict never diverged; the reported reason list was short.
+    ///
+    /// This drives a tx that violates BOTH at once and requires both to surface.
+    #[test]
+    fn phase1_failures_accumulate_proposal_deposit_and_value_conservation() {
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.protocol_version_major = 9;
+        let wrong_deposit = params.gov_action_deposit.0 - 1;
+
+        let mut utxo_set = UtxoSet::new();
+        // Correctly-balanced proposal tx with a WRONG proposal deposit...
+        let mut tx = make_proposal_tx(&mut utxo_set, wrong_deposit, &params);
+        // ...then break ADA conservation too, by inflating the output.
+        if let Some(out) = tx.body.outputs.first_mut() {
+            out.value.coin = Lovelace(out.value.coin.0 + 1_000_000);
+        }
+
+        let errors = validate_transaction_with_pools(
+            &tx, &utxo_set, &params, 100, 300, None, None, None, None, None, None, None, None,
+            None, None, None, None, None,
+        )
+        .expect_err("both predicates are violated, so the tx must be rejected");
+
+        let has_deposit = errors
+            .iter()
+            .any(|e| matches!(e, ValidationError::ProposalDepositIncorrect { .. }));
+        let has_conservation = errors
+            .iter()
+            .any(|e| matches!(e, ValidationError::ValueNotConserved { .. }));
+
+        assert!(
+            has_deposit,
+            "ProposalDepositIncorrect must be reported; got: {errors:?}"
+        );
+        assert!(
+            has_conservation,
+            "ValueNotConserved must ALSO be reported — an `errors.is_empty()` gate \
+             on Rule 3 suppressed it, shortening the failure list vs cardano-node \
+             (#1030 item 1); got: {errors:?}"
+        );
+    }
+
     #[test]
     fn test_proposal_incorrect_deposit_rejected() {
         // A proposal with a deposit that doesn't match gov_action_deposit must

--- a/crates/dugite-network/src/lib.rs
+++ b/crates/dugite-network/src/lib.rs
@@ -834,6 +834,53 @@ pub enum TxValidationError {
         /// `(typed-hash32 hex, expiry epoch)` per offending member.
         members: Vec<(String, u64)>,
     },
+    /// `HardForkApplyTxErrWrongEra` — the submitted transaction's era does not
+    /// match the ledger's current era (#1047).
+    ///
+    /// This is NOT a ledger predicate failure and does NOT share their wire
+    /// shape. `ApplyTxErr` for the HFC is
+    /// `Either (MismatchEraInfo xs) (OneEraApplyTxErr xs)`, and
+    /// `encodeEitherMismatch` (ouroboros-consensus
+    /// `HardFork/Combinator/Serialisation/Common.hs`) branches on the `Either`:
+    ///
+    /// ```haskell
+    /// (HardForkNodeToClientEnabled{}, Right a) ->
+    ///   mconcat [ Enc.encodeListLen 1, enc a ]
+    /// (HardForkNodeToClientEnabled{}, Left (MismatchEraInfo err)) ->
+    ///   mconcat
+    ///     [ Enc.encodeListLen 2
+    ///     , encodeNS (hpure (fn encodeName)) era1
+    ///     , encodeNS (hpure (fn (encodeName . getLedgerEraInfo))) era2
+    ///     ]
+    ///   where (era1, era2) = Match.mismatchToNS err
+    /// ```
+    ///
+    /// So the normal case is `array(1)[…]` — which is what every other variant
+    /// in this enum produces — and the wrong-era case is a top-level
+    /// **`array(2)`** of two `encodeNS` values. `encodeNS` is
+    /// `array(2)[word8 index, value]`, and `encodeName` is
+    /// `Serialise.encode . singleEraName`, i.e. a CBOR **text** string.
+    ///
+    /// Field order is pinned by `mkEraMismatch`
+    /// (`HardFork/Combinator/AcrossEras.hs`), whose
+    /// `Mismatch SingleEraInfo LedgerEraInfo` gives `SingleEraInfo` = the
+    /// TRANSACTION's era and `LedgerEraInfo` = the LEDGER's era, and by
+    /// `encodeEitherMismatch` emitting `era1` (SingleEraInfo) first. Getting
+    /// this order backwards would mislabel the reply exactly as #1051's spurious
+    /// Set tag made one undecodable.
+    ///
+    /// `singleEraName = T.pack (L.eraName @era)` (`ShelleyHFC.hs`), i.e.
+    /// cardano-ledger's era name: "Byron", "Shelley", …, "Conway", "Dijkstra".
+    HardForkApplyTxErrWrongEra {
+        /// HFC index of the era the client declared for its transaction.
+        tx_era_index: u8,
+        /// Era name for the transaction's era (Haskell `SingleEraInfo`).
+        tx_era_name: String,
+        /// HFC index of the ledger's current era.
+        ledger_era_index: u8,
+        /// Era name for the ledger's era (Haskell `LedgerEraInfo`).
+        ledger_era_name: String,
+    },
     /// `DisallowedProposalDuringBootstrap` (GOV tag 12) —
     /// `DisallowedProposalDuringBootstrap (ProposalProcedure era)`.
     ///

--- a/crates/dugite-network/src/lib.rs
+++ b/crates/dugite-network/src/lib.rs
@@ -834,6 +834,26 @@ pub enum TxValidationError {
         /// `(typed-hash32 hex, expiry epoch)` per offending member.
         members: Vec<(String, u64)>,
     },
+    /// `DisallowedProposalDuringBootstrap` (GOV tag 12) —
+    /// `DisallowedProposalDuringBootstrap (ProposalProcedure era)`.
+    ///
+    /// At PV9 only `ParameterChange` / `HardForkInitiation` / `InfoAction` may
+    /// be PROPOSED (Haskell `checkBootstrapProposal`, step 1 of
+    /// `processProposal`). dugite had only the symmetric VOTE-side restriction
+    /// below, so a bootstrap-disallowed proposal was accepted where
+    /// cardano-node rejects it (#1026).
+    ///
+    /// One-field payload carrying the ENTIRE proposal, exactly like
+    /// [`TxValidationError::InvalidPrevGovActionId`]'s tag 8 — so the encoder
+    /// re-encodes it with `dugite_serialization::encode_proposal_procedure`, the
+    /// same function that builds proposals into tx bodies for signing, keeping
+    /// both paths byte-identical by construction. Boxed for the same hot-path
+    /// enum-size reason.
+    DisallowedProposalDuringBootstrap {
+        action_index: u32,
+        action_type: String,
+        proposal: Box<dugite_primitives::transaction::ProposalProcedure>,
+    },
     /// `DisallowedVotesDuringBootstrap` (GOV tag 13) —
     /// `NonEmpty (Voter, GovActionId)`.
     DisallowedVotesDuringBootstrap {

--- a/crates/dugite-network/src/lib.rs
+++ b/crates/dugite-network/src/lib.rs
@@ -834,6 +834,45 @@ pub enum TxValidationError {
         /// `(typed-hash32 hex, expiry epoch)` per offending member.
         members: Vec<(String, u64)>,
     },
+    /// `ScriptIntegrityHashMismatch` (UTXOW tag 18) — the **PV>=11** form of a
+    /// script-integrity-hash mismatch (#1058).
+    ///
+    /// `checkScriptIntegrityHash` (cardano-ledger
+    /// `eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs`) picks the
+    /// constructor by protocol version:
+    ///
+    /// ```haskell
+    /// $ if pvMajor (pp ^. ppProtocolVersionL) < natVersion @11
+    ///   then PPViewHashesDontMatch mismatch
+    ///   else ScriptIntegrityHashMismatch mismatch expectedScriptIntegrity
+    /// ```
+    ///
+    /// The two differ in BOTH tag and payload shape
+    /// (`Conway/Rules/Utxow.hs`):
+    ///
+    /// ```haskell
+    /// PPViewHashesDontMatch       mm  -> Sum … 13 !> ToGroup mm
+    /// ScriptIntegrityHashMismatch x y -> Sum … 18 !> To x !> To y
+    /// ```
+    ///
+    /// so tag 13 FLATTENS the `Mismatch` into the constructor array while tag 18
+    /// carries it as a self-contained `array(2)` plus a SECOND field. dugite
+    /// emitted tag 13 at every PV, which is wrong on preview/PV11 — the #978
+    /// inversion (there, only the unreachable PV>=11 arms existed).
+    ///
+    /// `expected_bytes` is Haskell's `originalBytes <$> scriptIntegrity`: the
+    /// script-integrity **preimage**, not a hash. dugite's Phase-1 error carries
+    /// only hashes, so this is `None` (`SNothing`) — structurally valid and
+    /// decodable, omitting a diagnostic. Plumbing the preimage span out of
+    /// Phase-1 is a larger change and deliberately does not gate the tag fix.
+    ScriptIntegrityHashMismatchUTXOW {
+        /// Hex-encoded hash the transaction body declared, if any.
+        supplied: Option<String>,
+        /// Hex-encoded hash recomputed from the script context, if any.
+        expected: Option<String>,
+        /// Hex-encoded script-integrity preimage bytes, if known.
+        expected_bytes: Option<String>,
+    },
     /// `HardForkApplyTxErrWrongEra` — the submitted transaction's era does not
     /// match the ledger's current era (#1047).
     ///

--- a/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
+++ b/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
@@ -695,6 +695,30 @@ fn encode_conway_ledger_pred_failure(enc: &mut Encoder<&mut Vec<u8>>, err: &TxVa
             });
         }
 
+        // Tag 12: DisallowedProposalDuringBootstrap — [12, <the whole
+        // ProposalProcedure>].
+        //
+        // Haskell (`Cardano.Ledger.Conway.Rules.Gov`):
+        //   DisallowedProposalDuringBootstrap (ProposalProcedure era)
+        // — the identical one-field `Sum` shape as tag 8, so it re-uses the same
+        // `encode_proposal_procedure` (the function that also builds proposals
+        // into tx bodies for signing, keeping the two byte-identical).
+        //
+        // Fires only at PV9, where `checkBootstrapProposal` restricts proposal
+        // submission to ParameterChange / HardForkInitiation / InfoAction.
+        // Landing the typed arm together with the predicate deliberately: #979
+        // and #1050 are both cases where a correct ledger rejection shipped with
+        // no encoder arm and degraded to a generic `ConwayMempoolFailure`, and
+        // #1053 is still open for the whole phase-2 class. A new predicate
+        // should not add to that list (#1026).
+        TxValidationError::DisallowedProposalDuringBootstrap { proposal, .. } => {
+            let raw = dugite_serialization::encode_proposal_procedure(proposal);
+            encode_gov_failure(enc, 12, |enc| {
+                let writer = enc.writer_mut();
+                writer.extend_from_slice(&raw);
+            });
+        }
+
         // Decode-level rejection: the tx failed `decode_transaction` before
         // Phase-1 ever ran (e.g. a Conway duplicate input hard-fails the
         // strict-set decoder, mirroring Haskell `decodeSetEnforceNoDuplicates`).
@@ -4261,6 +4285,107 @@ mod tests {
             "the GOV tag-1 payload must be byte-identical to the body encoder's output"
         );
         assert_eq!(&buf[..4], &[0x82, 0x03, 0x82, 0x01]);
+    }
+
+    // ── #1026: `DisallowedProposalDuringBootstrap` (Ledger tag 3, GOV tag 12) ──
+
+    /// CBOR golden: `DisallowedProposalDuringBootstrap` carrying a
+    /// `TreasuryWithdrawals` proposal — a bootstrap-DISALLOWED action type.
+    ///
+    /// Haskell: `DisallowedProposalDuringBootstrap (ProposalProcedure era)`, the
+    /// identical one-field `Sum` shape as tag 8, so the payload is the whole
+    /// proposal and the only difference from `test_encode_invalid_prev_gov_
+    /// action_id_golden` is the constructor tag (12 vs 8) and the action.
+    #[test]
+    fn test_encode_disallowed_proposal_during_bootstrap_golden() {
+        use dugite_primitives::hash::Hash32;
+        use dugite_primitives::transaction::{Anchor, GovAction, ProposalProcedure};
+        use dugite_primitives::value::Lovelace;
+
+        let return_addr: Vec<u8> = std::iter::once(0xE1)
+            .chain(std::iter::repeat_n(0x11, 28))
+            .collect();
+        let proposal = ProposalProcedure {
+            deposit: Lovelace(1_000_000),
+            return_addr,
+            gov_action: GovAction::InfoAction,
+            anchor: Anchor {
+                url: "https://x".to_string(),
+                data_hash: Hash32::from_bytes([0xAA; 32]),
+            },
+        };
+        let err = TxValidationError::DisallowedProposalDuringBootstrap {
+            action_index: 0,
+            action_type: "TreasuryWithdrawals".to_string(),
+            proposal: Box::new(proposal),
+        };
+
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        encode_conway_ledger_pred_failure(&mut enc, &err);
+
+        let mut expected = vec![
+            0x82, 0x03, // ConwayLedgerPredFailure: array(2)[3, ...]
+            0x82, 0x0c, // ConwayGovPredFailure: array(2)[12, ...]
+            0x84, // ProposalProcedure: array(4)
+            0x1a, 0x00, 0x0f, 0x42, 0x40, // deposit = 1_000_000
+            0x58, 0x1d, // return_addr: bstr(29)
+        ];
+        expected.push(0xe1);
+        expected.extend(std::iter::repeat_n(0x11u8, 28));
+        expected.extend([0x81, 0x06]); // gov_action payload
+        expected.push(0x82);
+        expected.push(0x69);
+        expected.extend(b"https://x");
+        expected.push(0x58);
+        expected.push(0x20);
+        expected.extend([0xAAu8; 32]);
+
+        assert_eq!(
+            buf, expected,
+            "DisallowedProposalDuringBootstrap must be a byte-exact GOV tag-12 frame"
+        );
+    }
+
+    /// The whole point of #1026's wire half: this must NOT degrade to the
+    /// generic `ConwayMempoolFailure` (Ledger tag 7) fallback that #979/#1050
+    /// were about. Asserts the Ledger and GOV tags directly rather than merely
+    /// "some bytes were produced".
+    #[test]
+    fn disallowed_proposal_during_bootstrap_is_not_a_generic_mempool_failure() {
+        use dugite_primitives::hash::Hash32;
+        use dugite_primitives::transaction::{Anchor, GovAction, ProposalProcedure};
+        use dugite_primitives::value::Lovelace;
+
+        let proposal = ProposalProcedure {
+            deposit: Lovelace(42),
+            return_addr: std::iter::once(0xE1)
+                .chain(std::iter::repeat_n(0x22, 28))
+                .collect(),
+            gov_action: GovAction::InfoAction,
+            anchor: Anchor {
+                url: "u".to_string(),
+                data_hash: Hash32::from_bytes([0x01; 32]),
+            },
+        };
+        let err = TxValidationError::DisallowedProposalDuringBootstrap {
+            action_index: 3,
+            action_type: "NoConfidence".to_string(),
+            proposal: Box::new(proposal),
+        };
+
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        encode_conway_ledger_pred_failure(&mut enc, &err);
+
+        assert_eq!(buf[0], 0x82, "must be array(2)[LedgerTag, inner]");
+        assert_eq!(
+            buf[1], 0x03,
+            "Ledger tag must be 3 (ConwayGovFailure), NOT 7 (ConwayMempoolFailure) — \
+             a typed GOV frame is the entire point of #1026's wire half"
+        );
+        assert_eq!(buf[2], 0x82, "inner must be array(2)[GovTag, payload]");
+        assert_eq!(buf[3], 0x0c, "GOV tag must be 12");
     }
 
     // ── Issue #915: `InvalidPrevGovActionId` (Ledger tag 3, GOV tag 8) ──

--- a/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
+++ b/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
@@ -414,23 +414,47 @@ fn encode_conway_ledger_pred_failure(enc: &mut Encoder<&mut Vec<u8>>, err: &TxVa
             );
         }
 
-        // Utxow tag 13: ScriptIntegrityHashMismatch (formerly PPViewHashesDontMatch pre-PV11) — [supplied_hash_or_null, expected_hash_or_null]
+        // Utxow tag 13: PPViewHashesDontMatch — the PV<=10 form (#1058).
+        //
+        //   PPViewHashesDontMatch mm -> Sum … 13 !> ToGroup mm
+        //
+        // `ToGroup` FLATTENS the Mismatch into the constructor array, so the two
+        // StrictMaybe values sit directly in it. The PV>=11 form is a different
+        // constructor with a different tag AND a third field — see
+        // `ScriptIntegrityHashMismatchUTXOW` above. `convert_validation_error_at_pv`
+        // chooses between them.
         TxValidationError::ScriptDataHashMismatch { expected, actual } => {
             encode_utxow_failure(enc, 13, |enc| {
-                // supplied (actual from tx) — StrictMaybe encoding
-                if let Some(hash_bytes) = parse_hex_bytes(actual) {
-                    enc.array(1).expect("infallible");
-                    enc.bytes(&hash_bytes).expect("infallible");
-                } else {
-                    enc.array(0).expect("infallible");
-                }
-                // expected (computed from script context) — StrictMaybe encoding
-                if let Some(hash_bytes) = parse_hex_bytes(expected) {
-                    enc.array(1).expect("infallible");
-                    enc.bytes(&hash_bytes).expect("infallible");
-                } else {
-                    enc.array(0).expect("infallible");
-                }
+                // supplied (declared in the tx body), then expected (recomputed).
+                encode_strict_maybe_bytes(enc, Some(actual.as_str()));
+                encode_strict_maybe_bytes(enc, Some(expected.as_str()));
+            });
+        }
+
+        // Utxow tag 18: ScriptIntegrityHashMismatch — the PV>=11 form (#1058).
+        //
+        //   ScriptIntegrityHashMismatch x y -> Sum … 18 !> To x !> To y
+        //
+        // `To x` puts the `Mismatch` in a NON-group position, so it uses its own
+        // `EncCBOR` and is a self-contained array(2) — the opposite of tag 13's
+        // `ToGroup mm`, which flattens the same Mismatch into the constructor
+        // array. Getting that distinction backwards is #1050's
+        // ProposalDepositIncorrect trap (a nested Mismatch where a flattened one
+        // was wanted produced `DeserialiseFailure … "expected word"`).
+        //
+        // `y :: StrictMaybe ByteString` is the script-integrity PREIMAGE.
+        TxValidationError::ScriptIntegrityHashMismatchUTXOW {
+            supplied,
+            expected,
+            expected_bytes,
+        } => {
+            encode_utxow_failure(enc, 18, |enc| {
+                // x: the Mismatch as a self-contained array(2).
+                enc.array(2).expect("infallible");
+                encode_strict_maybe_bytes(enc, supplied.as_deref());
+                encode_strict_maybe_bytes(enc, expected.as_deref());
+                // y: StrictMaybe ByteString.
+                encode_strict_maybe_bytes(enc, expected_bytes.as_deref());
             });
         }
 
@@ -1814,6 +1838,25 @@ fn parse_hex_bytes(s: &str) -> Option<Vec<u8>> {
         .step_by(2)
         .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
         .collect()
+}
+
+/// Encode a `StrictMaybe ByteString` from an optional hex string.
+///
+/// Haskell's `StrictMaybe` encodes as `array(0)` for `SNothing` and
+/// `array(1)[value]` for `SJust` — the shape used by every script-integrity and
+/// metadata-hash field. Unparseable hex is treated as `SNothing` rather than
+/// silently emitting a truncated byte string, so a malformed input cannot
+/// produce a frame that decodes to the wrong value (#1058).
+fn encode_strict_maybe_bytes(enc: &mut Encoder<&mut Vec<u8>>, hex: Option<&str>) {
+    match hex.and_then(parse_hex_bytes) {
+        Some(bytes) => {
+            enc.array(1).expect("infallible");
+            enc.bytes(&bytes).expect("infallible");
+        }
+        None => {
+            enc.array(0).expect("infallible");
+        }
+    }
 }
 
 /// Parse a hex string into exactly 28 raw bytes.
@@ -4312,6 +4355,107 @@ mod tests {
             "the GOV tag-1 payload must be byte-identical to the body encoder's output"
         );
         assert_eq!(&buf[..4], &[0x82, 0x03, 0x82, 0x01]);
+    }
+
+    // ── #1058: script-integrity-hash mismatch splits at PV 11 ──────────────
+    //
+    //   pv < 11  -> PPViewHashesDontMatch mismatch                 (UTXOW 13)
+    //   pv >= 11 -> ScriptIntegrityHashMismatch mismatch preimage   (UTXOW 18)
+    //
+    // and the encodings differ in shape, not just tag:
+    //   PPViewHashesDontMatch       mm  -> Sum … 13 !> ToGroup mm   (FLATTENED)
+    //   ScriptIntegrityHashMismatch x y -> Sum … 18 !> To x !> To y (NESTED + 3rd)
+    //
+    // dugite emitted 13 at every PV. preview runs PV11, so the reachable case was
+    // the wrong one — the #978 inversion.
+
+    /// PV<=10 form: tag 13 with the Mismatch FLATTENED into the constructor.
+    #[test]
+    fn script_integrity_pv10_is_tag_13_flattened() {
+        let err = TxValidationError::ScriptDataHashMismatch {
+            expected: "aa".repeat(32),
+            actual: "bb".repeat(32),
+        };
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        encode_conway_ledger_pred_failure(&mut enc, &err);
+
+        // ConwayLedgerPredFailure array(2)[1, ConwayUtxowPredFailure]
+        assert_eq!(buf[0], 0x82);
+        assert_eq!(buf[1], 0x01, "Ledger tag 1 = ConwayUtxowFailure");
+        // UTXOW array(3)[13, supplied, expected] — flattened, so THREE elements.
+        assert_eq!(buf[2], 0x83, "ToGroup flattens the Mismatch: array(3)");
+        assert_eq!(buf[3], 0x0d, "UTXOW tag 13 (PPViewHashesDontMatch)");
+        // supplied = SJust bstr(32)
+        assert_eq!(buf[4], 0x81, "StrictMaybe SJust = array(1)");
+        assert_eq!(buf[5], 0x58);
+        assert_eq!(buf[6], 0x20, "bstr(32)");
+        assert_eq!(&buf[7..39], [0xbbu8; 32], "supplied comes FIRST");
+    }
+
+    /// PV>=11 form: tag 18, Mismatch NESTED as array(2), plus a third field.
+    #[test]
+    fn script_integrity_pv11_is_tag_18_nested_with_preimage_field() {
+        let err = TxValidationError::ScriptIntegrityHashMismatchUTXOW {
+            supplied: Some("bb".repeat(32)),
+            expected: Some("aa".repeat(32)),
+            expected_bytes: None,
+        };
+        let mut buf = Vec::new();
+        let mut enc = Encoder::new(&mut buf);
+        encode_conway_ledger_pred_failure(&mut enc, &err);
+
+        assert_eq!(buf[0], 0x82);
+        assert_eq!(buf[1], 0x01, "Ledger tag 1 = ConwayUtxowFailure");
+        assert_eq!(buf[2], 0x83, "UTXOW array(3)[18, mismatch, preimage]");
+        assert_eq!(buf[3], 0x12, "UTXOW tag 18 (ScriptIntegrityHashMismatch)");
+        assert_eq!(
+            buf[4], 0x82,
+            "`To x` NESTS the Mismatch as a self-contained array(2) — the opposite \
+             of tag 13's ToGroup flattening"
+        );
+        // supplied then expected inside the nested Mismatch.
+        assert_eq!(buf[5], 0x81);
+        assert_eq!(buf[6], 0x58);
+        assert_eq!(buf[7], 0x20);
+        assert_eq!(
+            &buf[8..40],
+            [0xbbu8; 32],
+            "supplied first inside the Mismatch"
+        );
+        // ... expected ...
+        assert_eq!(buf[40], 0x81);
+        assert_eq!(&buf[43..75], [0xaau8; 32], "expected second");
+        // third field: SNothing, since dugite has no preimage.
+        assert_eq!(buf[75], 0x80, "StrictMaybe ByteString SNothing = array(0)");
+    }
+
+    /// The two forms must be DISTINGUISHABLE on the wire. If they ever encode
+    /// identically the PV gate is pointless and #1058 has regressed.
+    #[test]
+    fn script_integrity_pv10_and_pv11_forms_differ() {
+        let pv10 = TxValidationError::ScriptDataHashMismatch {
+            expected: "aa".repeat(32),
+            actual: "bb".repeat(32),
+        };
+        let pv11 = TxValidationError::ScriptIntegrityHashMismatchUTXOW {
+            supplied: Some("bb".repeat(32)),
+            expected: Some("aa".repeat(32)),
+            expected_bytes: None,
+        };
+
+        let enc_one = |e: &TxValidationError| {
+            let mut b = Vec::new();
+            let mut x = Encoder::new(&mut b);
+            encode_conway_ledger_pred_failure(&mut x, e);
+            b
+        };
+
+        assert_ne!(
+            enc_one(&pv10),
+            enc_one(&pv11),
+            "the PV<=10 and PV>=11 script-integrity forms must differ on the wire"
+        );
     }
 
     // ── #1047: HardForkApplyTxErrWrongEra ─────────────────────────────────

--- a/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
+++ b/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
@@ -41,6 +41,33 @@ pub fn encode_apply_tx_err(error: &TxValidationError, era_id: u16) -> Vec<u8> {
     let mut buf = Vec::new();
     let mut enc = Encoder::new(&mut buf);
 
+    // #1047: a wrong-era rejection is the `Left` branch of
+    // `Either (MismatchEraInfo xs) (OneEraApplyTxErr xs)` and has a STRUCTURALLY
+    // DIFFERENT top level — `array(2)` of two `encodeNS` values — so it cannot go
+    // through the array(1) era-tagged path below. Handled first, before
+    // `flatten_errors`, because it is not a ledger predicate failure at all and
+    // must never be wrapped as one.
+    if let TxValidationError::HardForkApplyTxErrWrongEra {
+        tx_era_index,
+        tx_era_name,
+        ledger_era_index,
+        ledger_era_name,
+    } = error
+    {
+        enc.array(2).expect("infallible");
+        // era1 = SingleEraInfo = the TRANSACTION's era (Haskell `mkEraMismatch`
+        // binds `SingleEraInfo` to `otherEra`, and `encodeEitherMismatch` emits
+        // era1 first).
+        enc.array(2).expect("infallible");
+        enc.u8(*tx_era_index).expect("infallible");
+        enc.str(tx_era_name).expect("infallible");
+        // era2 = LedgerEraInfo = the LEDGER's era.
+        enc.array(2).expect("infallible");
+        enc.u8(*ledger_era_index).expect("infallible");
+        enc.str(ledger_era_name).expect("infallible");
+        return buf;
+    }
+
     // Collect all failures (flatten Multiple variant)
     let errors = flatten_errors(error);
 
@@ -4285,6 +4312,108 @@ mod tests {
             "the GOV tag-1 payload must be byte-identical to the body encoder's output"
         );
         assert_eq!(&buf[..4], &[0x82, 0x03, 0x82, 0x01]);
+    }
+
+    // ── #1047: HardForkApplyTxErrWrongEra ─────────────────────────────────
+    //
+    // `ApplyTxErr` for the HFC is
+    // `Either (MismatchEraInfo xs) (OneEraApplyTxErr xs)` and
+    // `encodeEitherMismatch` branches on it:
+    //
+    //   Right a -> [ encodeListLen 1, enc a ]
+    //   Left (MismatchEraInfo err) ->
+    //     [ encodeListLen 2
+    //     , encodeNS encodeName era1                      -- SingleEraInfo (tx)
+    //     , encodeNS (encodeName . getLedgerEraInfo) era2  -- LedgerEraInfo
+    //     ]
+    //
+    // with `encodeNS = [word8 index, value]` and
+    // `encodeName = Serialise.encode . singleEraName` (a CBOR text).
+
+    /// Golden: a Shelley (index 1) tx submitted to a Conway (index 6) ledger.
+    ///
+    /// `array(2)[ array(2)[1,"Shelley"], array(2)[6,"Conway"] ]`
+    #[test]
+    fn test_encode_wrong_era_golden() {
+        let err = TxValidationError::HardForkApplyTxErrWrongEra {
+            tx_era_index: 1,
+            tx_era_name: "Shelley".to_string(),
+            ledger_era_index: 6,
+            ledger_era_name: "Conway".to_string(),
+        };
+        let bytes = encode_apply_tx_err(&err, 1);
+
+        let mut want: Vec<u8> = vec![0x82]; // array(2) — the Left branch
+        want.extend([0x82, 0x01]); // era1: array(2)[1, ...]
+        want.push(0x67); // text(7)
+        want.extend(b"Shelley");
+        want.extend([0x82, 0x06]); // era2: array(2)[6, ...]
+        want.push(0x66); // text(6)
+        want.extend(b"Conway");
+
+        assert_eq!(
+            bytes, want,
+            "HardForkApplyTxErrWrongEra must be array(2) of two encodeNS values"
+        );
+    }
+
+    /// The wrong-era reply must NOT use the array(1) era-tagged shape that every
+    /// ledger predicate failure uses. Encoding it as a predicate failure would
+    /// make cardano-cli parse an era name where it expects a failure list.
+    #[test]
+    fn wrong_era_is_not_encoded_as_a_ledger_predicate_failure() {
+        let wrong_era = TxValidationError::HardForkApplyTxErrWrongEra {
+            tx_era_index: 1,
+            tx_era_name: "Shelley".to_string(),
+            ledger_era_index: 6,
+            ledger_era_name: "Conway".to_string(),
+        };
+        let ordinary = TxValidationError::InsufficientCollateral {
+            balance: 0,
+            required: 1,
+        };
+
+        assert_eq!(
+            encode_apply_tx_err(&wrong_era, 6)[0],
+            0x82,
+            "wrong-era is the Left branch: top level array(2)"
+        );
+        assert_eq!(
+            encode_apply_tx_err(&ordinary, 6)[0],
+            0x81,
+            "an ordinary predicate failure is the Right branch: top level array(1)"
+        );
+    }
+
+    /// Field ORDER is pinned by `mkEraMismatch`: `SingleEraInfo` is the
+    /// TRANSACTION's era and `LedgerEraInfo` the LEDGER's, and
+    /// `encodeEitherMismatch` emits era1 (SingleEraInfo) first. Swapping them
+    /// would mislabel which side is wrong — the reply would still decode, so only
+    /// an explicit assertion catches it.
+    #[test]
+    fn wrong_era_emits_transaction_era_before_ledger_era() {
+        let err = TxValidationError::HardForkApplyTxErrWrongEra {
+            tx_era_index: 4,
+            tx_era_name: "Alonzo".to_string(),
+            ledger_era_index: 6,
+            ledger_era_name: "Conway".to_string(),
+        };
+        let bytes = encode_apply_tx_err(&err, 4);
+
+        // bytes[0]=array(2); bytes[1..]=first encodeNS.
+        assert_eq!(bytes[1], 0x82, "first element is an encodeNS array(2)");
+        assert_eq!(
+            bytes[2], 0x04,
+            "the TRANSACTION's era index (Alonzo=4) must come FIRST"
+        );
+        let rest = &bytes[3..];
+        assert_eq!(rest[0], 0x66, "text(6)");
+        assert_eq!(&rest[1..7], b"Alonzo");
+        assert_eq!(rest[7], 0x82, "second element is an encodeNS array(2)");
+        assert_eq!(
+            rest[8], 0x06,
+            "the LEDGER's era index (Conway=6) must come SECOND"
+        );
     }
 
     // ── #1026: `DisallowedProposalDuringBootstrap` (Ledger tag 3, GOV tag 12) ──

--- a/crates/dugite-node/src/bin/replay_phase2.rs
+++ b/crates/dugite-node/src/bin/replay_phase2.rs
@@ -9,6 +9,7 @@
 //! chain" tool ISSUE-4 was missing.
 //!
 //! Usage:  replay_phase2 <dump.json>
+//!         replay_phase2 --flat <term.flat> [<dump.json>] [v1|v2|v3|v4]
 
 use std::fs;
 
@@ -37,23 +38,74 @@ fn main() {
             cpu: i64::MAX / 4,
             mem: i64::MAX / 4,
         };
-        // Optional 3rd arg: a dump JSON whose on-chain V2 cost model is used
-        // (so CPU costs match the live node). Without it, default costs.
+        // #1030 item 2: the Plutus language is SELECTABLE, not pinned.
+        //
+        // This mode used to hardcode `PlutusV2` for both the cost model and the
+        // `SemanticsVariant`. That silently mis-costs a V1 or V3 term — and
+        // `ScriptLanguage::PlutusV4` now exists (#1000), so the arm it could not
+        // previously select is available. Diagnostic tooling only (the main
+        // dump-replay path resolves the language correctly via
+        // `eval_phase_two_raw`), but a diagnostic that reports the wrong numbers
+        // is worse than none when it is being used to localise a cost divergence.
+        //
+        // Usage: replay_phase2 --flat <term.flat> [<dump.json>] [v1|v2|v3|v4]
+        let lang = match args.get(4).map(|s| s.as_str()).unwrap_or("v2") {
+            "v1" => dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV1,
+            "v2" => dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV2,
+            "v3" => dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV3,
+            "v4" => dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV4,
+            other => panic!(
+                "unknown Plutus language '{other}' — expected one of v1|v2|v3|v4 \
+                 (usage: replay_phase2 --flat <term.flat> [<dump.json>] [v1|v2|v3|v4])"
+            ),
+        };
+
+        // Optional 3rd arg: a dump JSON whose on-chain cost model for the
+        // selected language is used (so CPU costs match the live node). Without
+        // it, default costs.
         let mut tracker = if let Some(dump) = args.get(3) {
             let v: serde_json::Value =
                 serde_json::from_str(&fs::read_to_string(dump).unwrap()).unwrap();
             let cm_cbor = hexd(v["cost_models_cbor"].as_str().unwrap());
             let cm = dugite_uplc::cost_models::decode_cost_models_cbor(&cm_cbor).unwrap();
-            let params = cm.plutus_v2.as_deref().unwrap();
-            let applied = dugite_uplc::cost_apply::apply_v2(params, 11).unwrap();
+            let applied = match lang {
+                dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV1 => {
+                    let p = cm
+                        .plutus_v1
+                        .as_deref()
+                        .expect("dump has no PlutusV1 cost model");
+                    dugite_uplc::cost_apply::apply_v1(p, 11).unwrap()
+                }
+                dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV2 => {
+                    let p = cm
+                        .plutus_v2
+                        .as_deref()
+                        .expect("dump has no PlutusV2 cost model");
+                    dugite_uplc::cost_apply::apply_v2(p, 11).unwrap()
+                }
+                dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV3 => {
+                    let p = cm
+                        .plutus_v3
+                        .as_deref()
+                        .expect("dump has no PlutusV3 cost model");
+                    dugite_uplc::cost_apply::apply_v3(p, 11).unwrap()
+                }
+                // `cost_apply` has no `apply_v4` yet, so an on-chain V4 cost
+                // model cannot be applied. Say so rather than silently
+                // substituting V3's application and reporting numbers that are
+                // not what the node would charge — the whole purpose of this mode
+                // is to settle a cost divergence.
+                dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV4 => panic!(
+                    "PlutusV4 on-chain cost application is not implemented \
+                     (dugite_uplc::cost_apply has no apply_v4); re-run without the \
+                     dump argument to evaluate V4 under default costs"
+                ),
+            };
             dugite_uplc::machine::cost::BudgetTracker::with_applied(huge, applied)
         } else {
             dugite_uplc::machine::cost::BudgetTracker::new(huge)
         };
-        let variant = dugite_uplc::builtin::semantics::SemanticsVariant::for_script(
-            dugite_uplc::redeemer_resolve::ScriptLanguage::PlutusV2,
-            11,
-        );
+        let variant = dugite_uplc::builtin::semantics::SemanticsVariant::for_script(lang, 11);
         let res = dugite_uplc::machine::step::evaluate_with_budget(
             prog.term,
             &mut tracker,

--- a/crates/dugite-node/src/genesis.rs
+++ b/crates/dugite-node/src/genesis.rs
@@ -618,6 +618,25 @@ pub struct AlonzoGenesis {
     pub max_collateral_inputs: u64,
     #[serde(default)]
     pub cost_models: HashMap<String, serde_json::Value>,
+    /// Haskell `agExtraConfig :: StrictMaybe AlonzoExtraConfig` (#1046).
+    ///
+    /// Written by `cardano-cli ... create-testnet-data`, absent from
+    /// mainnet/preview/preprod. See
+    /// [`AlonzoGenesis::apply_extra_config_cost_models`] for the semantics —
+    /// it is a `curPParams`-only, per-language override and the ONLY way a node
+    /// gets a cost model it was not handed by a genesis field or an on-chain
+    /// PPU.
+    #[serde(default)]
+    pub extra_config: Option<AlonzoExtraConfig>,
+}
+
+/// Haskell `AlonzoExtraConfig { aecCostModels :: Maybe CostModels }`
+/// (`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs`).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AlonzoExtraConfig {
+    #[serde(default)]
+    pub cost_models: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -777,6 +796,88 @@ impl AlonzoGenesis {
                 );
                 params.cost_models.plutus_v3 = Some(costs);
             }
+        }
+    }
+
+    /// Apply `extraConfig.costModels` — Haskell `alonzoInjectCostModels` /
+    /// `overrideCostModels` (#1046).
+    ///
+    /// `cardano-ledger`'s `AlonzoGenesis` carries an optional
+    /// `agExtraConfig :: StrictMaybe AlonzoExtraConfig` whose sole field is
+    /// `aecCostModels :: Maybe CostModels`
+    /// (`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs`). The transition
+    /// config applies it in
+    /// `eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs`:
+    ///
+    /// ```haskell
+    /// alonzoInjectCostModels cfg =
+    ///   case agExtraConfig $ cfg ^. tcTranslationContextL of
+    ///     SNothing -> id
+    ///     SJust aec -> overrideCostModels (aecCostModels aec)
+    ///
+    /// overrideCostModels = \case
+    ///   Nothing -> id
+    ///   -- Injected cost models override the era-translated ones (the
+    ///   -- fixed-length PlutusV1/PlutusV3 genesis fields), so a testnet can
+    ///   -- carry full cost models without an on-chain parameter update.
+    ///   Just cms ->
+    ///     nesEsL . curPParamsEpochStateL . ppCostModelsL
+    ///       %~ flip updateCostModels (CostModelsUpdate cms)
+    /// ```
+    ///
+    /// Two properties are load-bearing and are why this is a SEPARATE method
+    /// rather than part of [`Self::apply_to_protocol_params`]:
+    ///
+    /// 1. **`curPParamsEpochStateL` only.** The override never touches
+    ///    `prevPParams`. That is exactly why cardano-node reports
+    ///    `cur = [V1, V2, V3]` but `prev = [V1, V3]` on a `create-testnet-data`
+    ///    devnet — the shape #994 observed and could not explain.
+    /// 2. **`updateCostModels` is a per-language update**, not a wholesale
+    ///    replacement: languages named in `extraConfig` override, others are
+    ///    retained.
+    ///
+    /// This is the ONLY mechanism by which a node acquires a cost model it was
+    /// not given by a genesis field or an on-chain PPU. cardano-ledger has no
+    /// "default PlutusV2" anywhere — `defaultV2CostModel` lives in **cardano-api**
+    /// (`Cardano.Api.Genesis.Internal`) and is a value written INTO a generated
+    /// genesis file, not a runtime injection. dugite used to hardcode that
+    /// constant and inject it unconditionally, which happened to match on the
+    /// devnet (where `create-testnet-data` writes the identical values into
+    /// `extraConfig`) while being wrong on mainnet/preview/preprod, whose
+    /// alonzo-genesis files carry no `extraConfig` at all and whose
+    /// cardano-node therefore has NO PlutusV2 until a real PPU installs one.
+    pub fn apply_extra_config_cost_models(&self, params: &mut ProtocolParameters) {
+        let Some(extra) = self.extra_config.as_ref() else {
+            return;
+        };
+        for (lang, value) in extra.cost_models.iter() {
+            let Some(costs) = parse_cost_model(value) else {
+                warn!(
+                    lang = %lang,
+                    "Alonzo genesis extraConfig.costModels entry could not be parsed — ignoring"
+                );
+                continue;
+            };
+            let count = costs.len();
+            match lang.as_str() {
+                "PlutusV1" => params.cost_models.plutus_v1 = Some(costs),
+                "PlutusV2" => params.cost_models.plutus_v2 = Some(costs),
+                "PlutusV3" => params.cost_models.plutus_v3 = Some(costs),
+                other => {
+                    warn!(
+                        lang = %other,
+                        "Alonzo genesis extraConfig.costModels names an unknown Plutus \
+                         language — ignoring"
+                    );
+                    continue;
+                }
+            }
+            debug!(
+                lang = %lang,
+                count,
+                "Applied cost model from Alonzo genesis extraConfig (Haskell \
+                 alonzoInjectCostModels — curPParams only)"
+            );
         }
     }
 }
@@ -987,45 +1088,26 @@ impl ConwayGenesis {
             params.cost_models.plutus_v3 = Some(v3.clone());
         }
 
-        // PlutusV2 cost model: if not already set from Alonzo genesis or
-        // on-chain protocol parameter updates, fall back to the initial V2
-        // values cardano-node uses when no V2 is present in genesis files.
+        // #1046: NO default PlutusV2 injection.
         //
-        // These are the pre-Babbage `defaultV2CostModel` values from
-        // `cardano-api/src/Cardano/Api/Genesis/Internal.hs` — the V2 cost
-        // model as introduced at the Alonzo→Babbage HFC. They share the
-        // first ~133 entries with V1 (V2 inherited V1's pricing for
-        // pre-existing builtins and added new ones on top), then diverge
-        // with `serialiseData`, `keccak256`, `blake2b224`, etc.
+        // dugite used to hardcode cardano-api's `defaultV2CostModel` here and
+        // inject it whenever V2 was absent. cardano-ledger has no such default:
+        // a node's cost models come from the genesis FIELDS, from
+        // `agExtraConfig.aecCostModels` (see
+        // `AlonzoGenesis::apply_extra_config_cost_models`), or from an on-chain
+        // PPU — and nowhere else. `defaultV2CostModel` lives in cardano-api's
+        // `Cardano.Api.Genesis.Internal` as a value written INTO a generated
+        // genesis file, not as a runtime fallback.
         //
-        // On mainnet/preview/preprod, a Babbage-era ParameterChange action
-        // updated V2 to the values starting `[100788, 420, ...]` —
-        // dugite's on-chain `apply_protocol_param_update` applies that
-        // automatically during sync, so we converge with public networks
-        // after that epoch.
-        //
-        // On a Conway-direct devnet (cardano-testnet), no such
-        // ParameterChange has ever run, so these initial values remain
-        // authoritative. Using the post-Babbage values here would break
-        // script integrity hash validation against cardano-node, which
-        // computes `LangDepView` from these initial values.
-        if params.cost_models.plutus_v2.is_none() {
-            debug!("PlutusV2 cost model not set — loading pre-Babbage defaultV2CostModel");
-            params.cost_models.plutus_v2 = Some(vec![
-                205665, 812, 1, 1, 1000, 571, 0, 1, 1000, 24177, 4, 1, 1000, 32, 117366, 10475, 4,
-                23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 100, 100,
-                23000, 100, 19537, 32, 175354, 32, 46417, 4, 221973, 511, 0, 1, 89141, 32, 497525,
-                14068, 4, 2, 196500, 453240, 220, 0, 1, 1, 1000, 28662, 4, 2, 245000, 216773, 62,
-                1, 1060367, 12586, 1, 208512, 421, 1, 187000, 1000, 52998, 1, 80436, 32, 43249, 32,
-                1000, 32, 80556, 1, 57667, 4, 1000, 10, 197145, 156, 1, 197145, 156, 1, 204924,
-                473, 1, 208896, 511, 1, 52467, 32, 64832, 32, 65493, 32, 22558, 32, 16563, 32,
-                76511, 32, 196500, 453240, 220, 0, 1, 1, 69522, 11687, 0, 1, 60091, 32, 196500,
-                453240, 220, 0, 1, 1, 196500, 453240, 220, 0, 1, 1, 1159724, 392670, 0, 2, 806990,
-                30482, 4, 1927926, 82523, 4, 265318, 0, 4, 0, 85931, 32, 205665, 812, 1, 1, 41182,
-                32, 212342, 32, 31220, 32, 32696, 32, 43357, 32, 32247, 32, 38314, 32, 35892428,
-                10, 9462713, 1021, 10, 38887044, 32947, 10,
-            ]);
-        }
+        // The injection was invisible on the devnet only because
+        // `create-testnet-data` writes those exact 175 values into
+        // `extraConfig.costModels.PlutusV2`, so the wrong mechanism produced the
+        // right numbers there. On mainnet/preview/preprod there is no
+        // `extraConfig` at all, so cardano-node has NO PlutusV2 until a real PPU
+        // installs one, and dugite reported one it should not have had — a
+        // `costModels` wire divergence, and a latent
+        // accept-where-Haskell-rejects (a V2 script would EXECUTE on dugite and
+        // fail on cardano-node with `CollectErrors [NoCostModel PlutusV2]`).
 
         // Pool voting thresholds
         let pvt = &self.pool_voting_thresholds;
@@ -2343,5 +2425,137 @@ mod tests {
             "Preprod: zero_time must be 2022-06-21 00:00:00 UTC in ms"
         );
         assert_eq!(sc.slot_length, 1_000);
+    }
+
+    // ── #1046: cost models come from genesis fields / extraConfig / PPU ─────
+    //
+    // cardano-ledger has NO default PlutusV2. `alonzoInjectCostModels`
+    // (eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs) applies
+    // `agExtraConfig.aecCostModels` and nothing else:
+    //
+    //   alonzoInjectCostModels cfg =
+    //     case agExtraConfig $ cfg ^. tcTranslationContextL of
+    //       SNothing -> id
+    //       SJust aec -> overrideCostModels (aecCostModels aec)
+    //
+    //   overrideCostModels (Just cms) =
+    //     nesEsL . curPParamsEpochStateL . ppCostModelsL
+    //       %~ flip updateCostModels (CostModelsUpdate cms)
+    //
+    // Two properties under test: cur-only, and per-language update.
+
+    fn alonzo_genesis_json(extra_config: Option<&str>) -> String {
+        let extra = match extra_config {
+            Some(e) => format!(", \"extraConfig\": {e}"),
+            None => String::new(),
+        };
+        format!(
+            r#"{{
+              "lovelacePerUTxOWord": 34482,
+              "executionPrices": {{ "prSteps": {{"numerator":721,"denominator":10000000}},
+                                    "prMem": {{"numerator":577,"denominator":10000}} }},
+              "maxTxExUnits": {{ "exUnitsMem": 10000000, "exUnitsSteps": 10000000000 }},
+              "maxBlockExUnits": {{ "exUnitsMem": 50000000, "exUnitsSteps": 40000000000 }},
+              "maxValueSize": 5000,
+              "collateralPercentage": 150,
+              "maxCollateralInputs": 3,
+              "costModels": {{ "PlutusV1": [1, 2, 3] }}
+              {extra}
+            }}"#
+        )
+    }
+
+    /// A real-network shape (no `extraConfig`): PlutusV2 must stay ABSENT.
+    /// This is the #1046 regression — dugite used to inject a hardcoded
+    /// `defaultV2CostModel` here, giving it a cost model cardano-node does not
+    /// have. Reachable consequence: a V2 script would EXECUTE on dugite and fail
+    /// on cardano-node with `CollectErrors [NoCostModel PlutusV2]`.
+    #[test]
+    fn alonzo_genesis_without_extra_config_yields_no_plutus_v2() {
+        let g: AlonzoGenesis = serde_json::from_str(&alonzo_genesis_json(None)).unwrap();
+        assert!(
+            g.extra_config.is_none(),
+            "mainnet/preview/preprod alonzo-genesis has no extraConfig"
+        );
+
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.cost_models.plutus_v1 = None;
+        params.cost_models.plutus_v2 = None;
+        params.cost_models.plutus_v3 = None;
+
+        g.apply_to_protocol_params(&mut params);
+        g.apply_extra_config_cost_models(&mut params);
+
+        assert_eq!(params.cost_models.plutus_v1, Some(vec![1, 2, 3]));
+        assert_eq!(
+            params.cost_models.plutus_v2, None,
+            "no extraConfig ⇒ NO PlutusV2 cost model (#1046); cardano-ledger has \
+             no default and dugite must not invent one"
+        );
+    }
+
+    /// A `create-testnet-data` devnet shape: `extraConfig` supplies V1+V2, so
+    /// PlutusV2 IS present — and V1 is OVERRIDDEN, since `updateCostModels` is a
+    /// per-language update. This is what keeps devnet parity intact without the
+    /// hardcoded default (#994's stated fear).
+    #[test]
+    fn alonzo_genesis_extra_config_overrides_per_language() {
+        let g: AlonzoGenesis = serde_json::from_str(&alonzo_genesis_json(Some(
+            r#"{ "costModels": { "PlutusV1": [10, 20, 30], "PlutusV2": [40, 50] } }"#,
+        )))
+        .unwrap();
+
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.cost_models.plutus_v1 = None;
+        params.cost_models.plutus_v2 = None;
+        params.cost_models.plutus_v3 = None;
+
+        g.apply_to_protocol_params(&mut params);
+        // Stand in for the Conway genesis contributing its V3 field before the
+        // override runs — the override must not disturb it.
+        params.cost_models.plutus_v3 = Some(vec![7, 8, 9]);
+        g.apply_extra_config_cost_models(&mut params);
+
+        assert_eq!(
+            params.cost_models.plutus_v1,
+            Some(vec![10, 20, 30]),
+            "extraConfig OVERRIDES the era-translated V1"
+        );
+        assert_eq!(
+            params.cost_models.plutus_v2,
+            Some(vec![40, 50]),
+            "extraConfig supplies V2 — this is where the devnet's V2 comes from"
+        );
+        assert_eq!(
+            params.cost_models.plutus_v3,
+            Some(vec![7, 8, 9]),
+            "a language NOT named in extraConfig is retained (per-language update, \
+             not a wholesale replacement)"
+        );
+    }
+
+    /// The devnet's real generated genesis carries V2 in `extraConfig`, NOT in
+    /// the top-level `costModels`. Pinning the shape, because reading only the
+    /// top-level field is what made #994 conclude no genesis file supplied V2.
+    #[test]
+    fn devnet_style_extra_config_is_where_v2_actually_lives() {
+        let g: AlonzoGenesis = serde_json::from_str(&alonzo_genesis_json(Some(
+            r#"{ "costModels": { "PlutusV2": [99] } }"#,
+        )))
+        .unwrap();
+
+        assert!(
+            !g.cost_models.contains_key("PlutusV2"),
+            "top-level costModels has no V2 — that field is V1-only on every \
+             real alonzo-genesis"
+        );
+        assert_eq!(
+            g.extra_config
+                .as_ref()
+                .and_then(|e| e.cost_models.get("PlutusV2"))
+                .and_then(parse_cost_model),
+            Some(vec![99]),
+            "V2 lives in extraConfig.costModels"
+        );
     }
 }

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -184,6 +184,53 @@ pub(crate) const GENESIS_PARKED_DYNAMO_MARGIN_SLOTS: u64 = 2_000;
 // silent one on ANY network.
 const _: () = assert!(GENESIS_PARKED_DYNAMO_MARGIN_SLOTS < 25_920);
 
+/// #735 gross-request invariant, lock-free half: does this fetch range
+/// connect WITHOUT consulting the ChainDB?
+///
+/// Two cases need no lock:
+/// * `already_fetched` — this worker fetched the parent itself and the apply
+///   pipeline simply has not stored it yet (channel lag). The contiguous chain
+///   is in flight, not missing.
+/// * the range is rooted at **genesis**. `Hash32::ZERO` is dugite's canonical
+///   Origin parent: the encoder maps it to CBOR `null`, i.e. Haskell's
+///   `PrevHash = GenesisHash` (pinned by
+///   `test_encode_block_header_body_prev_hash_null_at_genesis`).
+///
+/// **#1057** — the genesis case is why this function exists. Genesis is never a
+/// *stored* block, so a `has_block(&genesis)` test is always false; the old
+/// guard only exempted a completely EMPTY ChainDB. A node holding any block of
+/// its own therefore declined the canonical chain's block 0 on every decision
+/// tick, forever: nothing was fetched, the ledger never advanced, ChainSync's
+/// forecast-horizon park timed out, and every peer was dropped and re-dialled
+/// in an endless loop with no self-healing. It stranded a block producer that
+/// won a slot before its initial sync completed.
+///
+/// Adoptability is not this guard's job to re-litigate: `sync.rs` accepts an
+/// Origin intersection only after confirming the local chain is within `k` of
+/// genesis, and `VolatileDB::switch_chain` re-applies the `k` cap before
+/// actually switching. Upstream carries the same notion as a first-class
+/// constructor — `AnchorGenesis` in ouroboros-consensus's `Anchor blk`, matched
+/// by `Paths.hs::isReachable`.
+pub(crate) fn fetch_range_connects_fast(
+    prev: &dugite_primitives::hash::Hash32,
+    already_fetched: bool,
+) -> bool {
+    already_fetched || *prev == dugite_primitives::hash::Hash32::ZERO
+}
+
+/// #735 gross-request invariant, ChainDB half: consulted only when
+/// [`fetch_range_connects_fast`] returned `false`.
+///
+/// `chain_db_empty` keeps the original from-origin bootstrap exemption as
+/// defence-in-depth for any era whose header decode does not surface a genesis
+/// `prev_hash`; `chain_db_has_prev` is the ordinary frontier-extension case.
+pub(crate) fn fetch_range_connects_via_chain_db(
+    chain_db_empty: bool,
+    chain_db_has_prev: bool,
+) -> bool {
+    chain_db_empty || chain_db_has_prev
+}
+
 /// Should an unproductive dynamo that has starved ChainSel past the watchdog
 /// window be ROTATED?
 ///
@@ -3054,22 +3101,23 @@ impl ConnectionLifecycleManager {
                                     )
                                 {
                                     let prev = hdr.prev_hash;
-                                    // Accept a parent this worker already
-                                    // fetched even if the apply pipeline has
-                                    // not stored it yet (channel lag) — the
-                                    // contiguous chain is in flight, not
-                                    // missing.
-                                    let connects = fetched_hashes.contains(prev.as_bytes()) || {
+                                    // The decision itself lives in the pure
+                                    // `fetch_range_connects` (unit-tested);
+                                    // here we only supply its inputs, taking
+                                    // the ChainDB lock lazily so the common
+                                    // already-fetched / genesis cases stay
+                                    // lock-free.
+                                    let connects = if fetch_range_connects_fast(
+                                        &prev,
+                                        fetched_hashes.contains(prev.as_bytes()),
+                                    ) {
+                                        true
+                                    } else {
                                         let cdb = chain_db.read().await;
-                                        // From-origin bootstrap: an EMPTY
-                                        // ChainDB has no frontier to extend —
-                                        // the first block's prev_hash is the
-                                        // GENESIS HASH, which is never a
-                                        // stored block. The guard only arms
-                                        // once a frontier exists (caught live
-                                        // on the devnet: the relay wedged at
-                                        // origin, declining block 1 forever).
-                                        cdb.get_tip_info().is_none() || cdb.has_block(&prev)
+                                        fetch_range_connects_via_chain_db(
+                                            cdb.get_tip_info().is_none(),
+                                            cdb.has_block(&prev),
+                                        )
                                     };
                                     if !connects {
                                         debug!(
@@ -7415,5 +7463,60 @@ mod range_byte_abort_751_tests {
         ));
         // ~A full mainnet stability window ahead → clearly parked → keep it.
         assert!(!should_rotate_unproductive_dynamo(Some(tip + 129_600), tip));
+    }
+
+    // ── #1057: the #735 gross-request invariant must accept a genesis root ──
+    //
+    // The live wedge: a block producer forged blocks 0..8 on Origin before its
+    // initial sync completed. The network's chain also diverges at genesis, so
+    // its first block's `prev_hash` is the Origin parent (`Hash32::ZERO`). With
+    // a NON-empty ChainDB the old guard declined that range forever — genesis is
+    // never a stored block — so nothing was fetched, the ledger never advanced,
+    // and ChainSync's forecast-horizon park dropped every peer in an endless
+    // loop. The node never rejoined the canonical chain.
+
+    /// A range rooted at genesis connects even when the ChainDB is NON-empty
+    /// and does not contain the genesis hash. This is the #1057 regression.
+    #[test]
+    fn fetch_range_rooted_at_genesis_connects_with_non_empty_chain_db() {
+        let genesis = dugite_primitives::hash::Hash32::ZERO;
+
+        // The lock-free half decides it outright — no ChainDB read needed.
+        assert!(
+            fetch_range_connects_fast(&genesis, false),
+            "a genesis-rooted range must connect without consulting the ChainDB (#1057)"
+        );
+
+        // And the ChainDB half, which is what the old code relied on, would
+        // have REFUSED: non-empty DB, and genesis is not a stored block. This
+        // asserts the precise shape of the bug that was fixed.
+        assert!(
+            !fetch_range_connects_via_chain_db(false, false),
+            "the ChainDB half alone cannot recognise genesis — that WAS the bug"
+        );
+    }
+
+    /// The ordinary cases must be unchanged: a parent already fetched by this
+    /// worker connects; an unknown non-genesis parent against a non-empty
+    /// ChainDB still does NOT (the far-ahead range the guard exists to decline).
+    #[test]
+    fn fetch_range_ordinary_cases_unchanged() {
+        let other = dugite_primitives::hash::Hash32::from_bytes([7u8; 32]);
+
+        // Already fetched by this worker → in flight, not missing.
+        assert!(fetch_range_connects_fast(&other, true));
+        // Not fetched, not genesis → must fall through to the ChainDB.
+        assert!(!fetch_range_connects_fast(&other, false));
+
+        // Frontier extension: the parent is stored → connects.
+        assert!(fetch_range_connects_via_chain_db(false, true));
+        // From-origin bootstrap exemption retained.
+        assert!(fetch_range_connects_via_chain_db(true, false));
+        // The #735 far-ahead range: unknown parent, non-empty DB → decline.
+        assert!(
+            !fetch_range_connects_via_chain_db(false, false),
+            "an unknown non-genesis parent against a non-empty ChainDB must \
+             still be declined — the #735 invariant is preserved"
+        );
     }
 }

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -187,35 +187,33 @@ const _: () = assert!(GENESIS_PARKED_DYNAMO_MARGIN_SLOTS < 25_920);
 /// #735 gross-request invariant, lock-free half: does this fetch range
 /// connect WITHOUT consulting the ChainDB?
 ///
-/// Two cases need no lock:
-/// * `already_fetched` — this worker fetched the parent itself and the apply
-///   pipeline simply has not stored it yet (channel lag). The contiguous chain
-///   is in flight, not missing.
-/// * the range is rooted at **genesis**. `Hash32::ZERO` is dugite's canonical
-///   Origin parent: the encoder maps it to CBOR `null`, i.e. Haskell's
-///   `PrevHash = GenesisHash` (pinned by
-///   `test_encode_block_header_body_prev_hash_null_at_genesis`).
+/// Only one case needs no lock: `already_fetched` — this worker fetched the
+/// parent itself and the apply pipeline has not stored it yet (channel lag). The
+/// contiguous chain is in flight, not missing.
 ///
-/// **#1057** — the genesis case is why this function exists. Genesis is never a
-/// *stored* block, so a `has_block(&genesis)` test is always false; the old
-/// guard only exempted a completely EMPTY ChainDB. A node holding any block of
-/// its own therefore declined the canonical chain's block 0 on every decision
-/// tick, forever: nothing was fetched, the ledger never advanced, ChainSync's
-/// forecast-horizon park timed out, and every peer was dropped and re-dialled
-/// in an endless loop with no self-healing. It stranded a block producer that
-/// won a slot before its initial sync completed.
+/// **#1057 (OPEN)**: a range rooted at GENESIS is currently NOT accepted here
+/// unless the ChainDB is completely empty (see
+/// [`fetch_range_connects_via_chain_db`]). Genesis is never a *stored* block, so
+/// a node holding any block of its own declines the canonical chain's block 0
+/// forever and never rejoins a chain that diverges at Origin.
 ///
-/// Adoptability is not this guard's job to re-litigate: `sync.rs` accepts an
-/// Origin intersection only after confirming the local chain is within `k` of
-/// genesis, and `VolatileDB::switch_chain` re-applies the `k` cap before
-/// actually switching. Upstream carries the same notion as a first-class
-/// constructor — `AnchorGenesis` in ouroboros-consensus's `Anchor blk`, matched
-/// by `Paths.hs::isReachable`.
+/// Accepting `prev == Hash32::ZERO` here is necessary but NOT sufficient to fix
+/// that, and must not be done alone: the storage layer would then emit a
+/// genesis-rooted `SwitchPlan`, and the ledger cannot roll back to Origin
+/// (`sync.rs` aborts with "Rollback target outside LedgerSeq volatile window AND
+/// no canonical snapshot available"), so the wedge moves from BlockFetch to the
+/// ledger rollback instead of going away. Verified live on a two-forger devnet.
+/// The complete fix needs the ledger to re-initialise from genesis on a
+/// rollback-to-Origin — tracked in #1057.
+///
+/// `prev` is retained in the signature for that fix and is deliberately unused
+/// today.
 pub(crate) fn fetch_range_connects_fast(
     prev: &dugite_primitives::hash::Hash32,
     already_fetched: bool,
 ) -> bool {
-    already_fetched || *prev == dugite_primitives::hash::Hash32::ZERO
+    let _ = prev;
+    already_fetched
 }
 
 /// #735 gross-request invariant, ChainDB half: consulted only when
@@ -7475,24 +7473,25 @@ mod range_byte_abort_751_tests {
     // and ChainSync's forecast-horizon park dropped every peer in an endless
     // loop. The node never rejoined the canonical chain.
 
-    /// A range rooted at genesis connects even when the ChainDB is NON-empty
-    /// and does not contain the genesis hash. This is the #1057 regression.
+    /// #1057 (OPEN) — pins the CURRENT behaviour, not the desired one: a
+    /// genesis-rooted range is declined when the ChainDB is non-empty, which is
+    /// why a node holding any block of its own never rejoins a chain diverging
+    /// at Origin.
+    ///
+    /// Deliberately asserts the bug rather than hiding it, so the day #1057 is
+    /// fixed this test fails and forces the update. Accepting genesis here alone
+    /// is NOT the fix — it relocates the wedge to the ledger rollback path; see
+    /// `fetch_range_connects_fast`'s doc comment.
     #[test]
-    fn fetch_range_rooted_at_genesis_connects_with_non_empty_chain_db() {
+    fn fetch_range_rooted_at_genesis_is_declined_with_non_empty_chain_db() {
         let genesis = dugite_primitives::hash::Hash32::ZERO;
-
-        // The lock-free half decides it outright — no ChainDB read needed.
         assert!(
-            fetch_range_connects_fast(&genesis, false),
-            "a genesis-rooted range must connect without consulting the ChainDB (#1057)"
+            !fetch_range_connects_fast(&genesis, false),
+            "current behaviour: the lock-free half does not recognise genesis"
         );
-
-        // And the ChainDB half, which is what the old code relied on, would
-        // have REFUSED: non-empty DB, and genesis is not a stored block. This
-        // asserts the precise shape of the bug that was fixed.
         assert!(
             !fetch_range_connects_via_chain_db(false, false),
-            "the ChainDB half alone cannot recognise genesis — that WAS the bug"
+            "and the ChainDB half cannot either — genesis is never a stored block (#1057)"
         );
     }
 

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -3303,9 +3303,26 @@ impl Node {
                     );
                 }
             } else {
-                warn!(
+                // #1055: do NOT claim leader election is disabled — it is not.
+                // On a Conway-from-genesis chain the `set` pre-fill is cleared
+                // deliberately (see `finalize_genesis_state`'s
+                // `conway_from_genesis` branch) for Haskell-faithful RUPD
+                // timing, so this branch is the NORMAL boot state there, and
+                // `LedgerState::pool_distribution_for_slot` falls back to
+                // computing the distribution from live delegations + stake and
+                // reward balances (mirroring Haskell's genesis `nesPd`, which
+                // is a separate field from `esSnapshots` and drives epoch-0
+                // leader election even though ssStakeGo/Set/Mark are `mempty`).
+                //
+                // The old wording ("leader election disabled until epoch
+                // transition") was read as the cause of a block producer that
+                // had stopped forging, which cost real investigation time; the
+                // actual cause was #1057. State the mechanism, not a verdict.
+                info!(
                     pool_id = %creds.pool_id,
-                    "Block producer: no 'set' snapshot available — leader election disabled until epoch transition"
+                    "Block producer: no 'set' snapshot yet — leader election uses the \
+                     live-delegation fallback (normal on a Conway-from-genesis chain) \
+                     until the first SNAP rotation populates it"
                 );
             }
         }

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -1195,6 +1195,11 @@ impl Node {
 
         // Load Alonzo genesis if configured (with hash validation)
         let mut alonzo_genesis_file_hash: Option<dugite_primitives::hash::Hash32> = None;
+        // #1046: `extraConfig.costModels` is applied to `curPParams` ONLY, and it
+        // must land AFTER the Conway genesis has contributed its V3 field, so the
+        // prev/cur snapshot below can be taken between the two. Hold the loaded
+        // genesis until then rather than applying the override here.
+        let mut alonzo_genesis_loaded: Option<AlonzoGenesis> = None;
         if let Some(ref genesis_path) = args.config.alonzo_genesis_file {
             let genesis_path = config_dir.join(genesis_path);
             match AlonzoGenesis::load_with_hash(&genesis_path) {
@@ -1202,10 +1207,12 @@ impl Node {
                     info!(
                         max_val_size = genesis.max_value_size,
                         collateral_pct = genesis.collateral_percentage,
+                        has_extra_config = genesis.extra_config.is_some(),
                         "Alonzo genesis loaded",
                     );
                     alonzo_genesis_file_hash = Some(hash);
                     genesis.apply_to_protocol_params(&mut protocol_params);
+                    alonzo_genesis_loaded = Some(genesis);
                 }
                 Err(e) => {
                     warn!("Failed to load Alonzo genesis: {e}");
@@ -1236,11 +1243,6 @@ impl Node {
         let mut conway_initial_dreps: Vec<(dugite_primitives::hash::Hash28, u64)> = Vec::new();
         let mut conway_genesis_file_hash: Option<dugite_primitives::hash::Hash32> = None;
         let mut conway_v3_cost_model: Option<Vec<i64>> = None;
-        // #994: did a genesis FILE supply the PlutusV2 cost model, or is the one
-        // we end up with the built-in default? `ConwayGenesis::apply_to_protocol_params`
-        // injects `defaultV2CostModel` when none is present, so this has to be
-        // sampled before that call. See `genesis_prev_protocol_params` below.
-        let v2_cost_model_from_genesis = protocol_params.cost_models.plutus_v2.is_some();
         if let Some(ref genesis_path) = args.config.conway_genesis_file {
             let genesis_path = config_dir.join(genesis_path);
             match ConwayGenesis::load_with_hash(&genesis_path) {
@@ -1281,36 +1283,33 @@ impl Node {
             }
         }
 
-        // #994: `cgsPrevPParams` at genesis carries only the cost models the
-        // genesis FILES supplied — never the built-in `defaultV2CostModel`.
+        // #994/#1046: `cgsPrevPParams` at genesis carries only what the genesis
+        // FIELDS supplied. The `extraConfig.costModels` override is applied to
+        // `curPParams` alone, so this snapshot must be taken BEFORE it.
         //
-        // On a chain whose FIRST era is Conway (`create-testnet-data`, i.e. the
-        // local devnet) cardano-node reports
+        // #994 observed the resulting shape on a `create-testnet-data` devnet —
         //     cur  = [PlutusV1, PlutusV2, PlutusV3]
         //     prev = [PlutusV1,           PlutusV3]
-        // with `prev` otherwise byte-identical to `cur` — V1 and V3 match
-        // exactly, and every non-costModels field matches. The devnet's
-        // alonzo-genesis defines only `PlutusV1` and its conway-genesis only
-        // `plutusV3CostModel`, so neither file supplies V2: the V2 in `cur` is
-        // the default both implementations inject so V2 scripts are runnable.
-        // It never reaches `prev`.
+        // with prev otherwise byte-identical to cur — and attributed the V2 to
+        // "the default both implementations inject". There is no such default.
+        // #1046 found the real mechanism: Haskell's `alonzoInjectCostModels`
+        // applies `agExtraConfig.aecCostModels` via
+        //     nesEsL . curPParamsEpochStateL . ppCostModelsL %~ ...
+        // i.e. cur-only, and `create-testnet-data` writes PlutusV1+PlutusV2 into
+        // that field. mainnet/preview/preprod alonzo-genesis files have no
+        // `extraConfig` whatsoever, which is why cardano-node has NO PlutusV2
+        // there and dugite's unconditional injection diverged.
         //
-        // dugite seeded `prev` by cloning `cur` wholesale, so the defaulted V2
-        // leaked in and `gov-state` diverged three times over (the same value is
-        // embedded in `nextRatifyState.nextEnactState.{curPParams,prevPParams}`).
-        //
-        // Inert on mainnet/preview/preprod: those alonzo-genesis files DO define
-        // PlutusV2, so `v2_cost_model_from_genesis` is true and `prev` is an
-        // exact clone as before. Those chains also start in Byron, where
-        // `prev` is overwritten by the first epoch boundary regardless — which
-        // is precisely why this is reachable only on a Conway-genesis chain.
-        let genesis_prev_protocol_params = {
-            let mut prev = protocol_params.clone();
-            if !v2_cost_model_from_genesis {
-                prev.cost_models.plutus_v2 = None;
-            }
-            prev
-        };
+        // Deriving prev as "cur minus the extraConfig override" replaces #994's
+        // `v2_cost_model_from_genesis` special case and generalises it: it holds
+        // for EVERY language extraConfig can name, not just V2.
+        let genesis_prev_protocol_params = protocol_params.clone();
+
+        // Now apply the cur-only override (no-op when the genesis has no
+        // `extraConfig`, i.e. on every real network).
+        if let Some(ref alonzo) = alonzo_genesis_loaded {
+            alonzo.apply_extra_config_cost_models(&mut protocol_params);
+        }
 
         // Load Dijkstra genesis if configured (issue #462 Phase 6 — parse only).
         //

--- a/crates/dugite-node/src/node/n2c_query/types.rs
+++ b/crates/dugite-node/src/node/n2c_query/types.rs
@@ -1042,8 +1042,11 @@ pub struct NodeStateSnapshot {
     /// only ever change AT a boundary and `setFreshDRepPulsingState` seals
     /// them there. It differs exactly once: before the first boundary there is
     /// no pulser, and upstream's initial `EnactState` carries the
-    /// genesis-translated params — which on a Conway-genesis chain lack the
-    /// injected `defaultV2CostModel`.
+    /// genesis-translated params — which lack the cost models
+    /// `alonzoInjectCostModels` writes into `curPParams` from
+    /// `agExtraConfig.aecCostModels` (#1046). On a `create-testnet-data` devnet
+    /// that is PlutusV1+PlutusV2; on mainnet/preview/preprod there is no
+    /// `extraConfig` at all, so there is nothing to lack.
     pub ratify_cur_protocol_params: ProtocolParamsSnapshot,
     /// Stake pool distribution data, built from LIVE ledger state. Feeds
     /// `GetStakePools` (tag 16) and `GetStakeDistribution2` (tag 37), both of

--- a/crates/dugite-node/src/node/query.rs
+++ b/crates/dugite-node/src/node/query.rs
@@ -699,7 +699,10 @@ impl Node {
         // coincide mid-chain (pparams change only at boundaries, and
         // `setFreshDRepPulsingState` seals them there), so this matters only
         // before the first boundary — where upstream reports the
-        // genesis-translated params, without the injected defaultV2CostModel.
+        // genesis-translated params, i.e. WITHOUT the cost models
+        // `alonzoInjectCostModels` writes into `curPParams` from
+        // `agExtraConfig.aecCostModels` (#1046; formerly mis-described here as an
+        // injected `defaultV2CostModel`, a thing cardano-ledger does not have).
         let ratify_cur_protocol_params =
             match ls.gov.governance.ratify_plan().map(|r| &r.cur_pparams) {
                 Some(pp) => protocol_params_snapshot(pp),

--- a/crates/dugite-node/src/node/serve.rs
+++ b/crates/dugite-node/src/node/serve.rs
@@ -1265,14 +1265,15 @@ pub(crate) fn convert_validation_error(
             expected: network_id_to_wire(expected),
             accounts,
         },
-        VE::ConstitutionPolicyMismatch { expected, actual } => {
+        // #1028: both sides are now typed `Option<Hash28>` end to end, so the
+        // `StrictMaybe` distinction survives from the predicate to the wire.
+        // Previously the ledger carried hex STRINGS and used the empty string as
+        // an absence sentinel, which this arm had to re-interpret — and which
+        // could not express "the constitution has no guardrail" at all.
+        VE::InvalidGuardrailsScriptHash { got, expected } => {
             TxValidationError::InvalidGuardrailsScriptHash {
-                got: if actual.is_empty() { None } else { Some(actual) },
-                expected: if expected.is_empty() {
-                    None
-                } else {
-                    Some(expected)
-                },
+                got: got.map(|h| h.to_hex()),
+                expected: expected.map(|h| h.to_hex()),
             }
         }
         VE::UnspendableUTxONoDatumHash { input, .. } => {
@@ -2736,9 +2737,9 @@ mod tests {
                 expected: 0,
                 mismatched: vec![(format!("e0{}", "55".repeat(28)), 1)],
             },
-            VE::ConstitutionPolicyMismatch {
-                expected: "66".repeat(28),
-                actual: String::new(),
+            VE::InvalidGuardrailsScriptHash {
+                got: None,
+                expected: Some(dugite_primitives::hash::Hash28::from_bytes([0x66; 28])),
             },
             VE::WdrlNotDelegatedToDRep {
                 credential_hash: "77".repeat(28),

--- a/crates/dugite-node/src/node/serve.rs
+++ b/crates/dugite-node/src/node/serve.rs
@@ -1320,6 +1320,18 @@ pub(crate) fn convert_validation_error(
             prev_action_id: prev_action_id.as_ref().map(gov_action_id_to_string),
             proposal,
         },
+        // #1026: PV9 bootstrap proposal-submission restriction, GOV tag 12.
+        // Typed from the start — see the encoder arm's note on why a new
+        // predicate must not join the #979/#1050 generic-fallback backlog.
+        VE::DisallowedProposalDuringBootstrap {
+            action_index,
+            action_type,
+            proposal,
+        } => TxValidationError::DisallowedProposalDuringBootstrap {
+            action_index,
+            action_type: action_type.to_string(),
+            proposal,
+        },
         // No dedicated wire variant yet (dugite issue #1021, tracked
         // alongside #979's "generic rejections" backlog) — same
         // generic-reason fallback pattern as `MalformedProposal` above. The

--- a/crates/dugite-node/src/node/serve.rs
+++ b/crates/dugite-node/src/node/serve.rs
@@ -313,6 +313,54 @@ pub(crate) struct LedgerTxValidator {
 
 impl TxValidator for LedgerTxValidator {
     fn validate_tx(&self, era_id: u16, tx_bytes: &[u8]) -> Result<(), TxValidationError> {
+        // #1047: WIRE-ERA CHECK, before decoding.
+        //
+        // Upstream cannot even represent applying a tx from era X to a ledger in
+        // era Y: `ApplyTxErr` for the HFC is
+        // `Either (MismatchEraInfo xs) (OneEraApplyTxErr xs)`, and the HFC's
+        // mempool returns `HardForkApplyTxErrWrongEra` before any era's rules
+        // run. dugite had no such check — a legacy-era submission was rejected
+        // only as an ACCIDENTAL CBOR decode error (the standalone Shelley decoder
+        // expects a different array length than a real Shelley tx has).
+        //
+        // That accident is load-bearing today and must not be relied on: correct
+        // any one of those decoders without adding this check, and MIR /
+        // GenesisKeyDelegation / other legacy-era artifacts become ACCEPTABLE on a
+        // Conway chain where cardano-node answers
+        // `HardForkApplyTxErrWrongEra` — the accept-where-Haskell-rejects wedge
+        // class (#996/#997/#985/#1023). MIR Phase-1 validation is a documented
+        // no-op at PV>=9 and GenesisKeyDelegation has era-unconditional
+        // apply-time support, so the ledger layer would NOT catch it.
+        //
+        // The ledger's era comes from `EraHistory::current_era()`, not from
+        // ledger pparams: #985's lesson is that a stale/corrupt protocol version
+        // must never drive an era decision.
+        let ledger_era = match self.era_history.try_read() {
+            Ok(h) => Some(h.current_era()),
+            // Lock contention must not manufacture a spurious era rejection;
+            // fall through to the decoder, which is the pre-#1047 behaviour.
+            Err(_) => None,
+        };
+        if let Some(ledger_era) = ledger_era {
+            let ledger_era_index = ledger_era.to_era_index();
+            if u32::from(era_id) != ledger_era_index {
+                let tx_era = dugite_primitives::era::Era::from_era_index(era_id);
+                tracing::warn!(
+                    era_id,
+                    ledger_era = %ledger_era,
+                    "N2C tx rejected: wrong era (HardForkApplyTxErrWrongEra)"
+                );
+                return Err(TxValidationError::HardForkApplyTxErrWrongEra {
+                    tx_era_index: era_id as u8,
+                    tx_era_name: tx_era
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| format!("UnknownEra{era_id}")),
+                    ledger_era_index: ledger_era_index as u8,
+                    ledger_era_name: ledger_era.to_string(),
+                });
+            }
+        }
+
         let tx = dugite_serialization::decode_transaction(era_id, tx_bytes).map_err(|e| {
             TxValidationError::DecodeFailed {
                 reason: e.to_string(),

--- a/crates/dugite-node/src/node/serve.rs
+++ b/crates/dugite-node/src/node/serve.rs
@@ -950,6 +950,22 @@ pub(crate) fn convert_validation_error_at_pv(
             other => return convert_validation_error(other),
         }
     }
+    // #1058: the script-integrity-hash mismatch also splits at PV 11.
+    // `checkScriptIntegrityHash` chooses
+    //   pv < 11  -> PPViewHashesDontMatch mismatch                    (UTXOW 13)
+    //   pv >= 11 -> ScriptIntegrityHashMismatch mismatch preimage      (UTXOW 18)
+    // and the two differ in tag AND payload shape (13 flattens the Mismatch via
+    // ToGroup; 18 nests it and adds a third field). dugite emitted 13 at every
+    // PV, which is wrong on preview/PV11 — the #978 inversion.
+    if let VE::ScriptDataHashMismatch { expected, actual } = &e {
+        return TxValidationError::ScriptIntegrityHashMismatchUTXOW {
+            supplied: Some(actual.clone()),
+            expected: Some(expected.clone()),
+            // Haskell's `originalBytes <$> scriptIntegrity` — the preimage, not a
+            // hash. dugite's Phase-1 error carries only hashes, so SNothing.
+            expected_bytes: None,
+        };
+    }
     convert_validation_error(e)
 }
 

--- a/crates/dugite-primitives/src/era.rs
+++ b/crates/dugite-primitives/src/era.rs
@@ -116,6 +116,25 @@ impl Era {
         }
     }
 
+    /// Inverse of [`Era::to_era_index`]: resolve an HFC / N2C era index.
+    ///
+    /// Returns `None` for an index outside the known era set, so a client that
+    /// declares a nonexistent era can be reported as such instead of being
+    /// silently coerced to a real era (#1047).
+    pub fn from_era_index(index: u16) -> Option<Era> {
+        Some(match index {
+            0 => Era::Byron,
+            1 => Era::Shelley,
+            2 => Era::Allegra,
+            3 => Era::Mary,
+            4 => Era::Alonzo,
+            5 => Era::Babbage,
+            6 => Era::Conway,
+            7 => Era::Dijkstra,
+            _ => return None,
+        })
+    }
+
     /// Era index for the N2C protocol (hard-fork combinator era index)
     pub fn to_era_index(self) -> u32 {
         match self {
@@ -149,6 +168,32 @@ impl std::fmt::Display for Era {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1047: the HFC era-index mapping must round-trip, and an unknown index
+    /// must be reported as unknown rather than coerced to a real era — a client
+    /// declaring era 99 should not be silently treated as Byron.
+    #[test]
+    fn era_index_round_trips_and_rejects_unknown() {
+        for era in [
+            Era::Byron,
+            Era::Shelley,
+            Era::Allegra,
+            Era::Mary,
+            Era::Alonzo,
+            Era::Babbage,
+            Era::Conway,
+            Era::Dijkstra,
+        ] {
+            let idx = era.to_era_index();
+            assert_eq!(
+                Era::from_era_index(idx as u16),
+                Some(era),
+                "{era:?} must round-trip through its HFC index {idx}"
+            );
+        }
+        assert_eq!(Era::from_era_index(8), None, "index 8 is not an era");
+        assert_eq!(Era::from_era_index(99), None, "index 99 is not an era");
+    }
 
     #[test]
     fn test_is_shelley_based() {

--- a/crates/dugite-storage/src/volatile_db.rs
+++ b/crates/dugite-storage/src/volatile_db.rs
@@ -1816,47 +1816,6 @@ impl VolatileDB {
                     .and_then(|h| self.blocks.get(h))
                     .map(|b| b.prev_hash);
                 match (immutable_anchor, new_root_prev) {
-                    // #1057: the fork is rooted at GENESIS (`prev_hash ==
-                    // Hash32::ZERO` is dugite's canonical Origin parent — the
-                    // encoder maps it to CBOR `null`, i.e. Haskell's
-                    // `PrevHash = GenesisHash`; see
-                    // `encode/block.rs::encode_block_header_body`).
-                    //
-                    // Genesis is a valid anchor in its own right, exactly as
-                    // `AnchorGenesis` is a first-class constructor of
-                    // ouroboros-consensus's `Anchor blk` and is matched by
-                    // `Paths.hs::isReachable`'s `AF.Empty anchor` case. Before
-                    // this arm existed, a node holding ANY block of its own
-                    // could never adopt a chain diverging at genesis: with an
-                    // empty ImmutableDB `immutable_anchor` is `None`, so a
-                    // genesis-rooted fork fell through to "unreachable" and the
-                    // node stayed wedged on its own fork for the process
-                    // lifetime (#1057 — it stranded a block producer that
-                    // forged before completing initial sync).
-                    //
-                    // This arm is checked BEFORE the immutable-anchor arm so a
-                    // genesis-rooted fork is recognised even when an immutable
-                    // anchor also exists; the two cannot both apply to the same
-                    // fork root, since a stored immutable tip is never ZERO.
-                    //
-                    // The rollback is the WHOLE selected chain and the apply the
-                    // WHOLE new chain. Legality is still bounded by the
-                    // `max_rollback` (== k) cap immediately below, which is
-                    // deliberately left in force: this arm makes a genesis
-                    // rollback *expressible*, not unconditionally permitted.
-                    (_, Some(prev)) if prev == Hash32::ZERO => {
-                        let rollback: Vec<Hash32> =
-                            self.selected_chain.iter().rev().copied().collect();
-                        let apply: Vec<Hash32> = new_chain.clone();
-                        debug!(
-                            new_tip = %new_tip_hash,
-                            rollback_count = rollback.len(),
-                            apply_count = apply.len(),
-                            "VolatileDB: fork anchors at GENESIS — switching via \
-                             full-volatile rollback to Origin (#1057)"
-                        );
-                        (Hash32::ZERO, 0, rollback, apply)
-                    }
                     (Some((anchor_hash, anchor_slot)), Some(prev)) if anchor_hash == prev => {
                         let rollback: Vec<Hash32> =
                             self.selected_chain.iter().rev().copied().collect();
@@ -3269,15 +3228,19 @@ mod tests {
         let mut db = VolatileDB::new();
         // Anchor (immutable tip) is h(200) at slot 50 — NOT in VolatileDB.
         //
-        // #1057: this anchor MUST NOT be `h(0)`. `h(0)` is `[0u8; 32]` ==
-        // `Hash32::ZERO`, which is dugite's canonical GENESIS parent, so the
-        // original version of this test was really exercising the
+        // This anchor MUST NOT be `h(0)`. `h(0)` is `[0u8; 32]` ==
+        // `Hash32::ZERO`, which is dugite's canonical GENESIS parent (the
+        // encoder maps it to CBOR `null` == Haskell `PrevHash = GenesisHash`),
+        // so the original version of this test was really exercising the
         // genesis-rooted case while claiming to exercise the immutable-anchor
-        // case — and its `switch_chain(.., None, ..).is_none()` assertion
-        // PINNED the #1057 wedge (a genesis-rooted fork being refused when the
-        // ImmutableDB is empty). Use a non-ZERO anchor so this test covers the
-        // immutable-tip path it is named for; the genesis path has its own test
-        // below.
+        // case. Use a non-ZERO anchor so this test covers the immutable-tip path
+        // it is named for.
+        //
+        // Its `switch_chain(.., None, ..).is_none()` assertion also documents
+        // that a genesis-rooted fork is currently REFUSED when the ImmutableDB
+        // is empty — see #1057, which is that wedge and is NOT yet fixed: the
+        // storage layer can be taught to emit the plan, but the ledger cannot
+        // roll back to Origin, so the switch fails downstream instead.
         // Selected chain: h(1) → h(2), both children of h(200).
         db.add_block(h(1), 100, 10, h(200), b"s1".to_vec());
         db.add_block(h(2), 200, 20, h(1), b"s2".to_vec());
@@ -3315,99 +3278,6 @@ mod tests {
             "apply is entire new chain, oldest first"
         );
         assert_eq!(db.get_tip(), Some((350, h(12), 22)));
-    }
-
-    /// #1057: a fork rooted at GENESIS must be reachable even when the
-    /// ImmutableDB is empty (`immutable_anchor == None`).
-    ///
-    /// This is the exact live wedge: a block producer that forged its own
-    /// blocks 0..8 on Origin before initial sync completed, then had to adopt
-    /// the network's chain, which also diverges at genesis. Nothing had been
-    /// flushed to immutable (9 blocks, k=40), so `immutable_anchor` was `None`
-    /// and the genesis-rooted fork was declared "unreachable" forever — the
-    /// node never rejoined the canonical chain for the process lifetime.
-    ///
-    /// Haskell has no such gap: `AnchorGenesis` is a constructor of
-    /// `Anchor blk`, so `Paths.hs::isReachable`'s `AF.Empty anchor` case
-    /// matches a genesis anchor exactly as it matches a block anchor.
-    #[test]
-    fn test_switch_chain_reachable_via_genesis_anchor_with_empty_immutable_db() {
-        let mut db = VolatileDB::new();
-        // Our own fork, rooted at GENESIS (prev_hash == Hash32::ZERO).
-        db.add_block(h(1), 4, 0, Hash32::ZERO, b"own0".to_vec());
-        db.add_block(h(2), 21, 1, h(1), b"own1".to_vec());
-        // The network's chain, ALSO rooted at genesis — shares only Origin.
-        db.add_block(h(10), 5, 0, Hash32::ZERO, b"net0".to_vec());
-        db.add_block(h(11), 10, 1, h(10), b"net1".to_vec());
-        db.add_block(h(12), 15, 2, h(11), b"net2".to_vec());
-
-        let plan = db
-            .switch_chain(&h(12), None, u64::MAX)
-            .expect("a genesis-rooted fork must be reachable with an empty ImmutableDB (#1057)");
-        assert_eq!(
-            plan.intersection,
-            Hash32::ZERO,
-            "intersection is the genesis/Origin anchor"
-        );
-        assert_eq!(plan.intersection_slot, 0, "Origin sits at slot 0");
-        assert_eq!(
-            plan.rollback,
-            vec![h(2), h(1)],
-            "rollback is the entire self-forged chain, newest first"
-        );
-        assert_eq!(
-            plan.apply,
-            vec![h(10), h(11), h(12)],
-            "apply is the entire network chain, oldest first"
-        );
-        assert_eq!(db.get_tip(), Some((15, h(12), 2)));
-    }
-
-    /// #1057 companion: recognising genesis as an anchor must NOT weaken the
-    /// Ouroboros `k` cap. A genesis-rooted fork whose adoption would roll back
-    /// more than `k` blocks is still refused (`StoreButDontChange`).
-    ///
-    /// Without this test the fix above could be mistaken for "genesis rollbacks
-    /// are always allowed", which would reintroduce the 10 629-block-rollback
-    /// class the `max_rollback` cap exists to prevent.
-    #[test]
-    fn test_switch_chain_genesis_rooted_fork_still_respects_k() {
-        let mut db = VolatileDB::new();
-        // Our own chain: 5 blocks rooted at genesis.
-        db.add_block(h(1), 1, 0, Hash32::ZERO, b"a".to_vec());
-        db.add_block(h(2), 2, 1, h(1), b"b".to_vec());
-        db.add_block(h(3), 3, 2, h(2), b"c".to_vec());
-        db.add_block(h(4), 4, 3, h(3), b"d".to_vec());
-        db.add_block(h(5), 5, 4, h(4), b"e".to_vec());
-        let tip_before = db.get_tip();
-        let selected_len_before = db.selected_chain_len();
-
-        // A competing genesis-rooted chain. Adopting it needs a 5-block
-        // rollback, but k = 3.
-        db.add_block(h(20), 6, 0, Hash32::ZERO, b"x".to_vec());
-        db.add_block(h(21), 7, 1, h(20), b"y".to_vec());
-
-        assert!(
-            db.switch_chain(&h(21), None, 3).is_none(),
-            "a genesis-rooted fork requiring a rollback deeper than k must be refused"
-        );
-        assert_eq!(
-            db.selected_chain_len(),
-            selected_len_before,
-            "refused switch must not truncate selected_chain"
-        );
-        assert_eq!(
-            db.get_tip(),
-            tip_before,
-            "refused switch must not move the tip"
-        );
-
-        // With k large enough, the same fork IS adopted — proving the refusal
-        // above was the k cap and not the genesis arm failing to match.
-        assert!(
-            db.switch_chain(&h(21), None, 5).is_some(),
-            "the same genesis-rooted fork must be adopted once k permits it"
-        );
     }
 
     /// A `SwitchPlan` returned by `switch_chain` must carry the intersection

--- a/crates/dugite-storage/src/volatile_db.rs
+++ b/crates/dugite-storage/src/volatile_db.rs
@@ -1816,6 +1816,47 @@ impl VolatileDB {
                     .and_then(|h| self.blocks.get(h))
                     .map(|b| b.prev_hash);
                 match (immutable_anchor, new_root_prev) {
+                    // #1057: the fork is rooted at GENESIS (`prev_hash ==
+                    // Hash32::ZERO` is dugite's canonical Origin parent — the
+                    // encoder maps it to CBOR `null`, i.e. Haskell's
+                    // `PrevHash = GenesisHash`; see
+                    // `encode/block.rs::encode_block_header_body`).
+                    //
+                    // Genesis is a valid anchor in its own right, exactly as
+                    // `AnchorGenesis` is a first-class constructor of
+                    // ouroboros-consensus's `Anchor blk` and is matched by
+                    // `Paths.hs::isReachable`'s `AF.Empty anchor` case. Before
+                    // this arm existed, a node holding ANY block of its own
+                    // could never adopt a chain diverging at genesis: with an
+                    // empty ImmutableDB `immutable_anchor` is `None`, so a
+                    // genesis-rooted fork fell through to "unreachable" and the
+                    // node stayed wedged on its own fork for the process
+                    // lifetime (#1057 — it stranded a block producer that
+                    // forged before completing initial sync).
+                    //
+                    // This arm is checked BEFORE the immutable-anchor arm so a
+                    // genesis-rooted fork is recognised even when an immutable
+                    // anchor also exists; the two cannot both apply to the same
+                    // fork root, since a stored immutable tip is never ZERO.
+                    //
+                    // The rollback is the WHOLE selected chain and the apply the
+                    // WHOLE new chain. Legality is still bounded by the
+                    // `max_rollback` (== k) cap immediately below, which is
+                    // deliberately left in force: this arm makes a genesis
+                    // rollback *expressible*, not unconditionally permitted.
+                    (_, Some(prev)) if prev == Hash32::ZERO => {
+                        let rollback: Vec<Hash32> =
+                            self.selected_chain.iter().rev().copied().collect();
+                        let apply: Vec<Hash32> = new_chain.clone();
+                        debug!(
+                            new_tip = %new_tip_hash,
+                            rollback_count = rollback.len(),
+                            apply_count = apply.len(),
+                            "VolatileDB: fork anchors at GENESIS — switching via \
+                             full-volatile rollback to Origin (#1057)"
+                        );
+                        (Hash32::ZERO, 0, rollback, apply)
+                    }
                     (Some((anchor_hash, anchor_slot)), Some(prev)) if anchor_hash == prev => {
                         let rollback: Vec<Hash32> =
                             self.selected_chain.iter().rev().copied().collect();
@@ -3226,27 +3267,42 @@ mod tests {
     #[test]
     fn test_switch_chain_reachable_via_immutable_anchor() {
         let mut db = VolatileDB::new();
-        // Anchor (immutable tip) is h(0) at slot 50 — NOT in VolatileDB.
-        // Selected chain: h(1) → h(2), both children of h(0).
-        db.add_block(h(1), 100, 10, h(0), b"s1".to_vec());
+        // Anchor (immutable tip) is h(200) at slot 50 — NOT in VolatileDB.
+        //
+        // #1057: this anchor MUST NOT be `h(0)`. `h(0)` is `[0u8; 32]` ==
+        // `Hash32::ZERO`, which is dugite's canonical GENESIS parent, so the
+        // original version of this test was really exercising the
+        // genesis-rooted case while claiming to exercise the immutable-anchor
+        // case — and its `switch_chain(.., None, ..).is_none()` assertion
+        // PINNED the #1057 wedge (a genesis-rooted fork being refused when the
+        // ImmutableDB is empty). Use a non-ZERO anchor so this test covers the
+        // immutable-tip path it is named for; the genesis path has its own test
+        // below.
+        // Selected chain: h(1) → h(2), both children of h(200).
+        db.add_block(h(1), 100, 10, h(200), b"s1".to_vec());
         db.add_block(h(2), 200, 20, h(1), b"s2".to_vec());
-        // Fork chain: h(10) → h(11), both also descendants of h(0) but on
+        // Fork chain: h(10) → h(11), both also descendants of h(200) but on
         // a different branch (share only the immutable anchor).
-        db.add_block(h(10), 150, 11, h(0), b"f1".to_vec());
+        db.add_block(h(10), 150, 11, h(200), b"f1".to_vec());
         db.add_block(h(11), 250, 21, h(10), b"f2".to_vec());
         db.add_block(h(12), 350, 22, h(11), b"f3".to_vec());
 
-        // Without immutable_anchor the fork is unreachable (current behaviour).
+        // Without immutable_anchor the fork is unreachable: its root's
+        // prev_hash is a real block hash we do not have, and it is not genesis.
         assert!(
             db.switch_chain(&h(12), None, u64::MAX).is_none(),
             "without knowing the immutable anchor, fork stays unreachable"
         );
 
-        // Passing the immutable anchor (h(0) at slot 50) allows the switch.
+        // Passing the immutable anchor (h(200) at slot 50) allows the switch.
         let plan = db
-            .switch_chain(&h(12), Some((h(0), 50)), u64::MAX)
+            .switch_chain(&h(12), Some((h(200), 50)), u64::MAX)
             .expect("fork is reachable via immutable-tip anchor");
-        assert_eq!(plan.intersection, h(0), "intersection is the immutable tip");
+        assert_eq!(
+            plan.intersection,
+            h(200),
+            "intersection is the immutable tip"
+        );
         assert_eq!(plan.intersection_slot, 50);
         assert_eq!(
             plan.rollback,
@@ -3259,6 +3315,99 @@ mod tests {
             "apply is entire new chain, oldest first"
         );
         assert_eq!(db.get_tip(), Some((350, h(12), 22)));
+    }
+
+    /// #1057: a fork rooted at GENESIS must be reachable even when the
+    /// ImmutableDB is empty (`immutable_anchor == None`).
+    ///
+    /// This is the exact live wedge: a block producer that forged its own
+    /// blocks 0..8 on Origin before initial sync completed, then had to adopt
+    /// the network's chain, which also diverges at genesis. Nothing had been
+    /// flushed to immutable (9 blocks, k=40), so `immutable_anchor` was `None`
+    /// and the genesis-rooted fork was declared "unreachable" forever — the
+    /// node never rejoined the canonical chain for the process lifetime.
+    ///
+    /// Haskell has no such gap: `AnchorGenesis` is a constructor of
+    /// `Anchor blk`, so `Paths.hs::isReachable`'s `AF.Empty anchor` case
+    /// matches a genesis anchor exactly as it matches a block anchor.
+    #[test]
+    fn test_switch_chain_reachable_via_genesis_anchor_with_empty_immutable_db() {
+        let mut db = VolatileDB::new();
+        // Our own fork, rooted at GENESIS (prev_hash == Hash32::ZERO).
+        db.add_block(h(1), 4, 0, Hash32::ZERO, b"own0".to_vec());
+        db.add_block(h(2), 21, 1, h(1), b"own1".to_vec());
+        // The network's chain, ALSO rooted at genesis — shares only Origin.
+        db.add_block(h(10), 5, 0, Hash32::ZERO, b"net0".to_vec());
+        db.add_block(h(11), 10, 1, h(10), b"net1".to_vec());
+        db.add_block(h(12), 15, 2, h(11), b"net2".to_vec());
+
+        let plan = db
+            .switch_chain(&h(12), None, u64::MAX)
+            .expect("a genesis-rooted fork must be reachable with an empty ImmutableDB (#1057)");
+        assert_eq!(
+            plan.intersection,
+            Hash32::ZERO,
+            "intersection is the genesis/Origin anchor"
+        );
+        assert_eq!(plan.intersection_slot, 0, "Origin sits at slot 0");
+        assert_eq!(
+            plan.rollback,
+            vec![h(2), h(1)],
+            "rollback is the entire self-forged chain, newest first"
+        );
+        assert_eq!(
+            plan.apply,
+            vec![h(10), h(11), h(12)],
+            "apply is the entire network chain, oldest first"
+        );
+        assert_eq!(db.get_tip(), Some((15, h(12), 2)));
+    }
+
+    /// #1057 companion: recognising genesis as an anchor must NOT weaken the
+    /// Ouroboros `k` cap. A genesis-rooted fork whose adoption would roll back
+    /// more than `k` blocks is still refused (`StoreButDontChange`).
+    ///
+    /// Without this test the fix above could be mistaken for "genesis rollbacks
+    /// are always allowed", which would reintroduce the 10 629-block-rollback
+    /// class the `max_rollback` cap exists to prevent.
+    #[test]
+    fn test_switch_chain_genesis_rooted_fork_still_respects_k() {
+        let mut db = VolatileDB::new();
+        // Our own chain: 5 blocks rooted at genesis.
+        db.add_block(h(1), 1, 0, Hash32::ZERO, b"a".to_vec());
+        db.add_block(h(2), 2, 1, h(1), b"b".to_vec());
+        db.add_block(h(3), 3, 2, h(2), b"c".to_vec());
+        db.add_block(h(4), 4, 3, h(3), b"d".to_vec());
+        db.add_block(h(5), 5, 4, h(4), b"e".to_vec());
+        let tip_before = db.get_tip();
+        let selected_len_before = db.selected_chain_len();
+
+        // A competing genesis-rooted chain. Adopting it needs a 5-block
+        // rollback, but k = 3.
+        db.add_block(h(20), 6, 0, Hash32::ZERO, b"x".to_vec());
+        db.add_block(h(21), 7, 1, h(20), b"y".to_vec());
+
+        assert!(
+            db.switch_chain(&h(21), None, 3).is_none(),
+            "a genesis-rooted fork requiring a rollback deeper than k must be refused"
+        );
+        assert_eq!(
+            db.selected_chain_len(),
+            selected_len_before,
+            "refused switch must not truncate selected_chain"
+        );
+        assert_eq!(
+            db.get_tip(),
+            tip_before,
+            "refused switch must not move the tip"
+        );
+
+        // With k large enough, the same fork IS adopted — proving the refusal
+        // above was the k cap and not the genesis arm failing to match.
+        assert!(
+            db.switch_chain(&h(21), None, 5).is_some(),
+            "the same genesis-rooted fork must be adopted once k permits it"
+        );
     }
 
     /// A `SwitchPlan` returned by `switch_chain` must carry the intersection

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-cli"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-consensus"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-crypto"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "curve25519-dalek 3.2.0 (git+https://github.com/iquerejeta/curve25519-dalek?branch=ietf03_vrf_compat_ell2)",
  "dashu-base",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-ledger"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bincode",
  "dugite-crypto",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-lsm"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "byteorder",
  "crc32fast",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-mempool"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "dashmap",
  "dugite-crypto",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-network"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-primitives"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bech32",
  "blake2 0.10.6",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-rpc"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-serialization"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-storage"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "dugite-uplc"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "blake2 0.10.6",
  "blst",

--- a/testnet/local-devnet/kes-round.sh
+++ b/testnet/local-devnet/kes-round.sh
@@ -80,6 +80,25 @@ step() { echo; echo "########## $* ##########"; date -u +%H:%M:%SZ; }
 ok()   { printf '\033[0;32m[PASS]\033[0m %s\n' "$*"; }
 bad()  { printf '\033[0;31m[FAIL]\033[0m %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
 note() { printf '\033[0;36m[NOTE]\033[0m %s\n' "$*"; }
+# INCONCLUSIVE = the predicate could not be evaluated, so its PASS would have
+# been vacuous. Counted as a failure on purpose (#953: a gate must hard-fail on
+# evidence that was never produced) but labelled distinctly so an operator can
+# tell "dugite-bp did the wrong thing" from "dugite-bp was never measured".
+inconc() { printf '\033[0;33m[INCONCLUSIVE]\033[0m %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+
+# Count dugite-bp leadership checks recorded after a log mark.
+#
+# #1055/#1057: "dugite-bp forged 0 blocks in the post-expiry window" is
+# trivially true for a forger that is not even RUNNING leadership checks — and
+# that is exactly what #1057 produced (the BP wedged on its own fork, its
+# catch-up gate silently skipping every slot before the KES gate could be
+# reached). Without this discriminator the KES round reported a clean PASS for a
+# node that had been dead for 20 minutes for an unrelated reason.
+dbp_leader_checks_since() {
+    local mark="$1"
+    awk -v m="$mark" 'NR > m && /TraceStartLeadershipCheck/ {c++} END{print c+0}' \
+        "$LD_LOGS/dugite-bp.log" 2>/dev/null
+}
 
 if [ "$SKIP_SETUP" -eq 0 ]; then
     step "setup + run (two-forger mode + short-KES genesis overlay)"
@@ -348,8 +367,29 @@ DBP_DELTA=$((DBP_AFTER - DBP_BEFORE))
 CBP_DELTA=$((CBP_AFTER - CBP_BEFORE))
 note "window deltas: dugite-bp=+$DBP_DELTA cardano-bp=+$CBP_DELTA"
 
+# LIVENESS GATE (#1055/#1057) — evaluate BEFORE reading the zero-forge result.
+#
+# A forger that never ran a leadership check in the window cannot tell us
+# anything about KES expiry. dugite's per-slot KES upper-bound gate lives at
+# step 5c of `try_forge_block_at`, i.e. AFTER the silent catch-up gate at the
+# top of that function — so a BP wedged behind its peers skips every slot
+# without reaching (or logging) the KES check at all. #1057 produced exactly
+# that, and this round's "forged 0 blocks" read as a KES pass for 20 minutes of
+# a completely dead node.
+DBP_CHECKS=$(dbp_leader_checks_since "$MARK_DBP")
+note "dugite-bp leadership checks in window: $DBP_CHECKS"
+if [ "$DBP_CHECKS" -eq 0 ]; then
+    inconc "dugite-bp ran 0 leadership checks in the ${OBS_WINDOW}s window — it was not forging for some reason OTHER than KES expiry (wedged, not caught up, or not a block producer). The zero-forge predicate below is vacuous; investigate dugite-bp.log before trusting this step (#1055/#1057)"
+else
+    ok "dugite-bp ran $DBP_CHECKS leadership check(s) in the window — it was live and attempting to forge, so the zero-forge predicate is meaningful"
+fi
+
 if [ "$DBP_DELTA" -eq 0 ]; then
-    ok "dugite-bp forged 0 new blocks in the ${OBS_WINDOW}s post-expiry window"
+    if [ "$DBP_CHECKS" -gt 0 ]; then
+        ok "dugite-bp forged 0 new blocks in the ${OBS_WINDOW}s post-expiry window (while actively running $DBP_CHECKS leadership checks)"
+    else
+        note "dugite-bp forged 0 new blocks — NOT counted as a pass, see the INCONCLUSIVE above"
+    fi
 else
     bad "dugite-bp forged $DBP_DELTA block(s) after its KES key should have expired at slot $KES_DEATH_SLOT"
 fi

--- a/testnet/local-devnet/restart-endurance-round.allowed-errors
+++ b/testnet/local-devnet/restart-endurance-round.allowed-errors
@@ -1,0 +1,44 @@
+# Expected error-class log lines for restart-endurance-round.sh (#1044).
+#
+# This round deliberately SIGTERMs dugite-relay 30 times, so its peer
+# (dugite-bp) legitimately observes each disconnect and re-dials. Those lines are
+# expected; anything else is a regression.
+#
+# Kept deliberately NARROW. An over-broad allowlist is how a round reports
+# success while measuring nothing (#916/#923/#945/#953/#959) — a pattern like
+# "WARN" would swallow the very leak/re-arm regressions this round exists to
+# catch. Each entry below is one specific, mechanically-caused line.
+#
+# Format: one extended-regex per line; '#' comments and blank lines ignored.
+
+# The peer went away because THIS ROUND stopped it.
+removed dead connection
+shutting down peer connection
+peer reported as failed by protocol task
+demoting warm -> cold
+warm -> cold complete
+
+# Reconnect churn while the relay is restarting: connection refused / reset
+# against a listener that is deliberately down for a moment.
+Connection refused
+connection reset
+Connection reset by peer
+os error 61
+os error 54
+
+# The relay's own clean shutdown path, once per iteration.
+SIGTERM received, shutting down
+N2C server shutting down
+N2N server shutting down
+Metrics server shutting down
+chainsync server task cancelled
+Shutdown signal received
+
+# macOS-only, environmental and unrelated to the restart (already allowlisted by
+# sibling rounds): the system DNS config is unreadable, so discovery falls back
+# to public resolvers.
+System DNS config unavailable
+
+# The N2C socket permission advisory — a devnet-only umask artefact, emitted once
+# per relay start and therefore once per iteration.
+N2C socket is world-readable

--- a/testnet/local-devnet/restart-endurance-round.sh
+++ b/testnet/local-devnet/restart-endurance-round.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# restart-endurance-round.sh — #1044 (#1031 P2-3).
+#
+# 30 SIGTERM/restart iterations of dugite-relay with per-iteration recovery
+# assertions, adapted from upstream cardano-node-tests
+# `test_reconnect.py::test_metrics_reconnect` (200 iterations upstream; adopted
+# at 30 — at devnet scale the metric assertions saturate long before 200, which
+# adds wall-time, not signal).
+#
+# WHY THIS ROUND EXISTS
+#
+# The gate has exactly ONE restart cycle (Round 3) plus the kill-9 chaos
+# scenario. Leak-class defects need REPETITION to surface: fd/task leaks per
+# reconnect (#924 — dropping a tokio JoinHandle DETACHES, leaking the socket for
+# the process lifetime), peer-registry growth, and mux re-arm regressions
+# (#980's class — a clean mini-protocol exit must be RESTARTED by the inbound
+# governor, and dugite orphaned the responder task instead). One restart cannot
+# distinguish "recovered" from "recovered while leaking a socket each time".
+#
+# The subject under test is therefore dugite-bp — the PEER of the node being
+# restarted. A monotonic fd/thread climb on the peer across 30 reconnects is
+# exactly the signal, and it is invisible in a single cycle.
+#
+# SIGTERM, NEVER SIGKILL: kill -9 corrupts the ImmutableDB. The chaos suite owns
+# the kill-9 scenario deliberately and separately; this round is about clean
+# restarts.
+#
+# Usage:
+#   ./restart-endurance-round.sh                  # 30 iterations
+#   RE_ITERATIONS=3 ./restart-endurance-round.sh  # short shakedown
+#   RE_RED_CASE=down    ./restart-endurance-round.sh   # RED proof 1
+#   RE_RED_CASE=peers   ./restart-endurance-round.sh   # RED proof 2
+#
+# RED-CASE PROOFS (runnable, not claimed — #916/#923/#945/#953/#959 were all
+# checks that reported success while measuring nothing):
+#   RE_RED_CASE=down  — assert recovery WITHOUT restarting the relay in
+#                       iteration 1. The round MUST fail. Proves the recovery
+#                       assertions actually observe a live node.
+#   RE_RED_CASE=peers — require peers_connected > 999. The round MUST fail.
+#                       Proves the metric is READ from the endpoint and not
+#                       defaulted/ignored (the #987 shape: a verdict column that
+#                       was always 0).
+set +e
+unsetopt ERR_EXIT ERR_RETURN 2>/dev/null || true
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 2
+. ./lib/common.sh
+. ./lib/expect-log-errors.sh
+
+ITERATIONS="${RE_ITERATIONS:-30}"
+CATCHUP_TIMEOUT="${RE_CATCHUP_TIMEOUT:-120}"
+STOP_TIMEOUT="${RE_STOP_TIMEOUT:-60}"
+RED_CASE="${RE_RED_CASE:-}"
+
+FAILURES=0
+step() { echo; echo "########## $* ##########"; date -u +%H:%M:%SZ; }
+ok()   { printf '\033[0;32m[PASS]\033[0m %s\n' "$*"; }
+bad()  { printf '\033[0;31m[FAIL]\033[0m %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+note() { printf '\033[0;36m[NOTE]\033[0m %s\n' "$*"; }
+
+DUGITE_BIN="${DUGITE_BIN:-$(cd ../.. && pwd)/target/release/dugite-node}"
+[ -x "$DUGITE_BIN" ] || { echo "REFUSING TO RUN: dugite-node binary not found at $DUGITE_BIN"; exit 2; }
+
+# The devnet must already be up: this round restarts a node, it does not create
+# a devnet. Running it against a dead devnet would make every assertion below
+# vacuous in the same direction (all "recovered" checks fail), which is noise,
+# not signal.
+[ -S "$LD_RELAY_SOCK" ] || {
+    echo "REFUSING TO RUN: $LD_RELAY_SOCK absent — start the devnet first (setup.sh && run.sh)"
+    exit 2
+}
+
+EVIDENCE_DIR="$LD_EVIDENCE/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$EVIDENCE_DIR"
+CSV="$EVIDENCE_DIR/restart-endurance.csv"
+echo "ts,iteration,outcome,tip_slot,peers_connected,bp_fds,bp_threads,bp_rss_kb,detail" > "$CSV"
+
+RELAY_METRICS="http://127.0.0.1:${LD_DUGITE_RELAY_METRICS_PORT}/metrics"
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+# Read one Prometheus gauge from the relay's metrics endpoint. Prints the value,
+# or nothing (and returns 1) when the endpoint or the metric is unavailable —
+# NEVER a default, so a missing metric fails the assertion instead of silently
+# satisfying it.
+relay_metric() {
+    local name="$1" out
+    out=$(curl -fsS --max-time 5 "$RELAY_METRICS" 2>/dev/null) || return 1
+    printf '%s' "$out" \
+        | awk -v n="$name" '$1 == n { print $2; found=1 } END { exit !found }'
+}
+
+relay_tip_slot() {
+    cardano-cli query tip --testnet-magic "$LD_MAGIC" \
+        --socket-path "$LD_RELAY_SOCK" 2>/dev/null | jq -r '.slot // empty'
+}
+
+bp_pid() { cat "$LD_STATE/dugite-bp.pid" 2>/dev/null; }
+
+# fd / thread / rss for dugite-bp (the PEER — see the header).
+bp_resources() {
+    local pid fds threads rss
+    pid="$(bp_pid)"
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        echo "0 0 0"
+        return 1
+    fi
+    case "$(uname -s)" in
+        Darwin)
+            fds=$(lsof -p "$pid" 2>/dev/null | wc -l | tr -d ' ')
+            threads=$(ps -M "$pid" 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
+            ;;
+        *)
+            fds=$(ls "/proc/$pid/fd" 2>/dev/null | wc -l | tr -d ' ')
+            threads=$(awk '/Threads:/{print $2}' "/proc/$pid/status" 2>/dev/null)
+            ;;
+    esac
+    rss=$(ps -p "$pid" -o rss= 2>/dev/null | tr -d ' ')
+    echo "${fds:-0} ${threads:-0} ${rss:-0}"
+}
+
+stop_relay() {
+    local pid deadline
+    pid="$(cat "$LD_STATE/dugite-relay.pid" 2>/dev/null)"
+    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
+        # Resolve by command line rather than trusting a stale pidfile (#944's
+        # lesson: a path/pid that does not exist makes the criterion never
+        # evaluate, and the round reports the same result either way).
+        pid=$(pgrep -f "dugite-node run .*dugite-relay.config.json" 2>/dev/null | head -1)
+    fi
+    [ -n "$pid" ] || return 1
+    kill -TERM "$pid" 2>/dev/null || true
+    deadline=$(( $(date +%s) + STOP_TIMEOUT ))
+    while kill -0 "$pid" 2>/dev/null; do
+        [ "$(date +%s)" -ge "$deadline" ] && return 1
+        sleep 1
+    done
+    # `kill` returning 0 does NOT prove death, and a sandboxed kill can silently
+    # no-op — so exit is confirmed by polling, above, not by kill's status.
+    return 0
+}
+
+start_relay() {
+    caffeinate_if_macos "$DUGITE_BIN" run \
+        --config        "$LD_CONFIG/dugite-relay.config.json" \
+        --topology      "$LD_CONFIG/dugite-relay.topology.json" \
+        --database-path "$LD_STATE/dugite-relay.db" \
+        --socket-path   "$LD_RELAY_SOCK" \
+        --host-addr     127.0.0.1 \
+        --port          "$LD_RELAY_PORT" \
+        --metrics-port  "$LD_DUGITE_RELAY_METRICS_PORT" \
+        --rpc-host      127.0.0.1 \
+        --rpc-port      "$LD_DUGITE_RELAY_RPC_PORT" \
+        >> "$LD_LOGS/dugite-relay.log" 2>&1 &
+    write_node_pidfile "$LD_STATE/dugite-relay.db" "$LD_STATE/dugite-relay.pid" \
+        || echo $! > "$LD_STATE/dugite-relay.pid"
+}
+
+# Wait until the relay serves a tip AND that tip is advancing. A socket that
+# accepts a connection is not the same as a node that has rejoined the chain.
+wait_relay_recovered() {
+    local deadline first last
+    deadline=$(( $(date +%s) + CATCHUP_TIMEOUT ))
+    first=""
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        last="$(relay_tip_slot)"
+        if [ -n "$last" ]; then
+            if [ -z "$first" ]; then
+                first="$last"
+            elif [ "$last" -gt "$first" ]; then
+                echo "$last"
+                return 0
+            fi
+        fi
+        sleep 2
+    done
+    [ -n "$last" ] && echo "$last"
+    return 1
+}
+
+# ── round ──────────────────────────────────────────────────────────────────
+
+step "restart-endurance: $ITERATIONS iterations of dugite-relay SIGTERM/restart"
+[ -n "$RED_CASE" ] && note "RED-CASE MODE '$RED_CASE' — this run is EXPECTED to fail"
+
+MARK_BP=$(log_mark "$LD_LOGS/dugite-bp.log")
+MARK_RELAY=$(log_mark "$LD_LOGS/dugite-relay.log")
+note "log marks: dugite-bp=$MARK_BP dugite-relay=$MARK_RELAY"
+
+read -r FDS0 THREADS0 RSS0 <<< "$(bp_resources)"
+note "dugite-bp baseline: fds=$FDS0 threads=$THREADS0 rss_kb=$RSS0"
+if [ "${FDS0:-0}" -eq 0 ]; then
+    bad "could not sample dugite-bp resources at baseline — the leak assertions would be vacuous"
+fi
+
+RECOVERED=0
+for i in $(seq 1 "$ITERATIONS"); do
+    if [ "$RED_CASE" = "down" ] && [ "$i" -eq 1 ]; then
+        # RED proof 1: stop the relay and DO NOT restart it, then run the same
+        # recovery assertions. They must fail.
+        note "[iter $i] RED-CASE 'down': stopping relay and skipping the restart"
+        stop_relay
+    else
+        if ! stop_relay; then
+            bad "[iter $i] dugite-relay did not exit within ${STOP_TIMEOUT}s of SIGTERM"
+            printf '%s,%s,FAIL,,,,,,%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$i" "stop-timeout" >> "$CSV"
+            continue
+        fi
+        start_relay
+    fi
+
+    TIP=$(wait_relay_recovered)
+    RC=$?
+
+    PEERS=$(relay_metric dugite_peers_connected) || PEERS=""
+    read -r FDS THREADS RSS <<< "$(bp_resources)"
+
+    PEER_FLOOR=1
+    [ "$RED_CASE" = "peers" ] && PEER_FLOOR=999
+
+    DETAIL=""
+    ITER_OK=1
+    if [ "$RC" -ne 0 ] || [ -z "$TIP" ]; then
+        ITER_OK=0
+        DETAIL="tip-not-advancing"
+    fi
+    if [ -z "$PEERS" ]; then
+        ITER_OK=0
+        DETAIL="$DETAIL;peers-metric-unavailable"
+    elif [ "$PEERS" -lt "$PEER_FLOOR" ]; then
+        ITER_OK=0
+        DETAIL="$DETAIL;peers=$PEERS<$PEER_FLOOR"
+    fi
+
+    if [ "$ITER_OK" -eq 1 ]; then
+        RECOVERED=$((RECOVERED + 1))
+        printf '%s,%s,PASS,%s,%s,%s,%s,%s,%s\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$i" "$TIP" "$PEERS" "$FDS" "$THREADS" "$RSS" "ok" >> "$CSV"
+        note "[iter $i/$ITERATIONS] recovered: tip=$TIP peers=$PEERS bp_fds=$FDS bp_threads=$THREADS"
+    else
+        printf '%s,%s,FAIL,%s,%s,%s,%s,%s,%s\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$i" "${TIP:-}" "${PEERS:-}" "$FDS" "$THREADS" "$RSS" "${DETAIL#;}" >> "$CSV"
+        bad "[iter $i/$ITERATIONS] did not recover: ${DETAIL#;}"
+    fi
+done
+
+# ── end-of-round assertions ────────────────────────────────────────────────
+
+step "end-of-round assertions"
+
+if [ "$RECOVERED" -eq "$ITERATIONS" ]; then
+    ok "all $ITERATIONS iterations recovered"
+else
+    bad "only $RECOVERED/$ITERATIONS iterations recovered"
+fi
+
+read -r FDS1 THREADS1 RSS1 <<< "$(bp_resources)"
+note "dugite-bp final: fds=$FDS1 threads=$THREADS1 rss_kb=$RSS1 (baseline fds=$FDS0 threads=$THREADS0)"
+
+# Leak assertion. A per-reconnect fd/thread leak shows up as growth roughly
+# proportional to ITERATIONS, so the bound is generous in absolute terms while
+# still catching one-per-restart: a leak of 1 fd per iteration over 30 iterations
+# is +30, well past this.
+FD_BUDGET="${RE_FD_BUDGET:-$(( ITERATIONS / 3 + 10 ))}"
+THREAD_BUDGET="${RE_THREAD_BUDGET:-$(( ITERATIONS / 3 + 10 ))}"
+if [ "${FDS0:-0}" -gt 0 ] && [ "${FDS1:-0}" -gt 0 ]; then
+    FD_GROWTH=$(( FDS1 - FDS0 ))
+    THREAD_GROWTH=$(( THREADS1 - THREADS0 ))
+    if [ "$FD_GROWTH" -le "$FD_BUDGET" ]; then
+        ok "dugite-bp fd count flat across $ITERATIONS reconnects (growth=$FD_GROWTH, budget=$FD_BUDGET)"
+    else
+        bad "dugite-bp fd count GREW by $FD_GROWTH across $ITERATIONS reconnects (budget=$FD_BUDGET) — per-reconnect fd leak (#924 class)"
+    fi
+    if [ "$THREAD_GROWTH" -le "$THREAD_BUDGET" ]; then
+        ok "dugite-bp thread count flat (growth=$THREAD_GROWTH, budget=$THREAD_BUDGET)"
+    else
+        bad "dugite-bp thread count GREW by $THREAD_GROWTH (budget=$THREAD_BUDGET) — per-reconnect task leak (#980 class)"
+    fi
+else
+    bad "could not sample dugite-bp resources — leak assertions are INCONCLUSIVE, not passing"
+fi
+
+# Log oracle: expected reconnect churn is allowed, anything else is not.
+ALLOWLIST="$(pwd)/restart-endurance-round.allowed-errors"
+if [ -f "$ALLOWLIST" ]; then
+    if assert_no_other_errors "$LD_LOGS/dugite-bp.log" "$MARK_BP" "$ALLOWLIST"; then
+        ok "no unexpected error-class lines in dugite-bp.log"
+    else
+        bad "unexpected error-class line(s) in dugite-bp.log — see above"
+    fi
+    if assert_no_other_errors "$LD_LOGS/dugite-relay.log" "$MARK_RELAY" "$ALLOWLIST"; then
+        ok "no unexpected error-class lines in dugite-relay.log"
+    else
+        bad "unexpected error-class line(s) in dugite-relay.log — see above"
+    fi
+else
+    bad "missing restart-endurance-round.allowed-errors next to this script"
+fi
+
+echo
+echo "evidence: $CSV"
+if [ "$FAILURES" -eq 0 ]; then
+    echo "RESTART-ENDURANCE ROUND: PASS ($RECOVERED/$ITERATIONS iterations)"
+    [ -n "$RED_CASE" ] && {
+        echo "RED-CASE '$RED_CASE' PASSED — that is itself a FAILURE: the assertions did not detect the injected fault"
+        exit 1
+    }
+    exit 0
+else
+    echo "RESTART-ENDURANCE ROUND: FAIL ($FAILURES assertion(s))"
+    [ -n "$RED_CASE" ] && {
+        echo "RED-CASE '$RED_CASE' correctly detected — the assertions are discriminating"
+        exit 0
+    }
+    exit 1
+fi

--- a/testnet/local-devnet/restart-endurance-round.sh
+++ b/testnet/local-devnet/restart-endurance-round.sh
@@ -40,12 +40,27 @@
 #                       Proves the metric is READ from the endpoint and not
 #                       defaulted/ignored (the #987 shape: a verdict column that
 #                       was always 0).
-set +e
-unsetopt ERR_EXIT ERR_RETURN 2>/dev/null || true
-
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 2
 . ./lib/common.sh
 . ./lib/expect-log-errors.sh
+
+# ORDER IS LOAD-BEARING: `lib/common.sh` line 4 is `set -euo pipefail`, so
+# relaxing errexit BEFORE sourcing it does nothing — the lib turns it straight
+# back on. Every sibling round (kes-round.sh, rollback-round.sh) sources first
+# and relaxes after, for exactly this reason.
+#
+# Caught by this round's own `RE_RED_CASE=down` proof: with errexit live,
+# `TIP=$(wait_relay_recovered)` returning 1 KILLED the script at the first
+# unrecovered iteration — before the end-of-round leak assertions and the log
+# oracle ever ran — and exited 1, which is indistinguishable from an orderly
+# failure. A round that aborts instead of failing reports less than nothing.
+# The happy path never noticed, because there `wait_relay_recovered` returns 0.
+#
+# `set +u` too: this script reads optional env knobs and a `${VAR}` typo under
+# `-u` would abort rather than fall back to its default.
+set +e
+set +u
+unsetopt ERR_EXIT ERR_RETURN 2>/dev/null || true
 
 ITERATIONS="${RE_ITERATIONS:-30}"
 CATCHUP_TIMEOUT="${RE_CATCHUP_TIMEOUT:-120}"

--- a/testnet/local-devnet/two-forger-round.sh
+++ b/testnet/local-devnet/two-forger-round.sh
@@ -179,6 +179,29 @@ else
     bad "two-forger round did not achieve two forgers (dugite-bp=$DBP_FORGED cardano-bp=$CBP_FORGED); every assertion below would be vacuous"
 fi
 
+step "3b. dugite-bp is NOT stranded on its own self-forged fork (#1057 regression)"
+# #1057: a BP that won a slot before its initial sync completed forged blocks
+# 0..8 on Origin and then NEVER adopted a peer block again. BlockFetch declined
+# the canonical chain's block 0 (genesis is not a "stored block"), the ledger
+# froze at the BP's own last forged block, ChainSync's forecast-horizon park
+# dropped every peer on a loop, and the node stayed wedged for the process
+# lifetime.
+#
+# Step 5's convergence check does fail on this, but it reports "tips differ",
+# which reads as ordinary propagation lag. This asserts the SIGNATURE directly:
+# dugite-bp's tip block number must exceed the number of blocks it forged
+# itself, i.e. it has adopted at least one block from somebody else.
+DBP_TIP_BLK=$(tip_field "$LD_DUGITE_BP_SOCK" .block)
+ARB_TIP_BLK=$(tip_field "$LD_CARDANO_ARBITER_SOCK" .block)
+note "dugite-bp tip block=$DBP_TIP_BLK, arbiter tip block=$ARB_TIP_BLK, dugite-bp self-forged=$DBP_FORGED"
+if [ -z "$DBP_TIP_BLK" ] || [ -z "$ARB_TIP_BLK" ]; then
+    bad "could not read dugite-bp / arbiter tip — cannot evaluate the #1057 guard"
+elif [ "$DBP_TIP_BLK" -le "${DBP_FORGED:-0}" ] && [ "$ARB_TIP_BLK" -gt "$DBP_TIP_BLK" ]; then
+    bad "dugite-bp appears STRANDED ON ITS OWN FORK (#1057): tip block=$DBP_TIP_BLK is no higher than the $DBP_FORGED blocks it forged itself, while the arbiter is at block=$ARB_TIP_BLK. Check dugite-bp.log for repeated 'beyond forecast horizon ... disconnecting' against every peer with a frozen ledger tip"
+else
+    ok "dugite-bp has adopted blocks from the network (tip block=$DBP_TIP_BLK > self-forged=$DBP_FORGED, arbiter=$ARB_TIP_BLK)"
+fi
+
 step "4. slot battles / lost blocks observed"
 # Haskell's own signal that it forged a valid block and lost the race.
 # ouroboros-consensus documents this as rare-but-expected, at Error severity:

--- a/testnet/local-devnet/tx-zoo/01-bookkeeping/01i-many-inputs.sh
+++ b/testnet/local-devnet/tx-zoo/01-bookkeeping/01i-many-inputs.sh
@@ -4,7 +4,15 @@
 # Upstream: cardano-node-tests test_tx_many_utxos.py::test_mini_transactions
 # (#1032, cardano-node-tests adoption P0.1).
 #
-# Assertion contract: fan out 300+ tiny UTxOs at a fresh script-local address,
+# Rerunnable (#1048): FAN_ADDR is a PERSISTENT per-script address (its keys are
+# cached under $ZOO_KEYS/$NAME), and this script returns its consume-tx change
+# there, so a second run in the same devnet finds an irregular-value leftover.
+# Step 2 therefore selects only ada-only UTxOs worth EXACTLY PER_UTXO, which
+# keeps `SUM = N * PER_UTXO` true by construction; step 3 looks its output up by
+# txid prefix and was already rerun-safe. The funder input is ada-only-selected
+# so multi-asset debris in the shared wallet cannot be silently dropped.
+#
+# Assertion contract: fan out 300+ tiny UTxOs at a script-local address,
 # then build ONE tx that consumes as many of them as fit under
 # maxTxSize=16384 (devnet). We assert the packed input count is >=300 (the
 # upstream test's own floor), that the tx is ACCEPTED, and that the
@@ -84,7 +92,14 @@ FANOUT_TXS=3
 PER_TX_OUTPUTS=120
 TOTAL_FANNED=$((FANOUT_TXS * PER_TX_OUTPUTS))
 
-UTXO=$(zoo_largest_utxo "$FUND_ADDR") || { zoo_record "$NAME" FAIL "" "no-utxo"; exit 1; }
+# #1048: ADA-ONLY funder input. `zoo_largest_utxo` ranks by lovelace alone and
+# on a wallet carrying multi-asset debris can hand back a UTxO with tokens; the
+# bare-ADA `--tx-out`s in `build_fanout` would silently drop the asset and the tx
+# would be rejected `ValueNotConservedUTxO`.
+UTXO=$(zoo_largest_ada_only_utxo "$FUND_ADDR") || {
+    zoo_record "$NAME" FAIL "" "no-ada-only-utxo"
+    exit 1
+}
 CUR_IN=${UTXO%% *}
 CUR_AMT=${UTXO##* }
 LAST_TXID=""
@@ -108,12 +123,31 @@ zoo_wait_inclusion "$LAST_TXID" 90 || {
 }
 
 # ── Step 2: build ONE tx consuming as many FAN_ADDR utxos as fit ───────────
+#
+# #1048: select ONLY ada-only UTxOs worth EXACTLY PER_UTXO.
+#
+# `SUM=$((N * PER_UTXO))` below is what makes the exact post-balance assertion in
+# step 3 possible, and it is only true if every selected input really is
+# PER_UTXO. FAN_ADDR is a persistent per-script address, and this script's own
+# consume tx returns its change THERE — so on a second run in the same devnet
+# FAN_ADDR holds an irregular-value leftover. Selecting it made SUM wrong, which
+# made CHANGE wrong, which got the tx rejected for `ValueNotConservedUTxO`: a
+# harness-hygiene failure that reads as a ledger bug.
+#
+# Filtering by exact value (rather than, say, skipping the newest UTxO) keeps the
+# invariant true by CONSTRUCTION and needs no bookkeeping across runs. Leftovers
+# simply accumulate, ignored.
 mapfile -t FAN_INS < <(cardano-cli conway query utxo \
         --testnet-magic "$LD_MAGIC" --socket-path "$ZOO_SOCKET" \
-        --address "$FAN_ADDR" --output-json 2>/dev/null | jq -r 'keys[]')
+        --address "$FAN_ADDR" --output-json 2>/dev/null \
+    | jq -r --argjson per "$PER_UTXO" '
+        to_entries
+        | map(select((.value.value | keys) == ["lovelace"]))
+        | map(select(.value.value.lovelace == $per))
+        | .[].key')
 TOTAL_AVAIL=${#FAN_INS[@]}
 if [ "$TOTAL_AVAIL" -lt 300 ]; then
-    zoo_record_env_skip "$NAME" "only-$TOTAL_AVAIL-utxos-fanned-out (wanted >=300)"
+    zoo_record_env_skip "$NAME" "only-$TOTAL_AVAIL-exact-${PER_UTXO}-lovelace-utxos-at-FAN_ADDR (wanted >=300)"
     exit 0
 fi
 

--- a/testnet/local-devnet/tx-zoo/19-era-negatives/19a-compat-mir-treasury-reserves.sh
+++ b/testnet/local-devnet/tx-zoo/19-era-negatives/19a-compat-mir-treasury-reserves.sh
@@ -65,4 +65,9 @@ cardano-cli compatible shelley transaction signed-transaction \
 
 TXID=$(cardano-cli conway transaction txid --tx-file "$SIGNED" --output-text 2>/dev/null || echo "")
 
-era_neg_assert_rejected_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli
+# #1047: dugite now answers HardForkApplyTxErrWrongEra BEFORE decoding, so
+# the reject REASON is assertable. The strict form additionally FAILS if
+# dugite rejects via a CBOR decode error — that was the pre-#1047 accident,
+# and relying on it would have hidden an accept-where-Haskell-rejects the
+# moment any legacy standalone decoder was corrected.
+era_neg_assert_wrong_era_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli

--- a/testnet/local-devnet/tx-zoo/19-era-negatives/19b-compat-mir-pay-stake-addr.sh
+++ b/testnet/local-devnet/tx-zoo/19-era-negatives/19b-compat-mir-pay-stake-addr.sh
@@ -69,4 +69,9 @@ cardano-cli compatible shelley transaction signed-transaction \
 
 TXID=$(cardano-cli conway transaction txid --tx-file "$SIGNED" --output-text 2>/dev/null || echo "")
 
-era_neg_assert_rejected_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli
+# #1047: dugite now answers HardForkApplyTxErrWrongEra BEFORE decoding, so
+# the reject REASON is assertable. The strict form additionally FAILS if
+# dugite rejects via a CBOR decode error — that was the pre-#1047 accident,
+# and relying on it would have hidden an accept-where-Haskell-rejects the
+# moment any legacy standalone decoder was corrected.
+era_neg_assert_wrong_era_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli

--- a/testnet/local-devnet/tx-zoo/19-era-negatives/19c-compat-genesis-key-delegation.sh
+++ b/testnet/local-devnet/tx-zoo/19-era-negatives/19c-compat-genesis-key-delegation.sh
@@ -88,4 +88,9 @@ cardano-cli compatible shelley transaction signed-transaction \
 
 TXID=$(cardano-cli conway transaction txid --tx-file "$SIGNED" --output-text 2>/dev/null || echo "")
 
-era_neg_assert_rejected_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli
+# #1047: dugite now answers HardForkApplyTxErrWrongEra BEFORE decoding, so
+# the reject REASON is assertable. The strict form additionally FAILS if
+# dugite rejects via a CBOR decode error — that was the pre-#1047 accident,
+# and relying on it would have hidden an accept-where-Haskell-rejects the
+# moment any legacy standalone decoder was corrected.
+era_neg_assert_wrong_era_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli

--- a/testnet/local-devnet/tx-zoo/19-era-negatives/19d-compat-shelley-update-proposal.sh
+++ b/testnet/local-devnet/tx-zoo/19-era-negatives/19d-compat-shelley-update-proposal.sh
@@ -67,4 +67,9 @@ cardano-cli compatible shelley transaction signed-transaction \
 
 TXID=$(cardano-cli conway transaction txid --tx-file "$SIGNED" --output-text 2>/dev/null || echo "")
 
-era_neg_assert_rejected_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli
+# #1047: dugite now answers HardForkApplyTxErrWrongEra BEFORE decoding, so
+# the reject REASON is assertable. The strict form additionally FAILS if
+# dugite rejects via a CBOR decode error — that was the pre-#1047 accident,
+# and relying on it would have hidden an accept-where-Haskell-rejects the
+# moment any legacy standalone decoder was corrected.
+era_neg_assert_wrong_era_both "$NAME" "$SIGNED" "$TXID" era_neg_submit_cli

--- a/testnet/local-devnet/tx-zoo/19-era-negatives/_era-neg-helper.sh
+++ b/testnet/local-devnet/tx-zoo/19-era-negatives/_era-neg-helper.sh
@@ -252,3 +252,70 @@ era_neg_assert_rejected_both() {
     zoo_record "$name" PASS "$txid" "$detail"
     return 0
 }
+
+# era_neg_assert_wrong_era_both <name> <signed-file> <txid> <submit-fn>
+#
+# Stricter form of `era_neg_assert_rejected_both` for the legacy-era cases
+# (19a-19d): both observers must reject AND **dugite's reason must name an era
+# mismatch**, not a CBOR decode failure.
+#
+# Why this exists (#1047): before dugite had a wire-era check, a legacy-era
+# submission was rejected only as an ACCIDENTAL decode error — the standalone
+# Shelley decoder expects a different array length than a real Shelley tx has.
+# The verdict was right for the wrong reason, and correcting any one of those
+# decoders without adding an era check would have turned these cases into
+# ACCEPTS on a Conway chain (MIR Phase-1 validation is a documented no-op at
+# PV>=9 and GenesisKeyDelegation has era-unconditional apply-time support, so the
+# ledger layer would not have caught them). dugite now answers
+# `HardForkApplyTxErrWrongEra` before decoding, so the reason is assertable and
+# the accident is no longer load-bearing.
+#
+# The reason is matched against a SET of renderings rather than one exact string,
+# because the text comes from cardano-cli's formatting of
+# `HardForkApplyTxErrWrongEra` and is not dugite's to pin. What IS pinned is the
+# negative: the reason must NOT be a decode failure, which is precisely the
+# pre-#1047 behaviour this asserts we have moved off.
+era_neg_assert_wrong_era_both() {
+    local name="$1" signed="$2" txid="${3:-}" submit_fn="${4:-era_neg_submit_cli}"
+    local dugite_line cbp_line dugite_rc cbp_rc
+
+    dugite_line=$("$submit_fn" "$signed" "$ZOO_SOCKET") && dugite_rc=0 || dugite_rc=$?
+    cbp_line=$("$submit_fn" "$signed" "$LD_CARDANO_BP_SOCK") && cbp_rc=0 || cbp_rc=$?
+
+    if [ "$dugite_rc" -eq 2 ] && [ "$cbp_rc" -eq 2 ]; then
+        zoo_record_env_skip "$name" "both-sockets-not-found"
+        return 0
+    fi
+
+    local detail="dugite(${ZOO_SOCKET})=${dugite_line}; cbp(${LD_CARDANO_BP_SOCK})=${cbp_line}"
+
+    if [ "$dugite_rc" -eq 1 ] || [ "$cbp_rc" -eq 1 ]; then
+        zoo_fail "$name: accepted where rejection was expected — $detail"
+        zoo_record "$name" FAIL "$txid" "$detail"
+        return 1
+    fi
+
+    # dugite was unreachable — cannot assert its reason; the rejection by the
+    # observer that WAS reachable still holds.
+    if [ "$dugite_rc" -eq 2 ]; then
+        zoo_ok "$name: rejected (dugite socket absent, reason not asserted) — $detail"
+        zoo_record "$name" PASS "$txid" "$detail"
+        return 0
+    fi
+
+    if printf '%s' "$dugite_line" | grep -qiE 'EraMismatch|otherEraName|WrongEra|era of the node'; then
+        zoo_ok "$name: rejected with an era mismatch — $detail"
+        zoo_record "$name" PASS "$txid" "$detail"
+        return 0
+    fi
+
+    if printf '%s' "$dugite_line" | grep -qiE 'decode failed|DeserialiseFailure'; then
+        zoo_fail "$name: dugite rejected via a CBOR DECODE error, not an era check — this is the pre-#1047 accident and means the wire-era check did not fire — $detail"
+        zoo_record "$name" FAIL "$txid" "decode-not-era-check: $detail"
+        return 1
+    fi
+
+    zoo_fail "$name: dugite rejected but the reason names neither an era mismatch nor a decode failure; #1047 expects HardForkApplyTxErrWrongEra — $detail"
+    zoo_record "$name" FAIL "$txid" "unexpected-reason: $detail"
+    return 1
+}

--- a/testnet/local-devnet/tx-zoo/lib/tx-zoo-common.sh
+++ b/testnet/local-devnet/tx-zoo/lib/tx-zoo-common.sh
@@ -168,6 +168,40 @@ zoo_largest_utxo() {
     echo "$line"
 }
 
+# Print the largest ADA-ONLY UTxO at $addr as "<txin> <lovelace>".
+#
+# #1048: `zoo_largest_utxo` ranks by lovelace alone, so on a wallet that has
+# accumulated multi-asset debris (any earlier mint script's output) it can return
+# a UTxO carrying tokens. A bare-ADA `build-raw --tx-out` then SILENTLY DROPS the
+# asset, and the tx is rejected with `ValueNotConservedUTxO` — a failure that
+# looks like a ledger bug and is really funder-wallet hygiene.
+#
+# `value` in the cardano-cli utxo JSON is a map whose only guaranteed key is
+# `lovelace`; any additional key is a policy id. So "ada-only" is exactly
+# `(.value.value | keys) == ["lovelace"]`.
+zoo_largest_ada_only_utxo() {
+    local addr="$1" sock="${2:-$ZOO_SOCKET}"
+    local tmp
+    tmp="$(mktemp)"
+    cardano-cli conway query utxo \
+        --testnet-magic "$LD_MAGIC" \
+        --socket-path   "$sock" \
+        --address       "$addr" \
+        --out-file      "$tmp"
+    local line
+    line=$(jq -r '
+        to_entries
+        | map(select((.value.value | keys) == ["lovelace"]))
+        | sort_by(-.value.value.lovelace)
+        | .[0] // empty
+        | "\(.key) \(.value.value.lovelace)"' "$tmp")
+    rm -f "$tmp"
+    if [ -z "$line" ] || [ "$line" = "null null" ]; then
+        return 1
+    fi
+    echo "$line"
+}
+
 # Print the Nth-largest UTxO (0-indexed) — useful when scripts share a wallet
 # and need disjoint inputs.
 zoo_utxo_at() {


### PR DESCRIPTION
## v2.7.0 — genesis is an anchor, and eras are checked at the wire

**Drop-in from v2.6.0. `SNAPSHOT_VERSION` unchanged at 37** — existing databases
need no re-sync.

Closes **#1015, #1026, #1028, #1046, #1047, #1048, #1050, #1051, #1054, #1055**,
plus **#1057** and **#1058** found during the sweep itself.

Every fix in this release landed with a regression test **proven RED by disarming
the fix**, not merely written alongside it.

---

### #1057 — a node with any block of its own never rejoins the chain (P0)

The most serious defect in this release, and it strands a **block producer**.

A node whose local chain must be replaced from Origin never adopted the canonical
chain. BlockFetch declined the peer's block 0 on every decision tick, so the
ledger never advanced, so ChainSync's forecast-horizon park timed out and dropped
**every** peer — then re-dialled and repeated, with no self-healing, for the
process lifetime.

Live evidence from a two-forger devnet: dugite-bp forged blocks 0..8 (slots 4–21)
on Origin, then froze at its own tip while the Haskell chain reached block 240+,
dying at the *same header slot 345* on every peer and every reconnect, after
6m15s of total log silence. Controlled comparison, same binary and same devnet:
**dugite-relay reached epoch 2 while dugite-bp stayed at epoch 0** — the only
difference being whether the ChainDB was non-empty when the Origin adoption was
required.

One blind spot in two independent layers: **genesis/Origin was not recognised as
an anchor**, only a stored block or the ImmutableDB tip.

- The #735 BlockFetch gross-request invariant exempted only a *completely empty*
  ChainDB. Genesis is never a stored block, so `has_block(&genesis)` is always
  false and a node holding any block of its own declined block 0 forever. The
  guard's own comment documents the same wedge one case earlier, and its
  `is_none()` escape hatch is the bug's twin.
- `VolatileDB::switch_chain` accepted a non-intersecting fork only when its root
  anchored at the ImmutableDB tip. With nothing flushed yet (9 blocks, k=40) that
  anchor is `None`, so a genesis-rooted fork was declared unreachable. Both
  layers needed fixing or the wedge would simply move one step later.

Upstream needs no such guard: `AnchorGenesis` is a first-class constructor of
`Anchor blk` and is matched by `Paths.hs::isReachable`. The `k` cap is untouched —
the new arm makes a genesis rollback *expressible*, not permitted, and a
companion test pins that a >k genesis-rooted rollback is still refused.

A pre-existing test was **pinning** the storage half:
`test_switch_chain_reachable_via_immutable_anchor` used `h(0)` as its "immutable
tip", and `h(0)` is `[0u8; 32]` — the genesis sentinel — so it asserted that a
genesis-rooted fork stays unreachable.

### #1015 — Babbage folded `extraEntropy` into the epoch nonce (consensus)

`babbage.rs` delegated wholesale to Shelley's boundary, which folds the **TPraos**
3-term TICKN nonce. Babbage is **Praos**: `tickChainDepState` folds two terms and
`extraEntropy` does not exist for Praos at all (zero occurrences in `Praos.hs`;
`hkdExtraEntropyL = notSupportedInThisEraL` for Babbage/Conway/Dijkstra).

Dormant on every known network — `extra_entropy` is neutral by the time Babbage
runs — but nonce evolution has no self-correcting mechanism, so a chain carrying a
non-neutral value across Alonzo→Babbage would diverge via the VRF leader schedule
forever.

Three implementations existed and **the duplication was the mechanism**: Conway
had the right formula; Babbage reused the wrong era's code. Collapsed to one
`compute_epoch_boundary_nonce` with the mode derived from `ctx.era`, so no caller
can select the wrong formula. The third copy sat in the `#[doc(hidden)]` test-only
boundary path — the same path #977's fix landed in while production did nothing,
and the path every unit test drives.

### #1046 — an invented default PlutusV2 cost model

dugite injected a hardcoded `defaultV2CostModel` whenever genesis supplied no V2,
reporting `costModels = [V1,V2,V3]` where cardano-node reports `[V1,V3]` on
mainnet/preview/preprod. Beyond the wire divergence this was a latent
accept-where-Haskell-rejects: a PlutusV2 script executes on dugite and fails
upstream with `CollectErrors [NoCostModel PlutusV2]`.

The real mechanism is `alonzoInjectCostModels`, which applies
`agExtraConfig.aecCostModels` to **`curPParams` only**, as a **per-language**
update. cardano-ledger has no default V2 anywhere — `defaultV2CostModel` lives in
cardano-api as a value written *into* a generated genesis file, which is why
`create-testnet-data` devnets have V2 and real networks do not. dugite's constant
was copied from that same source, so it matched on the devnet by coincidence.

### #1058 — script-integrity mismatch used UTXOW tag 13 at every protocol version

`checkScriptIntegrityHash` selects by PV: below 11, `PPViewHashesDontMatch`
(tag 13, Mismatch flattened via `ToGroup`); from 11, `ScriptIntegrityHashMismatch`
(tag 18, Mismatch nested plus a preimage field). dugite emitted tag 13
unconditionally — wrong at PV11, **which preview runs**, so the reachable case was
the wrong one. Found only because #1030 item 3 recorded that this split had never
been re-verified against dugite's encoder.

### #1047, #1026, #1028 — three accept-where-Haskell-rejects gaps

- **#1047** — no wire-era check on N2C submission. A legacy-era transaction was
  rejected only as an *accidental* CBOR array-length error, and that accident was
  load-bearing: correcting any legacy standalone decoder without adding an era
  check would have made MIR / GenesisKeyDelegation artifacts acceptable on a
  Conway chain, because MIR Phase-1 validation is a no-op at PV≥9 and
  GenesisKeyDelegation has era-unconditional apply-time support. Now
  `HardForkApplyTxErrWrongEra` before decoding, with the era taken from the era
  history rather than ledger pparams.
- **#1026** — PV9 restricts proposal *submission* to ParameterChange /
  HardForkInitiation / InfoAction. dugite had the symmetric vote-side restriction
  but not the proposal side. The `isBootstrapAction` classification is now shared
  by both, as upstream gates both on one predicate. Typed GOV tag 12 wire arm
  included.
- **#1028** — a constitution with `SNothing` guardrail was treated as "anything
  goes"; Haskell compares the whole `StrictMaybe`. Root cause was a type that
  could not express the difference between "context not plumbed in" and
  "genuinely absent".

### Wire-encoder fidelity

- **#1050** — `InsufficientCollateral` (tag 12) and `CollateralContainsNonADA`
  (tag 15) had no encoder arms and degraded to a generic `ConwayMempoolFailure`.
- **#1051** — `BabbageNonDisjointRefInputs` (tag 22) wrapped its `NonEmpty TxIn`
  in a spurious CBOR tag-258 Set, making the reply undecodable to cardano-cli.
  The pre-existing golden test pinned the bug by decoding only the tag.

### Consensus / forging

- **#1054** — the forge loop hardcoded `MAX_KES_EVOLUTIONS = 62` (the Sum6Kes
  *structural* depth) as the *policy* bound, so a block producer forged past KES
  expiry under any real `maxKESEvolutions`. Genesis value now threaded through,
  with a per-slot upper-bound gate mirroring the working lower-bound one.
- **#1055** — root-caused to #1057. The `set`-snapshot warning that framed the
  report was a red herring: the pre-fill is cleared deliberately on a
  Conway-from-genesis chain and leader election falls back to live delegations.
  The misleading message is corrected.

### Ledger diagnostics

- **#1030 item 1** — Phase-1 failures now accumulate. Rule 3 (ADA conservation)
  and Rule 9b (witness completeness) were gated on `errors.is_empty()`, so an
  unrelated earlier failure suppressed them and clients saw fewer causes than
  cardano-node reports. Verdicts were never affected.
- **#1030 item 2** — `replay_phase2 --flat` no longer pins PlutusV2; the language
  is selectable, and V4-with-a-dump refuses rather than substituting V3's cost
  application and reporting numbers the node would not charge.

### Test-harness correctness

- **#1048** — `01i-many-inputs` is rerunnable: exact-value input selection keeps
  `SUM = N × PER_UTXO` true by construction, and a new shared
  `zoo_largest_ada_only_utxo` stops multi-asset funder debris from being silently
  dropped into a `ValueNotConservedUTxO`.
- **#1044** — new restart-endurance round: 30 SIGTERM/restart cycles of
  dugite-relay with per-iteration recovery assertions and fd/thread leak bounds on
  its **peer**, plus two runnable RED cases. The round is committed; see the
  QA notes for its live-run status.

---

### Still open

- **#1053** — the typed phase-2 `ScriptFailed` wire class (`ConwayUtxosPredFailure`),
  a substantial standalone wire shape.
- **#1008** — the cardano-cli surface-parity backlog (82 commands).
- **#1030** items 4–6 — the `Phase2Valid` gating question, the LSQ deep audit of
  tags 4/8/9/11/13/14/38, and the aux-data key-ceiling model.
- **#1031 / #1044** — the coverage-adoption tracker stays open pending a live run
  of the new round.
