### PR TITLE
fix(ledger): gate treasury-value and ref-script-size on Phase2Valid (#1061)

### DIFF
--- a/crates/dugite-ledger/src/validation/mod.rs
+++ b/crates/dugite-ledger/src/validation/mod.rs
@@ -4434,8 +4434,16 @@ pub fn validate_transaction_with_pools(
     // Conway LEDGER rule: currentTreasuryValue must match ledger treasury.
     // This prevents mempool admission of transactions with stale/wrong
     // treasury assertions, which would cause forged blocks to be rejected.
+    //
+    // #1061: SKIPPED ENTIRELY when the tx declares `is_valid: false`.
+    // `conwayLedgerTransition` runs `validateTreasuryValue` only inside the
+    // `isPhase2ValidTxL == Phase2Valid` branch, alongside
+    // `validateRefScriptSize` (see the matching note in `phase1.rs`). Running it
+    // unconditionally was a FALSE REJECT — cardano-node accepts a
+    // phase-2-failing tx carrying a stale treasury assertion, and at block level
+    // dugite refusing such a block is the #985 symptom class.
     // ------------------------------------------------------------------
-    if params.protocol_version_major >= 9 {
+    if params.protocol_version_major >= 9 && tx.is_valid {
         if let (Some(declared), Some(actual)) = (tx.body.treasury_value.as_ref(), current_treasury)
         {
             if declared.0 != actual {

--- a/crates/dugite-ledger/src/validation/phase1.rs
+++ b/crates/dugite-ledger/src/validation/phase1.rs
@@ -1723,7 +1723,27 @@ pub(super) fn run_phase1_rules(
     // limit was previously accepted at Phase-1 where cardano-node rejects
     // it outright.
     // ------------------------------------------------------------------
-    if params.protocol_version_major >= 9 {
+    // #1061: SKIPPED ENTIRELY when the tx declares `is_valid: false`.
+    //
+    // Haskell's `conwayLedgerTransition` runs this test only inside the
+    // Phase2Valid branch (`eras/conway/impl/src/Cardano/Ledger/Conway/Rules/
+    // Ledger.hs`):
+    //
+    //     if tx ^. isPhase2ValidTxL == Phase2Valid
+    //       then do
+    //         runTest $ validateTreasuryValue txBody (chainAccountState ^. casTreasuryL)
+    //         runTest $ validateRefScriptSize pp (utxoState ^. utxoL) tx
+    //
+    // so a phase-2-failing tx is never checked for either. dugite ran both
+    // unconditionally, which is a FALSE REJECT: cardano-node accepts such a tx
+    // and dugite refuses it. At block level that means refusing a block
+    // cardano-node accepts — the #985 symptom class, i.e. the dangerous
+    // direction, not the safe one.
+    //
+    // The gate must SKIP the check, not suppress its failure: an is_valid=false
+    // tx legitimately carries oversized reference scripts as far as the LEDGER
+    // rule is concerned.
+    if params.protocol_version_major >= 9 && tx.is_valid {
         const MAX_REF_SCRIPT_SIZE_PER_TX: u64 = 200 * 1024;
         let total_ref_script_size = super::scripts::calculate_ref_script_size(
             &body.inputs,

--- a/crates/dugite-ledger/src/validation/tests.rs
+++ b/crates/dugite-ledger/src/validation/tests.rs
@@ -9507,6 +9507,88 @@ mod tests {
     // `Cardano.Ledger.Conway.Rules.Ledger`.
     // ---------------------------------------------------------------------------
 
+    // ── #1061: treasury-value is gated on Phase2Valid ─────────────────────
+    //
+    // Haskell `conwayLedgerTransition` runs `validateTreasuryValue` ONLY inside
+    // the `isPhase2ValidTxL == Phase2Valid` branch, alongside
+    // `validateRefScriptSize`:
+    //
+    //     if tx ^. isPhase2ValidTxL == Phase2Valid
+    //       then do
+    //         runTest $ validateTreasuryValue txBody (chainAccountState ^. casTreasuryL)
+    //         runTest $ validateRefScriptSize pp (utxoState ^. utxoL) tx
+    //
+    // dugite ran both unconditionally, so a tx declaring `is_valid: false` was
+    // REJECTED where cardano-node ACCEPTS it. False reject — and at block level,
+    // refusing a block cardano-node accepts is the #985 symptom class.
+    //
+    // BOTH directions are asserted. Asserting only the skip would pass trivially
+    // if the check had simply been deleted.
+
+    /// The #1061 regression: identical tx to
+    /// `test_issue_186_treasury_value_mismatch_rejects` except `is_valid: false`
+    /// ⇒ `TreasuryValueMismatch` must NOT fire.
+    #[test]
+    fn treasury_value_mismatch_skipped_when_phase2_invalid() {
+        let mut utxo_set = UtxoSet::new();
+        let input = TransactionInput {
+            transaction_id: Hash32::from_bytes([0xD1u8; 32]),
+            index: 0,
+        };
+        utxo_set.insert(
+            input.clone(),
+            TransactionOutput {
+                address: Address::Byron(ByronAddress {
+                    payload: vec![0u8; 32],
+                }),
+                value: Value::lovelace(10_000_000),
+                datum: OutputDatum::None,
+                script_ref: None,
+                is_legacy: false,
+                raw_cbor: None,
+            },
+        );
+        let mut params = ProtocolParameters::mainnet_defaults();
+        params.protocol_version_major = 9;
+
+        let mut tx = make_simple_tx(input, 9_800_000, 200_000);
+        tx.body.treasury_value = Some(Lovelace(999));
+        // The ONLY difference from the sibling test above.
+        tx.is_valid = false;
+
+        let result = validate_transaction_with_pools(
+            &tx,
+            &utxo_set,
+            &params,
+            100,
+            300,
+            None,
+            None,
+            Some(500), // current_treasury — mismatches declared 999
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        if let Err(errors) = result {
+            assert!(
+                !errors
+                    .iter()
+                    .any(|e| matches!(e, ValidationError::TreasuryValueMismatch { .. })),
+                "TreasuryValueMismatch must be SKIPPED when is_valid=false — Haskell runs \
+                 validateTreasuryValue only inside the Phase2Valid branch (#1061); \
+                 got: {errors:?}"
+            );
+        }
+    }
+
     #[test]
     fn test_issue_186_treasury_value_mismatch_rejects() {
         // A tx that declares treasury_value = 999 when the ledger holds 500 must


### PR DESCRIPTION
Closes #1061. Resolves #1030 item 4.

## The gap

`conwayLedgerTransition` runs both tests **only** inside the Phase2Valid branch:

```haskell
if tx ^. isPhase2ValidTxL == Phase2Valid
  then do
    runTest $ validateTreasuryValue txBody (chainAccountState ^. casTreasuryL)
    runTest $ validateRefScriptSize pp (utxoState ^. utxoL) tx
```

dugite ran both unconditionally at PV>=9 — `grep -c is_valid` in `phase1.rs` returned 2, neither a gate.

## Direction: false reject, the dangerous one

A tx declaring `is_valid: false` with a mismatched `currentTreasuryValue` or oversized reference scripts is **accepted by cardano-node and was rejected by dugite**. At mempool admission that's a spurious rejection; at block level it means refusing a block cardano-node accepts — the #985 symptom class, where the node cannot progress on the honest chain.

Constructible rather than theoretical: `treasury_value` is an ordinary optional body field, independent of the `is_valid` flag.

## Both gates SKIP, not suppress

Matching the Haskell branch — an `is_valid=false` tx legitimately carries oversized reference scripts as far as the LEDGER rule is concerned.

## Tests assert BOTH directions

Asserting only the skip would pass trivially if the check had been deleted:

| test | is_valid | expected |
|---|---|---|
| `test_issue_186_treasury_value_mismatch_rejects` (existing) | true | REJECTS |
| `treasury_value_mismatch_skipped_when_phase2_invalid` (new) | false | SKIPS |

The new test is byte-identical to the existing positive one except `tx.is_valid = false`, so the flag is provably the only variable. **Proven RED** by disarming the gate — the skip test failed while the reject test still passed.

```
Workspace: 8069 tests run: 8069 passed, 13 skipped
clippy --all-targets -D warnings: clean;  fmt: clean
```

Not in v2.7.0 (tagged before this).