### PR TITLE
fix: typed phase-2 wire class, LSQ tag 14, tx-zoo 16a, and #1057 reproduction + mitigations

### DIFF
--- a/crates/dugite-network/src/lib.rs
+++ b/crates/dugite-network/src/lib.rs
@@ -246,8 +246,48 @@ pub enum TxValidationError {
         current_slot: u64,
         valid_from: u64,
     },
+    /// **CATCH-ALL — do NOT give this variant a typed encoder arm.**
+    ///
+    /// `serve.rs` routes roughly twenty unrelated `ValidationError`s onto this
+    /// one carrier (`RefScriptsSizeTooBig`, `Phase2EvalPanic`,
+    /// `GovernancePreConway`, `MissingDatumWitness`, `ZeroWithdrawal`,
+    /// `ScriptLockedCollateral`, …). Its only invariant is "some rejection whose
+    /// reason survives as free text", so any typed wire class attached here
+    /// would MISLABEL most of what flows through it — an arm that is worse than
+    /// the generic fallback (#979).
+    ///
+    /// The genuine phase-2 script failure now has its own carrier,
+    /// [`TxValidationError::Phase2ScriptsFailedUnexpectedly`].
     ScriptFailed {
         reason: String,
+    },
+    /// Conway `UtxosFailure (ValidationTagMismatch Phase2Valid
+    /// (FailedUnexpectedly …))` — the transaction declared `is_valid = true`
+    /// and its Plutus scripts then failed evaluation (#1053).
+    ///
+    /// This is the ONLY ledger error that means "phase-2 evaluation ran and
+    /// disagreed with a `Phase2Valid` tag", so it gets a dedicated carrier
+    /// rather than riding the [`TxValidationError::ScriptFailed`] catch-all —
+    /// otherwise the typed wire class would also be stamped on every unrelated
+    /// rejection that happens to share that variant.
+    ///
+    /// Haskell (`Cardano.Ledger.Alonzo.Rules.Utxos`
+    /// `scriptsValidateTransition`):
+    ///
+    /// ```haskell
+    /// Fails _ps fs ->
+    ///   failBecause $
+    ///     ValidationTagMismatch
+    ///       (tx ^. isValidTxL)
+    ///       (FailedUnexpectedly (scriptFailureToFailureDescription <$> fs))
+    /// ```
+    Phase2ScriptsFailedUnexpectedly {
+        /// One entry per failed script — the `Text` half of each Haskell
+        /// `PlutusFailure Text ByteString`. dugite raises a single aggregated
+        /// message today; the field is a `Vec` because Haskell's payload is a
+        /// `NonEmpty FailureDescription` and the shape must stay correct if a
+        /// future evaluator reports per-script failures.
+        messages: Vec<String>,
     },
     /// `InsufficientCollateral DeltaCoin Coin` (Conway `ConwayUtxoPredFailure`
     /// tag 12) — `balance` is the collateral balance actually present (may be

--- a/crates/dugite-network/src/n2c_client.rs
+++ b/crates/dugite-network/src/n2c_client.rs
@@ -1857,10 +1857,66 @@ fn decode_conway_utxos_pred_failure(decoder: &mut minicbor::Decoder<'_>) -> Opti
     let _ = decoder.array().ok()?;
     let tag = decoder.u8().ok()?;
     match tag {
+        // ValidationTagMismatch IsPhase2Valid TagMismatchDescription (#1053).
+        //
+        // `IsPhase2Valid` is a BARE bool (`encCBOR = encCBOR . isPhase2Valid`),
+        // and `TagMismatchDescription` is `[0]` = PassedUnexpectedly or
+        // `[1, NonEmpty FailureDescription]` = FailedUnexpectedly, where each
+        // `FailureDescription` is `[1, text, bytes]` (Sum tag 1 — tag 0 belonged
+        // to a removed `OnePhaseFailure`).
+        //
+        // The failure TEXT is the whole diagnostic value of this frame, so it is
+        // surfaced rather than skipped.
         0 => {
-            let _ = decoder.skip();
-            let _ = decoder.skip();
-            Some("ValidationTagMismatch: script validity tag mismatch".to_string())
+            let declared_valid = decoder.bool().ok()?;
+            let _ = decoder.array().ok()?;
+            let descr = decoder.u8().ok()?;
+            match descr {
+                0 => Some(format!(
+                    "ValidationTagMismatch: transaction declared is_valid = {declared_valid} \
+                     but every script PASSED (PassedUnexpectedly)"
+                )),
+                1 => {
+                    let n = decoder.array().ok().flatten().unwrap_or(0);
+                    let mut msgs: Vec<String> = Vec::new();
+                    for _ in 0..n {
+                        // FailureDescription = [1, text, bytes]
+                        if decoder.array().ok().is_none() {
+                            break;
+                        }
+                        match decoder.u8() {
+                            Ok(1) => {}
+                            _ => {
+                                let _ = decoder.skip();
+                                continue;
+                            }
+                        }
+                        let text = decoder.str().ok().map(str::to_string);
+                        // The base64 `PlutusWithContext` blob: consumed, not
+                        // rendered — it is diagnostic input for `plutus debug`,
+                        // not a human-readable reason.
+                        let _ = decoder.skip();
+                        if let Some(t) = text {
+                            msgs.push(t);
+                        }
+                    }
+                    if msgs.is_empty() {
+                        Some(format!(
+                            "ValidationTagMismatch: transaction declared is_valid = \
+                             {declared_valid} but scripts FAILED (FailedUnexpectedly)"
+                        ))
+                    } else {
+                        Some(format!(
+                            "ValidationTagMismatch: transaction declared is_valid = \
+                             {declared_valid} but scripts FAILED: {}",
+                            msgs.join("; ")
+                        ))
+                    }
+                }
+                other => Some(format!(
+                    "ValidationTagMismatch: unknown TagMismatchDescription tag {other}"
+                )),
+            }
         }
         1 => {
             // CollectErrors NonEmpty(CollectError)

--- a/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
+++ b/crates/dugite-network/src/protocol/local_tx_submission/encode.rs
@@ -307,6 +307,47 @@ fn encode_conway_ledger_pred_failure(enc: &mut Encoder<&mut Vec<u8>>, err: &TxVa
             }
         }
 
+        // ── Conway UTXOS: ValidationTagMismatch (#1053) ──
+        //
+        // Ledger(1) → Utxow(0) → Utxo(0=UtxosFailure) → Utxos(0=ValidationTagMismatch)
+        //
+        // Before these two arms existed, EVERY phase-2 script failure — the whole
+        // class, for spend/mint/cert/vote/propose — degraded to the generic
+        // `ConwayMempoolFailure "transaction validation failed"`, so a client could
+        // not tell a script failure from any other rejection. Verdict parity was
+        // never affected; only the reason was (#1053, the #979 class).
+        TxValidationError::Phase2ScriptsFailedUnexpectedly { messages } => {
+            if messages.is_empty() {
+                // `FailedUnexpectedly` carries a Haskell `NonEmpty`; an empty
+                // list is undecodable, so a truthful generic beats a broken
+                // typed frame.
+                partial_fallback(enc, err);
+            } else {
+                encode_validation_tag_mismatch(enc, true, Some(messages));
+            }
+        }
+
+        // The mirror case: the tx declared `is_valid = false` and every script
+        // PASSED (#522's DoS class) → `ValidationTagMismatch Phase2Invalid
+        // PassedUnexpectedly`.
+        //
+        // `phase2_admission_error` only ever raises this polarity — the opposite
+        // one becomes `ScriptFailed` and so reaches the arm above — but both are
+        // encoded here so the shape cannot silently go wrong if that changes.
+        TxValidationError::IsValidTagMismatch {
+            declared,
+            evaluated,
+        } => {
+            if *evaluated {
+                encode_validation_tag_mismatch(enc, *declared, None);
+            } else {
+                let synthesized = [String::from(
+                    "phase-2 script evaluation failed while the transaction declared is_valid = true",
+                )];
+                encode_validation_tag_mismatch(enc, *declared, Some(&synthesized));
+            }
+        }
+
         // Tag 22: BabbageNonDisjointRefInputs — `NonEmpty TxIn`.
         //
         // #1051: this MUST be a bare list, NOT a `Set` — `Sum
@@ -1456,6 +1497,86 @@ fn encode_conway_ledger_pred_failure(enc: &mut Encoder<&mut Vec<u8>>, err: &TxVa
 fn partial_fallback(enc: &mut Encoder<&mut Vec<u8>>, err: &TxValidationError) {
     tracing::debug!(err = ?err, "LocalTxSubmission: typed arm could not encode payload faithfully");
     encode_mempool_fallback(enc, "transaction validation failed");
+}
+
+/// Conway `UtxosFailure (ValidationTagMismatch IsPhase2Valid TagMismatchDescription)`
+/// — the phase-2 wire class (#1053).
+///
+/// `failures = None` encodes `PassedUnexpectedly`; `Some(msgs)` encodes
+/// `FailedUnexpectedly` with one `PlutusFailure` per message. **`msgs` must be
+/// non-empty** — it becomes a Haskell `NonEmpty`, and an empty list is
+/// undecodable; callers use `partial_fallback` instead.
+///
+/// Oracle-verified against cardano-ledger `master`:
+///
+/// ```haskell
+/// -- eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+/// ValidationTagMismatch v descr -> Sum ValidationTagMismatch 0 !> To v !> To descr
+/// CollectErrors cs              -> Sum (CollectErrors @era) 1 !> To cs
+///
+/// -- eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+/// encCBOR PassedUnexpectedly      = encode (Sum PassedUnexpectedly 0)
+/// encCBOR (FailedUnexpectedly fs) = encode (Sum FailedUnexpectedly 1 !> To fs)
+/// encCBOR (PlutusFailure s b)     = encode $ Sum PlutusFailure 1 !> To s !> To b
+/// ```
+///
+/// Four details that are easy to get wrong:
+///
+/// * `IsPhase2Valid` is `encCBOR = encCBOR . isPhase2Valid` — a **bare CBOR
+///   bool**, with no array or tag wrapper.
+/// * `PlutusFailure` is Sum tag **1**, not 0. Tag 0 belonged to a removed
+///   `OnePhaseFailure` and is deliberately absent from the decoder
+///   (`1 -> SumD PlutusFailure …; n -> Invalid n`), so emitting 0 is rejected.
+/// * `PassedUnexpectedly` has no fields, so it is `array(1) [0]` — not a bare
+///   integer.
+/// * `NonEmpty FailureDescription` is `encCBOR . toList`, a
+///   `variableListLenEncoding` list (definite at <= 23, indefinite above, #938),
+///   never a `Set` — no CBOR tag 258 (#1051's mistake).
+///
+/// **Known non-parity field, deliberate.** Haskell's second `PlutusFailure`
+/// component is `B64.encode (Plain.serialize' pwc)` — base64 of the CBOR
+/// `PlutusWithContext`, which `plutus debug` can replay. dugite has no
+/// byte-exact `PlutusWithContext` encoder, so this emits an EMPTY bytestring:
+/// well-formed and decodable, where a fabricated blob under that field name
+/// would invite a client to decode garbage. The failure `Text` — the part that
+/// carries the diagnostic — is real.
+fn encode_validation_tag_mismatch(
+    enc: &mut Encoder<&mut Vec<u8>>,
+    declared_valid: bool,
+    failures: Option<&[String]>,
+) {
+    encode_utxo_failure(enc, 0, |enc| {
+        // ConwayUtxosPredFailure: array(3) [0, IsPhase2Valid, TagMismatchDescription]
+        enc.array(3).expect("infallible");
+        enc.u8(0).expect("infallible");
+        enc.bool(declared_valid).expect("infallible");
+        match failures {
+            None => {
+                // TagMismatchDescription::PassedUnexpectedly = array(1) [0]
+                enc.array(1).expect("infallible");
+                enc.u8(0).expect("infallible");
+            }
+            Some(msgs) => {
+                debug_assert!(
+                    !msgs.is_empty(),
+                    "FailedUnexpectedly carries a Haskell NonEmpty; callers must \
+                     route the empty case to partial_fallback"
+                );
+                // TagMismatchDescription::FailedUnexpectedly = array(2) [1, NonEmpty]
+                enc.array(2).expect("infallible");
+                enc.u8(1).expect("infallible");
+                list_open(enc, msgs.len());
+                for msg in msgs {
+                    // FailureDescription::PlutusFailure = array(3) [1, text, bytes]
+                    enc.array(3).expect("infallible");
+                    enc.u8(1).expect("infallible");
+                    enc.str(msg).expect("infallible");
+                    enc.bytes(&[]).expect("infallible");
+                }
+                list_close(enc, msgs.len());
+            }
+        }
+    });
 }
 
 /// The three UTXOW arms whose payload is exactly `Set ScriptHash`.
@@ -3609,6 +3730,177 @@ mod tests {
         let hash_bytes = dec.bytes().unwrap();
         assert_eq!(hash_bytes, &[0xABu8; 32][..]);
         assert_eq!(dec.u32().unwrap(), 3);
+    }
+
+    /// #1053: a phase-2 script failure must reach the client as the TYPED
+    /// `ValidationTagMismatch … FailedUnexpectedly`, walking every nested tag:
+    ///   Ledger(1) → Utxow(0) → Utxo(0=UtxosFailure) →
+    ///   Utxos(0=ValidationTagMismatch) → [IsPhase2Valid bool,
+    ///   TagMismatchDescription(1=FailedUnexpectedly) →
+    ///   NonEmpty[ FailureDescription(1=PlutusFailure) → text, bytes ]].
+    ///
+    /// Before the fix this whole class encoded as the generic
+    /// `ConwayMempoolFailure "transaction validation failed"` (Ledger tag 7), so
+    /// disarming the arm turns the very first assertion RED on the Ledger tag.
+    #[test]
+    fn test_encode_phase2_scripts_failed_unexpectedly_typed() {
+        let err = TxValidationError::Phase2ScriptsFailedUnexpectedly {
+            messages: vec!["script returned Error term".to_string()],
+        };
+        let bytes = encode_apply_tx_err(&err, 6);
+
+        let mut dec = Decoder::new(&bytes);
+        assert_eq!(dec.array().unwrap(), Some(1)); // HFC wrapper
+        assert_eq!(dec.array().unwrap(), Some(2)); // [era_id, failures]
+        let _era = dec.u16().unwrap();
+        assert_eq!(dec.array().unwrap(), Some(1)); // one failure
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 1, "Ledger tag = ConwayUtxowFailure");
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 0, "Utxow tag = UtxoFailure");
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 0, "Utxo tag = UtxosFailure");
+        // ConwayUtxosPredFailure: array(3) [0, IsPhase2Valid, descr]
+        assert_eq!(dec.array().unwrap(), Some(3));
+        assert_eq!(dec.u8().unwrap(), 0, "Utxos tag = ValidationTagMismatch");
+        // `IsPhase2Valid` is a BARE bool — not an array, not an int.
+        assert!(
+            dec.bool().unwrap(),
+            "the tx declared is_valid = true, so IsPhase2Valid = Phase2Valid"
+        );
+        // TagMismatchDescription: array(2) [1=FailedUnexpectedly, NonEmpty]
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 1, "descr tag = FailedUnexpectedly");
+        // NonEmpty FailureDescription — a bare list, NEVER a Set (no tag 258).
+        assert_eq!(dec.array().unwrap(), Some(1));
+        // FailureDescription: array(3) [1=PlutusFailure, text, bytes]
+        assert_eq!(dec.array().unwrap(), Some(3));
+        assert_eq!(
+            dec.u8().unwrap(),
+            1,
+            "FailureDescription tag = PlutusFailure — tag 0 belonged to the \
+             removed OnePhaseFailure and the Haskell decoder rejects it"
+        );
+        assert_eq!(dec.str().unwrap(), "script returned Error term");
+        assert!(
+            dec.bytes().unwrap().is_empty(),
+            "the base64 PlutusWithContext blob is deliberately empty — dugite \
+             has no byte-exact PlutusWithContext encoder"
+        );
+    }
+
+    /// #1053 mirror case: `is_valid = false` while every script PASSED must
+    /// encode `PassedUnexpectedly`, which is `array(1) [0]` — a Sum with no
+    /// fields, not a bare integer.
+    #[test]
+    fn test_encode_is_valid_tag_mismatch_passed_unexpectedly() {
+        let err = TxValidationError::IsValidTagMismatch {
+            declared: false,
+            evaluated: true,
+        };
+        let bytes = encode_apply_tx_err(&err, 6);
+
+        let mut dec = Decoder::new(&bytes);
+        assert_eq!(dec.array().unwrap(), Some(1));
+        assert_eq!(dec.array().unwrap(), Some(2));
+        let _era = dec.u16().unwrap();
+        assert_eq!(dec.array().unwrap(), Some(1));
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 1, "Ledger tag = ConwayUtxowFailure");
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 0, "Utxow tag = UtxoFailure");
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(dec.u8().unwrap(), 0, "Utxo tag = UtxosFailure");
+        assert_eq!(dec.array().unwrap(), Some(3));
+        assert_eq!(dec.u8().unwrap(), 0, "Utxos tag = ValidationTagMismatch");
+        assert!(
+            !dec.bool().unwrap(),
+            "the tx declared is_valid = false, so IsPhase2Valid = Phase2Invalid"
+        );
+        assert_eq!(
+            dec.array().unwrap(),
+            Some(1),
+            "PassedUnexpectedly is a no-field Sum: array(1), not a bare int"
+        );
+        assert_eq!(dec.u8().unwrap(), 0, "descr tag = PassedUnexpectedly");
+    }
+
+    /// #1053: the two frames must survive dugite's OWN decoder and surface the
+    /// script message, since the failure text is the whole diagnostic value.
+    ///
+    /// A same-process round-trip cannot catch a wrong shape shared by both
+    /// halves — the tag walk above is what pins the shape against Haskell.
+    #[test]
+    fn test_roundtrip_validation_tag_mismatch() {
+        let failed = TxValidationError::Phase2ScriptsFailedUnexpectedly {
+            messages: vec!["eval_phase_two_raw error: script returned Error term".to_string()],
+        };
+        let bytes = encode_apply_tx_err(&failed, 6);
+        let mut dec = Decoder::new(&bytes);
+        let reason = crate::n2c_client::decode_reject_reason(&mut dec)
+            .expect("dugite's own decoder must parse its own encoder's output");
+        assert!(
+            reason.contains("ValidationTagMismatch") && reason.contains("script returned Error"),
+            "the failure text must survive to the client; got: {reason}"
+        );
+
+        let passed = TxValidationError::IsValidTagMismatch {
+            declared: false,
+            evaluated: true,
+        };
+        let bytes = encode_apply_tx_err(&passed, 6);
+        let mut dec = Decoder::new(&bytes);
+        let reason = crate::n2c_client::decode_reject_reason(&mut dec)
+            .expect("dugite's own decoder must parse its own encoder's output");
+        assert!(reason.contains("PassedUnexpectedly"), "got: {reason}");
+    }
+
+    /// #1053: the SPLIT is the point. `TxValidationError::ScriptFailed` is the
+    /// free-text catch-all for ~20 unrelated rejections, so it must KEEP the
+    /// generic `ConwayMempoolFailure` (Ledger tag 7) — giving it the phase-2
+    /// typed class would mislabel most of what flows through it (#979).
+    ///
+    /// This test fails if someone later "completes" the fix by pointing the
+    /// catch-all at `encode_validation_tag_mismatch`.
+    #[test]
+    fn test_script_failed_catchall_stays_generic() {
+        let err = TxValidationError::ScriptFailed {
+            reason: "ConwayTxRefScriptsSizeTooBig: total ref-script size 300000 exceeds 204800"
+                .to_string(),
+        };
+        let bytes = encode_apply_tx_err(&err, 6);
+        let mut dec = Decoder::new(&bytes);
+        assert_eq!(dec.array().unwrap(), Some(1));
+        assert_eq!(dec.array().unwrap(), Some(2));
+        let _era = dec.u16().unwrap();
+        assert_eq!(dec.array().unwrap(), Some(1));
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(
+            dec.u8().unwrap(),
+            7,
+            "the catch-all must stay ConwayMempoolFailure, NOT a typed phase-2 class"
+        );
+    }
+
+    /// #1053: an empty message list would produce an empty Haskell `NonEmpty`,
+    /// which is undecodable — so it must fall back to the generic rejection
+    /// rather than emit a typed frame cardano-cli would reject with
+    /// `DeserialiseFailure`.
+    #[test]
+    fn test_phase2_empty_messages_falls_back_to_generic() {
+        let err = TxValidationError::Phase2ScriptsFailedUnexpectedly { messages: vec![] };
+        let bytes = encode_apply_tx_err(&err, 6);
+        let mut dec = Decoder::new(&bytes);
+        assert_eq!(dec.array().unwrap(), Some(1));
+        assert_eq!(dec.array().unwrap(), Some(2));
+        let _era = dec.u16().unwrap();
+        assert_eq!(dec.array().unwrap(), Some(1));
+        assert_eq!(dec.array().unwrap(), Some(2));
+        assert_eq!(
+            dec.u8().unwrap(),
+            7,
+            "empty NonEmpty must degrade to ConwayMempoolFailure"
+        );
     }
 
     /// dugite #470: encoder↔decoder round-trip — the produced bytes must

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -191,42 +191,65 @@ const _: () = assert!(GENESIS_PARKED_DYNAMO_MARGIN_SLOTS < 25_920);
 /// parent itself and the apply pipeline has not stored it yet (channel lag). The
 /// contiguous chain is in flight, not missing.
 ///
-/// **#1057 (OPEN)**: a range rooted at GENESIS is currently NOT accepted here
-/// unless the ChainDB is completely empty (see
-/// [`fetch_range_connects_via_chain_db`]). Genesis is never a *stored* block, so
-/// a node holding any block of its own declines the canonical chain's block 0
-/// forever and never rejoins a chain that diverges at Origin.
-///
-/// Accepting `prev == Hash32::ZERO` here is necessary but NOT sufficient to fix
-/// that, and must not be done alone: the storage layer would then emit a
-/// genesis-rooted `SwitchPlan`, and the ledger cannot roll back to Origin
-/// (`sync.rs` aborts with "Rollback target outside LedgerSeq volatile window AND
-/// no canonical snapshot available"), so the wedge moves from BlockFetch to the
-/// ledger rollback instead of going away. Verified live on a two-forger devnet.
-/// The complete fix needs the ledger to re-initialise from genesis on a
-/// rollback-to-Origin — tracked in #1057.
-///
-/// `prev` is retained in the signature for that fix and is deliberately unused
-/// today.
-pub(crate) fn fetch_range_connects_fast(
-    prev: &dugite_primitives::hash::Hash32,
-    already_fetched: bool,
-) -> bool {
-    let _ = prev;
+/// `prev` is deliberately absent: the genesis case needs the ledger tip, which
+/// needs a lock, so it lives in [`fetch_range_connects_via_chain_db`] where a lock
+/// is being taken anyway. This half stays allocation- and lock-free.
+pub(crate) fn fetch_range_connects_fast(already_fetched: bool) -> bool {
     already_fetched
 }
 
-/// #735 gross-request invariant, ChainDB half: consulted only when
+/// #735 gross-request invariant, locked half: consulted only when
 /// [`fetch_range_connects_fast`] returned `false`.
 ///
 /// `chain_db_empty` keeps the original from-origin bootstrap exemption as
 /// defence-in-depth for any era whose header decode does not surface a genesis
 /// `prev_hash`; `chain_db_has_prev` is the ordinary frontier-extension case.
+///
+/// **#1057, half A** — `prev_is_genesis && ledger_at_origin` is the new clause.
+///
+/// Genesis is never a *stored* block, so `chain_db_has_prev` is always false for
+/// the canonical chain's block 0, and `chain_db_empty` exempts only a COMPLETELY
+/// empty ChainDB. A node holding any block of its own therefore declined that
+/// block forever and never rejoined a chain diverging at Origin: the ledger never
+/// advanced, ChainSync's forecast-horizon park timed out, and every peer was
+/// dropped and re-dialled in a loop with no self-healing. It strands a block
+/// producer.
+///
+/// THE `ledger_at_origin` CONJUNCT IS THE WHOLE REASON THIS IS SAFE, and it is
+/// there because the unconditional version was tried and REVERTED. Accepting
+/// genesis regardless of the ledger makes the storage layer emit a genesis-rooted
+/// `SwitchPlan`; chain selection then asks the ledger to roll back to Origin and
+/// `sync.rs` aborts —
+///
+/// ```text
+/// ERROR Rollback target outside LedgerSeq volatile window AND no canonical
+///   snapshot available. Aborting rollback
+/// WARN  Fork rollback failed; skipping fork replay
+/// ```
+///
+/// — which MOVES the wedge from BlockFetch to the ledger rather than removing it.
+/// Measured live: the node sat at block 4 while the network was at 84, i.e. WORSE
+/// than unfixed. When the ledger is already at Origin there is no rollback to
+/// perform, so that failure cannot arise.
+///
+/// Reaching Origin from a NON-Origin ledger is the other half of #1057 and is not
+/// solved here. This clause repairs exactly the case where the ledger is already at
+/// genesis — which a live devnet run proved is a real and SEPARATE wedge: a node
+/// restarted with a genesis ledger over a ChainDB still holding its own 18-block
+/// fork did not adopt the peer's 208-block chain. The ChainDB fork blocks adoption
+/// independently of ledger state, so this half is required either way.
+///
+/// `Hash32::ZERO` IS dugite's canonical Origin parent — the encoder maps it to
+/// CBOR `null`, i.e. Haskell `PrevHash = GenesisHash`. Upstream needs no clause at
+/// all here because `AnchorGenesis` is a first-class constructor of `Anchor blk`,
+/// matched by `Paths.hs::isReachable`.
 pub(crate) fn fetch_range_connects_via_chain_db(
     chain_db_empty: bool,
     chain_db_has_prev: bool,
+    prev_is_genesis: bool,
+    ledger_at_origin: bool,
 ) -> bool {
-    chain_db_empty || chain_db_has_prev
+    chain_db_empty || chain_db_has_prev || (prev_is_genesis && ledger_at_origin)
 }
 
 /// Should an unproductive dynamo that has starved ChainSel past the watchdog
@@ -2628,6 +2651,11 @@ impl ConnectionLifecycleManager {
         let fetched_blocks_tx = self.fetched_blocks_tx.clone();
         let candidate_chains = self.candidate_chains.clone();
         let chain_db = self.chain_db.clone();
+        // #1057 half A: the gross-request invariant's genesis clause is conditional
+        // on the LEDGER being at Origin, so this worker needs the ledger tip. Read
+        // only when `prev` is the genesis sentinel — see
+        // `fetch_range_connects_via_chain_db`.
+        let ledger_state = self.ledger_state.clone();
         let bel = self.byron_epoch_length;
         // Shared flag: only ONE BlockFetch worker is active at a time.
         // Matches Haskell's bfcMaxConcurrencyBulkSync = 1.
@@ -3106,15 +3134,27 @@ impl ConnectionLifecycleManager {
                                     // already-fetched / genesis cases stay
                                     // lock-free.
                                     let connects = if fetch_range_connects_fast(
-                                        &prev,
                                         fetched_hashes.contains(prev.as_bytes()),
                                     ) {
                                         true
                                     } else {
+                                        // #1057 half A: the genesis clause needs the
+                                        // LEDGER tip, not the ChainDB tip. Read it
+                                        // only when `prev` is actually the genesis
+                                        // sentinel, so the ordinary
+                                        // frontier-extension path takes exactly the
+                                        // one lock it always did.
+                                        let prev_is_genesis =
+                                            prev == dugite_primitives::hash::Hash32::ZERO;
+                                        let ledger_at_origin = prev_is_genesis
+                                            && ledger_state.read().await.tip.point
+                                                == dugite_primitives::Point::Origin;
                                         let cdb = chain_db.read().await;
                                         fetch_range_connects_via_chain_db(
                                             cdb.get_tip_info().is_none(),
                                             cdb.has_block(&prev),
+                                            prev_is_genesis,
+                                            ledger_at_origin,
                                         )
                                     };
                                     if !connects {
@@ -7478,20 +7518,29 @@ mod range_byte_abort_751_tests {
     /// why a node holding any block of its own never rejoins a chain diverging
     /// at Origin.
     ///
-    /// Deliberately asserts the bug rather than hiding it, so the day #1057 is
-    /// fixed this test fails and forces the update. Accepting genesis here alone
-    /// is NOT the fix — it relocates the wedge to the ledger rollback path; see
-    /// `fetch_range_connects_fast`'s doc comment.
+    /// #1057 half A: a genesis-rooted range is now ACCEPTED against a non-empty
+    /// ChainDB — but only when the ledger is at Origin. Both conjuncts are
+    /// asserted separately, because the version WITHOUT the ledger condition was
+    /// implemented, measured live at block 4 against a network at 84, and reverted.
     #[test]
-    fn fetch_range_rooted_at_genesis_is_declined_with_non_empty_chain_db() {
-        let genesis = dugite_primitives::hash::Hash32::ZERO;
+    fn fetch_range_rooted_at_genesis_is_accepted_only_when_ledger_at_origin() {
+        // The case the wedge was: non-empty ChainDB, parent not stored, genesis
+        // root, ledger at Origin → must connect.
         assert!(
-            !fetch_range_connects_fast(&genesis, false),
-            "current behaviour: the lock-free half does not recognise genesis"
+            fetch_range_connects_via_chain_db(false, false, true, true),
+            "a genesis-rooted range must be fetchable when the ledger is at Origin, \
+             otherwise a node holding any block of its own never rejoins a chain \
+             diverging at genesis (#1057)"
         );
+
+        // Same range, ledger NOT at Origin → must still be declined. Accepting it
+        // here makes storage emit a genesis-rooted SwitchPlan the ledger cannot
+        // execute, relocating the wedge instead of removing it.
         assert!(
-            !fetch_range_connects_via_chain_db(false, false),
-            "and the ChainDB half cannot either — genesis is never a stored block (#1057)"
+            !fetch_range_connects_via_chain_db(false, false, true, false),
+            "with a non-Origin ledger the genesis clause MUST NOT fire — that is \
+             the reverted two-layer fix, which left the node at block 4 while the \
+             network was at 84"
         );
     }
 
@@ -7500,22 +7549,26 @@ mod range_byte_abort_751_tests {
     /// ChainDB still does NOT (the far-ahead range the guard exists to decline).
     #[test]
     fn fetch_range_ordinary_cases_unchanged() {
-        let other = dugite_primitives::hash::Hash32::from_bytes([7u8; 32]);
-
         // Already fetched by this worker → in flight, not missing.
-        assert!(fetch_range_connects_fast(&other, true));
-        // Not fetched, not genesis → must fall through to the ChainDB.
-        assert!(!fetch_range_connects_fast(&other, false));
+        assert!(fetch_range_connects_fast(true));
+        // Not fetched → must fall through to the locked half.
+        assert!(!fetch_range_connects_fast(false));
 
         // Frontier extension: the parent is stored → connects.
-        assert!(fetch_range_connects_via_chain_db(false, true));
+        assert!(fetch_range_connects_via_chain_db(false, true, false, false));
         // From-origin bootstrap exemption retained.
-        assert!(fetch_range_connects_via_chain_db(true, false));
-        // The #735 far-ahead range: unknown parent, non-empty DB → decline.
+        assert!(fetch_range_connects_via_chain_db(true, false, false, false));
+        // The #735 far-ahead range: unknown NON-genesis parent, non-empty DB →
+        // decline, regardless of where the ledger is. The genesis clause must not
+        // become a general-purpose escape hatch.
         assert!(
-            !fetch_range_connects_via_chain_db(false, false),
+            !fetch_range_connects_via_chain_db(false, false, false, false),
             "an unknown non-genesis parent against a non-empty ChainDB must \
              still be declined — the #735 invariant is preserved"
+        );
+        assert!(
+            !fetch_range_connects_via_chain_db(false, false, false, true),
+            "and a ledger at Origin must NOT excuse a non-genesis unknown parent"
         );
     }
 }

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -198,6 +198,15 @@ pub(crate) fn fetch_range_connects_fast(already_fetched: bool) -> bool {
     already_fetched
 }
 
+/// Should the rate-limited #1057 genesis-decline WARN be emitted now?
+///
+/// Extracted so the throttle is unit-testable rather than only observable by
+/// counting log lines after a 20-minute devnet round — which is how the
+/// unthrottled first version got as far as 29,435 lines before anyone noticed.
+pub(crate) fn genesis_warn_due(last_warn_ms: Option<u64>, now_ms: u64, interval_ms: u64) -> bool {
+    last_warn_ms.is_none_or(|last| now_ms.saturating_sub(last) >= interval_ms)
+}
+
 /// #735 gross-request invariant, locked half: consulted only when
 /// [`fetch_range_connects_fast`] returned `false`.
 ///
@@ -2775,6 +2784,15 @@ impl ConnectionLifecycleManager {
                 // Haskell starvation path cannot reach (it requires a current
                 // fetch peer with an outstanding request).
                 let mut unproductive_since_ms: Option<u64> = None;
+                // #1057: latch so the actionable "cannot rejoin" ERROR is emitted ONCE
+                // per worker rather than on every declined range. Repeating the remedy
+                // every few seconds would bury it.
+                let mut genesis_wedge_reported = false;
+                // #1057: rate-limit state for the per-decline WARN. BlockFetch re-claims
+                // the declined range continuously — measured at ~100 declines/second, so
+                // an unthrottled WARN produced 29,435 lines / 17 MB in ten minutes.
+                let mut last_genesis_warn_ms: Option<u64> = None;
+                let mut genesis_declines_since_warn: u64 = 0;
 
                 info!(%addr, "blockfetch worker started (waiting for turn)");
 
@@ -3127,6 +3145,13 @@ impl ConnectionLifecycleManager {
                                     )
                                 {
                                     let prev = hdr.prev_hash;
+                                    // Hoisted out of the `else` below because the
+                                    // decline branch needs it too: a range rooted at
+                                    // genesis is the #1057 wedge and gets its own
+                                    // diagnostic, distinct from the ordinary
+                                    // far-ahead decline.
+                                    let prev_is_genesis =
+                                        prev == dugite_primitives::hash::Hash32::ZERO;
                                     // The decision itself lives in the pure
                                     // `fetch_range_connects` (unit-tested);
                                     // here we only supply its inputs, taking
@@ -3144,8 +3169,6 @@ impl ConnectionLifecycleManager {
                                         // sentinel, so the ordinary
                                         // frontier-extension path takes exactly the
                                         // one lock it always did.
-                                        let prev_is_genesis =
-                                            prev == dugite_primitives::hash::Hash32::ZERO;
                                         let ledger_at_origin = prev_is_genesis
                                             && ledger_state.read().await.tip.point
                                                 == dugite_primitives::Point::Origin;
@@ -3158,14 +3181,56 @@ impl ConnectionLifecycleManager {
                                         )
                                     };
                                     if !connects {
-                                        debug!(
-                                            %addr,
-                                            first_slot = first.slot,
-                                            prev = %prev.to_hex(),
-                                            "BlockFetch: declining far-ahead range — \
-                                             first block does not extend a stored block \
-                                             (gross-request invariant, #735)"
-                                        );
+                                        if prev_is_genesis {
+                                            // RATE-LIMITED, and the first version was not.
+                                            //
+                                            // BlockFetch re-claims the range continuously, so
+                                            // an unconditional per-decline WARN emitted 29,435
+                                            // lines and 17 MB of log in ten minutes on the
+                                            // devnet round — roughly 100/second. A diagnostic
+                                            // that buries every other line, and can fill a
+                                            // disk, is not an improvement on silence; it just
+                                            // moves the operator's problem.
+                                            //
+                                            // One line per 30s per worker, carrying the count
+                                            // suppressed since the last one so the recurrence
+                                            // is still visible without the volume.
+                                            const GENESIS_WARN_INTERVAL_MS: u64 = 30_000;
+                                            let now_ms = std::time::SystemTime::now()
+                                                .duration_since(std::time::UNIX_EPOCH)
+                                                .map(|d| d.as_millis() as u64)
+                                                .unwrap_or(0);
+                                            genesis_declines_since_warn += 1;
+                                            if genesis_warn_due(
+                                                last_genesis_warn_ms,
+                                                now_ms,
+                                                GENESIS_WARN_INTERVAL_MS,
+                                            ) {
+                                                last_genesis_warn_ms = Some(now_ms);
+                                                let suppressed =
+                                                    genesis_declines_since_warn.saturating_sub(1);
+                                                genesis_declines_since_warn = 0;
+                                                warn!(
+                                                    %addr,
+                                                    first_slot = first.slot,
+                                                    suppressed_since_last = suppressed,
+                                                    "BlockFetch: declining a range rooted at \
+                                                     GENESIS — this node holds a chain that \
+                                                     diverges from the peer's at genesis and \
+                                                     cannot adopt it in place (#1057). The \
+                                                     ledger will not advance from this peer."
+                                                );
+                                            }
+                                        } else {
+                                            debug!(
+                                                %addr,
+                                                first_slot = first.slot,
+                                                prev = %prev.to_hex(),
+                                                "BlockFetch: declining far-ahead range — \
+                                                 first block does not extend a stored block \
+                                                 (gross-request invariant, #735)"
+                                            );
+                                        }
                                         // #742 watchdog: a perpetual decline is the
                                         // exact #735 far-ahead wedge — same treatment
                                         // as the empty-runs case above: rotate the
@@ -3178,6 +3243,88 @@ impl ConnectionLifecycleManager {
                                         if unproductive_since_ms.is_none() {
                                             unproductive_since_ms = Some(now_ms);
                                         }
+
+                                        // #1057: escalate ONCE to an actionable ERROR when
+                                        // the genesis decline has persisted past the
+                                        // watchdog window, and PERSIST A MARKER so the
+                                        // next start recovers.
+                                        //
+                                        // By this point it is not a transient or hostile
+                                        // peer: the same condition has held for 3x the
+                                        // BlockFetch grace period.
+                                        //
+                                        // The node does NOT exit itself. The trigger is a
+                                        // peer's claim, so turning it into an automatic
+                                        // discard-my-chain-and-resync would be a
+                                        // remotely-triggerable forced resync — and
+                                        // dugite-node is adversarial-deployment software.
+                                        // The marker makes "restart the node" sufficient
+                                        // (which today it is NOT — measured); WHEN to
+                                        // restart stays with the operator or supervisor.
+                                        //
+                                        // `genesis_divergence::decide` then applies two
+                                        // bounds at startup: refuse if anything is flushed
+                                        // to the ImmutableDB (a rollback past the immutable
+                                        // tip is protocol-impossible), and refuse after
+                                        // MAX_RESET_ATTEMPTS, since a divergence that
+                                        // survives a full re-sync is a genesis-config error.
+                                        if prev_is_genesis && !genesis_wedge_reported {
+                                            if let Some(since) = unproductive_since_ms {
+                                                let wedge_ms = 3 * block_fetch_grace_period
+                                                    .as_millis()
+                                                    as u64;
+                                                if now_ms.saturating_sub(since) >= wedge_ms {
+                                                    genesis_wedge_reported = true;
+                                                    let db_path = {
+                                                        let cdb = chain_db.read().await;
+                                                        cdb.db_path().to_path_buf()
+                                                    };
+                                                    let attempt =
+                                                        crate::node::genesis_divergence::record(
+                                                            &db_path,
+                                                            &addr.to_string(),
+                                                            first.slot,
+                                                        );
+                                                    match attempt {
+                                                        Ok(n) => tracing::error!(
+                                                            %addr,
+                                                            wedged_secs = now_ms
+                                                                .saturating_sub(since)
+                                                                / 1000,
+                                                            attempt = n,
+                                                            "#1057: this node cannot rejoin the \
+                                                             network. Its chain diverges from \
+                                                             the peers' at GENESIS, so every \
+                                                             block range they offer is rooted \
+                                                             at genesis and is declined; the \
+                                                             ledger cannot advance and peers \
+                                                             will churn indefinitely. This does \
+                                                             NOT recover on its own. RESTART \
+                                                             THE NODE: a marker has been \
+                                                             written, and on the next start \
+                                                             dugite discards the local \
+                                                             dead-end chain and re-syncs from \
+                                                             genesis (only while the \
+                                                             ImmutableDB is empty — otherwise \
+                                                             it refuses and the operator must \
+                                                             decide)."
+                                                        ),
+                                                        Err(e) => tracing::error!(
+                                                            %addr,
+                                                            "#1057: this node cannot rejoin the \
+                                                             network (its chain diverges from \
+                                                             the peers' at GENESIS) AND the \
+                                                             recovery marker could not be \
+                                                             written: {e}. REMEDY: stop the \
+                                                             node, delete its database \
+                                                             directory, and re-sync or restore \
+                                                             a Mithril snapshot."
+                                                        ),
+                                                    }
+                                                }
+                                            }
+                                        }
+
                                         if let (Some(ref cs), Some(since)) =
                                             (&csj, unproductive_since_ms)
                                         {
@@ -7541,6 +7688,40 @@ mod range_byte_abort_751_tests {
             "with a non-Origin ledger the genesis clause MUST NOT fire — that is \
              the reverted two-layer fix, which left the node at block 4 while the \
              network was at 84"
+        );
+    }
+
+    /// #1057: the genesis-decline WARN must be THROTTLED.
+    ///
+    /// This exists because the first version was not. BlockFetch re-claims the
+    /// declined range continuously — measured at roughly 100 declines/second — so
+    /// an unconditional per-decline WARN wrote **29,435 lines and 17 MB** of log
+    /// in a ten-minute devnet round. A diagnostic that buries every other line and
+    /// can fill a disk is not an improvement on silence.
+    ///
+    /// Caught only by looking at the log volume after the round, which is why the
+    /// decision is now a pure function with a test rather than an inline
+    /// comparison.
+    #[test]
+    fn genesis_warn_is_throttled_to_one_per_interval() {
+        const IVL: u64 = 30_000;
+
+        // First ever decline always warns — the operator must learn immediately.
+        assert!(genesis_warn_due(None, 1_000, IVL));
+
+        // Inside the window: suppressed, including at the boundary-1.
+        assert!(!genesis_warn_due(Some(1_000), 1_000, IVL));
+        assert!(!genesis_warn_due(Some(1_000), 1_000 + IVL - 1, IVL));
+
+        // Exactly at the interval: due (`>=`).
+        assert!(genesis_warn_due(Some(1_000), 1_000 + IVL, IVL));
+        assert!(genesis_warn_due(Some(1_000), 10_000_000, IVL));
+
+        // A clock that goes BACKWARDS must not produce a warn storm: the
+        // saturating subtraction yields 0, which is inside the window.
+        assert!(
+            !genesis_warn_due(Some(10_000), 5_000, IVL),
+            "a backwards clock must suppress, not spam — SystemTime is not monotonic"
         );
     }
 

--- a/crates/dugite-node/src/node/connection_lifecycle.rs
+++ b/crates/dugite-node/src/node/connection_lifecycle.rs
@@ -1022,6 +1022,13 @@ pub struct ConnectionLifecycleManager {
     /// Shared ChainDB — protocol tasks read chain state for intersection finding.
     chain_db: Arc<RwLock<ChainDB>>,
 
+    /// #1057: can the ledger be rolled back to Origin? THE SAME CELL chain
+    /// selection reads, not a second predicate computed here — the two disagreed
+    /// once (storage on this flag, BlockFetch on `ledger tip == Origin`) and the
+    /// result was a node that would have accepted the fork switch but never
+    /// received the blocks to switch to.
+    ledger_can_reach_origin: Arc<std::sync::atomic::AtomicBool>,
+
     /// Shared LedgerState — protocol tasks read ledger tip for intersection.
     ledger_state: Arc<RwLock<LedgerState>>,
 
@@ -1330,6 +1337,7 @@ impl ConnectionLifecycleManager {
         fetched_blocks_tx: mpsc::Sender<FetchedBlock>,
         block_announcement_tx: broadcast::Sender<BlockAnnouncement>,
         chain_db: Arc<RwLock<ChainDB>>,
+        ledger_can_reach_origin: Arc<std::sync::atomic::AtomicBool>,
         ledger_state: Arc<RwLock<LedgerState>>,
         ledger_view: Arc<arc_swap::ArcSwap<super::ledger_view::LedgerView>>,
         ledger_tip_slot_tx: tokio::sync::watch::Sender<u64>,
@@ -1367,6 +1375,7 @@ impl ConnectionLifecycleManager {
             fetched_blocks_tx,
             block_announcement_tx,
             chain_db,
+            ledger_can_reach_origin,
             ledger_state,
             ledger_view,
             ledger_tip_slot_tx,
@@ -2660,11 +2669,11 @@ impl ConnectionLifecycleManager {
         let fetched_blocks_tx = self.fetched_blocks_tx.clone();
         let candidate_chains = self.candidate_chains.clone();
         let chain_db = self.chain_db.clone();
-        // #1057 half A: the gross-request invariant's genesis clause is conditional
-        // on the LEDGER being at Origin, so this worker needs the ledger tip. Read
-        // only when `prev` is the genesis sentinel — see
-        // `fetch_range_connects_via_chain_db`.
-        let ledger_state = self.ledger_state.clone();
+        // #1057: the gross-request invariant's genesis clause is conditional on the
+        // ledger being able to ROLL BACK to Origin. Read from the SAME cell chain
+        // selection uses, so the two layers cannot gate one decision on two
+        // different predicates — see `fetch_range_connects_via_chain_db`.
+        let ledger_can_reach_origin = self.ledger_can_reach_origin.clone();
         let bel = self.byron_epoch_length;
         // Shared flag: only ONE BlockFetch worker is active at a time.
         // Matches Haskell's bfcMaxConcurrencyBulkSync = 1.
@@ -3163,15 +3172,16 @@ impl ConnectionLifecycleManager {
                                     ) {
                                         true
                                     } else {
-                                        // #1057 half A: the genesis clause needs the
-                                        // LEDGER tip, not the ChainDB tip. Read it
-                                        // only when `prev` is actually the genesis
-                                        // sentinel, so the ordinary
-                                        // frontier-extension path takes exactly the
-                                        // one lock it always did.
+                                        // #1057: an atomic load, no lock — and the
+                                        // SAME cell chain selection reads. The
+                                        // previous version tested `ledger tip ==
+                                        // Origin` here while storage tested
+                                        // "can reach Origin", so BlockFetch declined
+                                        // the very blocks storage was prepared to
+                                        // switch to.
                                         let ledger_at_origin = prev_is_genesis
-                                            && ledger_state.read().await.tip.point
-                                                == dugite_primitives::Point::Origin;
+                                            && ledger_can_reach_origin
+                                                .load(std::sync::atomic::Ordering::Relaxed);
                                         let cdb = chain_db.read().await;
                                         fetch_range_connects_via_chain_db(
                                             cdb.get_tip_info().is_none(),
@@ -4676,6 +4686,9 @@ impl ConnectionLifecycleManager {
             fetched_blocks_tx,
             block_announcement_tx,
             Arc::new(RwLock::new(chain_db2)),
+            // #1057: tests default the shared flag OFF — the conservative direction,
+            // matching a node that has not published yet.
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
             ledger_arc,
             ledger_view,
             ledger_tip_slot_tx,
@@ -4754,6 +4767,9 @@ impl ConnectionLifecycleManager {
             fetched_blocks_tx,
             block_announcement_tx,
             Arc::new(RwLock::new(chain_db2)),
+            // #1057: tests default the shared flag OFF — the conservative direction,
+            // matching a node that has not published yet.
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
             ledger_arc,
             ledger_view,
             ledger_tip_slot_tx,

--- a/crates/dugite-node/src/node/genesis_divergence.rs
+++ b/crates/dugite-node/src/node/genesis_divergence.rs
@@ -1,0 +1,293 @@
+//! #1057: the on-disk marker that makes a RESTART recover a genesis-divergent node.
+//!
+//! A node whose chain diverges from the network's at GENESIS cannot rejoin in
+//! place. BlockFetch's #735 gross-request invariant declines every range rooted at
+//! genesis (genesis is never a *stored* block), so the ledger never advances,
+//! ChainSync's forecast-horizon park times out, and every peer is dropped and
+//! re-dialled forever. It strands a block producer.
+//!
+//! **Restarting alone does not help, and that is measured, not assumed.** On a
+//! two-forger devnet, deleting `ledger-snapshot.bin` and restarting left the node
+//! at its own fork's tip within twelve seconds — `run()` replays the existing
+//! ChainDB and re-applies its own chain before any peer connects — and it still did
+//! not adopt the peer's 246-block chain. So a fix has to discard the dead-end
+//! chain, not merely the ledger derived from it.
+//!
+//! This marker is how that happens WITHOUT a live in-place ledger
+//! re-initialisation. Everything destructive runs at startup, on the path that
+//! already exists and is already validated:
+//!
+//! * the ledger snapshot is treated as unusable, so `Node::new` builds a fresh
+//!   genesis ledger via `init_fresh_ledger`;
+//! * `wipe_utxo_store_before_replay` fires, which the LSM block already honours —
+//!   and that wipe is load-bearing, not hygiene: a stale store roughly doubles
+//!   `sumCoinUTxO` at the Byron→Shelley boundary, drives the reserves recompute to
+//!   0, and underflows the first MIR debit into a panic;
+//! * the VolatileDB is cleared (WAL truncated), so the dead-end fork is gone and
+//!   startup replay has nothing to re-apply, leaving the ledger at Origin.
+//!
+//! The node then syncs from genesis down the ordinary, well-trodden path.
+//!
+//! ## Why this is a marker and not an automatic self-restart
+//!
+//! The node does not exit itself. Writing the marker plus the actionable ERROR
+//! makes "restart the node" sufficient, where today it is not — but the decision
+//! to restart stays with the operator or the supervisor.
+//!
+//! That matters because the trigger is a *peer's claim*: it is reached when peers
+//! offer chains rooted at genesis. Turning that into an automatic
+//! discard-my-chain-and-resync would be a remotely-triggerable forced resync, and
+//! dugite-node is adversarial-deployment software.
+//!
+//! ## Two bounds, both deliberate
+//!
+//! **The ImmutableDB must be empty.** A rollback past the immutable tip is
+//! protocol-impossible under Ouroboros k-finality, so a node that has flushed
+//! anything must NOT act on this marker — it is refused and cleared instead. This
+//! also bounds the blast radius hard: only a node whose entire chain is still
+//! volatile (< k blocks) can be reset at all, and such a node loses seconds of
+//! sync, not history.
+//!
+//! **Attempts are counted.** A node pointed at the WRONG genesis file would
+//! diverge, reset, resync, diverge again — an endless resync loop. After
+//! [`MAX_RESET_ATTEMPTS`] the marker is refused and the operator is told the
+//! genesis configuration is the likely cause, which is the actual defect in that
+//! scenario.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use tracing::{error, info, warn};
+
+/// Refuse to reset more than this many times. A recurring genesis divergence is a
+/// configuration error (wrong genesis files), not something to keep resyncing
+/// through.
+pub(crate) const MAX_RESET_ATTEMPTS: u32 = 3;
+
+const MARKER_FILE: &str = "genesis-divergence-detected";
+
+fn marker_path(db_path: &Path) -> PathBuf {
+    db_path.join(MARKER_FILE)
+}
+
+/// Record that this node cannot rejoin because its chain diverges at genesis.
+///
+/// Idempotent per restart in effect: the attempt counter is incremented so a
+/// repeat-offending configuration is caught rather than looped on. Returns the new
+/// attempt count.
+pub(crate) fn record(db_path: &Path, peer: &str, peer_tip_slot: u64) -> io::Result<u32> {
+    let path = marker_path(db_path);
+    let attempts = read_attempts(db_path).unwrap_or(0) + 1;
+    // Plain text on purpose: an operator finding this file should be able to read
+    // it without tooling, and it is also the audit trail for why a database was
+    // reset.
+    let body = format!(
+        "attempts={attempts}\n\
+         peer={peer}\n\
+         peer_tip_slot={peer_tip_slot}\n\
+         reason=this node's chain diverges from the network's at GENESIS; BlockFetch \
+         declines every range rooted at genesis, so the ledger cannot advance (#1057)\n\
+         action=on the next start, dugite discards the local chain and re-syncs from \
+         genesis (only while the ImmutableDB is empty)\n"
+    );
+    std::fs::write(&path, body)?;
+    Ok(attempts)
+}
+
+/// The recorded attempt count, or `None` when no marker is present.
+pub(crate) fn read_attempts(db_path: &Path) -> Option<u32> {
+    let body = std::fs::read_to_string(marker_path(db_path)).ok()?;
+    body.lines()
+        .find_map(|l| l.strip_prefix("attempts="))
+        .and_then(|v| v.trim().parse().ok())
+}
+
+/// Remove the marker. Called once the reset has been performed, and also when the
+/// marker is refused, so a stale file cannot make every future start suspicious.
+pub(crate) fn clear(db_path: &Path) {
+    let path = marker_path(db_path);
+    if path.exists() {
+        if let Err(e) = std::fs::remove_file(&path) {
+            warn!(path = %path.display(), "failed to remove the #1057 marker: {e}");
+        }
+    }
+}
+
+/// What `Node::new` should do about a marker, decided from the two bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResetDecision {
+    /// No marker — ordinary start.
+    None,
+    /// Discard the local chain and rebuild from genesis.
+    Reset { attempt: u32 },
+    /// Marker present but must NOT be acted on. The marker is cleared and the
+    /// reason logged; the node starts normally (and will re-detect the wedge if it
+    /// is still real, which is the honest outcome).
+    Refused(RefusalReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RefusalReason {
+    /// Blocks have been flushed to the ImmutableDB, so rolling back to Origin is
+    /// protocol-impossible (Ouroboros k-finality).
+    ImmutableNotEmpty,
+    /// Too many resets — the genesis configuration is the likely defect.
+    TooManyAttempts { attempts: u32 },
+}
+
+/// Decide, from the marker and the ImmutableDB state, whether to reset.
+///
+/// Pure so the two bounds are unit-testable without a filesystem or a node:
+/// getting either wrong is the difference between a bounded recovery and either an
+/// unbounded resync loop or a node that discards flushed history.
+pub(crate) fn decide(attempts: Option<u32>, immutable_is_empty: bool) -> ResetDecision {
+    match attempts {
+        None => ResetDecision::None,
+        Some(attempts) if !immutable_is_empty => {
+            let _ = attempts;
+            ResetDecision::Refused(RefusalReason::ImmutableNotEmpty)
+        }
+        Some(attempts) if attempts > MAX_RESET_ATTEMPTS => {
+            ResetDecision::Refused(RefusalReason::TooManyAttempts { attempts })
+        }
+        Some(attempt) => ResetDecision::Reset { attempt },
+    }
+}
+
+/// Log the decision. Separated from [`decide`] so the decision stays pure and the
+/// wording lives in one place.
+pub(crate) fn log_decision(decision: ResetDecision, db_path: &Path) {
+    match decision {
+        ResetDecision::None => {}
+        ResetDecision::Reset { attempt } => {
+            warn!(
+                attempt,
+                max_attempts = MAX_RESET_ATTEMPTS,
+                db = %db_path.display(),
+                "#1057 recovery: this node previously could not rejoin because its chain \
+                 diverges from the network's at GENESIS. Discarding the local chain \
+                 (VolatileDB + ledger snapshot + UTxO store) and re-syncing from genesis. \
+                 The ImmutableDB is empty, so no finalised history is being discarded."
+            );
+        }
+        ResetDecision::Refused(RefusalReason::ImmutableNotEmpty) => {
+            error!(
+                db = %db_path.display(),
+                "#1057 marker present but REFUSED: blocks have been flushed to the \
+                 ImmutableDB, so a rollback to Origin is protocol-impossible under \
+                 Ouroboros k-finality and dugite will not discard finalised history. If \
+                 this node genuinely needs to re-sync, that is an operator decision: stop \
+                 it, remove the database directory, and re-sync or restore a Mithril \
+                 snapshot."
+            );
+        }
+        ResetDecision::Refused(RefusalReason::TooManyAttempts { attempts }) => {
+            error!(
+                attempts,
+                max_attempts = MAX_RESET_ATTEMPTS,
+                db = %db_path.display(),
+                "#1057 marker present but REFUSED: already reset {attempts} times. A \
+                 genesis divergence that recurs after a full re-sync is almost certainly \
+                 a CONFIGURATION error — check that the genesis files (and their hashes) \
+                 match the network this node is meant to join. Repeatedly re-syncing would \
+                 hide that, not fix it."
+            );
+        }
+    }
+}
+
+/// Announce that the reset completed, with what was discarded.
+pub(crate) fn log_reset_performed(volatile_blocks_cleared: usize) {
+    info!(
+        volatile_blocks_cleared,
+        "#1057 recovery: local chain discarded; the ledger starts at Origin and the \
+         node will sync the network's chain from genesis"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_marker_means_ordinary_start() {
+        assert_eq!(decide(None, true), ResetDecision::None);
+        assert_eq!(decide(None, false), ResetDecision::None);
+    }
+
+    /// The ImmutableDB bound is checked BEFORE the attempt bound on purpose: a node
+    /// with flushed history must never be reset, however few attempts it has made.
+    #[test]
+    fn flushed_history_is_never_discarded() {
+        assert_eq!(
+            decide(Some(1), false),
+            ResetDecision::Refused(RefusalReason::ImmutableNotEmpty)
+        );
+        assert_eq!(
+            decide(Some(MAX_RESET_ATTEMPTS + 5), false),
+            ResetDecision::Refused(RefusalReason::ImmutableNotEmpty),
+            "immutable-not-empty must win over the attempt count — discarding \
+             finalised history is the worse outcome"
+        );
+    }
+
+    /// A node pointed at the WRONG genesis would diverge → reset → resync →
+    /// diverge, forever. The counter bounds that and blames the right thing.
+    #[test]
+    fn repeated_resets_are_refused_as_a_config_error() {
+        for attempt in 1..=MAX_RESET_ATTEMPTS {
+            assert_eq!(
+                decide(Some(attempt), true),
+                ResetDecision::Reset { attempt },
+                "attempt {attempt} is within budget"
+            );
+        }
+        assert_eq!(
+            decide(Some(MAX_RESET_ATTEMPTS + 1), true),
+            ResetDecision::Refused(RefusalReason::TooManyAttempts {
+                attempts: MAX_RESET_ATTEMPTS + 1
+            })
+        );
+    }
+
+    #[test]
+    fn marker_round_trips_and_counts_attempts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = tmp.path();
+        assert_eq!(read_attempts(db), None, "no marker to begin with");
+
+        assert_eq!(record(db, "127.0.0.1:3001", 342).unwrap(), 1);
+        assert_eq!(read_attempts(db), Some(1));
+
+        // A second detection on a later run increments rather than resetting, which
+        // is what makes the config-error bound work at all.
+        assert_eq!(record(db, "127.0.0.1:3001", 900).unwrap(), 2);
+        assert_eq!(read_attempts(db), Some(2));
+
+        clear(db);
+        assert_eq!(
+            read_attempts(db),
+            None,
+            "cleared after the reset is performed"
+        );
+        // Clearing twice must not panic or complain.
+        clear(db);
+    }
+
+    /// The file is plain text an operator can read without tooling, and it records
+    /// WHY the database was reset — it doubles as the audit trail.
+    #[test]
+    fn marker_body_is_human_readable_and_names_the_issue() {
+        let tmp = tempfile::tempdir().unwrap();
+        record(tmp.path(), "10.0.0.5:3001", 1234).unwrap();
+        let body = std::fs::read_to_string(tmp.path().join(MARKER_FILE)).unwrap();
+        assert!(body.contains("attempts=1"));
+        assert!(body.contains("peer=10.0.0.5:3001"));
+        assert!(body.contains("peer_tip_slot=1234"));
+        assert!(body.contains("#1057"), "must name the issue: {body}");
+        assert!(
+            body.contains("GENESIS"),
+            "must name the cause, not just the effect: {body}"
+        );
+    }
+}

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2865,6 +2865,19 @@ impl Node {
         // `send` returns Err only when there are zero receivers — that's
         // fine, we don't care if no one is listening yet.
         let _ = self.ledger_tip_slot_tx.send(new_tip_slot);
+        // #1057 half A: chain selection lives in `dugite-storage`, which sits below
+        // the ledger and cannot read it, but `switch_chain`'s genesis-anchor arm
+        // must only fire when the ledger can execute the plan. Published from the
+        // ONE place that already fans out every ledger-tip change, so a new call
+        // site cannot forget it.
+        //
+        // The comparison is against `Point::Origin` and NOT `slot == 0`: genesis is
+        // slot-less, a real block can sit at slot 0, and an Origin test that is
+        // merely "slot is zero" is how a genesis sentinel gets confused with a
+        // block (see the `h(0) == Hash32::ZERO` test that pinned this very bug).
+        if let Some(ref cs) = self.chain_sel_handle {
+            cs.set_ledger_at_origin(ls.tip.point == Point::Origin);
+        }
     }
 
     /// Convenience: re-publish the view by taking the read lock and
@@ -2894,6 +2907,20 @@ impl Node {
                 mempool_txs = self.mempool.len(),
                 "Chain tip",
             );
+
+            // #1057 half A: seed the ledger-at-Origin flag HERE, not only from
+            // `publish_ledger_view`.
+            //
+            // That helper runs only on the LIVE apply path (see the #742 note
+            // below), so a node that comes up with a genesis ledger — the exact
+            // case this fix repairs — would never publish before its first applied
+            // block, and the genesis-anchor arm would stay disabled through the
+            // whole window in which it is needed. Same trap as #985's dead
+            // `recover_ledger_seq`: a mechanism wired to a path the scenario does
+            // not take is not wired at all.
+            if let Some(ref cs) = self.chain_sel_handle {
+                cs.set_ledger_at_origin(ls.tip.point == Point::Origin);
+            }
 
             // Initialize Prometheus metrics from loaded ledger state so they
             // are accurate immediately on startup (before any blocks arrive).

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -5056,6 +5056,12 @@ impl Node {
                 .expect("block_announcement_tx was just set")
                 .clone(),
             self.chain_db.clone(),
+            // #1057: the SAME cell chain selection gates its genesis-anchor arm on,
+            // so BlockFetch cannot decline blocks storage is prepared to switch to.
+            self.chain_sel_handle
+                .as_ref()
+                .map(|cs| cs.ledger_can_reach_origin_flag())
+                .unwrap_or_else(|| std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false))),
             self.ledger_state.clone(),
             self.ledger_view.clone(),
             self.ledger_tip_slot_tx.clone(),

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -20,6 +20,8 @@
 #[allow(dead_code)]
 pub(crate) mod connection_lifecycle;
 pub(crate) mod epoch;
+// #1057: the on-disk marker that makes a restart recover a genesis-divergent node.
+pub(crate) mod genesis_divergence;
 pub(crate) mod ledger_view;
 pub(crate) mod n2c_query;
 pub(crate) mod networking;
@@ -1163,11 +1165,68 @@ impl Node {
         // Uses default epoch parameters (epoch 0, length 432000) since era_history
         // isn't built yet. The active chunk gets correctly named at the first
         // finalize_chunk() call during epoch transitions, which passes real epoch info.
-        let chain_db = Arc::new(RwLock::new(ChainDB::open_with_config(
+        let mut opened_chain_db = ChainDB::open_with_config(
             &args.database_path,
             &args.storage_config.immutable,
             security_param_k,
-        )?));
+        )?;
+
+        // #1057: act on the genesis-divergence marker HERE, while the ChainDB is
+        // still unshared.
+        //
+        // The marker means a previous run established that this node cannot rejoin
+        // the network because its chain diverges at GENESIS: BlockFetch declines
+        // every range rooted at genesis, so the ledger never advances and peers
+        // churn forever. Restarting alone does NOT recover — measured on a
+        // two-forger devnet, `run()`'s replay re-applies the node's own fork within
+        // twelve seconds and it still did not adopt the peer's chain. The dead-end
+        // chain has to go, not just the ledger derived from it.
+        //
+        // Doing it at startup means the whole reset rides the ALREADY-VALIDATED
+        // from-genesis path: a fresh `init_fresh_ledger` plus the LSM
+        // `wipe_utxo_store_before_replay` whose own comment records that a stale
+        // store roughly doubles `sumCoinUTxO` at the Byron→Shelley boundary and
+        // underflows the first MIR debit. No live in-place ledger re-initialisation
+        // — that is what #989 deleted `reset_to_origin` over.
+        //
+        // Placed before the `Arc<RwLock<_>>` wrap deliberately: `Node::new` is not
+        // async, and `blocking_read()` on a tokio lock from inside a runtime panics.
+        // Owning the value outright is simpler than making the constructor async and
+        // is safe precisely because nothing else can hold it yet.
+        //
+        // Both bounds live in `genesis_divergence::decide` and are unit-tested: a
+        // node with anything flushed to the ImmutableDB is REFUSED (a rollback past
+        // the immutable tip is protocol-impossible under k-finality), and repeated
+        // resets are refused as the configuration error they almost certainly are.
+        let genesis_reset = {
+            let decision = genesis_divergence::decide(
+                genesis_divergence::read_attempts(&args.database_path),
+                opened_chain_db.get_immutable_tip_point().is_none(),
+            );
+            genesis_divergence::log_decision(decision, &args.database_path);
+            match decision {
+                genesis_divergence::ResetDecision::Reset { .. } => true,
+                genesis_divergence::ResetDecision::None => false,
+                genesis_divergence::ResetDecision::Refused(_) => {
+                    // Cleared so a stale marker does not make every future start
+                    // suspicious. If the wedge is still real the node re-detects it
+                    // and writes a fresh marker, which is the honest outcome.
+                    genesis_divergence::clear(&args.database_path);
+                    false
+                }
+            }
+        };
+        if genesis_reset {
+            // Discard the dead-end chain. `clear_volatile` truncates the WAL too, so
+            // the fork does not come back on the next start, and startup replay then
+            // has nothing to re-apply — which is what leaves the ledger at Origin.
+            let cleared = opened_chain_db.volatile_block_count();
+            opened_chain_db.clear_volatile();
+            genesis_divergence::log_reset_performed(cleared);
+            genesis_divergence::clear(&args.database_path);
+        }
+
+        let chain_db = Arc::new(RwLock::new(opened_chain_db));
 
         // Load Shelley genesis if configured (with hash for nonce initialization)
         let (shelley_genesis, shelley_genesis_hash) =
@@ -1438,11 +1497,23 @@ impl Node {
         // the setup (see `utxo_store_is_usable`). `wipe_utxo_store_before_replay`
         // is honoured in the LSM block further down.
         let mut wipe_utxo_store_before_replay = false;
-        let snapshot_usable = if snapshot_path.exists()
+
+        // #1057: the reset itself already happened at ChainDB open (above). Here it
+        // only has to force the ledger side: any snapshot describes the chain that
+        // was just discarded, and the on-disk UTxO store must be rebuilt.
+        if genesis_reset {
+            wipe_utxo_store_before_replay = true;
+        }
+
+        let snapshot_usable = if genesis_reset {
+            // Any snapshot describes the chain we just discarded.
+            false
+        } else if snapshot_path.exists()
             && matches!(
                 args.storage_config.utxo.backend,
                 dugite_storage::UtxoBackend::Lsm
-            ) {
+            )
+        {
             let probe_slot = Self::peek_snapshot_slot(&snapshot_path).unwrap_or(0);
             let ok = Self::utxo_store_is_usable(
                 &args.database_path.join("utxo-store"),

--- a/crates/dugite-node/src/node/mod.rs
+++ b/crates/dugite-node/src/node/mod.rs
@@ -2936,19 +2936,54 @@ impl Node {
         // `send` returns Err only when there are zero receivers — that's
         // fine, we don't care if no one is listening yet.
         let _ = self.ledger_tip_slot_tx.send(new_tip_slot);
-        // #1057 half A: chain selection lives in `dugite-storage`, which sits below
-        // the ledger and cannot read it, but `switch_chain`'s genesis-anchor arm
-        // must only fire when the ledger can execute the plan. Published from the
-        // ONE place that already fans out every ledger-tip change, so a new call
+        // #1057: chain selection lives in `dugite-storage`, which sits below the
+        // ledger and cannot read it, but `switch_chain`'s genesis-anchor arm must
+        // only fire when the ledger can EXECUTE the resulting plan. Published from
+        // the ONE place that already fans out every ledger-tip change, so a new call
         // site cannot forget it.
         //
-        // The comparison is against `Point::Origin` and NOT `slot == 0`: genesis is
-        // slot-less, a real block can sit at slot 0, and an Origin test that is
-        // merely "slot is zero" is how a genesis sentinel gets confused with a
-        // block (see the `h(0) == Hash32::ZERO` test that pinned this very bug).
-        if let Some(ref cs) = self.chain_sel_handle {
-            cs.set_ledger_at_origin(ls.tip.point == Point::Origin);
-        }
+        // NOTE the genesis-anchor gate is NOT published here. It depends on the
+        // LedgerSeq ANCHOR, not on the ledger tip, and the anchor changes in exactly
+        // two places — `reanchor_ledger_seq` and `advance_anchor`. Publishing where
+        // the value actually changes is both cheaper and harder to get wrong than
+        // recomputing it on every tip change (and this fn is sync, so it could not
+        // take the seq lock anyway). See `publish_ledger_can_reach_origin`.
+    }
+
+    /// #1057: publish whether a rollback to Origin is currently EXECUTABLE.
+    ///
+    /// This is the gate on `VolatileDB::switch_chain`'s genesis-anchor arm and on
+    /// BlockFetch's genesis clause. It is deliberately NOT "the ledger tip is
+    /// Origin" — that version was implemented and measured too narrow, because
+    /// holding ANY chain disqualifies a longer genesis-divergent one. On the devnet
+    /// a node that had just recovered re-adopted a stale 10-block chain from its
+    /// sibling and was wedged again against the canonical 155-block chain thirty
+    /// seconds later.
+    ///
+    /// The executable condition is that `LedgerSeq::find_rollback_n(Origin)` will
+    /// succeed, which is its `target == anchor` full-rewind case:
+    ///
+    /// * the seq's anchor point IS Origin — true for any node that started from
+    ///   genesis and has not yet advanced its anchor past it; false for a
+    ///   snapshot-restored ledger, which is exactly why the earlier attempt hit
+    ///   "Rollback target outside LedgerSeq volatile window AND no canonical
+    ///   snapshot available";
+    /// * the window is coherent (#985) — an incoherent window makes
+    ///   `find_rollback_n` decline for every target, and reconstructing from it
+    ///   would produce a chimera.
+    ///
+    /// Nothing is inferred about the ledger TIP here: a node 10 blocks in with an
+    /// Origin anchor can roll all 10 back, which is precisely the case that has to
+    /// work.
+    pub(crate) async fn publish_ledger_can_reach_origin(&self) {
+        let Some(ref cs) = self.chain_sel_handle else {
+            return;
+        };
+        // Lock order: ledger_state before ledger_seq (per Node docs). The caller
+        // may already hold the ledger_state read guard, so only the seq is taken.
+        let seq = self.ledger_seq.read().await;
+        let can = *seq.anchor_point() == Point::Origin && !seq.is_incoherent();
+        cs.set_ledger_can_reach_origin(can);
     }
 
     /// Convenience: re-publish the view by taking the read lock and
@@ -2978,20 +3013,6 @@ impl Node {
                 mempool_txs = self.mempool.len(),
                 "Chain tip",
             );
-
-            // #1057 half A: seed the ledger-at-Origin flag HERE, not only from
-            // `publish_ledger_view`.
-            //
-            // That helper runs only on the LIVE apply path (see the #742 note
-            // below), so a node that comes up with a genesis ledger — the exact
-            // case this fix repairs — would never publish before its first applied
-            // block, and the genesis-anchor arm would stay disabled through the
-            // whole window in which it is needed. Same trap as #985's dead
-            // `recover_ledger_seq`: a mechanism wired to a path the scenario does
-            // not take is not wired at all.
-            if let Some(ref cs) = self.chain_sel_handle {
-                cs.set_ledger_at_origin(ls.tip.point == Point::Origin);
-            }
 
             // Initialize Prometheus metrics from loaded ledger state so they
             // are accurate immediately on startup (before any blocks arrive).

--- a/crates/dugite-node/src/node/n2c_query/encoding.rs
+++ b/crates/dugite-node/src/node/n2c_query/encoding.rs
@@ -377,19 +377,10 @@ pub(crate) fn encode_query_result_value(
                 last_epoch_block_nonce,
             );
         }
-        QueryResult::RewardProvenance {
-            epoch,
-            total_rewards_pot,
-            treasury_tax,
-            active_stake,
-        } => {
-            // Reward provenance: array(4) [epoch, rewards_pot, treasury_tax, active_stake]
-            enc.array(4).ok();
-            enc.u64(*epoch).ok();
-            enc.u64(*total_rewards_pot).ok();
-            enc.u64(*treasury_tax).ok();
-            enc.u64(*active_stake).ok();
-        }
+        // GetRewardProvenance (tag 14) has no arm: the variant is gone. It used to
+        // emit `array(4)` where Haskell's `SL.RewardProvenance` is a 16-field
+        // `Rec`, making the reply undecodable. `handle_reward_provenance` now
+        // returns an explicit error instead.
         QueryResult::RewardInfoPools(pools) => {
             encode_reward_info_pools(enc, pools);
         }

--- a/crates/dugite-node/src/node/n2c_query/mod.rs
+++ b/crates/dugite-node/src/node/n2c_query/mod.rs
@@ -1620,8 +1620,15 @@ mod tests {
         }
     }
 
+    /// #1030 item 5: tag 14 answers with an explicit error through the real
+    /// dispatch, not just at the handler.
+    ///
+    /// This test previously asserted `total_rewards_pot == 30_000` and
+    /// `treasury_tax == 6_000` — arithmetic on an invented `array(4)` that
+    /// Haskell's 16-field `SL.RewardProvenance` decoder could never read. It was a
+    /// green test for an undecodable reply.
     #[test]
-    fn test_query_handler_reward_provenance() {
+    fn test_query_handler_reward_provenance_returns_error() {
         let mut handler = QueryHandler::new(11);
         handler.update_state(NodeStateSnapshot {
             epoch: EpochNo(42),
@@ -1636,17 +1643,13 @@ mod tests {
             ..NodeStateSnapshot::default()
         });
         match query(&handler, 14) {
-            QueryResult::RewardProvenance {
-                epoch,
-                total_rewards_pot,
-                treasury_tax,
-                ..
-            } => {
-                assert_eq!(epoch, 42);
-                assert_eq!(total_rewards_pot, 30_000); // 10M * 3/1000
-                assert_eq!(treasury_tax, 6_000); // 30K * 2/10
-            }
-            other => panic!("Expected RewardProvenance, got {other:?}"),
+            QueryResult::Error(msg) => assert!(
+                msg.contains("GetRewardProvenance"),
+                "the error must name the query: {msg}"
+            ),
+            other => panic!(
+                "tag 14 must return an explicit error, not a fabricated payload; got {other:?}"
+            ),
         }
     }
 

--- a/crates/dugite-node/src/node/n2c_query/protocol.rs
+++ b/crates/dugite-node/src/node/n2c_query/protocol.rs
@@ -495,27 +495,49 @@ pub(crate) fn handle_debug_chain_dep_state(state: &NodeStateSnapshot) -> QueryRe
     }
 }
 
-/// Handle GetRewardProvenance (tag 14) — reward calculation provenance.
+/// Handle GetRewardProvenance (tag 14) — answered with an explicit error.
 ///
-/// Returns aggregate reward provenance data: total rewards pot, treasury tax,
-/// and total active stake for the current epoch.
-pub(crate) fn handle_reward_provenance(state: &NodeStateSnapshot) -> QueryResult {
-    debug!("Query: GetRewardProvenance");
-    let total_active_stake: u64 = state.stake_pools.iter().map(|p| p.stake).sum();
-    // Reward pot = reserves * rho (monetary expansion)
-    let rho_num = state.protocol_params.rho_num;
-    let rho_den = state.protocol_params.rho_den.max(1);
-    let total_rewards_pot = (state.reserves as u128 * rho_num as u128 / rho_den as u128) as u64;
-    // Treasury tax = reward_pot * tau
-    let tau_num = state.protocol_params.tau_num;
-    let tau_den = state.protocol_params.tau_den.max(1);
-    let treasury_tax = (total_rewards_pot as u128 * tau_num as u128 / tau_den as u128) as u64;
-    QueryResult::RewardProvenance {
-        epoch: state.epoch.0,
-        total_rewards_pot,
-        treasury_tax,
-        active_stake: total_active_stake,
-    }
+/// dugite used to reply with a self-invented `array(4)`
+/// `[epoch, rewards_pot, treasury_tax, active_stake]`. Haskell's result type is
+/// `SL.RewardProvenance`, a **16-field `Rec`** (oracle-verified against
+/// cardano-ledger `Shelley/RewardProvenance.hs`), encoded via
+/// `LC.toEraCBOR @era`:
+///
+/// ```haskell
+/// data RewardProvenance = RewardProvenance
+///   { spe :: !Word64, blocks :: !BlocksMade, maxLL :: !Coin
+///   , deltaR1 :: !Coin, deltaR2 :: !Coin, r :: !Coin, totalStake :: !Coin
+///   , blocksCount :: !Integer, d :: !Rational, expBlocks :: !Integer
+///   , eta :: !Rational, rPot :: !Coin, deltaT1 :: !Coin, activeStake :: !Coin
+///   , pools :: !(Map (KeyHash StakePool) RewardProvenancePool)
+///   , desirabilities :: !(Map (KeyHash StakePool) Desirability)
+///   }
+/// ```
+///
+/// So the old reply was **structurally undecodable** by any real client: a
+/// decoder expecting 16 fields fails on 4 with `DeserialiseFailure`, the #993 /
+/// #968 shape — and it fails with a confusing framing error rather than
+/// anything actionable.
+///
+/// An explicit error is returned instead of the wrong shape, following #993's
+/// conclusion that an undecodable reply is worse than an honest refusal. Note
+/// the direction: upstream ANSWERS this query, so dugite is deliberately choosing
+/// a false reject over a false answer for a query with **no cardano-cli
+/// exposure** at all. Filling it in faithfully needs `RewardProvenancePool` and
+/// `Desirability` per pool plus the deltaR1/deltaR2/eta/expBlocks terms of the
+/// reward calculation, none of which dugite currently retains after a boundary —
+/// tracked separately rather than approximated here, because a plausible-looking
+/// 16-field answer built from guesses would be worse than either option.
+pub(crate) fn handle_reward_provenance(_state: &NodeStateSnapshot) -> QueryResult {
+    debug!("Query: GetRewardProvenance (tag 14) — unsupported, returning an error");
+    QueryResult::Error(
+        "GetRewardProvenance (tag 14) is not supported by dugite. Its Haskell result \
+         is a 16-field RewardProvenance record; dugite does not retain the \
+         deltaR1/deltaR2/eta/expBlocks terms or the per-pool desirabilities needed \
+         to answer it faithfully, and a wrong-arity reply would be undecodable. \
+         Use GetRewardInfoPools (tag 18) for per-pool reward data."
+            .to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -604,44 +626,45 @@ mod tests {
         }
     }
 
+    /// #1030 item 5: tag 14 must answer with an EXPLICIT ERROR, not a
+    /// well-formed-but-wrong `array(4)`.
+    ///
+    /// The two tests this replaces asserted the invented shape's arithmetic
+    /// (`pot = reserves * rho`, `tax = pot * tau`) and so PINNED the divergence:
+    /// they were green for a reply no client could decode, because Haskell's
+    /// `SL.RewardProvenance` is a 16-field `Rec`. The same shape as #968, where
+    /// the test helper encoded the same wrong frame as the code.
     #[test]
-    fn test_reward_provenance() {
+    fn test_reward_provenance_is_an_explicit_error_not_a_wrong_shape() {
         let state = make_state();
-        let result = handle_reward_provenance(&state);
-        match result {
-            QueryResult::RewardProvenance {
-                epoch,
-                total_rewards_pot,
-                treasury_tax,
-                active_stake,
-            } => {
-                assert_eq!(epoch, 42);
-                // reserves=10B, rho=3/1000 => pot=30M
-                assert_eq!(total_rewards_pot, 30_000_000);
-                // pot=30M, tau=2/10 => tax=6M
-                assert_eq!(treasury_tax, 6_000_000);
-                assert_eq!(active_stake, 1_000_000_000);
+        match handle_reward_provenance(&state) {
+            QueryResult::Error(msg) => {
+                assert!(
+                    msg.contains("GetRewardProvenance"),
+                    "the error must name the query so a client can act on it: {msg}"
+                );
+                assert!(
+                    msg.contains("GetRewardInfoPools") || msg.contains("tag 18"),
+                    "point the caller at the supported alternative: {msg}"
+                );
             }
-            _ => panic!("Expected RewardProvenance"),
+            other => panic!(
+                "tag 14 must return an explicit error rather than a fabricated \
+                 payload — a wrong-arity reply is undecodable (#993). Got {other:?}"
+            ),
         }
     }
 
+    /// The reserves value must not change the answer: there is no arithmetic left
+    /// to get wrong, which is the point of removing the variant.
     #[test]
-    fn test_reward_provenance_zero_reserves() {
+    fn test_reward_provenance_error_is_state_independent() {
         let mut state = make_state();
         state.reserves = 0;
-        let result = handle_reward_provenance(&state);
-        match result {
-            QueryResult::RewardProvenance {
-                total_rewards_pot,
-                treasury_tax,
-                ..
-            } => {
-                assert_eq!(total_rewards_pot, 0);
-                assert_eq!(treasury_tax, 0);
-            }
-            _ => panic!("Expected RewardProvenance"),
-        }
+        assert!(matches!(
+            handle_reward_provenance(&state),
+            QueryResult::Error(_)
+        ));
     }
 
     #[test]

--- a/crates/dugite-node/src/node/n2c_query/types.rs
+++ b/crates/dugite-node/src/node/n2c_query/types.rs
@@ -227,13 +227,14 @@ pub enum QueryResult {
         /// Last epoch block nonce — lab nonce from the last block of the prior epoch
         last_epoch_block_nonce: Vec<u8>,
     },
-    /// GetRewardProvenance (tag 14): reward calculation provenance
-    RewardProvenance {
-        epoch: u64,
-        total_rewards_pot: u64,
-        treasury_tax: u64,
-        active_stake: u64,
-    },
+    // GetRewardProvenance (tag 14) has NO variant on purpose.
+    //
+    // It used to carry a self-invented `{epoch, total_rewards_pot, treasury_tax,
+    // active_stake}` that encoded as `array(4)`, while Haskell's
+    // `SL.RewardProvenance` is a 16-field `Rec` — so the reply was undecodable by
+    // any real client (#993's shape). Deleting the variant makes that wrong shape
+    // inexpressible rather than merely unused; `handle_reward_provenance` returns
+    // an explicit error and documents what a faithful answer would require.
     /// GetRewardInfoPools (tag 18): per-pool reward info
     RewardInfoPools(Vec<PoolRewardInfo>),
     /// GetPoolState (tag 19): QueryPoolStateResult

--- a/crates/dugite-node/src/node/serve.rs
+++ b/crates/dugite-node/src/node/serve.rs
@@ -1004,7 +1004,18 @@ pub(crate) fn convert_validation_error(
             current_slot,
             valid_from,
         },
-        VE::ScriptFailed(reason) => TxValidationError::ScriptFailed { reason },
+        // `ValidationError::ScriptFailed` has exactly ONE producer —
+        // `phase2_admission_error`, for `is_valid = true` + a genuine evaluation
+        // failure — so it maps to the dedicated phase-2 carrier and gets the
+        // typed `ValidationTagMismatch … FailedUnexpectedly` wire class (#1053).
+        //
+        // It deliberately does NOT ride `TxValidationError::ScriptFailed`: that
+        // network variant is the free-text catch-all for ~20 unrelated
+        // rejections below, and a typed phase-2 class stamped on all of them
+        // would be worse than the generic fallback (#979).
+        VE::ScriptFailed(reason) => TxValidationError::Phase2ScriptsFailedUnexpectedly {
+            messages: vec![reason],
+        },
         VE::InsufficientCollateral { balance, required } => {
             TxValidationError::InsufficientCollateral { balance, required }
         }
@@ -1817,6 +1828,49 @@ mod tests {
     // failures (etc.) — exactly the class of bug that bites operators in
     // production.
 
+    /// #1053 WIRING test. The typed `ValidationTagMismatch` encoder arm is
+    /// worthless if this mapping still points `VE::ScriptFailed` at the free-text
+    /// catch-all — #977's exact failure mode, where the fix landed in a path
+    /// nothing reached.
+    ///
+    /// The assertion is deliberately two-sided: the phase-2 failure must become
+    /// the dedicated carrier, AND a rejection that merely BORROWS the catch-all
+    /// (`RefScriptsSizeTooBig`) must NOT, because a typed phase-2 class stamped
+    /// on it would be a confident lie (#979).
+    #[test]
+    fn convert_validation_error_routes_phase2_failure_to_its_own_carrier() {
+        use dugite_ledger::validation::ValidationError as VE;
+
+        let e = convert_validation_error(VE::ScriptFailed(
+            "Plutus evaluation failed: script returned Error term".to_string(),
+        ));
+        match e {
+            TxValidationError::Phase2ScriptsFailedUnexpectedly { messages } => {
+                assert_eq!(messages.len(), 1, "one message per failed script");
+                assert!(
+                    messages[0].contains("script returned Error term"),
+                    "the evaluator's diagnostic must survive: {:?}",
+                    messages[0]
+                );
+            }
+            other => panic!(
+                "VE::ScriptFailed must map to the dedicated phase-2 carrier so it \
+                 reaches the client as a typed ValidationTagMismatch; got {other:?}"
+            ),
+        }
+
+        // The catch-all must keep its other tenants.
+        let e = convert_validation_error(VE::RefScriptsSizeTooBig {
+            maximum: 204_800,
+            actual: 300_000,
+        });
+        assert!(
+            matches!(e, TxValidationError::ScriptFailed { .. }),
+            "RefScriptsSizeTooBig is NOT a phase-2 script failure and must not \
+             acquire the phase-2 wire class; got {e:?}"
+        );
+    }
+
     #[test]
     fn convert_validation_error_preserves_known_variants() {
         use dugite_ledger::validation::ValidationError as VE;
@@ -2064,7 +2118,12 @@ mod tests {
                 "dugite parse guard; no Conway constructor",
             ),
             ("ZeroWithdrawal", "no Conway constructor"),
-            ("ScriptFailed", "the generic failure itself"),
+            // `ScriptFailed` was here as "the generic failure itself" until
+            // #1053. It is now the ONLY ledger error meaning "phase-2 evaluation
+            // ran and disagreed with a Phase2Valid tag", and it maps to
+            // `Phase2ScriptsFailedUnexpectedly` → the typed
+            // `ValidationTagMismatch … FailedUnexpectedly`. Re-adding it here
+            // would mean the typed arm had been unwired.
             // ── Payload insufficient: counterpart exists, data does not ──
             (
                 "MalformedProposal",
@@ -2157,6 +2216,18 @@ mod tests {
         let body = &src[start..];
         let end = body.find("\n/// ").unwrap_or(body.len());
         let body = &body[..end];
+
+        // Comments are STRIPPED before scanning. A comment that merely NAMES
+        // `TxValidationError::ScriptFailed` — for instance to explain why a
+        // neighbouring arm deliberately does NOT use it (#1053) — would
+        // otherwise be attributed to the arm it sits after and reported as an
+        // unjustified degradation. The guard must measure code, not prose.
+        let body: String = body
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .map(|l| format!("{l}\n"))
+            .collect();
+        let body = body.as_str();
 
         let mut found: Vec<&str> = Vec::new();
         let arms: Vec<(usize, &str)> = body

--- a/crates/dugite-node/src/node/sync.rs
+++ b/crates/dugite-node/src/node/sync.rs
@@ -352,6 +352,12 @@ impl Node {
             dropped_deltas = dropped,
             "LedgerSeq re-anchored on the live ledger state"
         );
+        drop(seq);
+        drop(ls);
+        // #1057: the anchor just moved, so the "can this ledger roll back to Origin"
+        // answer may have flipped in either direction. Published HERE — one of only
+        // two places the anchor changes — rather than recomputed on every tip change.
+        self.publish_ledger_can_reach_origin().await;
     }
 
     async fn handle_rollback_inner(&self, rollback_point: &Point) -> bool {
@@ -1792,6 +1798,11 @@ impl Node {
                     // Advance LedgerSeq anchor — the oldest volatile delta
                     // is now immutable and can be absorbed into the anchor.
                     self.ledger_seq.write().await.advance_anchor();
+                    // #1057: advancing the anchor is how it stops being Origin, which
+                    // correctly DISABLES the genesis-anchor arm once the chain is
+                    // more than k blocks in (a rollback to Origin is then illegal
+                    // under Ouroboros k-finality anyway).
+                    self.publish_ledger_can_reach_origin().await;
 
                     // Flush DiffSeq entries for the now-immutable block.
                     // These diffs can never be rolled back, so keeping them

--- a/crates/dugite-storage/src/chain_db.rs
+++ b/crates/dugite-storage/src/chain_db.rs
@@ -511,6 +511,15 @@ impl ChainDB {
         self.volatile.selected_chain_len()
     }
 
+    /// The database directory this ChainDB was opened from.
+    ///
+    /// Needed by #1057's genesis-divergence marker: the BlockFetch worker that
+    /// detects the wedge has the ChainDB but not the node's config, and the marker
+    /// must land next to the data it describes.
+    pub fn db_path(&self) -> &Path {
+        &self._path
+    }
+
     /// Clear all volatile blocks. Used when the volatile DB has blocks from
     /// a fork that no longer connects to the ledger tip (e.g., after crash
     /// or restart with a different chain).

--- a/crates/dugite-storage/src/chain_db.rs
+++ b/crates/dugite-storage/src/chain_db.rs
@@ -1067,15 +1067,15 @@ impl ChainDB {
     /// Passes the current ImmutableDB tip to VolatileDB so that forks whose
     /// ancestry terminates at the immutable tip can be identified as reachable
     /// via the `AF.Empty anchor` case in Haskell's `isReachable`.
-    /// `ledger_at_origin` (#1057 half A) is forwarded as
-    /// `VolatileDB::switch_chain`'s `allow_genesis_anchor`: a fork rooted at
-    /// genesis is reachable only when the ledger can actually execute the
-    /// resulting plan, i.e. when it is already at Origin. Storage cannot see the
-    /// ledger, so the caller supplies it.
+    /// `ledger_can_reach_origin` (#1057) is forwarded as
+    /// `VolatileDB::switch_chain`'s `allow_genesis_anchor`: a fork rooted at genesis
+    /// is reachable only when the ledger can actually execute the resulting plan,
+    /// i.e. when a rollback to Origin is legal (LedgerSeq anchored at Origin, window
+    /// coherent). Storage cannot see the ledger, so the caller supplies it.
     pub fn switch_to_fork(
         &mut self,
         new_tip_hash: &BlockHeaderHash,
-        ledger_at_origin: bool,
+        ledger_can_reach_origin: bool,
     ) -> Option<crate::volatile_db::SwitchPlan> {
         let immutable_anchor = self
             .immutable_tip
@@ -1084,7 +1084,7 @@ impl ChainDB {
             new_tip_hash,
             immutable_anchor,
             self.security_param_k as u64,
-            ledger_at_origin,
+            ledger_can_reach_origin,
         )
     }
 

--- a/crates/dugite-storage/src/chain_db.rs
+++ b/crates/dugite-storage/src/chain_db.rs
@@ -1058,15 +1058,25 @@ impl ChainDB {
     /// Passes the current ImmutableDB tip to VolatileDB so that forks whose
     /// ancestry terminates at the immutable tip can be identified as reachable
     /// via the `AF.Empty anchor` case in Haskell's `isReachable`.
+    /// `ledger_at_origin` (#1057 half A) is forwarded as
+    /// `VolatileDB::switch_chain`'s `allow_genesis_anchor`: a fork rooted at
+    /// genesis is reachable only when the ledger can actually execute the
+    /// resulting plan, i.e. when it is already at Origin. Storage cannot see the
+    /// ledger, so the caller supplies it.
     pub fn switch_to_fork(
         &mut self,
         new_tip_hash: &BlockHeaderHash,
+        ledger_at_origin: bool,
     ) -> Option<crate::volatile_db::SwitchPlan> {
         let immutable_anchor = self
             .immutable_tip
             .map(|(slot, hash, _block_no)| (hash, slot.0));
-        self.volatile
-            .switch_chain(new_tip_hash, immutable_anchor, self.security_param_k as u64)
+        self.volatile.switch_chain(
+            new_tip_hash,
+            immutable_anchor,
+            self.security_param_k as u64,
+            ledger_at_origin,
+        )
     }
 
     /// Whether the volatile chain ending at `tip_hash` contains a known-invalid

--- a/crates/dugite-storage/src/chain_sel_queue.rs
+++ b/crates/dugite-storage/src/chain_sel_queue.rs
@@ -573,11 +573,25 @@ async fn run_selection_pass(
         // no chain selection occurs.  We fall through so the caller does
         // NOT attempt a ledger rollback; the block will re-enter chain
         // selection later if its ancestry becomes complete.
+        // #1057: report the INPUTS to the decision, not just its outcome.
+        //
+        // "fork unreachable" is the same message whether the fork's root is genesis
+        // or an unknown mid-chain hash, and whether the genesis arm was closed
+        // because the ledger cannot reach Origin or because the root simply does not
+        // anchor anywhere. Three separate live runs were spent guessing between those
+        // cases from a log line that could not distinguish them.
+        //
+        // `ledger_can_reach_origin` is the one input a reader cannot recover from the
+        // ChainDB afterwards, so it is the important one to state.
         warn!(
             fork_hash = %fork_hash.to_hex(),
             fork_block_no = fork_bn.0,
             fork_slot = fork_slot.0,
             current_tip_block_no,
+            ledger_can_reach_origin =
+                ledger_can_reach_origin.load(std::sync::atomic::Ordering::Relaxed),
+            immutable_anchored = db.get_immutable_tip_point().is_some(),
+            volatile_selected_len = db.volatile_selected_chain_count(),
             "chain_sel: fork unreachable — StoreButDontChange"
         );
     }

--- a/crates/dugite-storage/src/chain_sel_queue.rs
+++ b/crates/dugite-storage/src/chain_sel_queue.rs
@@ -313,6 +313,8 @@ pub async fn add_block_runner(
     mut rx: mpsc::Receiver<ChainSelMessage>,
     chain_db: Arc<RwLock<ChainDB>>,
     invalid_cache: Arc<RwLock<InvalidBlockCache>>,
+    // #1057 half A: published by the node; gates `switch_chain`'s genesis arm.
+    ledger_at_origin: Arc<std::sync::atomic::AtomicBool>,
 ) {
     debug!("add_block_runner: started");
 
@@ -338,6 +340,7 @@ pub async fn add_block_runner(
                     self_forged,
                     &chain_db,
                     &invalid_cache,
+                    &ledger_at_origin,
                 )
                 .await;
 
@@ -364,9 +367,10 @@ pub async fn add_block_runner(
                         Some(cache.hash_set())
                     }
                 };
-                let result = run_selection_pass(&chain_db, &invalid_snapshot, true)
-                    .await
-                    .unwrap_or(AddBlockResult::StoredAsFork);
+                let result =
+                    run_selection_pass(&chain_db, &invalid_snapshot, true, &ledger_at_origin)
+                        .await
+                        .unwrap_or(AddBlockResult::StoredAsFork);
                 if result_tx.send(result).is_err() {
                     trace!("add_block_runner: ReprocessLoE receiver dropped");
                 }
@@ -394,6 +398,7 @@ async fn run_selection_pass(
     chain_db: &Arc<RwLock<ChainDB>>,
     invalid_snapshot: &Option<std::collections::HashSet<Hash32>>,
     prefer_praos: bool,
+    ledger_at_origin: &Arc<std::sync::atomic::AtomicBool>,
 ) -> Option<AddBlockResult> {
     let mut db = chain_db.write().await;
 
@@ -546,7 +551,10 @@ async fn run_selection_pass(
             "chain_sel: switching to longer fork"
         );
 
-        if let Some(plan) = db.switch_to_fork(&fork_hash) {
+        if let Some(plan) = db.switch_to_fork(
+            &fork_hash,
+            ledger_at_origin.load(std::sync::atomic::Ordering::Relaxed),
+        ) {
             return Some(AddBlockResult::TriggeredFork {
                 intersection_hash: plan.intersection,
                 intersection_slot: SlotNo(plan.intersection_slot),
@@ -587,6 +595,8 @@ async fn process_add_block(
     self_forged: bool,
     chain_db: &Arc<RwLock<ChainDB>>,
     invalid_cache: &Arc<RwLock<InvalidBlockCache>>,
+    // #1057 half A: gates `switch_chain`'s genesis-anchor arm.
+    ledger_at_origin: &Arc<std::sync::atomic::AtomicBool>,
 ) -> AddBlockResult {
     // --- Step 1: Duplicate check (VolatileDB + ImmutableDB) ----------------
     {
@@ -692,7 +702,14 @@ async fn process_add_block(
     // Factored into `run_selection_pass` so the LoE reprocess path
     // (`ChainSelMessage::ReprocessLoE`) can re-run selection without a new
     // block. See that function for the full Haskell-parity notes.
-    if let Some(result) = run_selection_pass(chain_db, &invalid_snapshot, header.is_some()).await {
+    if let Some(result) = run_selection_pass(
+        chain_db,
+        &invalid_snapshot,
+        header.is_some(),
+        ledger_at_origin,
+    )
+    .await
+    {
         return result;
     }
 
@@ -738,6 +755,17 @@ pub struct ChainSelHandle {
     /// Shared invalid-block cache.  Exposed so callers can pre-seed the cache
     /// (e.g. from a persisted blacklist) or inspect it for monitoring.
     pub invalid_cache: Arc<RwLock<InvalidBlockCache>>,
+    /// #1057 half A: is the LEDGER at Origin?
+    ///
+    /// `dugite-storage` sits below `dugite-ledger` in the dependency flow and
+    /// cannot read ledger state, but `switch_chain`'s genesis-anchor arm must not
+    /// fire unless the ledger can execute the plan it produces. The node publishes
+    /// the answer here via [`ChainSelHandle::set_ledger_at_origin`].
+    ///
+    /// Defaults to `false`, which is the conservative direction: the genesis arm
+    /// stays off, i.e. exactly the pre-#1057 behaviour. A caller that forgets to
+    /// publish loses the fix, never correctness.
+    ledger_at_origin: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl ChainSelHandle {
@@ -769,12 +797,34 @@ impl ChainSelHandle {
     ) -> (Self, impl std::future::Future<Output = ()>) {
         let invalid_cache = Arc::new(RwLock::new(InvalidBlockCache::new()));
         let (tx, rx) = mpsc::channel(capacity);
+        let ledger_at_origin = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
-        let runner = add_block_runner(rx, chain_db, Arc::clone(&invalid_cache));
+        let runner = add_block_runner(
+            rx,
+            chain_db,
+            Arc::clone(&invalid_cache),
+            Arc::clone(&ledger_at_origin),
+        );
 
-        let handle = ChainSelHandle { tx, invalid_cache };
+        let handle = ChainSelHandle {
+            tx,
+            invalid_cache,
+            ledger_at_origin,
+        };
 
         (handle, runner)
+    }
+
+    /// Publish whether the ledger is at Origin (#1057 half A).
+    ///
+    /// The node calls this whenever the ledger tip changes. It gates
+    /// `VolatileDB::switch_chain`'s genesis-anchor arm, which must not emit a
+    /// genesis-rooted `SwitchPlan` the ledger cannot execute — doing so relocates
+    /// the #1057 wedge from BlockFetch to the ledger rollback, which was measured
+    /// live and reverted.
+    pub fn set_ledger_at_origin(&self, at_origin: bool) {
+        self.ledger_at_origin
+            .store(at_origin, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Re-run chain selection after the Limit on Eagerness advanced

--- a/crates/dugite-storage/src/chain_sel_queue.rs
+++ b/crates/dugite-storage/src/chain_sel_queue.rs
@@ -847,6 +847,19 @@ impl ChainSelHandle {
         (handle, runner)
     }
 
+    /// The shared `ledger_can_reach_origin` flag (#1057).
+    ///
+    /// Handed to BlockFetch's gross-request invariant so BOTH layers read the SAME
+    /// predicate from the SAME cell. They disagreed once — storage on
+    /// `ledger_can_reach_origin` while BlockFetch still tested `ledger tip ==
+    /// Origin` — and the result was a node that would have accepted the fork switch
+    /// but never received the blocks to switch to. Two layers gating one decision on
+    /// two different predicates is a bug waiting to happen; sharing the cell makes
+    /// it inexpressible.
+    pub fn ledger_can_reach_origin_flag(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.ledger_can_reach_origin)
+    }
+
     /// Publish whether the ledger can be rolled back to Origin (#1057).
     ///
     /// The node calls this whenever the ledger tip changes. It gates

--- a/crates/dugite-storage/src/chain_sel_queue.rs
+++ b/crates/dugite-storage/src/chain_sel_queue.rs
@@ -314,7 +314,7 @@ pub async fn add_block_runner(
     chain_db: Arc<RwLock<ChainDB>>,
     invalid_cache: Arc<RwLock<InvalidBlockCache>>,
     // #1057 half A: published by the node; gates `switch_chain`'s genesis arm.
-    ledger_at_origin: Arc<std::sync::atomic::AtomicBool>,
+    ledger_can_reach_origin: Arc<std::sync::atomic::AtomicBool>,
 ) {
     debug!("add_block_runner: started");
 
@@ -340,7 +340,7 @@ pub async fn add_block_runner(
                     self_forged,
                     &chain_db,
                     &invalid_cache,
-                    &ledger_at_origin,
+                    &ledger_can_reach_origin,
                 )
                 .await;
 
@@ -367,10 +367,14 @@ pub async fn add_block_runner(
                         Some(cache.hash_set())
                     }
                 };
-                let result =
-                    run_selection_pass(&chain_db, &invalid_snapshot, true, &ledger_at_origin)
-                        .await
-                        .unwrap_or(AddBlockResult::StoredAsFork);
+                let result = run_selection_pass(
+                    &chain_db,
+                    &invalid_snapshot,
+                    true,
+                    &ledger_can_reach_origin,
+                )
+                .await
+                .unwrap_or(AddBlockResult::StoredAsFork);
                 if result_tx.send(result).is_err() {
                     trace!("add_block_runner: ReprocessLoE receiver dropped");
                 }
@@ -398,7 +402,7 @@ async fn run_selection_pass(
     chain_db: &Arc<RwLock<ChainDB>>,
     invalid_snapshot: &Option<std::collections::HashSet<Hash32>>,
     prefer_praos: bool,
-    ledger_at_origin: &Arc<std::sync::atomic::AtomicBool>,
+    ledger_can_reach_origin: &Arc<std::sync::atomic::AtomicBool>,
 ) -> Option<AddBlockResult> {
     let mut db = chain_db.write().await;
 
@@ -553,7 +557,7 @@ async fn run_selection_pass(
 
         if let Some(plan) = db.switch_to_fork(
             &fork_hash,
-            ledger_at_origin.load(std::sync::atomic::Ordering::Relaxed),
+            ledger_can_reach_origin.load(std::sync::atomic::Ordering::Relaxed),
         ) {
             return Some(AddBlockResult::TriggeredFork {
                 intersection_hash: plan.intersection,
@@ -596,7 +600,7 @@ async fn process_add_block(
     chain_db: &Arc<RwLock<ChainDB>>,
     invalid_cache: &Arc<RwLock<InvalidBlockCache>>,
     // #1057 half A: gates `switch_chain`'s genesis-anchor arm.
-    ledger_at_origin: &Arc<std::sync::atomic::AtomicBool>,
+    ledger_can_reach_origin: &Arc<std::sync::atomic::AtomicBool>,
 ) -> AddBlockResult {
     // --- Step 1: Duplicate check (VolatileDB + ImmutableDB) ----------------
     {
@@ -706,7 +710,7 @@ async fn process_add_block(
         chain_db,
         &invalid_snapshot,
         header.is_some(),
-        ledger_at_origin,
+        ledger_can_reach_origin,
     )
     .await
     {
@@ -755,17 +759,31 @@ pub struct ChainSelHandle {
     /// Shared invalid-block cache.  Exposed so callers can pre-seed the cache
     /// (e.g. from a persisted blacklist) or inspect it for monitoring.
     pub invalid_cache: Arc<RwLock<InvalidBlockCache>>,
-    /// #1057 half A: is the LEDGER at Origin?
+    /// #1057: can the LEDGER be rolled back to Origin?
     ///
-    /// `dugite-storage` sits below `dugite-ledger` in the dependency flow and
-    /// cannot read ledger state, but `switch_chain`'s genesis-anchor arm must not
-    /// fire unless the ledger can execute the plan it produces. The node publishes
-    /// the answer here via [`ChainSelHandle::set_ledger_at_origin`].
+    /// NOT "is the ledger at Origin" — that gate was implemented, measured, and
+    /// found too narrow: holding ANY chain disqualified the longer one, including a
+    /// chain adopted seconds earlier from a peer that was itself broken. On the
+    /// devnet a node that had just reset re-adopted a stale 10-block chain from its
+    /// sibling and was wedged again 30 seconds later against the canonical
+    /// 155-block chain.
     ///
-    /// Defaults to `false`, which is the conservative direction: the genesis arm
-    /// stays off, i.e. exactly the pre-#1057 behaviour. A caller that forgets to
-    /// publish loses the fix, never correctness.
-    ledger_at_origin: Arc<std::sync::atomic::AtomicBool>,
+    /// The real predicate is that a rollback to Origin is EXECUTABLE, which holds
+    /// when the LedgerSeq's anchor IS Origin and the window is coherent:
+    /// `find_rollback_n(Origin)` then returns `Some(deltas.len())` — the
+    /// full-rewind-to-anchor case — so no snapshot and no re-initialisation is
+    /// needed. A snapshot-restored ledger has a non-Origin anchor, which is exactly
+    /// why the earlier attempt hit "Rollback target outside LedgerSeq volatile
+    /// window AND no canonical snapshot available".
+    ///
+    /// `dugite-storage` sits below `dugite-ledger` and cannot read either, so the
+    /// node publishes the answer via
+    /// [`ChainSelHandle::set_ledger_can_reach_origin`].
+    ///
+    /// Defaults to `false`, the conservative direction: the genesis arm stays off,
+    /// i.e. exactly the pre-#1057 behaviour. A caller that forgets to publish loses
+    /// the fix, never correctness.
+    ledger_can_reach_origin: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl ChainSelHandle {
@@ -797,33 +815,33 @@ impl ChainSelHandle {
     ) -> (Self, impl std::future::Future<Output = ()>) {
         let invalid_cache = Arc::new(RwLock::new(InvalidBlockCache::new()));
         let (tx, rx) = mpsc::channel(capacity);
-        let ledger_at_origin = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ledger_can_reach_origin = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let runner = add_block_runner(
             rx,
             chain_db,
             Arc::clone(&invalid_cache),
-            Arc::clone(&ledger_at_origin),
+            Arc::clone(&ledger_can_reach_origin),
         );
 
         let handle = ChainSelHandle {
             tx,
             invalid_cache,
-            ledger_at_origin,
+            ledger_can_reach_origin,
         };
 
         (handle, runner)
     }
 
-    /// Publish whether the ledger is at Origin (#1057 half A).
+    /// Publish whether the ledger can be rolled back to Origin (#1057).
     ///
     /// The node calls this whenever the ledger tip changes. It gates
     /// `VolatileDB::switch_chain`'s genesis-anchor arm, which must not emit a
     /// genesis-rooted `SwitchPlan` the ledger cannot execute — doing so relocates
     /// the #1057 wedge from BlockFetch to the ledger rollback, which was measured
     /// live and reverted.
-    pub fn set_ledger_at_origin(&self, at_origin: bool) {
-        self.ledger_at_origin
+    pub fn set_ledger_can_reach_origin(&self, at_origin: bool) {
+        self.ledger_can_reach_origin
             .store(at_origin, std::sync::atomic::Ordering::Relaxed);
     }
 

--- a/crates/dugite-storage/src/volatile_db.rs
+++ b/crates/dugite-storage/src/volatile_db.rs
@@ -1754,11 +1754,11 @@ impl VolatileDB {
     /// (10 000) back, which the `k`-deep `LedgerSeq` then cannot roll back to,
     /// forcing a catastrophic snapshot+genesis-replay (observed: a 10 629-block
     /// rollback → ledger reset to genesis → unrecoverable stall).
-    /// `allow_genesis_anchor` (#1057 half A) — may a fork rooted at GENESIS be
-    /// treated as reachable? The caller passes "the ledger is at Origin", because
-    /// this function's output is executed by the ledger and a genesis-rooted plan
-    /// is only executable from there. See the arm inside for why it is a hard
-    /// precondition rather than a preference.
+    /// `allow_genesis_anchor` (#1057) — may a fork rooted at GENESIS be treated as
+    /// reachable? The caller passes "the ledger CAN BE ROLLED BACK to Origin",
+    /// because this function's output is executed by the ledger and a genesis-rooted
+    /// plan is only executable when that rollback is legal. See the arm inside for
+    /// why it is a hard precondition rather than a preference.
     pub fn switch_chain(
         &mut self,
         new_tip_hash: &Hash32,

--- a/crates/dugite-storage/src/volatile_db.rs
+++ b/crates/dugite-storage/src/volatile_db.rs
@@ -1754,11 +1754,17 @@ impl VolatileDB {
     /// (10 000) back, which the `k`-deep `LedgerSeq` then cannot roll back to,
     /// forcing a catastrophic snapshot+genesis-replay (observed: a 10 629-block
     /// rollback → ledger reset to genesis → unrecoverable stall).
+    /// `allow_genesis_anchor` (#1057 half A) — may a fork rooted at GENESIS be
+    /// treated as reachable? The caller passes "the ledger is at Origin", because
+    /// this function's output is executed by the ledger and a genesis-rooted plan
+    /// is only executable from there. See the arm inside for why it is a hard
+    /// precondition rather than a preference.
     pub fn switch_chain(
         &mut self,
         new_tip_hash: &Hash32,
         immutable_anchor: Option<(Hash32, u64)>,
         max_rollback: u64,
+        allow_genesis_anchor: bool,
     ) -> Option<SwitchPlan> {
         let new_chain = self.walk_chain_back(new_tip_hash);
         if new_chain.is_empty() {
@@ -1815,59 +1821,107 @@ impl VolatileDB {
                     .first()
                     .and_then(|h| self.blocks.get(h))
                     .map(|b| b.prev_hash);
-                match (immutable_anchor, new_root_prev) {
-                    (Some((anchor_hash, anchor_slot)), Some(prev)) if anchor_hash == prev => {
-                        let rollback: Vec<Hash32> =
-                            self.selected_chain.iter().rev().copied().collect();
-                        let apply: Vec<Hash32> = new_chain.clone();
-                        debug!(
-                            new_tip = %new_tip_hash,
-                            anchor = %anchor_hash,
-                            anchor_slot,
-                            rollback_count = rollback.len(),
-                            apply_count = apply.len(),
-                            "VolatileDB: fork anchors at immutable tip — \
-                             switching via full-volatile rollback"
-                        );
-                        (anchor_hash, anchor_slot, rollback, apply)
-                    }
-                    _ => {
-                        // Truly unreachable: the fork's ancestry does not connect
-                        // to our current volatile chain or its anchor.  Leave
-                        // `selected_chain` untouched; the block stays in
-                        // VolatileDB inert.
-                        //
-                        // Diagnostic instrumentation (Bug J, 2026-05-16): log the
-                        // full shape of both chains and the anchor.  This lets us
-                        // distinguish the three plausible failure modes:
-                        //   1. walk_chain_back stopped at a too-shallow block
-                        //      (its first prev_hash is some peer block already
-                        //      flushed to immutable, not the immutable tip).
-                        //   2. selected_chain is shorter than expected because
-                        //      our own forges drifted past the volatile window.
-                        //   3. immutable_anchor is None when it shouldn't be
-                        //      (e.g., we never flushed but should have).
-                        warn!(
-                            new_tip = %new_tip_hash,
-                            new_tip_slot = self.blocks.get(new_tip_hash).map(|b| b.slot).unwrap_or(0),
-                            new_tip_block_no = self.blocks.get(new_tip_hash).map(|b| b.block_no).unwrap_or(0),
-                            new_chain_len = new_chain.len(),
-                            new_chain_first = ?new_chain.first().map(|h| h.to_hex()),
-                            new_chain_first_slot = ?new_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.slot),
-                            new_chain_first_block_no = ?new_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
-                            new_root_prev = ?new_root_prev.map(|h| h.to_hex()),
-                            selected_len = self.selected_chain.len(),
-                            selected_first = ?self.selected_chain.first().map(|h| h.to_hex()),
-                            selected_first_slot = ?self.selected_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.slot),
-                            selected_first_block_no = ?self.selected_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
-                            selected_last = ?self.selected_chain.last().map(|h| h.to_hex()),
-                            selected_last_slot = ?self.selected_chain.last().and_then(|h| self.blocks.get(h)).map(|b| b.slot),
-                            selected_last_block_no = ?self.selected_chain.last().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
-                            immutable_anchor_hash = ?immutable_anchor.map(|(h, _)| h.to_hex()),
-                            immutable_anchor_slot = ?immutable_anchor.map(|(_, s)| s),
-                            "VolatileDB: fork unreachable — no common anchor (Haskell: isReachable = Nothing)"
-                        );
-                        return None;
+                // #1057 half A: a fork rooted at GENESIS is reachable when the
+                // ledger is at Origin.
+                //
+                // `Hash32::ZERO` is dugite's canonical Origin parent (the encoder
+                // maps it to CBOR `null` == Haskell `PrevHash = GenesisHash`).
+                // Upstream needs no arm here at all: `AnchorGenesis` is a
+                // first-class constructor of `Anchor blk` and `Paths.hs::isReachable`
+                // matches it directly. dugite models the anchor as
+                // `Option<(Hash32, u64)>`, so with nothing flushed the anchor is
+                // `None` and a genesis-rooted fork looked unreachable — which is
+                // half of why a node with any block of its own never rejoined a
+                // chain diverging at genesis.
+                //
+                // `allow_genesis_anchor` is NOT optional politeness. Emitting this
+                // plan when the ledger is NOT at Origin asks chain selection to roll
+                // the ledger back to Origin, and that aborts ("Rollback target
+                // outside LedgerSeq volatile window AND no canonical snapshot
+                // available"), moving the wedge from BlockFetch to the ledger. That
+                // was implemented, measured live at block 4 against a network at 84,
+                // and REVERTED. Unit tests on this function all passed while it was
+                // wrong, because nothing drove the plan through the ledger.
+                // This arm yields the (intersection, slot, rollback, apply) TUPLE
+                // rather than returning a `SwitchPlan` directly. Returning early
+                // here skipped everything after the match — the Ouroboros
+                // k-finality `max_rollback` cap, the `gc_schedule` updates and the
+                // `selected_chain` rewrite — so the plan was handed out while the
+                // VolatileDB still pointed at the old tip, and a rollback deeper
+                // than k would have bypassed its own guard. Caught by
+                // `test_switch_chain_genesis_anchor_requires_ledger_at_origin`
+                // asserting the resulting tip, not just the returned plan.
+                //
+                // The k cap applying here is correct, not incidental: a rollback
+                // deeper than k is protocol-impossible, and it matches ChainSync's
+                // own "local chain is within k blocks of genesis" condition for
+                // accepting the Origin intersection in the first place.
+                if allow_genesis_anchor && new_root_prev == Some(Hash32::ZERO) {
+                    let rollback: Vec<Hash32> = self.selected_chain.iter().rev().copied().collect();
+                    let apply: Vec<Hash32> = new_chain.clone();
+                    debug!(
+                        new_tip = %new_tip_hash,
+                        rollback_count = rollback.len(),
+                        apply_count = apply.len(),
+                        "VolatileDB: fork anchors at GENESIS and the ledger is at \
+                         Origin — switching via full-volatile rollback (#1057)"
+                    );
+                    (Hash32::ZERO, 0, rollback, apply)
+                } else {
+                    match (immutable_anchor, new_root_prev) {
+                        (Some((anchor_hash, anchor_slot)), Some(prev)) if anchor_hash == prev => {
+                            let rollback: Vec<Hash32> =
+                                self.selected_chain.iter().rev().copied().collect();
+                            let apply: Vec<Hash32> = new_chain.clone();
+                            debug!(
+                                new_tip = %new_tip_hash,
+                                anchor = %anchor_hash,
+                                anchor_slot,
+                                rollback_count = rollback.len(),
+                                apply_count = apply.len(),
+                                "VolatileDB: fork anchors at immutable tip — \
+                                 switching via full-volatile rollback"
+                            );
+                            (anchor_hash, anchor_slot, rollback, apply)
+                        }
+                        _ => {
+                            // Truly unreachable: the fork's ancestry does not connect
+                            // to our current volatile chain or its anchor.  Leave
+                            // `selected_chain` untouched; the block stays in
+                            // VolatileDB inert.
+                            //
+                            // Diagnostic instrumentation (Bug J, 2026-05-16): log the
+                            // full shape of both chains and the anchor.  This lets us
+                            // distinguish the three plausible failure modes:
+                            //   1. walk_chain_back stopped at a too-shallow block
+                            //      (its first prev_hash is some peer block already
+                            //      flushed to immutable, not the immutable tip).
+                            //   2. selected_chain is shorter than expected because
+                            //      our own forges drifted past the volatile window.
+                            //   3. immutable_anchor is None when it shouldn't be
+                            //      (e.g., we never flushed but should have).
+                            warn!(
+                                new_tip = %new_tip_hash,
+                                new_tip_slot = self.blocks.get(new_tip_hash).map(|b| b.slot).unwrap_or(0),
+                                new_tip_block_no = self.blocks.get(new_tip_hash).map(|b| b.block_no).unwrap_or(0),
+                                new_chain_len = new_chain.len(),
+                                new_chain_first = ?new_chain.first().map(|h| h.to_hex()),
+                                new_chain_first_slot = ?new_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.slot),
+                                new_chain_first_block_no = ?new_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
+                                new_root_prev = ?new_root_prev.map(|h| h.to_hex()),
+                                selected_len = self.selected_chain.len(),
+                                selected_first = ?self.selected_chain.first().map(|h| h.to_hex()),
+                                selected_first_slot = ?self.selected_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.slot),
+                                selected_first_block_no = ?self.selected_chain.first().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
+                                selected_last = ?self.selected_chain.last().map(|h| h.to_hex()),
+                                selected_last_slot = ?self.selected_chain.last().and_then(|h| self.blocks.get(h)).map(|b| b.slot),
+                                selected_last_block_no = ?self.selected_chain.last().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
+                                immutable_anchor_hash = ?immutable_anchor.map(|(h, _)| h.to_hex()),
+                                immutable_anchor_slot = ?immutable_anchor.map(|(_, s)| s),
+                                "VolatileDB: fork unreachable — no common anchor (Haskell: isReachable = Nothing)"
+                            );
+                            return None;
+                        }
                     }
                 }
             }
@@ -3119,7 +3173,7 @@ mod tests {
         db.add_block(h(6), 400, 40, h(5), b"b6".to_vec());
 
         // Switch to the longer fork.
-        db.switch_chain(&h(6), None, u64::MAX);
+        db.switch_chain(&h(6), None, u64::MAX, false);
 
         // After the switch, selected_chain = [h1, h4, h5, h6].
         // h3 has no successors and is NOT on selected_chain → fork tip.
@@ -3157,7 +3211,7 @@ mod tests {
         db.add_block(h(6), 400, 40, h(5), b"b6".to_vec());
 
         assert_eq!(db.get_tip(), Some((300, h(3), 30)));
-        let plan = db.switch_chain(&h(6), None, u64::MAX).unwrap();
+        let plan = db.switch_chain(&h(6), None, u64::MAX, false).unwrap();
         assert_eq!(plan.intersection, h(1));
         assert_eq!(plan.rollback, vec![h(3), h(2)]);
         assert_eq!(plan.apply, vec![h(4), h(5), h(6)]);
@@ -3190,7 +3244,7 @@ mod tests {
         db.add_block(h(99), 400, 40, h(98), b"detached1".to_vec());
         db.add_block(h(100), 500, 50, h(99), b"detached2".to_vec());
 
-        let plan = db.switch_chain(&h(100), None, u64::MAX);
+        let plan = db.switch_chain(&h(100), None, u64::MAX, false);
         assert!(
             plan.is_none(),
             "switch_chain must return None when the fork is unreachable \
@@ -3236,11 +3290,8 @@ mod tests {
         // case. Use a non-ZERO anchor so this test covers the immutable-tip path
         // it is named for.
         //
-        // Its `switch_chain(.., None, ..).is_none()` assertion also documents
-        // that a genesis-rooted fork is currently REFUSED when the ImmutableDB
-        // is empty — see #1057, which is that wedge and is NOT yet fixed: the
-        // storage layer can be taught to emit the plan, but the ledger cannot
-        // roll back to Origin, so the switch fails downstream instead.
+        // The genesis-rooted case is covered separately by
+        // `test_switch_chain_genesis_anchor_requires_ledger_at_origin` (#1057).
         // Selected chain: h(1) → h(2), both children of h(200).
         db.add_block(h(1), 100, 10, h(200), b"s1".to_vec());
         db.add_block(h(2), 200, 20, h(1), b"s2".to_vec());
@@ -3253,13 +3304,13 @@ mod tests {
         // Without immutable_anchor the fork is unreachable: its root's
         // prev_hash is a real block hash we do not have, and it is not genesis.
         assert!(
-            db.switch_chain(&h(12), None, u64::MAX).is_none(),
+            db.switch_chain(&h(12), None, u64::MAX, false).is_none(),
             "without knowing the immutable anchor, fork stays unreachable"
         );
 
         // Passing the immutable anchor (h(200) at slot 50) allows the switch.
         let plan = db
-            .switch_chain(&h(12), Some((h(200), 50)), u64::MAX)
+            .switch_chain(&h(12), Some((h(200), 50)), u64::MAX, false)
             .expect("fork is reachable via immutable-tip anchor");
         assert_eq!(
             plan.intersection,
@@ -3280,6 +3331,84 @@ mod tests {
         assert_eq!(db.get_tip(), Some((350, h(12), 22)));
     }
 
+    /// #1057 half A: a fork rooted at GENESIS is reachable with an EMPTY
+    /// ImmutableDB — but only when the caller says the ledger is at Origin.
+    ///
+    /// This is the storage half of the wedge. `Hash32::ZERO` is dugite's canonical
+    /// Origin parent, and with nothing flushed the immutable anchor is `None`, so
+    /// the previous code found no reachable ancestor and returned
+    /// `StoreButDontChange` forever.
+    ///
+    /// BOTH polarities are asserted, and the `false` one is the important one: the
+    /// version of this fix WITHOUT the ledger condition was implemented and
+    /// reverted, because storage then handed chain selection a plan the ledger
+    /// could not execute ("Rollback target outside LedgerSeq volatile window AND
+    /// no canonical snapshot available"), leaving the node at block 4 while the
+    /// network was at 84 — worse than unfixed.
+    ///
+    /// Note what a unit test can and cannot do here: this bounds `switch_chain`.
+    /// It does NOT establish that the resulting plan is executable — nothing here
+    /// drives it through the ledger, which is exactly how the reverted attempt
+    /// passed four RED-proven unit tests. The system-level check is
+    /// `testnet/local-devnet/genesis-fork-round.sh`.
+    #[test]
+    fn test_switch_chain_genesis_anchor_requires_ledger_at_origin() {
+        let mut db = VolatileDB::new();
+        // Selected chain: our own two blocks, rooted at GENESIS.
+        db.add_block(h(1), 100, 10, Hash32::ZERO, b"mine1".to_vec());
+        db.add_block(h(2), 200, 20, h(1), b"mine2".to_vec());
+        // A competing chain, also rooted at GENESIS, sharing NO block with ours.
+        db.add_block(h(10), 150, 11, Hash32::ZERO, b"theirs1".to_vec());
+        db.add_block(h(11), 250, 21, h(10), b"theirs2".to_vec());
+        db.add_block(h(12), 350, 22, h(11), b"theirs3".to_vec());
+
+        // Ledger NOT at Origin → must refuse, even though the fork is longer.
+        assert!(
+            db.switch_chain(&h(12), None, u64::MAX, false).is_none(),
+            "a genesis-rooted plan the ledger cannot execute must NOT be emitted \
+             — that is the reverted fix"
+        );
+
+        // Ledger at Origin → reachable, anchored at genesis.
+        let plan = db
+            .switch_chain(&h(12), None, u64::MAX, true)
+            .expect("a genesis-rooted fork is reachable when the ledger is at Origin");
+        assert_eq!(
+            plan.intersection,
+            Hash32::ZERO,
+            "the intersection IS genesis"
+        );
+        assert_eq!(plan.intersection_slot, 0);
+        assert_eq!(
+            plan.rollback,
+            vec![h(2), h(1)],
+            "roll back our entire own chain, newest first"
+        );
+        assert_eq!(
+            plan.apply,
+            vec![h(10), h(11), h(12)],
+            "apply the peer's entire chain, oldest first"
+        );
+        assert_eq!(db.get_tip(), Some((350, h(12), 22)));
+    }
+
+    /// The genesis clause must not become a general escape hatch: a fork whose
+    /// root's `prev_hash` is an unknown NON-genesis hash stays unreachable even
+    /// with `allow_genesis_anchor = true`.
+    #[test]
+    fn test_genesis_anchor_does_not_excuse_unknown_non_genesis_root() {
+        let mut db = VolatileDB::new();
+        db.add_block(h(1), 100, 10, Hash32::ZERO, b"mine1".to_vec());
+        // Fork root's parent h(200) is neither in the DB nor genesis.
+        db.add_block(h(10), 150, 11, h(200), b"theirs1".to_vec());
+        db.add_block(h(11), 250, 21, h(10), b"theirs2".to_vec());
+        assert!(
+            db.switch_chain(&h(11), None, u64::MAX, true).is_none(),
+            "an unknown non-genesis root must stay unreachable regardless of the \
+             ledger — otherwise the clause weakens Haskell's isReachable"
+        );
+    }
+
     /// A `SwitchPlan` returned by `switch_chain` must carry the intersection
     /// slot — not just the hash — so callers can build a `Point::Specific(slot,
     /// hash)` for ledger rollback without a second lookup that could miss the
@@ -3296,7 +3425,7 @@ mod tests {
         db.add_block(h(6), 444, 40, h(5), b"b-chain-tip".to_vec());
 
         let plan = db
-            .switch_chain(&h(6), None, u64::MAX)
+            .switch_chain(&h(6), None, u64::MAX, false)
             .expect("reachable fork");
         assert_eq!(plan.intersection, h(1));
         assert_eq!(
@@ -3371,7 +3500,7 @@ mod tests {
 
         // k = 3 < rollback depth 4 → refuse, leaving the selected chain intact.
         assert!(
-            db.switch_chain(&h(24), None, 3).is_none(),
+            db.switch_chain(&h(24), None, 3, false).is_none(),
             "fork requiring a 4-block rollback must be refused when k = 3"
         );
         assert_eq!(
@@ -3382,7 +3511,7 @@ mod tests {
 
         // k = 4 == rollback depth 4 → permitted (Haskell allows rollback ≤ k).
         let plan = db
-            .switch_chain(&h(24), None, 4)
+            .switch_chain(&h(24), None, 4, false)
             .expect("rollback of exactly k must be permitted");
         assert_eq!(plan.intersection, h(1));
         assert_eq!(plan.rollback, vec![h(5), h(4), h(3), h(2)]);
@@ -3408,7 +3537,8 @@ mod tests {
 
         // Full-volatile rollback depth = 3 (entire selected chain). k = 2 → refuse.
         assert!(
-            db.switch_chain(&h(13), Some((h(0), 50)), 2).is_none(),
+            db.switch_chain(&h(13), Some((h(0), 50)), 2, false)
+                .is_none(),
             "full-volatile rollback of 3 blocks must be refused when k = 2"
         );
         assert_eq!(
@@ -3429,7 +3559,7 @@ mod tests {
         assert!(db.has_block(&h(2)));
         assert!(db.has_block(&h(3)));
 
-        let plan = db.switch_chain(&h(3), None, u64::MAX).unwrap();
+        let plan = db.switch_chain(&h(3), None, u64::MAX, false).unwrap();
         assert_eq!(plan.apply, vec![h(3)]);
         assert_eq!(db.get_tip(), Some((100, h(3), 10)));
         assert_eq!(db.len(), 3);
@@ -3740,7 +3870,7 @@ mod tests {
         );
 
         // Attempt switch — must return None (unreachable fork).
-        let plan = db.switch_chain(&fork_tip, None, u64::MAX);
+        let plan = db.switch_chain(&fork_tip, None, u64::MAX, false);
         assert!(
             plan.is_none(),
             "switch_chain must return None for a deep detached fork \

--- a/crates/dugite-storage/src/volatile_db.rs
+++ b/crates/dugite-storage/src/volatile_db.rs
@@ -1918,6 +1918,14 @@ impl VolatileDB {
                                 selected_last_block_no = ?self.selected_chain.last().and_then(|h| self.blocks.get(h)).map(|b| b.block_no),
                                 immutable_anchor_hash = ?immutable_anchor.map(|(h, _)| h.to_hex()),
                                 immutable_anchor_slot = ?immutable_anchor.map(|(_, s)| s),
+                                // #1057: the two facts that decide whether the
+                                // genesis arm above could have fired. Without them
+                                // this line cannot distinguish "the root is not
+                                // genesis" from "the root IS genesis but the ledger
+                                // could not roll back to it", and three live runs
+                                // were spent guessing between exactly those.
+                                root_is_genesis = new_root_prev == Some(Hash32::ZERO),
+                                allow_genesis_anchor,
                                 "VolatileDB: fork unreachable — no common anchor (Haskell: isReachable = Nothing)"
                             );
                             return None;

--- a/testnet/local-devnet/genesis-fork-round.allowed-errors
+++ b/testnet/local-devnet/genesis-fork-round.allowed-errors
@@ -1,0 +1,43 @@
+# Expected error-class log lines for genesis-fork-round.sh (#1057).
+#
+# This round DELIBERATELY constructs an unrecoverable state: two islands that
+# share only genesis, then a reconnect where one dugite node must adopt a chain
+# diverging at Origin. Until #1057 half B lands the node cannot, and it now says
+# so loudly — those lines are the round's evidence, not a regression.
+#
+# Kept deliberately NARROW. An over-broad allowlist is how a round reports
+# success while measuring nothing (#916/#923/#945/#953/#959) — a pattern like
+# "ERROR" would swallow the ledger-rollback failure this round exists to
+# distinguish a BAD fix by. Each entry below is one specific, mechanically-caused
+# line.
+#
+# Format: one extended-regex per line; '#' comments and blank lines ignored.
+
+# The frozen island's forge loop cannot build a ledger view for the current slot,
+# because step 2b deliberately parks its tip ~300 slots behind. Expected on
+# dugite-bp for the whole freeze and reconnect window.
+TraceNoLedgerView
+
+# #1057 itself: the wedge announcing itself. The WARN fires per declined range and
+# the ERROR once per worker with the operator remedy. Their ABSENCE is what step 4
+# treats as a failure — a silent unrecoverable state cannot be diagnosed in the
+# field.
+declining a range rooted at GENESIS
+#1057: this node cannot rejoin the network
+
+# The relay's ChainSync task is dropped when the peer's headers sit beyond the
+# forecast horizon and the ledger has not advanced. This is the park→disconnect
+# half of the loop and is counted by step 4.
+beyond forecast horizon
+
+# Step 2b stops dugite-relay and step 3 stops cardano-bp to swap topologies, so
+# their peers legitimately observe the disconnect and re-dial.
+removed dead connection
+shutting down peer connection
+
+# NOT allowlisted, on purpose — these must fail the round if they appear:
+#   "Fork rollback failed"                         (the BAD-FIX shape: storage
+#                                                   emitted a genesis-rooted plan
+#                                                   the ledger could not execute)
+#   "Rollback target outside LedgerSeq"            (same, one layer down)
+#   "LedgerSeq was incoherent"                     (#985's chimera)

--- a/testnet/local-devnet/genesis-fork-round.allowed-errors
+++ b/testnet/local-devnet/genesis-fork-round.allowed-errors
@@ -18,12 +18,19 @@
 # dugite-bp for the whole freeze and reconnect window.
 TraceNoLedgerView
 
-# #1057 itself: the wedge announcing itself. The WARN fires per declined range and
-# the ERROR once per worker with the operator remedy. Their ABSENCE is what step 4
-# treats as a failure — a silent unrecoverable state cannot be diagnosed in the
-# field.
+# #1057 itself: the wedge announcing itself. The WARN fires per declined range
+# (rate-limited to one per 30s) and the ERROR once per worker with the operator
+# remedy. Their ABSENCE is what step 4 treats as a failure — a silent unrecoverable
+# state cannot be diagnosed in the field.
+#
+# NOTE THE MISSING '#'. The parser treats any line starting with '#' as a COMMENT
+# (`case "$pat" in ''|\#*) continue ;;`), so a pattern written as
+# "#1057: this node cannot rejoin…" is silently DROPPED and the line it was meant
+# to allow then fails the round. That is exactly what happened on the first run
+# here — the silently-weakened-check class (#953) reproduced inside an allowlist.
+# Never start a pattern with '#'.
 declining a range rooted at GENESIS
-#1057: this node cannot rejoin the network
+1057: this node cannot rejoin the network
 
 # The relay's ChainSync task is dropped when the peer's headers sit beyond the
 # forecast horizon and the ledger has not advanced. This is the park→disconnect

--- a/testnet/local-devnet/genesis-fork-round.sh
+++ b/testnet/local-devnet/genesis-fork-round.sh
@@ -445,7 +445,17 @@ DBP_SWITCHED=$(awk -v m="${MARK:-0}" '
 note "dugite-bp chain-switch / ledger-rollback lines after reconnect: ${DBP_SWITCHED:-0}"
 
 if [ "$CONVERGED" -ne 1 ]; then
-    bad "dugite-bp did NOT converge with cardano-bp within ${CONVERGE_TIMEOUT}s (stuck at block ${DBP_AFTER:-?}, cardano-bp at ${CBP_AFTER:-?}) — this is #1057"
+    # NOT a failure by itself, and this is a deliberate change of semantics.
+    #
+    # #1057 half B does not make the LIVE path self-heal — it makes the wedge
+    # RECOVERABLE BY RESTART, which is a different and weaker claim, honestly stated.
+    # The node still cannot adopt a genesis-divergent chain in place: doing that
+    # automatically off a peer's claim would be a remotely-triggerable forced resync.
+    #
+    # So the verdict moved to step 5. Keeping a hard FAIL here would mean the round
+    # could never pass however well recovery worked, and a check that can only ever
+    # fail stops being read.
+    note "dugite-bp did NOT converge on the live path (stuck at block ${DBP_AFTER:-?}, cardano-bp at ${CBP_AFTER:-?}) — EXPECTED with #1057 half B, which recovers by restart rather than in place. Step 5 carries the verdict."
 elif [ "${DBP_SWITCHED:-0}" -eq 0 ]; then
     inconc "tips agree at block ${DBP_AFTER:-?} but dugite-bp logged NO chain switch — its own fork WON chain selection and cardano-bp adopted it, so the genesis-rooted adoption under test never happened. Not a pass: the scenario resolved in the wrong direction. Raise GF_HEAD_START_SLOTS so the cardano island's chain is longer by a wider margin."
 else
@@ -494,7 +504,7 @@ HORIZON=$(count_sig "beyond forecast horizon")
 # `debug!` indistinguishable from the ordinary far-ahead decline, which is half of
 # why this step once reported 0/0/0/0 through a live wedge.
 GENESIS_DECLINE=$(count_sig "declining a range rooted at GENESIS")
-CANNOT_REJOIN=$(count_sig "#1057: this node cannot rejoin the network")
+CANNOT_REJOIN=$(count_sig "1057: this node cannot rejoin the network")
 ROLLBACK_FAIL=$(count_sig "Fork rollback failed")
 ROLLBACK_FAIL_BP=$(count_sig "Fork rollback failed" "$LD_LOGS/dugite-bp.log" "${MARK:-0}")
 ROLLBACK_FAIL=$(( ROLLBACK_FAIL + ROLLBACK_FAIL_BP ))
@@ -521,12 +531,21 @@ note "Fork rollback FAILED (either node)    : ${ROLLBACK_FAIL:-0}"
 #                            #985's "LedgerSeq was incoherent", neither of which is
 #                            allowlisted on purpose.
 if [ "$CONVERGED" -ne 1 ]; then
+    # REQUIRE ONLY WHAT THE NODE UNDER TEST MUST SAY ABOUT ITSELF.
+    #
+    # The genesis-decline WARN is dugite's own diagnostic for its own state, so its
+    # absence is unambiguously a defect. "beyond forecast horizon" was in this set on
+    # the first run and produced a FALSE FAILURE: it is a downstream CONSEQUENCE
+    # whose appearance depends on the 60s park timer landing inside the observation
+    # window and on the log being flushed by the time step 4 reads it — step 4's own
+    # counter saw it while `expect_log_errors` did not, in the same run. A
+    # timing-dependent side effect belongs in the reported NOTEs, not in a hard
+    # assertion.
     if expect_log_errors "$LD_LOGS/dugite-relay.log" "${RELAY_MARK:-0}" \
-            "declining a range rooted at GENESIS" \
-            "beyond forecast horizon"; then
-        ok "the wedge is self-announcing: the genesis-range decline WARN and the horizon drop both appear on dugite-relay after the reconnect (#1057)"
+            "declining a range rooted at GENESIS"; then
+        ok "the wedge is self-announcing: dugite-relay logs the genesis-range decline at the DEFAULT log level (#1057)"
     else
-        bad "the node wedged SILENTLY: a required diagnostic is missing from dugite-relay (see stderr above). An unrecoverable state that logs nothing at the default level cannot be diagnosed in the field (#1057)"
+        bad "the node wedged SILENTLY: dugite-relay never logged 'declining a range rooted at GENESIS'. An unrecoverable state that logs nothing at the default level cannot be diagnosed in the field (#1057)"
     fi
 
     # The WARN is rate-limited to one per 30s per worker. A count in the hundreds
@@ -566,42 +585,91 @@ else
     note "the round FAILED but neither the unfixed nor the bad-fix signature is present — read $LD_LOGS/dugite-relay.log directly before drawing any conclusion"
 fi
 
-# ── step 5: does a genesis-ledger RESTART clear the wedge? ─────────────────
+# ── step 5: does a RESTART recover the node? (#1057 half B) ────────────────
 #
-# DIAGNOSTIC, not an assertion. It runs only when step 3 already established the
-# wedge, and it never changes the verdict — it answers the one question the fix
-# plan turns on.
+# ASSERTION now, not a diagnostic. Half B writes a marker when the wedge is
+# confirmed, and `Node::new` acts on it: discard the dead-end VolatileDB chain
+# (WAL truncated), treat the ledger snapshot as unusable, and wipe the on-disk UTxO
+# store — all on the already-validated from-genesis startup path. So a plain
+# restart MUST now recover, where before it demonstrably did not.
 #
-# The candidate fix is to MARK-AND-RESTART rather than re-initialise the ledger in
-# place: a rollback-to-Origin persists a marker, the node exits cleanly, and
-# `Node::new`'s already-validated from-genesis path rebuilds. That path matters
-# because it WIPES the on-disk LSM UTxO store, and that wipe is load-bearing — the
-# code comment on it records that a stale store makes `sumCoinUTxO` roughly double
-# at the Byron→Shelley boundary, drives the reserves recompute to 0, and underflows
-# the first MIR debit into a panic. A live in-place re-init would have to invent
-# that teardown against open handles; the startup path already has it.
+# BOTH DUGITE NODES ARE RESTARTED, RELAY FIRST, and the order is the point.
 #
-# For that plan to be sufficient, a dugite node whose LEDGER is at Origin but whose
-# ChainDB still holds its own dead-end fork must be able to adopt the peer's chain.
-# Deleting `ledger-snapshot.bin` and restarting reproduces exactly that state.
+# dugite-relay is the node that peers with cardano-bp, so it is the one that
+# declines the genesis-rooted ranges and therefore the one that writes the marker.
+# dugite-bp never sees a genesis-rooted range from the relay while they share a
+# chain — it is stranded behind the relay, not independently wedged. Recovery is
+# therefore TWO HOP: the relay resets and adopts the canonical chain, and only then
+# does dugite-bp see a chain diverging from its own at genesis, wedge in turn, write
+# its own marker, and need its own restart.
 #
-#   adopts -> the restart path alone is sufficient; the storage/BlockFetch genesis
-#             clauses are NOT needed, and the reverted two-layer attempt was
-#             solving the wrong problem entirely.
-#   wedged -> the ChainDB fork blocks adoption regardless of ledger state, so
-#             BlockFetch's #735 gross-request invariant and `switch_chain`'s
-#             ImmutableDB-anchor test each need their genesis clause as well.
+# An operator restarting "the node" would hit exactly this, so the round models it:
+# restart the relay, let it converge, then restart dugite-bp. Anything less would
+# pass a fix that only works on a single-node topology.
 if [ "$CONVERGED" -ne 1 ] && [ "${GF_SKIP_RESTART_PROBE:-0}" -ne 1 ]; then
-    step "5. DIAGNOSTIC — does a genesis-ledger restart clear the wedge?"
-    stop_pid_file "$LD_STATE/dugite-bp.pid" || note "dugite-bp did not exit within 60s of SIGTERM"
-    SNAP="$LD_STATE/dugite-bp.db/ledger-snapshot.bin"
-    if [ -f "$SNAP" ]; then
-        rm -f "$SNAP"
-        note "removed $SNAP — dugite-bp will come up with a GENESIS ledger over a ChainDB that still holds its own ${DBP_NOW_BLK}-block fork"
+    step "5. #1057 half B — a restart must recover both dugite nodes"
+
+    # The marker is the mechanism; if it is absent the rest cannot work, and saying
+    # so here is more useful than a convergence timeout 300s later.
+    RELAY_MARKER="$LD_STATE/dugite-relay.db/genesis-divergence-detected"
+    if [ -f "$RELAY_MARKER" ]; then
+        ok "dugite-relay wrote the #1057 recovery marker: $(tr '\n' ' ' < "$RELAY_MARKER" | cut -c1-120)"
     else
-        note "no ledger-snapshot.bin present; dugite-bp already comes up from genesis"
+        bad "dugite-relay did NOT write $RELAY_MARKER — half B's recovery cannot trigger, so a restart will not help (#1057)"
     fi
-    RESTART_MARK=$(wc -l < "$LD_LOGS/dugite-bp.log" 2>/dev/null)
+
+    # ── hop 1: the relay ──
+    stop_pid_file "$LD_STATE/dugite-relay.pid" || note "dugite-relay did not exit within 60s of SIGTERM"
+    RELAY_RESTART_MARK=$(wc -l < "$LD_LOGS/dugite-relay.log" 2>/dev/null)
+    start_dugite dugite-relay "$LD_RELAY_PORT" "$LD_DUGITE_RELAY_METRICS_PORT" "$LD_RELAY_SOCK"
+    wait_for_socket "$LD_RELAY_SOCK" 180 >/dev/null 2>&1
+
+    if expect_log_errors "$LD_LOGS/dugite-relay.log" "${RELAY_RESTART_MARK:-0}" \
+            "#1057 recovery"; then
+        ok "dugite-relay acted on the marker at startup (#1057 half B)"
+    else
+        bad "dugite-relay restarted but did NOT act on the #1057 marker — check the ImmutableDB-empty and attempt bounds in genesis_divergence::decide"
+    fi
+
+    R_RELAY_CONVERGED=0
+    deadline=$(( $(date +%s) + CONVERGE_TIMEOUT ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        sleep 5
+        RH=$(tip_field "$LD_RELAY_SOCK" .hash)
+        CH=$(tip_field "$LD_CARDANO_BP_SOCK" .hash)
+        if [ -n "$RH" ] && [ -n "$CH" ] && [ "$RH" = "$CH" ]; then
+            R_RELAY_CONVERGED=1
+            break
+        fi
+    done
+    R_RELAY_BLK=$(tip_field "$LD_RELAY_SOCK" .block)
+    R_CBP=$(tip_field "$LD_CARDANO_BP_SOCK" .block)
+    if [ "$R_RELAY_CONVERGED" -eq 1 ]; then
+        ok "hop 1: dugite-relay re-synced from genesis and now matches cardano-bp at block ${R_RELAY_BLK:-?}"
+    else
+        bad "hop 1: dugite-relay did NOT converge with cardano-bp within ${CONVERGE_TIMEOUT}s after the marker restart (relay=${R_RELAY_BLK:-?} cardano-bp=${R_CBP:-?}) — #1057 half B did not recover it"
+    fi
+
+    # ── hop 2: dugite-bp, now facing a relay on the canonical chain ──
+    #
+    # dugite-bp is NOT given any manual help: no snapshot deletion, no marker
+    # written by hand. It must detect the divergence itself, write its own marker,
+    # and recover on its own restart — which is what makes this a test of the
+    # mechanism rather than of the harness.
+    note "hop 2: dugite-bp still holds its own ${DBP_NOW_BLK:-?}-block chain; waiting for it to detect the divergence and write its own marker"
+    BP_MARKER="$LD_STATE/dugite-bp.db/genesis-divergence-detected"
+    deadline=$(( $(date +%s) + 240 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        [ -f "$BP_MARKER" ] && break
+        sleep 5
+    done
+    if [ -f "$BP_MARKER" ]; then
+        ok "dugite-bp detected the divergence and wrote its own marker"
+    else
+        bad "dugite-bp never wrote $BP_MARKER — a node stranded behind a recovered relay must detect its own genesis divergence (#1057)"
+    fi
+
+    stop_pid_file "$LD_STATE/dugite-bp.pid" || note "dugite-bp did not exit within 60s of SIGTERM"
     start_dugite dugite-bp "$LD_DUGITE_BP_PORT" "$LD_DUGITE_BP_METRICS_PORT" "$LD_DUGITE_BP_SOCK" pool1
     wait_for_socket "$LD_DUGITE_BP_SOCK" 180 >/dev/null 2>&1
 
@@ -618,28 +686,10 @@ if [ "$CONVERGED" -ne 1 ] && [ "${GF_SKIP_RESTART_PROBE:-0}" -ne 1 ]; then
     done
     R_DBP=$(tip_field "$LD_DUGITE_BP_SOCK" .block)
     R_CBP=$(tip_field "$LD_CARDANO_BP_SOCK" .block)
-    R_HORIZON=$(count_sig "beyond forecast horizon" "$LD_LOGS/dugite-bp.log" "${RESTART_MARK:-0}")
     if [ "$R_CONVERGED" -eq 1 ]; then
-        note "RESTART PATH IS SUFFICIENT: with a genesis ledger, dugite-bp adopted the peer's chain (block ${R_DBP:-?} == cardano-bp). The fix is marker + clean exit + the existing from-genesis startup path; the storage/BlockFetch genesis clauses are NOT required."
+        ok "hop 2: dugite-bp recovered too — tip hash matches cardano-bp at block ${R_DBP:-?}. #1057 is RECOVERABLE BY RESTART."
     else
-        # TWO DIFFERENT CAUSES look identical here, and conflating them wasted a
-        # cycle: the genesis clause may be ABSENT, or it may be PRESENT but gated
-        # off. #1057 half A gates both layers on `ledger_at_origin`, and that turns
-        # out to be a transient boot state — `run()` replays the ChainDB and
-        # re-applies the node's own fork within seconds, so the ledger has left
-        # Origin long before a peer offers a genesis-rooted range. Measured:
-        # `tip_slot=36` twelve seconds after boot, `lag_slots=766`.
-        #
-        # The discriminator is dugite-bp's OWN ledger tip after the restart. If it
-        # is at its own fork's tip rather than Origin, the clause was gated off, not
-        # missing.
-        R_DBP_SLOT=$(tip_field "$LD_DUGITE_BP_SOCK" .slot)
-        note "RESTART PATH IS NOT SUFFICIENT: dugite-bp came up at genesis and STILL did not adopt (block ${R_DBP:-?} vs cardano-bp ${R_CBP:-?}, slot ${R_DBP_SLOT:-?}, horizon drops ${R_HORIZON:-0})."
-        if [ "${R_DBP_SLOT:-0}" -gt 0 ]; then
-            note "  ... and its ledger is at slot ${R_DBP_SLOT} — NOT Origin. The startup ChainDB replay re-applied its own fork, so any fix gated on \"the ledger is at Origin\" is DORMANT: the precondition is false by the time it would matter. The gate needs to be \"the ledger CAN be taken to Origin\" (local chain within k of genesis, matching ChainSync's own clause) plus a real genesis re-init — #1057 half B."
-        else
-            note "  ... and its ledger IS still at Origin, so the genesis clause in BlockFetch's #735 invariant / switch_chain's anchor test is genuinely missing or not reached."
-        fi
+        bad "hop 2: dugite-bp did NOT converge within ${CONVERGE_TIMEOUT}s after its own marker restart (dugite-bp=${R_DBP:-?} cardano-bp=${R_CBP:-?}) — #1057"
     fi
 fi
 
@@ -654,7 +704,7 @@ elif [ "$INCONCLUSIVE" -gt 0 ]; then
     ./stop.sh >/dev/null 2>&1
     exit 3
 else
-    echo "GENESIS-FORK ROUND: PASS — dugite-bp crossed a genesis-rooted fork"
+    echo "GENESIS-FORK ROUND: PASS — the genesis divergence was detected, announced, and RECOVERED (see step 5). Note this is recovery-by-restart, not live self-healing: #1057's wedge still occurs, it is no longer permanent."
     ./stop.sh >/dev/null 2>&1
     exit 0
 fi

--- a/testnet/local-devnet/genesis-fork-round.sh
+++ b/testnet/local-devnet/genesis-fork-round.sh
@@ -71,37 +71,58 @@
 # The lesson generalises past this script: when a negative result says "the node
 # refused to do X", first prove the node was CONFIGURED to do X.
 #
-# Usage:
-#   ./genesis-fork-round.sh
-#   GF_MIN_FORK_BLOCKS=3 ./genesis-fork-round.sh
+# THE HEAD START IS LOAD-BEARING, and this is the second thing the round got wrong.
 #
-# Terminal: tears the devnet down at the end.
+# With both islands running up symmetrically, they reach roughly equal depth and
+# DUGITE's fork tends to win chain selection — cardano-bp adopts dugite's chain and
+# the adoption path under test is never entered. Measured, on main with the #1057
+# fix reverted:
 #
-# STATUS: THIS CONSTRUCTION DOES NOT YET WORK. Two attempts, both measured:
+#   GF_MIN_FORK_BLOCKS=4  dugite=4 cardano=5  converged at block 11, 0 switches
+#   GF_MIN_FORK_BLOCKS=8  dugite=9 cardano=9  converged at block 13, 0 switches
 #
-#   (a) dugite-bp fully isolated (empty topology): forged 0 blocks while
-#       cardano-bp reached 43.
-#   (b) dugite-bp peered with dugite-relay, the pair isolated from the cardano
-#       island: forged 0 blocks, ZERO `TraceStartLeadershipCheck`, while
-#       cardano-bp reached 60.
+# Both INCONCLUSIVE, and both would have read as PASS on tip-hash equality alone.
 #
-# In (b) the forge loop never even reached its leadership check, so the silent
-# catch-up gate at the top of `try_forge_block_at` short-circuited every slot.
-# Both dugite nodes start at Origin, so no peer can supply the non-Origin
-# intersection the peer-connectivity gate wants, and `tip_slot` stays 0 — the
-# dugite island cannot bootstrap its own chain at all. That is the deliberate
-# Bug-A/Bug-G protection working: a dugite BP does not mint the first block of a
-# chain.
+# So the dugite island is FROZEN at a shallow tip while the cardano island runs
+# far ahead (step 2b): stop dugite-relay and dugite-bp loses its only peer, which
+# makes the peer-connectivity forge gate stop it extending its own chain — the
+# gate working FOR the construction. dugite-bp itself is never restarted.
 #
-# WHICH LEAVES AN OPEN QUESTION ON #1057: in the original occurrence dugite-bp
-# DID forge `block_no=0` (slot 4) and its 9-block chain shared NO block with the
-# peer's. Something let it past both gates. Until that mechanism is understood
-# this round will keep reporting INCONCLUSIVE, and #1057's fix cannot be
-# verified — which is exactly why the first fix attempt shipped broken.
+# The gap is measured in SLOTS, not blocks, because the target is the forecast
+# horizon: devnet is k=40, f=0.5, slotLength=1s, so 3k/f = 240 slots. A default
+# GF_HEAD_START_SLOTS=300 puts the peer's headers definitively beyond it. That
+# mirrors the original occurrence — dugite frozen at slot 21 while the network ran
+# to slot 1004 — and the horizon park is what turns a declined BlockFetch range
+# into the endless peer-churn loop.
 #
-# The round is checked in anyway because it (1) records these two measured
-# negatives so they are not re-derived, and (2) refuses to emit a verdict when
-# the scenario is unbuilt, instead of passing vacuously.
+# MEASURED — #1057 REPRODUCED (2026-08-06, main with the reverted fix):
+#
+#   fork depths           dugite-bp=5 (6 forged), cardano-bp=7, chains differ
+#   after the freeze      dugite-bp slot=18 block=5 | cardano-bp slot=326 block=93
+#                         slot gap=308 (> the 240-slot horizon)
+#   bridge restored       dugite-bp STAYED at block 5 for the full 300s while
+#                         cardano-bp reached 167. 0 chain switches. FAIL.
+#
+# dugite-bp's own log shows it frozen and unable even to try:
+#   ERROR forge: TraceNoLedgerView: chain tip too far behind for ledger view
+#     forecast — skipping forge current_slot=627 tip_slot=18 lag_slots=609
+#     stability_window=240
+#
+# and dugite-relay's log carries the loop itself, repeating verbatim on every
+# reconnect with nothing in between:
+#   ChainSync intersection found peer_addr=127.0.0.1:3003 point=origin
+#     tip_slot=332 tip_block_number=95
+#   ChainSync intersection at Origin with non-Origin local chain — accepting
+#     because local chain is within k blocks of genesis …
+#   ChainSync rollback rollback_point=origin tip_slot=332 tip_block_number=95
+#   WARN chainsync task failed addr=127.0.0.1:3003 error=… header slot 340
+#     beyond forecast horizon — no ledger progress for 60s
+#
+# That refines #1057's diagnosis in one useful way: ChainSync ALREADY accepts the
+# Origin intersection, and nothing at all is logged between the rollback and the
+# 60s timeout. The blocker is downstream of ChainSync — BlockFetch's #735
+# gross-request invariant declines the peer's block 0 (at `debug!`, hence the
+# silence), the ledger never advances, and the horizon park kills the peer.
 
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 2
 . ./lib/common.sh
@@ -116,6 +137,13 @@ unsetopt ERR_EXIT ERR_RETURN 2>/dev/null || true
 MIN_FORK_BLOCKS="${GF_MIN_FORK_BLOCKS:-5}"
 CONVERGE_TIMEOUT="${GF_CONVERGE_TIMEOUT:-300}"
 FORK_BUILD_TIMEOUT="${GF_FORK_BUILD_TIMEOUT:-300}"
+# > 3k/f = 240 slots on this devnet (k=40, f=0.5), so the peer's headers land
+# beyond dugite-bp's forecast horizon — the condition the original #1057
+# occurrence had and the reason its park loop never self-healed.
+HEAD_START_SLOTS="${GF_HEAD_START_SLOTS:-300}"
+# slotLength is 1s and only pool2 (40% stake) forges on the cardano island, so
+# 300 slots of lead is ~300s of wall clock. 900 leaves generous headroom.
+HEAD_START_TIMEOUT="${GF_HEAD_START_TIMEOUT:-900}"
 
 FAILURES=0
 INCONCLUSIVE=0
@@ -298,11 +326,64 @@ if [ "$INCONCLUSIVE" -gt 0 ]; then
     exit 3
 fi
 
+# ── step 2b: freeze the dugite island, let cardano run far ahead ───────────
+# Equal-depth forks resolve in the WRONG direction (dugite's fork wins and cardano
+# adopts it), so the peer's chain must be strictly longer AND its headers must sit
+# beyond dugite-bp's forecast horizon.
+#
+# dugite-relay is dugite-bp's only peer, so stopping it leaves dugite-bp peerless
+# and the peer-connectivity forge gate stops it extending its own chain. dugite-bp
+# is NOT restarted — the adoption still has to happen on the live path.
+step "2b. freeze the dugite island; cardano runs >= ${HEAD_START_SLOTS} slots ahead"
+
+stop_pid_file "$LD_STATE/dugite-relay.pid" || note "dugite-relay did not exit within 60s of SIGTERM"
+sleep 5
+DBP_FROZEN_SLOT=$(tip_field "$LD_DUGITE_BP_SOCK" .slot); DBP_FROZEN_SLOT=${DBP_FROZEN_SLOT:-0}
+DBP_FROZEN_BLK=$(tip_field "$LD_DUGITE_BP_SOCK" .block); DBP_FROZEN_BLK=${DBP_FROZEN_BLK:-0}
+note "dugite-bp frozen at slot=$DBP_FROZEN_SLOT block=$DBP_FROZEN_BLK (peerless)"
+
+deadline=$(( $(date +%s) + HEAD_START_TIMEOUT ))
+CBP_SLOT=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    CBP_SLOT=$(tip_field "$LD_CARDANO_BP_SOCK" .slot); CBP_SLOT=${CBP_SLOT:-0}
+    [ "$CBP_SLOT" -ge $(( DBP_FROZEN_SLOT + HEAD_START_SLOTS )) ] && break
+    sleep 10
+done
+
+# Re-read dugite-bp: if it kept forging while peerless, the gap must be recomputed
+# from where it ACTUALLY is, not from where it was when the relay died.
+DBP_NOW_SLOT=$(tip_field "$LD_DUGITE_BP_SOCK" .slot); DBP_NOW_SLOT=${DBP_NOW_SLOT:-0}
+DBP_NOW_BLK=$(tip_field "$LD_DUGITE_BP_SOCK" .block);  DBP_NOW_BLK=${DBP_NOW_BLK:-0}
+CBP_BLK2=$(tip_field "$LD_CARDANO_BP_SOCK" .block);    CBP_BLK2=${CBP_BLK2:-0}
+SLOT_GAP=$(( CBP_SLOT - DBP_NOW_SLOT ))
+note "dugite-bp slot=$DBP_NOW_SLOT block=$DBP_NOW_BLK | cardano-bp slot=$CBP_SLOT block=$CBP_BLK2 | slot gap=$SLOT_GAP"
+
+if [ "$DBP_NOW_BLK" -gt "$DBP_FROZEN_BLK" ]; then
+    note "dugite-bp advanced $DBP_FROZEN_BLK -> $DBP_NOW_BLK while peerless (the forge gate did not hold it); the gap below is what matters"
+fi
+
+if [ "$CBP_BLK2" -le "$DBP_NOW_BLK" ]; then
+    inconc "cardano-bp's chain is NOT strictly longer (cardano=$CBP_BLK2 dugite=$DBP_NOW_BLK) — dugite's fork would win chain selection again. Raise GF_HEAD_START_SLOTS or GF_HEAD_START_TIMEOUT."
+fi
+if [ "$SLOT_GAP" -lt 240 ]; then
+    inconc "slot gap $SLOT_GAP is inside the 240-slot forecast horizon — the horizon park that made #1057 unrecoverable would not be reached. Raise GF_HEAD_START_SLOTS or GF_HEAD_START_TIMEOUT."
+fi
+
+if [ "$INCONCLUSIVE" -gt 0 ]; then
+    echo; echo "GENESIS-FORK ROUND: INCONCLUSIVE ($INCONCLUSIVE precondition(s) unmet)"
+    ./stop.sh >/dev/null 2>&1
+    exit 3
+fi
+ok "preconditions met: dugite-bp holds its own $DBP_NOW_BLK-block genesis-rooted chain, cardano-bp is $((CBP_BLK2 - DBP_NOW_BLK)) blocks / $SLOT_GAP slots ahead on an incompatible one"
+
 # ── step 3: restore the bridge; dugite-bp must adopt ───────────────────────
 step "3. restore the bridge — dugite-bp must adopt a chain diverging at GENESIS"
 MARK=$(wc -l < "$LD_LOGS/dugite-bp.log" 2>/dev/null)
+# Both node logs are APPENDED across the restart, so step 4 must count only what
+# happens after the bridge is restored. The pre-restore relay never saw cardano-bp
+# at all, but relying on that is fragile — mark it explicitly.
+RELAY_MARK=$(wc -l < "$LD_LOGS/dugite-relay.log" 2>/dev/null)
 
-stop_pid_file "$LD_STATE/dugite-relay.pid" || note "dugite-relay did not exit within 60s of SIGTERM"
 stop_pid_file "$LD_STATE/cardano-bp.pid"   || note "cardano-bp did not exit within 60s of SIGTERM"
 
 cp "$LD_STATE/relay.topology.real.json" "$RELAY_TOPO"
@@ -362,37 +443,134 @@ note "dugite-bp chain-switch / ledger-rollback lines after reconnect: ${DBP_SWIT
 if [ "$CONVERGED" -ne 1 ]; then
     bad "dugite-bp did NOT converge with cardano-bp within ${CONVERGE_TIMEOUT}s (stuck at block ${DBP_AFTER:-?}, cardano-bp at ${CBP_AFTER:-?}) — this is #1057"
 elif [ "${DBP_SWITCHED:-0}" -eq 0 ]; then
-    inconc "tips agree at block ${DBP_AFTER:-?} but dugite-bp logged NO chain switch — its own fork WON chain selection and cardano-bp adopted it, so the genesis-rooted adoption under test never happened. Not a pass: the scenario resolved in the wrong direction. Give the cardano island a head start (raise GF_MIN_FORK_BLOCKS or start it first) so its chain is strictly longer."
+    inconc "tips agree at block ${DBP_AFTER:-?} but dugite-bp logged NO chain switch — its own fork WON chain selection and cardano-bp adopted it, so the genesis-rooted adoption under test never happened. Not a pass: the scenario resolved in the wrong direction. Raise GF_HEAD_START_SLOTS so the cardano island's chain is longer by a wider margin."
 else
     ok "dugite-bp ADOPTED the genesis-divergent chain: crossed a fork it did not build (${DBP_SWITCHED} switch/rollback line(s)), tip hash matches cardano-bp at block ${DBP_AFTER:-?}"
 fi
 
 # ── step 4: name the wedge signatures ──────────────────────────────────────
+#
+# THE WEDGED NODE IS THE RELAY, and the first version of this step looked in the
+# wrong place. dugite-relay is the node that peers directly with cardano-bp, so it
+# is the one that must adopt the genesis-divergent chain; dugite-bp is one hop
+# downstream and cannot adopt anything the relay has not adopted first. Both hold
+# their own copy of dugite's short chain, so both need the fix — but only the
+# relay's log carries the loop.
+#
+# Measured signature counts on dugite-bp.log alone were 0/0/0/0 while the wedge
+# was plainly happening on the relay. Two independent reasons, both worth knowing:
+#
+#   1. wrong node's log (above), and
+#   2. "BlockFetch: declining far-ahead range" is a `debug!`, so it never appears
+#      at the devnet's default log level at all. A signature that cannot be
+#      observed is not a signature.
+#
+# So the loop itself is the signature, and every line of it IS emitted at INFO:
+#
+#   ChainSync intersection found  peer_addr=<cardano-bp> point=origin tip_slot=332
+#   ChainSync intersection at Origin with non-Origin local chain — accepting …
+#   ChainSync rollback            rollback_point=origin
+#   WARN chainsync task failed    error=… header slot 340 beyond forecast horizon
+#                                 — no ledger progress for 60s
+#   … then reconnect and repeat, forever.
+#
+# Note what that sequence proves: ChainSync ALREADY accepts the Origin
+# intersection. The blocker is downstream — BlockFetch's #735 gross-request
+# invariant declines the peer's block 0, the ledger never advances, and the
+# horizon park then kills the peer. #1057's ChainSync layer needs no change.
 step "4. wedge signatures — these distinguish unfixed from a BAD fix"
-count_sig() {
-    awk -v m="${MARK:-0}" -v p="$1" 'NR > m && index($0, p) {c++} END{print c+0}' \
-        "$LD_LOGS/dugite-bp.log" 2>/dev/null
+count_sig() { # <phrase> [logfile] [mark]
+    awk -v p="$1" -v m="${3:-${RELAY_MARK:-0}}" 'NR > m && index($0, p) {c++} END{print c+0}' \
+        "${2:-$LD_LOGS/dugite-relay.log}" 2>/dev/null
 }
-DECLINED=$(count_sig "declining far-ahead range")
+ORIGIN_ACCEPT=$(count_sig "intersection at Origin with non-Origin local chain")
+ORIGIN_RB=$(count_sig "rollback_point=origin")
 HORIZON=$(count_sig "beyond forecast horizon")
 ROLLBACK_FAIL=$(count_sig "Fork rollback failed")
-ORIGIN_RB=$(count_sig "intersection=00000000")
-note "BlockFetch declined a far-ahead range : ${DECLINED:-0}"
+ROLLBACK_FAIL_BP=$(count_sig "Fork rollback failed" "$LD_LOGS/dugite-bp.log" "${MARK:-0}")
+ROLLBACK_FAIL=$(( ROLLBACK_FAIL + ROLLBACK_FAIL_BP ))
+note "relay accepted an Origin intersection : ${ORIGIN_ACCEPT:-0}"
+note "relay rolled ChainSync back to Origin : ${ORIGIN_RB:-0}"
 note "peer dropped at forecast horizon      : ${HORIZON:-0}"
-note "ledger asked to roll back to Origin   : ${ORIGIN_RB:-0}"
-note "Fork rollback FAILED                  : ${ROLLBACK_FAIL:-0}"
+note "Fork rollback FAILED (either node)    : ${ROLLBACK_FAIL:-0}"
+RELAY_TIP=$(tip_field "$LD_RELAY_SOCK" .block)
+note "dugite-relay block=${RELAY_TIP:-?} vs cardano-bp block=${CBP_AFTER:-?}"
 
-# unfixed  -> declined/horizon > 0, rollback_fail == 0  (switch never attempted)
-# bad fix  -> rollback_fail > 0                         (attempted, ledger refused)
-# fixed    -> converged, both 0
+# unfixed  -> origin intersection accepted, horizon drops > 0, rollback_fail == 0
+#             (ChainSync tried, BlockFetch declined block 0, nothing advanced)
+# bad fix  -> rollback_fail > 0  (storage emitted a genesis-rooted SwitchPlan and
+#                                 the ledger refused it — the reverted attempt)
+# fixed    -> converged, horizon drops 0
 if [ "${ROLLBACK_FAIL:-0}" -gt 0 ]; then
     bad "BAD-FIX SHAPE: the chain switch was ATTEMPTED but the ledger could not roll back to Origin. A genesis-rooted SwitchPlan from storage is necessary but NOT sufficient — the ledger must re-initialise from genesis (#1057)"
 elif [ "$CONVERGED" -eq 1 ] && [ "${DBP_SWITCHED:-0}" -gt 0 ]; then
     ok "no wedge signatures after a successful genesis-rooted adoption"
 elif [ "$CONVERGED" -eq 1 ]; then
     note "no wedge signatures — but see the INCONCLUSIVE above: dugite-bp never crossed the fork, so their absence is not evidence about #1057"
+elif [ "${HORIZON:-0}" -gt 0 ] && [ "${ORIGIN_RB:-0}" -gt 0 ]; then
+    note "UNFIXED SHAPE CONFIRMED on dugite-relay: it accepted the Origin intersection ${ORIGIN_ACCEPT} time(s), rolled ChainSync back to Origin ${ORIGIN_RB} time(s), made no ledger progress, and was dropped at the forecast horizon ${HORIZON} time(s) — the endless reconnect loop of #1057, with dugite-bp stranded behind it"
 else
-    note "UNFIXED SHAPE: the switch was never attempted (BlockFetch declined the range / the horizon park dropped peers)"
+    note "the round FAILED but neither the unfixed nor the bad-fix signature is present — read $LD_LOGS/dugite-relay.log directly before drawing any conclusion"
+fi
+
+# ── step 5: does a genesis-ledger RESTART clear the wedge? ─────────────────
+#
+# DIAGNOSTIC, not an assertion. It runs only when step 3 already established the
+# wedge, and it never changes the verdict — it answers the one question the fix
+# plan turns on.
+#
+# The candidate fix is to MARK-AND-RESTART rather than re-initialise the ledger in
+# place: a rollback-to-Origin persists a marker, the node exits cleanly, and
+# `Node::new`'s already-validated from-genesis path rebuilds. That path matters
+# because it WIPES the on-disk LSM UTxO store, and that wipe is load-bearing — the
+# code comment on it records that a stale store makes `sumCoinUTxO` roughly double
+# at the Byron→Shelley boundary, drives the reserves recompute to 0, and underflows
+# the first MIR debit into a panic. A live in-place re-init would have to invent
+# that teardown against open handles; the startup path already has it.
+#
+# For that plan to be sufficient, a dugite node whose LEDGER is at Origin but whose
+# ChainDB still holds its own dead-end fork must be able to adopt the peer's chain.
+# Deleting `ledger-snapshot.bin` and restarting reproduces exactly that state.
+#
+#   adopts -> the restart path alone is sufficient; the storage/BlockFetch genesis
+#             clauses are NOT needed, and the reverted two-layer attempt was
+#             solving the wrong problem entirely.
+#   wedged -> the ChainDB fork blocks adoption regardless of ledger state, so
+#             BlockFetch's #735 gross-request invariant and `switch_chain`'s
+#             ImmutableDB-anchor test each need their genesis clause as well.
+if [ "$CONVERGED" -ne 1 ] && [ "${GF_SKIP_RESTART_PROBE:-0}" -ne 1 ]; then
+    step "5. DIAGNOSTIC — does a genesis-ledger restart clear the wedge?"
+    stop_pid_file "$LD_STATE/dugite-bp.pid" || note "dugite-bp did not exit within 60s of SIGTERM"
+    SNAP="$LD_STATE/dugite-bp.db/ledger-snapshot.bin"
+    if [ -f "$SNAP" ]; then
+        rm -f "$SNAP"
+        note "removed $SNAP — dugite-bp will come up with a GENESIS ledger over a ChainDB that still holds its own ${DBP_NOW_BLK}-block fork"
+    else
+        note "no ledger-snapshot.bin present; dugite-bp already comes up from genesis"
+    fi
+    RESTART_MARK=$(wc -l < "$LD_LOGS/dugite-bp.log" 2>/dev/null)
+    start_dugite dugite-bp "$LD_DUGITE_BP_PORT" "$LD_DUGITE_BP_METRICS_PORT" "$LD_DUGITE_BP_SOCK" pool1
+    wait_for_socket "$LD_DUGITE_BP_SOCK" 180 >/dev/null 2>&1
+
+    R_CONVERGED=0
+    deadline=$(( $(date +%s) + CONVERGE_TIMEOUT ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        sleep 5
+        DBP_H=$(tip_field "$LD_DUGITE_BP_SOCK" .hash)
+        CBP_H=$(tip_field "$LD_CARDANO_BP_SOCK" .hash)
+        if [ -n "$DBP_H" ] && [ -n "$CBP_H" ] && [ "$DBP_H" = "$CBP_H" ]; then
+            R_CONVERGED=1
+            break
+        fi
+    done
+    R_DBP=$(tip_field "$LD_DUGITE_BP_SOCK" .block)
+    R_CBP=$(tip_field "$LD_CARDANO_BP_SOCK" .block)
+    R_HORIZON=$(count_sig "beyond forecast horizon" "$LD_LOGS/dugite-bp.log" "${RESTART_MARK:-0}")
+    if [ "$R_CONVERGED" -eq 1 ]; then
+        note "RESTART PATH IS SUFFICIENT: with a genesis ledger, dugite-bp adopted the peer's chain (block ${R_DBP:-?} == cardano-bp). The fix is marker + clean exit + the existing from-genesis startup path; the storage/BlockFetch genesis clauses are NOT required."
+    else
+        note "RESTART PATH IS NOT SUFFICIENT: dugite-bp came up at genesis and STILL did not adopt (block ${R_DBP:-?} vs cardano-bp ${R_CBP:-?}, horizon drops ${R_HORIZON:-0}). The ChainDB fork blocks adoption independently of ledger state, so BlockFetch's #735 invariant and switch_chain's anchor test both need their genesis clause."
+    fi
 fi
 
 # ── summary ────────────────────────────────────────────────────────────────

--- a/testnet/local-devnet/genesis-fork-round.sh
+++ b/testnet/local-devnet/genesis-fork-round.sh
@@ -168,6 +168,28 @@ tip_field() {
     cardano-cli query tip --testnet-magic "$LD_MAGIC" --socket-path "$1" 2>/dev/null \
         | jq -r "$2 // empty" 2>/dev/null
 }
+
+# Why `tip_field` returned nothing.
+#
+# Three runs in a row reported `relay=?` from an EMPTY `tip_field`, and I read that
+# as "the relay did not converge" when it actually meant "the measurement failed" —
+# the node was alive with peers and its N2C socket was listening. An assertion built
+# on an unreadable value is the reports-nothing-while-looking-definite class
+# (#916/#945): it cannot distinguish a wedged node from an unqueryable one.
+#
+# So when a tip read comes back empty, say WHY: whether the socket file exists, and
+# what cardano-cli actually wrote to stderr.
+explain_tip_failure() { # <label> <sock>
+    local label="$1" sock="$2" err
+    [ -S "$sock" ] || { note "  $label: no socket at $sock (node not listening)"; return; }
+    err=$(cardano-cli query tip --testnet-magic "$LD_MAGIC" --socket-path "$sock" 2>&1 >/dev/null \
+          | tr '\n' ' ' | cut -c1-220)
+    if [ -n "$err" ]; then
+        note "  $label: socket present but 'query tip' failed: $err"
+    else
+        note "  $label: socket present and 'query tip' succeeded — the jq field selector found nothing (unexpected shape)"
+    fi
+}
 forge_count() { awk '/TraceForgedBlock/ {c++} END{print c+0}' "$1" 2>/dev/null; }
 
 # start_dugite <name> <port> <metrics> <sock> [forge-pool]
@@ -646,8 +668,12 @@ if [ "$CONVERGED" -ne 1 ] && [ "${GF_SKIP_RESTART_PROBE:-0}" -ne 1 ]; then
     R_CBP=$(tip_field "$LD_CARDANO_BP_SOCK" .block)
     if [ "$R_RELAY_CONVERGED" -eq 1 ]; then
         ok "hop 1: dugite-relay re-synced from genesis and now matches cardano-bp at block ${R_RELAY_BLK:-?}"
+    elif [ -z "$R_RELAY_BLK" ]; then
+        # UNMEASURED is not the same as FAILED, and conflating them cost three runs.
+        inconc "hop 1: dugite-relay's tip is UNREADABLE, so whether it recovered is unknown — not a failure, an unmeasured result"
+        explain_tip_failure "dugite-relay" "$LD_RELAY_SOCK"
     else
-        bad "hop 1: dugite-relay did NOT converge with cardano-bp within ${CONVERGE_TIMEOUT}s after the marker restart (relay=${R_RELAY_BLK:-?} cardano-bp=${R_CBP:-?}) — #1057 half B did not recover it"
+        bad "hop 1: dugite-relay did NOT converge with cardano-bp within ${CONVERGE_TIMEOUT}s after the marker restart (relay=${R_RELAY_BLK} cardano-bp=${R_CBP:-?}) — #1057 half B did not recover it"
     fi
 
     # ── hop 2: dugite-bp, now facing a relay on the canonical chain ──
@@ -688,8 +714,12 @@ if [ "$CONVERGED" -ne 1 ] && [ "${GF_SKIP_RESTART_PROBE:-0}" -ne 1 ]; then
     R_CBP=$(tip_field "$LD_CARDANO_BP_SOCK" .block)
     if [ "$R_CONVERGED" -eq 1 ]; then
         ok "hop 2: dugite-bp recovered too — tip hash matches cardano-bp at block ${R_DBP:-?}. #1057 is RECOVERABLE BY RESTART."
+    elif [ -z "$R_DBP" ]; then
+        inconc "hop 2: dugite-bp's tip is UNREADABLE, so whether it recovered is unknown — not a failure, an unmeasured result"
+        explain_tip_failure "dugite-bp" "$LD_DUGITE_BP_SOCK"
     else
-        bad "hop 2: dugite-bp did NOT converge within ${CONVERGE_TIMEOUT}s after its own marker restart (dugite-bp=${R_DBP:-?} cardano-bp=${R_CBP:-?}) — #1057"
+        bad "hop 2: dugite-bp did NOT converge within ${CONVERGE_TIMEOUT}s after its own marker restart (dugite-bp=${R_DBP} cardano-bp=${R_CBP:-?}) — #1057"
+        explain_tip_failure "dugite-bp" "$LD_DUGITE_BP_SOCK"
     fi
 fi
 

--- a/testnet/local-devnet/genesis-fork-round.sh
+++ b/testnet/local-devnet/genesis-fork-round.sh
@@ -569,7 +569,24 @@ if [ "$CONVERGED" -ne 1 ] && [ "${GF_SKIP_RESTART_PROBE:-0}" -ne 1 ]; then
     if [ "$R_CONVERGED" -eq 1 ]; then
         note "RESTART PATH IS SUFFICIENT: with a genesis ledger, dugite-bp adopted the peer's chain (block ${R_DBP:-?} == cardano-bp). The fix is marker + clean exit + the existing from-genesis startup path; the storage/BlockFetch genesis clauses are NOT required."
     else
-        note "RESTART PATH IS NOT SUFFICIENT: dugite-bp came up at genesis and STILL did not adopt (block ${R_DBP:-?} vs cardano-bp ${R_CBP:-?}, horizon drops ${R_HORIZON:-0}). The ChainDB fork blocks adoption independently of ledger state, so BlockFetch's #735 invariant and switch_chain's anchor test both need their genesis clause."
+        # TWO DIFFERENT CAUSES look identical here, and conflating them wasted a
+        # cycle: the genesis clause may be ABSENT, or it may be PRESENT but gated
+        # off. #1057 half A gates both layers on `ledger_at_origin`, and that turns
+        # out to be a transient boot state — `run()` replays the ChainDB and
+        # re-applies the node's own fork within seconds, so the ledger has left
+        # Origin long before a peer offers a genesis-rooted range. Measured:
+        # `tip_slot=36` twelve seconds after boot, `lag_slots=766`.
+        #
+        # The discriminator is dugite-bp's OWN ledger tip after the restart. If it
+        # is at its own fork's tip rather than Origin, the clause was gated off, not
+        # missing.
+        R_DBP_SLOT=$(tip_field "$LD_DUGITE_BP_SOCK" .slot)
+        note "RESTART PATH IS NOT SUFFICIENT: dugite-bp came up at genesis and STILL did not adopt (block ${R_DBP:-?} vs cardano-bp ${R_CBP:-?}, slot ${R_DBP_SLOT:-?}, horizon drops ${R_HORIZON:-0})."
+        if [ "${R_DBP_SLOT:-0}" -gt 0 ]; then
+            note "  ... and its ledger is at slot ${R_DBP_SLOT} — NOT Origin. The startup ChainDB replay re-applied its own fork, so any fix gated on \"the ledger is at Origin\" is DORMANT: the precondition is false by the time it would matter. The gate needs to be \"the ledger CAN be taken to Origin\" (local chain within k of genesis, matching ChainSync's own clause) plus a real genesis re-init — #1057 half B."
+        else
+            note "  ... and its ledger IS still at Origin, so the genesis clause in BlockFetch's #735 invariant / switch_chain's anchor test is genuinely missing or not reached."
+        fi
     fi
 fi
 

--- a/testnet/local-devnet/genesis-fork-round.sh
+++ b/testnet/local-devnet/genesis-fork-round.sh
@@ -126,6 +126,10 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 2
 . ./lib/common.sh
+# The shared expected-error/allowlist oracle (#1041), same as kes-round and
+# rollback-round. Sourced BEFORE the errexit relaxation below for the same
+# order-is-load-bearing reason: anything it pulls in may `set -e`.
+. ./lib/expect-log-errors.sh
 
 # ORDER IS LOAD-BEARING: lib/common.sh line 4 is `set -euo pipefail`, so relaxing
 # errexit before sourcing it does nothing. A round that ABORTS instead of FAILING
@@ -486,13 +490,62 @@ count_sig() { # <phrase> [logfile] [mark]
 ORIGIN_ACCEPT=$(count_sig "intersection at Origin with non-Origin local chain")
 ORIGIN_RB=$(count_sig "rollback_point=origin")
 HORIZON=$(count_sig "beyond forecast horizon")
+# The decline itself, now observable at the DEFAULT log level. It used to be a
+# `debug!` indistinguishable from the ordinary far-ahead decline, which is half of
+# why this step once reported 0/0/0/0 through a live wedge.
+GENESIS_DECLINE=$(count_sig "declining a range rooted at GENESIS")
+CANNOT_REJOIN=$(count_sig "#1057: this node cannot rejoin the network")
 ROLLBACK_FAIL=$(count_sig "Fork rollback failed")
 ROLLBACK_FAIL_BP=$(count_sig "Fork rollback failed" "$LD_LOGS/dugite-bp.log" "${MARK:-0}")
 ROLLBACK_FAIL=$(( ROLLBACK_FAIL + ROLLBACK_FAIL_BP ))
 note "relay accepted an Origin intersection : ${ORIGIN_ACCEPT:-0}"
 note "relay rolled ChainSync back to Origin : ${ORIGIN_RB:-0}"
+note "BlockFetch declined a GENESIS range   : ${GENESIS_DECLINE:-0}"
+note "escalated 'cannot rejoin' ERROR       : ${CANNOT_REJOIN:-0}"
 note "peer dropped at forecast horizon      : ${HORIZON:-0}"
 note "Fork rollback FAILED (either node)    : ${ROLLBACK_FAIL:-0}"
+
+# The diagnostics are an ASSERTION, not decoration — via the SHARED oracle
+# (lib/expect-log-errors.sh, #1041) rather than a hand-rolled count, so this round
+# classifies error-class lines the same way analyze-evidence.sh and
+# generate-release-report.sh do. A round with its own private notion of "an error"
+# is how three components come to disagree (#916).
+#
+# Two directions, both required:
+#   expect_log_errors      — the fault MUST have produced its diagnostic. A wedge
+#                            that logs nothing at the default level is the state an
+#                            operator cannot act on, and the state this round itself
+#                            was fooled by.
+#   assert_no_other_errors — no UNDECLARED error-class line. This is what would
+#                            catch the BAD-FIX shape ("Fork rollback failed") or
+#                            #985's "LedgerSeq was incoherent", neither of which is
+#                            allowlisted on purpose.
+if [ "$CONVERGED" -ne 1 ]; then
+    if expect_log_errors "$LD_LOGS/dugite-relay.log" "${RELAY_MARK:-0}" \
+            "declining a range rooted at GENESIS" \
+            "beyond forecast horizon"; then
+        ok "the wedge is self-announcing: the genesis-range decline WARN and the horizon drop both appear on dugite-relay after the reconnect (#1057)"
+    else
+        bad "the node wedged SILENTLY: a required diagnostic is missing from dugite-relay (see stderr above). An unrecoverable state that logs nothing at the default level cannot be diagnosed in the field (#1057)"
+    fi
+
+    # The WARN is rate-limited to one per 30s per worker. A count in the hundreds
+    # would mean the throttle regressed — the unthrottled first version emitted
+    # 29,435 lines / 17 MB in ten minutes, which buries every other line and can
+    # fill a disk.
+    if [ "${GENESIS_DECLINE:-0}" -gt 200 ]; then
+        bad "genesis-decline WARN appeared ${GENESIS_DECLINE} times — the 30s throttle has regressed (#1057). A diagnostic that floods the log is not an improvement on silence."
+    else
+        ok "genesis-decline WARN is throttled (${GENESIS_DECLINE} line(s) for the whole wedge window)"
+    fi
+
+    if assert_no_other_errors "$LD_LOGS/dugite-relay.log" "${RELAY_MARK:-0}" \
+            ./genesis-fork-round.allowed-errors; then
+        ok "no UNDECLARED error-class line on dugite-relay after the reconnect"
+    else
+        bad "undeclared error-class line(s) on dugite-relay — listed above. If one of them is 'Fork rollback failed' or 'LedgerSeq was incoherent', that is the BAD-FIX / #985 shape, not something to allowlist."
+    fi
+fi
 RELAY_TIP=$(tip_field "$LD_RELAY_SOCK" .block)
 note "dugite-relay block=${RELAY_TIP:-?} vs cardano-bp block=${CBP_AFTER:-?}"
 

--- a/testnet/local-devnet/tx-zoo/16-cert-negatives/16a-stake-key-already-registered.sh
+++ b/testnet/local-devnet/tx-zoo/16-cert-negatives/16a-stake-key-already-registered.sh
@@ -4,6 +4,36 @@
 #         Ledger 2 -> CERTS 1 -> CERT 1 -> DELEG 2.
 #
 # Before #979 this reached cardano-cli as ConwayMempoolFailure.
+#
+# #1060 — TWO FIXTURE DEFECTS, both of which made this case assert something it
+# was not testing. Neither was a node bug: dugite's reported reason was correct
+# and cardano-node reports the same one.
+#
+# 1. THE TX WAS NOT WITNESSED. `--key-reg-deposit-amt` makes cardano-cli emit the
+#    Conway `reg_cert` (index 7), and that variant REQUIRES a vkey witness from
+#    the stake credential. Oracle-verified against cardano-ledger
+#    `Conway/TxCert.hs::getVKeyWitnessConwayTxCert`:
+#
+#      ConwayRegCert _ (SJust _)  -> credKeyHashWitness  -- index 7, WITNESS REQUIRED
+#      ConwayRegCert _ SNothing   -> Nothing             -- index 0, permissionless
+#
+#    with the source comment noting the exemption applies "only during the
+#    transitional period of Conway era and only for staking credential
+#    registration certificates without a deposit". The script signed with
+#    `payment.skey` alone, so the tx was genuinely missing a required witness and
+#    `MissingVKeyWitnessesUTXOW` was the RIGHT answer — cardano-node would say the
+#    same. See also #965: only the deposit-less reg_cert is permissionless.
+#
+# 2. IT BORROWED ITS PRECONDITION FROM ANOTHER CATEGORY. "Already registered"
+#    depended on 05-governance-certs having run first, which is why
+#    `run-all.sh`'s ALL_CATEGORIES carries an ordering comment. A negative case
+#    whose precondition is established elsewhere silently stops testing its own
+#    predicate the moment that ordering changes — and cannot be run standalone at
+#    all. It now establishes its own state: register, wait for inclusion, THEN
+#    re-register.
+#
+# The generalisable half: when a negative case reports the wrong REASON, check
+# whether the transaction is well-formed for the case before suspecting the node.
 set -euo pipefail
 ZOO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ZOO_DIR/lib/tx-zoo-common.sh"
@@ -14,6 +44,12 @@ zoo_require_devnet
 WA="$ZOO_KEYS/wallet-a"
 ADDR=$(cat "$WA/payment-stake.addr")
 [ -s "$WA/stake.vkey" ] || { zoo_record_env_skip "$NAME" "wallet-a stake key missing"; exit 0; }
+[ -s "$WA/stake.skey" ] || {
+    # The index-7 cert cannot be witnessed without it, so the case would only
+    # ever be able to observe a missing-witness failure.
+    zoo_record_env_skip "$NAME" "wallet-a stake SIGNING key missing (index-7 reg_cert needs its witness)"
+    exit 0
+}
 
 PPARAMS=$(zoo_pparams_file)
 DEPOSIT=$(jq -r '.stakeAddressDeposit // .keyDeposit // 2000000' "$PPARAMS")
@@ -25,7 +61,36 @@ cardano-cli conway stake-address registration-certificate \
     --out-file "$CERT" 2>/dev/null \
     || { zoo_record "$NAME" FAIL "" "cert-create"; exit 1; }
 
-SIGNED=$(cert_build_signed "$NAME" "$ADDR" "$WA/payment.skey" -- \
+# ── establish the precondition ourselves ──────────────────────────────────
+#
+# If the key is not registered yet, register it and wait for the tx to land.
+# `stake-address-info` returns an empty array for an unregistered credential.
+REG_INFO=$(cardano-cli conway query stake-address-info \
+             --testnet-magic "$LD_MAGIC" --socket-path "$ZOO_SOCKET" \
+             --address "$(cat "$WA/stake.addr")" --output-json 2>/dev/null || echo '[]')
+ALREADY=$(echo "$REG_INFO" | jq 'length' 2>/dev/null || echo 0)
+
+if [ "${ALREADY:-0}" -lt 1 ]; then
+    zoo_info "$NAME: stake key not registered yet — registering it first so the re-registration below is the thing under test"
+    SETUP=$(cert_build_signed "$NAME-setup" "$ADDR" "$WA/payment.skey" "$WA/stake.skey" -- \
+                --certificate-file "$CERT") || {
+        zoo_fail "$NAME: could not build the first-time registration: $(grep -m1 Error "$ZOO_LOGS/$NAME-setup.err" 2>/dev/null | cut -c1-140)"
+        zoo_record "$NAME" FAIL "" "setup-build-failed"; exit 1
+    }
+    TXID=$(zoo_submit "$SETUP") || {
+        zoo_fail "$NAME: the FIRST registration was rejected — the precondition cannot be established"
+        zoo_record "$NAME" FAIL "" "setup-submit-rejected"; exit 1
+    }
+    zoo_wait_inclusion "$TXID" 90 "$ADDR" || {
+        zoo_fail "$NAME: the first registration never landed, so 'already registered' is unproven"
+        zoo_record "$NAME" FAIL "" "setup-not-included"; exit 1
+    }
+fi
+
+# ── the case: re-register the same key, correctly witnessed ────────────────
+#
+# Signed with BOTH keys, so a missing witness cannot mask the DELEG failure.
+SIGNED=$(cert_build_signed "$NAME" "$ADDR" "$WA/payment.skey" "$WA/stake.skey" -- \
             --certificate-file "$CERT") || {
     # cardano-cli's `build` resolves the ledger state and may refuse locally.
     if grep -qiE "StakeKeyRegistered|already registered" "$ZOO_LOGS/$NAME.err"; then

--- a/testnet/local-devnet/tx-zoo/run-all.sh
+++ b/testnet/local-devnet/tx-zoo/run-all.sh
@@ -51,10 +51,16 @@ ALL_CATEGORIES=(
     # Multi-asset / size lattice (#961). Independent of governance state, so
     # position is not load-bearing; last keeps the governance ordering intact.
     15-asset-lattice
-    # Certificate-level reject-REASON negatives (#979). Runs after 05 (which
-    # registers drep-1 and the wallet stake key) because 16a/16d assert on
-    # "already registered" — they need that state to exist. Independent of
-    # governance actions, so it does not perturb 06/10/12/14.
+    # Certificate-level reject-REASON negatives (#979). 16d asserts on "DRep
+    # already registered", so it needs 05a to have run.
+    #
+    # #1060 corrected the other half of this note: it used to claim 05 "registers
+    # the wallet stake key", which 05 has never done — 05a/05c register a DREP.
+    # The wallet stake key is registered by 04a. 16a depended on that, was run
+    # without it, and so was never testing its own predicate. It now establishes
+    # its own precondition and depends on neither category.
+    #
+    # Independent of governance actions, so it does not perturb 06/10/12/14.
     16-cert-negatives
     # ScriptContext-inspecting validators + the ExUnits bracket (#969). Each
     # script locks and spends its own UTxO and touches no shared state, so the


### PR DESCRIPTION
Refs #1053, #1030, #1060, #1057.

**Three issues are fully fixed and verified. #1057 is diagnosed and mitigated but NOT fixed** — its live path still does not converge, and nothing here claims otherwise.

## Fully fixed

### #1053 — typed `ValidationTagMismatch` for phase-2 script failures

Every phase-2 script failure reached clients as the generic `ConwayMempoolFailure`, so a client could not tell a script failure from any other rejection. Verdict parity was never affected.

**The split is the fix, not the encoder arm.** `TxValidationError::ScriptFailed` looks like the natural home and would have been wrong — `serve.rs` routes ~20 unrelated ledger errors onto that one carrier, so a phase-2 class hung there would mislabel most of them (#979). The ledger side is clean: `ValidationError::ScriptFailed` has exactly one producer, so it gets a dedicated carrier.

Wire shape oracle-verified; four easy-to-get-wrong details pinned by a tag walk (`IsPhase2Valid` is a bare bool; `PlutusFailure` is Sum tag **1**; `PassedUnexpectedly` is `array(1)`; the `NonEmpty` is a bare list, never a `Set`). The base64 `PlutusWithContext` blob is deliberately empty and documented.

6 tests, 3 RED-proven, including a **wiring** test (#977's failure mode) and one that fails if someone later points the catch-all at the typed encoder.

### #1030 item 5 — `GetRewardProvenance` was undecodable

Tag 14 replied with a self-invented `array(4)` where Haskell's `SL.RewardProvenance` is a **16-field `Rec`**, so any client issuing it got `DeserialiseFailure` on the arity (#993's shape). Now an explicit error, per #993's conclusion that an undecodable reply is worse than an honest refusal; the payload genuinely is not reconstructible and the query has no cardano-cli exposure. The `QueryResult` variant is **deleted** so the wrong shape is inexpressible.

**Three tests pinned the bug.** The other six audited tags are clean and recorded as such; all 40 tags 0-39 confirmed present. With item 6 confirmed a non-issue with evidence, **all six #1030 items are resolved**.

### #1060 — tx-zoo 16a: two fixture defects, the node was right

`--key-reg-deposit-amt` emits the Conway `reg_cert` (index 7), which **requires** the stake credential's witness (oracle-verified: `ConwayRegCert _ (SJust _) -> credKeyHashWitness`). 16a signed with `payment.skey` alone, so `MissingVKeyWitnessesUTXOW` was correct — and it was the only case in its category with that defect. It also borrowed its precondition from 05, which has never registered a stake key (04a does).

**Verified live:** `16a-stake-key-already-registered,PASS,,rejected-StakeKeyRegisteredDELEG`.

## #1057 — diagnosed, mitigated, still open

The reproduction (`genesis-fork-round.sh`) is deterministic; depth asymmetry was the missing ingredient, with the head start measured in **slots** past the 240-slot horizon.

**What landed:**
* The wedge is no longer silent — a throttled WARN per declined genesis range plus one latched, actionable ERROR. The first version of this was a **29,435-line / 17 MB log storm**, now 11 lines for the whole window, with the throttle decision extracted into a tested pure function (including a backwards-clock case, since `SystemTime` is not monotonic).
* A marker makes a restart recover where it previously could not, bounded by two unit-tested conditions: ImmutableDB must be empty (a rollback past the immutable tip is protocol-impossible, and this caps the blast radius at nodes with <k blocks), and attempts are counted so a wrong-genesis node is told that rather than resyncing forever. The node does **not** exit itself — the trigger is a peer's claim, and auto-resyncing on that would be a remotely-triggerable forced resync.
* The genesis-anchor gate is `ledger_can_reach_origin` (LedgerSeq anchor is Origin, window coherent) — not "ledger is at Origin", which a live run proved too narrow: a node that had just recovered re-adopted a stale 10-block chain from its sibling and was wedged again 30 seconds later against the canonical 155-block chain. `find_rollback_n`'s `target == anchor` case is what makes the rollback executable; the abort that got the first attempt reverted only happens for a **snapshot-restored** ledger, whose anchor is not Origin.
* The decision's inputs are now logged at both unreachable sites. Those WARNs already looked informative while being unable to separate the branches they cover, which invited three wrong inferences.

**What has not been demonstrated:** convergence on the live path. Latest run has dugite-bp at block 17 while cardano-bp reached 135. The commit messages and #1057 say so explicitly.

## Also fixed: four defects in my own checks

Each was found by running the round, not reading it — worth listing because they are all the same family:

* An allowlist pattern written as `#1057: …` was parsed as a **comment** and silently dropped, so the line it was meant to allow failed the round — the silently-weakened-check class (#953) reproduced inside an allowlist.
* `beyond forecast horizon` as a *required* pattern was a false failure: step 4's own counter saw it while `expect_log_errors` did not, in the same run. Required patterns are now only what the node asserts about itself.
* Step 5 restarted the wrong node — the marker lands in the **relay's** database, and recovery is two-hop.
* Three runs reported `relay=?` from an unreadable tip and I read it as "did not converge". Hop 1 and hop 2 now report INCONCLUSIVE with a stderr explanation. **Unmeasured is not failed.**

The round also now uses the shared `lib/expect-log-errors.sh` oracle (#1041) rather than a hand-rolled count, so it classifies error lines the same way the release report does.

## Verification

`cargo nextest --workspace` **8083/8083** · `clippy --all-targets -D warnings` clean · `fmt` clean · `bash -n` clean · `genesis-fork-round.sh` FAIL (#1057 reproduced, as intended) · tx-zoo 16a PASS live.

https://claude.ai/code/session_01K7GmDovQyUKGfRTYUygXJD
